### PR TITLE
feat: Add /compact command for exporting chat conversations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ tools:
       - "^git log --oneline -n [0-9]+$"
       - "^docker ps$"
       - "^kubectl get pods$"
+compact:
+  output_dir: ".infer"  # Directory for compact command exports (default: project root/.infer)
 ```
 
 ### Command Structure
@@ -152,6 +154,7 @@ tools:
   - `list`: List deployed models
   - `prompt <text>`: Send prompts to models
   - `chat`: Interactive chat with model selection and tool support
+    - `/compact`: Export conversation to markdown file
   - `tools`: Tool management and execution
   - `version`: Version information
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Start an interactive chat session with model selection and tool support. Provide
 - Tool execution (when enabled)
 - Conversation history management
 - Real-time streaming responses
+- Conversation export to markdown files
 
 **Examples:**
 ```bash
@@ -179,6 +180,7 @@ infer chat
 - `/history` - Show conversation history
 - `/models` - Show available models
 - `/switch` - Switch to a different model
+- `/compact` - Export conversation to markdown file
 - `/help` - Show help information
 
 ### `infer tools`
@@ -271,6 +273,8 @@ tools:
       - "^git log --oneline -n [0-9]+$"
       - "^docker ps$"
       - "^kubectl get pods$"
+compact:
+  output_dir: ".infer"  # Directory for compact command exports
 ```
 
 ### Configuration Options
@@ -288,6 +292,9 @@ tools:
 - **tools.enabled**: Enable/disable tool execution for LLMs (default: false)
 - **tools.whitelist.commands**: List of allowed commands (supports arguments)
 - **tools.whitelist.patterns**: Regex patterns for complex command validation
+
+**Compact Settings:**
+- **compact.output_dir**: Directory for compact command exports (default: ".infer")
 
 ## Global Flags
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -76,7 +76,7 @@ func startChatSession() error {
 	}
 
 	fmt.Printf("\n🤖 Starting chat session with %s\n", selectedModel)
-	fmt.Println("Commands: '/exit' to quit, '/clear' for history, '/switch' for models, '/help' for all")
+	fmt.Println("Commands: '/exit' to quit, '/clear' for history, '/compact' to export, '/help' for all")
 	fmt.Println("Commands are processed immediately and won't be sent to the model")
 	fmt.Println("📁 File references: Use @filename to include file contents in your message")
 
@@ -242,6 +242,12 @@ func handleChatCommands(input string, conversation *[]sdk.Message, selectedModel
 			fmt.Printf("Switched to model: %s\n", newModel)
 		}
 		return true
+	case "/compact":
+		err := compactConversation(*conversation, *selectedModel)
+		if err != nil {
+			fmt.Printf("❌ Error creating compact file: %v\n", err)
+		}
+		return true
 	case "/help":
 		showChatHelp()
 		return true
@@ -290,6 +296,7 @@ func showChatHelp() {
 	fmt.Println("  /history         - Show conversation history")
 	fmt.Println("  /models          - Show current and available models")
 	fmt.Println("  /switch          - Switch to a different model")
+	fmt.Println("  /compact         - Export conversation to markdown file")
 	fmt.Println("  /help            - Show this help")
 	fmt.Println()
 	fmt.Println("File References:")
@@ -647,6 +654,95 @@ func displayChatMetrics(metrics *ChatMetrics) {
 			fmt.Printf(" | Total: %d tokens", metrics.Usage.TotalTokens)
 		}
 	}
+}
+
+func compactConversation(conversation []sdk.Message, selectedModel string) error {
+	cfg, err := config.LoadConfig("")
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if len(conversation) == 0 {
+		fmt.Println("📝 No conversation to export - conversation history is empty")
+		return nil
+	}
+
+	outputDir := cfg.Compact.OutputDir
+	if outputDir == "" {
+		outputDir = ".infer"
+	}
+
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory '%s': %w", outputDir, err)
+	}
+
+	timestamp := time.Now().Format("20060102-150405")
+	filename := fmt.Sprintf("chat-export-%s.md", timestamp)
+	filePath := filepath.Join(outputDir, filename)
+
+	var content strings.Builder
+	content.WriteString("# Chat Session Export\n\n")
+	content.WriteString(fmt.Sprintf("**Model:** %s\n", selectedModel))
+	content.WriteString(fmt.Sprintf("**Date:** %s\n", time.Now().Format("2006-01-02 15:04:05")))
+	content.WriteString(fmt.Sprintf("**Total Messages:** %d\n\n", len(conversation)))
+	content.WriteString("---\n\n")
+
+	for i, msg := range conversation {
+		var role string
+		switch msg.Role {
+		case sdk.User:
+			role = "👤 **You**"
+		case sdk.Assistant:
+			role = "🤖 **Assistant**"
+		case sdk.System:
+			role = "⚙️ **System**"
+		case sdk.Tool:
+			role = "🔧 **Tool Result**"
+		default:
+			role = fmt.Sprintf("**%s**", string(msg.Role))
+		}
+
+		content.WriteString(fmt.Sprintf("## Message %d - %s\n\n", i+1, role))
+
+		if msg.Content != "" {
+			content.WriteString(msg.Content)
+			content.WriteString("\n\n")
+		}
+
+		if msg.ToolCalls != nil && len(*msg.ToolCalls) > 0 {
+			content.WriteString("### Tool Calls\n\n")
+			for _, toolCall := range *msg.ToolCalls {
+				content.WriteString(fmt.Sprintf("**Tool:** %s\n\n", toolCall.Function.Name))
+				if toolCall.Function.Arguments != "" {
+					content.WriteString("**Arguments:**\n```json\n")
+					content.WriteString(toolCall.Function.Arguments)
+					content.WriteString("\n```\n\n")
+				}
+			}
+		}
+
+		if msg.ToolCallId != nil {
+			content.WriteString(fmt.Sprintf("*Tool Call ID: %s*\n\n", *msg.ToolCallId))
+		}
+
+		content.WriteString("---\n\n")
+	}
+
+	content.WriteString(fmt.Sprintf("*Exported on %s using Inference Gateway CLI*\n", time.Now().Format("2006-01-02 15:04:05")))
+
+	if err := os.WriteFile(filePath, []byte(content.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write file '%s': %w", filePath, err)
+	}
+
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		absPath = filePath
+	}
+
+	fmt.Printf("📝 Conversation exported successfully to: %s\n", absPath)
+	fmt.Printf("📊 Exported %d message(s) from chat session with %s\n", len(conversation), selectedModel)
+
+	return nil
 }
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Gateway GatewayConfig `yaml:"gateway"`
 	Output  OutputConfig  `yaml:"output"`
 	Tools   ToolsConfig   `yaml:"tools"`
