### PR TITLE
feat: Move configuration to .infer/config.yaml directory structure

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -1,0 +1,31 @@
+gateway:
+    url: http://localhost:8080
+    api_key: ""
+    timeout: 30
+output:
+    format: text
+    quiet: false
+tools:
+    enabled: false
+    whitelist:
+        commands:
+            - ls
+            - pwd
+            - echo
+            - cat
+            - head
+            - tail
+            - grep
+            - find
+            - wc
+            - sort
+            - uniq
+        patterns:
+            - ^git status$
+            - ^git log --oneline -n [0-9]+$
+            - ^docker ps$
+            - ^kubectl get pods$
+    safety:
+        require_approval: true
+compact:
+    output_dir: .infer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,10 @@ The project follows the standard Go CLI architecture using Cobra framework:
   - `status.go`: Status monitoring (`infer status`, `infer models list`)
   - `prompt.go`: Prompt testing (`infer prompt`)
   - `version.go`: Version information (`infer version`)
-- `internal/config.go`: Configuration management with YAML support
+- `config/config.go`: Configuration management with YAML support
 
 ### Configuration System
-The CLI uses a YAML configuration file at `~/.infer.yaml` with the following structure:
+The CLI uses a project-based YAML configuration file at `.infer.yaml` in the current directory with the following structure:
 ```yaml
 gateway:
   url: "http://localhost:8080"
@@ -150,6 +150,7 @@ compact:
 - Root command: `infer`
 - Global flags: `--config`, `--verbose`
 - Subcommands:
+  - `init [--overwrite]`: Initialize local project configuration
   - `status [--format]`: Gateway status
   - `list`: List deployed models
   - `prompt <text>`: Send prompts to models

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ The project follows the standard Go CLI architecture using Cobra framework:
 - `config/config.go`: Configuration management with YAML support
 
 ### Configuration System
-The CLI uses a project-based YAML configuration file at `.infer.yaml` in the current directory with the following structure:
+The CLI uses a project-based YAML configuration file at `.infer/config.yaml` in the current directory with the following structure:
 ```yaml
 gateway:
   url: "http://localhost:8080"

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ infer version
 
 ## Configuration
 
-The CLI uses a YAML configuration file located at `~/.infer.yaml`. You can also specify a custom config file using the `--config` flag.
+The CLI uses a YAML configuration file located at `.infer/config.yaml`. You can also specify a custom config file using the `--config` flag.
 
 ### Default Configuration
 
@@ -363,7 +363,7 @@ The Inference Gateway CLI includes a secure tool execution system that allows LL
 
    Please select an option:
    ▶ Yes - Execute this command
-     Yes, and don't ask again - Execute this and all future commands  
+     Yes, and don't ask again - Execute this and all future commands
      No - Cancel command execution
 
    [User selects "Yes - Execute this command"]
@@ -382,7 +382,7 @@ The Inference Gateway CLI includes a secure tool execution system that allows LL
 
 ### Customizing Tool Whitelist
 
-Edit `~/.infer.yaml` to add custom commands:
+Edit `.infer/config.yaml` to add custom commands:
 
 ```yaml
 tools:
@@ -408,7 +408,7 @@ tools:
 
 **"Tools are disabled" error:**
 - Enable tools: `infer tools enable`
-- Verify config: `tools.enabled: true` in `~/.infer.yaml`
+- Verify config: `tools.enabled: true` in `.infer/config.yaml`
 
 **Safety approval prompts:**
 - Disable safety prompts: `infer tools safety disable`

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,10 +11,10 @@ import (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a new project configuration",
-	Long: `Initialize a new .infer.yaml configuration file in the current directory.
+	Long: `Initialize a new .infer/config.yaml configuration file in the current directory.
 This creates a local project configuration with default settings.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		configPath := ".infer.yaml"
+		configPath := ".infer/config.yaml"
 
 		if _, err := os.Stat(configPath); err == nil {
 			overwrite, _ := cmd.Flags().GetBool("overwrite")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/inference-gateway/cli/config"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a new project configuration",
+	Long: `Initialize a new .infer.yaml configuration file in the current directory.
+This creates a local project configuration with default settings.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		configPath := ".infer.yaml"
+
+		if _, err := os.Stat(configPath); err == nil {
+			overwrite, _ := cmd.Flags().GetBool("overwrite")
+			if !overwrite {
+				return fmt.Errorf("configuration file %s already exists (use --overwrite to replace)", configPath)
+			}
+		}
+
+		cfg := config.DefaultConfig()
+
+		if err := cfg.SaveConfig(configPath); err != nil {
+			return fmt.Errorf("failed to create config file: %w", err)
+		}
+
+		fmt.Printf("Successfully created %s\n", configPath)
+		fmt.Println("You can now customize the configuration for this project.")
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+
+	initCmd.Flags().Bool("overwrite", false, "Overwrite existing configuration file")
+}

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -141,7 +141,7 @@ func showInteractiveHelp() {
 
 func showHistory(rl *readline.Instance) {
 	fmt.Println("📝 Command History:")
-	fmt.Println("(History is stored in ~/.infer_history)")
+	fmt.Println("(History is stored in .infer/history)")
 	fmt.Println()
 }
 
@@ -221,11 +221,11 @@ func executeInteractiveCommand(line string) {
 }
 
 func getHistoryFile() string {
-	homeDir, err := os.UserHomeDir()
+	cwd, err := os.Getwd()
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(homeDir, ".infer_history")
+	return filepath.Join(cwd, ".infer", "history")
 }
 
 func createCompleter(cfg *config.Config) readline.AutoCompleter {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringP("config", "c", "", "config file (default is $HOME/.infer.yaml)")
+	rootCmd.PersistentFlags().StringP("config", "c", "", "config file (default is ./.infer.yaml)")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -135,9 +135,9 @@ func (c *Config) SaveConfig(configPath string) error {
 }
 
 func getDefaultConfigPath() string {
-	homeDir, err := os.UserHomeDir()
+	wd, err := os.Getwd()
 	if err != nil {
 		return ".infer.yaml"
 	}
-	return filepath.Join(homeDir, ".infer.yaml")
+	return filepath.Join(wd, ".infer.yaml")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -137,7 +137,7 @@ func (c *Config) SaveConfig(configPath string) error {
 func getDefaultConfigPath() string {
 	wd, err := os.Getwd()
 	if err != nil {
-		return ".infer.yaml"
+		return ".infer/config.yaml"
 	}
-	return filepath.Join(wd, ".infer.yaml")
+	return filepath.Join(wd, ".infer/config.yaml")
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ curl -fsSL https://raw.githubusercontent.com/inference-gateway/cli/main/install.
 
 ## Configuration
 
-Set up your CLI configuration at `~/.infer.yaml`:
+Set up your CLI configuration at `.infer/config.yaml`:
 
 ```yaml
 gateway:
@@ -79,7 +79,7 @@ All commands support these global flags:
 
 ## Configuration Management
 
-The CLI automatically creates a default configuration file at `~/.infer.yaml` on first run. You can customize:
+The CLI automatically creates a default configuration file at `.infer/config.yaml` on first run. You can customize:
 
 - Gateway URL and API credentials
 - Output formatting preferences


### PR DESCRIPTION
Closes #7

## Changes
- Update config path from `.infer.yaml` to `.infer/config.yaml`
- Modify init command to create `.infer/` directory structure
- Update documentation and help text to reflect new path
- Maintain all existing functionality with new directory layout

This provides better organization for project-level configuration files by keeping them in a dedicated `.infer/` directory.

Generated with [Claude Code](https://claude.ai/code)