### PR TITLE
feat: Add system prompt configuration support

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -31,3 +31,4 @@ compact:
   output_dir: .infer
 chat:
   default_model: ""
+  system_prompt: ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,7 @@ compact:
   output_dir: ".infer"  # Directory for compact command exports (default: project root/.infer)
 chat:
   default_model: ""  # Default model for chat sessions (when set, skips model selection)
+  system_prompt: ""  # System prompt included with every chat session
 ```
 
 ### Command Structure
@@ -170,6 +171,7 @@ chat:
   - `config`: Manage CLI configuration
     - `init [--overwrite]`: Initialize local project configuration
     - `set-model [MODEL_NAME]`: Set default model for chat sessions
+    - `set-system [SYSTEM_PROMPT]`: Set system prompt for chat sessions
     - `tools`: Manage tool execution settings
       - `enable`: Enable tool execution for LLMs
       - `disable`: Disable tool execution for LLMs
@@ -212,6 +214,16 @@ infer config set-model gpt-4-turbo
 infer chat
 ```
 
+### Setting a System Prompt
+```bash
+# Set a system prompt for chat sessions
+infer config set-system "You are a helpful assistant."
+
+# The system prompt will now be included with every chat session
+# providing context and instructions to the AI model
+infer chat
+```
+
 ### Configuration Management
 ```bash
 # Initialize a new project configuration
@@ -223,9 +235,10 @@ infer config init --overwrite
 # View current configuration (check .infer/config.yaml)
 cat .infer/config.yaml
 
-# The default model will be saved in the chat section:
+# The default model and system prompt will be saved in the chat section:
 # chat:
 #   default_model: "gpt-4-turbo"
+#   system_prompt: "You are a helpful assistant."
 ```
 
 ### Tool Management

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,6 +31,18 @@ the chat command will skip the model selection view and use the configured model
 	},
 }
 
+var setSystemCmd = &cobra.Command{
+	Use:   "set-system [SYSTEM_PROMPT]",
+	Short: "Set the system prompt for chat sessions",
+	Long: `Set the system prompt that will be included with every chat session.
+The system prompt provides context and instructions to the AI model about how to behave.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		systemPrompt := args[0]
+		return setSystemPrompt(systemPrompt)
+	},
+}
+
 var configInitCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a new project configuration",
@@ -176,8 +188,27 @@ func setDefaultModel(modelName string) error {
 	return nil
 }
 
+func setSystemPrompt(systemPrompt string) error {
+	cfg, err := config.LoadConfig("")
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	cfg.Chat.SystemPrompt = systemPrompt
+
+	if err := cfg.SaveConfig(""); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	fmt.Printf("✅ System prompt set successfully\n")
+	fmt.Printf("System prompt: %s\n", systemPrompt)
+	fmt.Println("This prompt will be included with every chat session.")
+	return nil
+}
+
 func init() {
 	configCmd.AddCommand(setModelCmd)
+	configCmd.AddCommand(setSystemCmd)
 	configCmd.AddCommand(configInitCmd)
 	configCmd.AddCommand(configToolsCmd)
 

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,7 @@ type CompactConfig struct {
 // ChatConfig contains chat-related settings
 type ChatConfig struct {
 	DefaultModel string `yaml:"default_model"`
+	SystemPrompt string `yaml:"system_prompt"`
 }
 
 // DefaultConfig returns a default configuration
@@ -100,6 +101,7 @@ func DefaultConfig() *Config {
 		},
 		Chat: ChatConfig{
 			DefaultModel: "",
+			SystemPrompt: "",
 		},
 	}
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -68,6 +68,7 @@ func (c *ServiceContainer) initializeDomainServices() {
 		c.config.Gateway.APIKey,
 		c.config.Gateway.Timeout,
 		c.toolService,
+		c.config.Chat.SystemPrompt,
 	)
 }
 


### PR DESCRIPTION
This PR implements system prompt configuration for the Inference Gateway CLI as requested in issue #25.

## Changes

- Add `system_prompt` field to ChatConfig in config structure
- Implement `infer config set-system` command for setting system prompts
- Update chat service to include system prompt in API messages
- Modify service container to pass system prompt to chat service
- Update documentation with new command and configuration examples

## Usage

```bash
# Set a system prompt
infer config set-system "You are a helpful assistant."

# The system prompt is now included with every chat session
infer chat
```

The system prompt is configurable via command or by modifying the config directly and is included in SDK messages as a system prompt.

Resolves #25

Generated with [Claude Code](https://claude.ai/code)