+	Compact CompactConfig `yaml:"compact"`
 }
 
 // GatewayConfig contains gateway connection settings
@@ -38,6 +39,11 @@ type ToolsConfig struct {
 type ToolWhitelistConfig struct {
 	Commands []string `yaml:"commands"`
 	Patterns []string `yaml:"patterns"`
+}
+
+// CompactConfig contains settings for compact command
+type CompactConfig struct {
+	OutputDir string `yaml:"output_dir"`
 }
 
 // DefaultConfig returns a default configuration
@@ -66,6 +72,9 @@ func DefaultConfig() *Config {
 					"^kubectl get pods$",
 				},
 			},
+		},
+		Compact: CompactConfig{
+			OutputDir: ".infer",
 		},
 	}
 }


### PR DESCRIPTION
Closes #2

Adds a new `/compact` command to chat sessions that exports conversation history to markdown files.

## Changes

- Add CompactConfig to configuration system with configurable output directory
- Implement /compact command in chat sessions to export conversation history
- Support rich markdown formatting with role indicators and timestamps
- Include tool calls and arguments with proper JSON syntax highlighting
- Handle all message types (User, Assistant, System, Tool)
- Provide user feedback with file paths and message counts
- Update documentation in README.md and CLAUDE.md

## Usage

In any chat session, simply type `/compact` to export the current conversation to a timestamped markdown file in the configured output directory (default: `.infer/`).

Generated with [Claude Code](https://claude.ai/code)