### PR TITLE
feat: Implement Delete Tool with improved security features

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -30,6 +30,16 @@ tools:
   write:
     enabled: true
     require_approval: true
+  delete:
+    enabled: true
+    require_approval: true
+    protected_paths:
+      - .infer/
+      - .infer/*
+      - .git/
+      - .git/*
+    allow_wildcards: true
+    restrict_to_workdir: true
   file_search:
     enabled: true
     require_approval: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,16 @@ tools:
       - "^git log --oneline -n [0-9]+$"
       - "^docker ps$"
       - "^kubectl get pods$"
+  delete:
+    enabled: true  # Enable delete tool for file/directory deletion
+    allow_wildcards: true  # Enable wildcard patterns like *.txt
+    restrict_to_workdir: true  # Only allow deletion within current working directory
+    protected_paths:  # Additional paths protected from deletion
+      - ".infer/"     # Protect infer's configuration directory
+      - ".infer/*"    # Protect all files in infer's configuration directory
+      - ".git/"       # Protect git repository
+      - ".git/*"      # Protect all git files
+    require_approval: true  # Require user approval before deletion
   safety:
     require_approval: true  # Prompt user before executing any command
   exclude_paths:  # Paths excluded from tool access for security
@@ -394,6 +404,90 @@ When the LLM uses the WebSearch tool, it can specify:
 2. **DuckDuckGo**: Optionally set `DUCKDUCKGO_SEARCH_API_KEY` environment variable, or use built-in fallback (no setup required)
 
 Results include title, URL, and snippet for each search result.
+
+### Delete Tool
+
+The CLI includes a delete tool that allows LLMs to safely delete files and directories with comprehensive security restrictions and wildcard support.
+
+#### Security Features
+
+The Delete Tool implements multiple layers of security to prevent accidental or malicious deletions:
+
+1. **Working Directory Restriction**: By default, only allows deletion within the current working directory
+2. **Protected Paths**: Configurable list of paths that are completely protected from deletion
+3. **Approval Prompts**: Requires user confirmation before executing any deletion operation
+4. **Path Exclusions**: Respects the global tool exclusion paths
+
+#### Default Protected Paths
+
+- `.infer/` - Protects the CLI's configuration directory
+- `.git/` - Protects Git repository files and metadata
+
+#### Configuration Options
+
+```yaml
+tools:
+  delete:
+    enabled: true                    # Enable/disable the delete tool
+    allow_wildcards: true           # Enable wildcard patterns (*.txt, temp/*)
+    restrict_to_workdir: true       # Restrict deletions to current working directory
+    require_approval: true          # Require user approval before deletion
+    protected_paths:                # Additional paths to protect
+      - "important/"
+      - "*.config"
+      - "backups/*"
+```
+
+#### Usage Examples
+
+**Single File Deletion:**
+```json
+{
+  "name": "Delete",
+  "parameters": {
+    "path": "temp.txt"
+  }
+}
+```
+
+**Directory Deletion (Recursive):**
+```json
+{
+  "name": "Delete",
+  "parameters": {
+    "path": "temp_folder",
+    "recursive": true
+  }
+}
+```
+
+**Wildcard Pattern Deletion:**
+```json
+{
+  "name": "Delete",
+  "parameters": {
+    "path": "*.log",
+    "force": true
+  }
+}
+```
+
+#### Tool Parameters
+
+When the LLM uses the Delete tool, it can specify:
+
+- `path` (required): File or directory path to delete. Supports wildcards when enabled.
+- `recursive` (optional): Whether to delete directories recursively (default: false)
+- `force` (optional): Ignore non-existent files without error (default: false)
+- `format` (optional): Output format ("text" or "json", default: "text")
+
+#### Safety Considerations
+
+- Always requires approval by default for destructive operations
+- Cannot delete outside the current working directory when `restrict_to_workdir` is true
+- Protected paths cannot be deleted even with wildcard patterns
+- Wildcard support can be disabled for additional safety
+- Comprehensive validation prevents path traversal attacks
 
 ## Code Style Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,9 +407,10 @@ Results include title, URL, and snippet for each search result.
 
 ### Delete Tool
 
-The CLI includes a delete tool that allows LLMs to safely delete files and directories with comprehensive security restrictions and wildcard support.
+The CLI includes a delete tool that allows LLMs to safely delete files and directories with
+comprehensive security restrictions and wildcard support.
 
-#### Security Features
+#### Delete Tool Security Features
 
 The Delete Tool implements multiple layers of security to prevent accidental or malicious deletions:
 
@@ -438,9 +439,10 @@ tools:
       - "backups/*"
 ```
 
-#### Usage Examples
+#### Delete Tool Usage Examples
 
 **Single File Deletion:**
+
 ```json
 {
   "name": "Delete",
@@ -451,6 +453,7 @@ tools:
 ```
 
 **Directory Deletion (Recursive):**
+
 ```json
 {
   "name": "Delete",
@@ -462,6 +465,7 @@ tools:
 ```
 
 **Wildcard Pattern Deletion:**
+
 ```json
 {
   "name": "Delete",
@@ -472,7 +476,7 @@ tools:
 }
 ```
 
-#### Tool Parameters
+#### Delete Tool Parameters
 
 When the LLM uses the Delete tool, it can specify:
 

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type ToolsConfig struct {
 	Bash         BashToolConfig       `yaml:"bash"`
 	Read         ReadToolConfig       `yaml:"read"`
 	Write        WriteToolConfig      `yaml:"write"`
+	Delete       DeleteToolConfig     `yaml:"delete"`
 	FileSearch   FileSearchToolConfig `yaml:"file_search"`
 	Tree         TreeToolConfig       `yaml:"tree"`
 	Fetch        FetchToolConfig      `yaml:"fetch"`
@@ -64,6 +65,15 @@ type ReadToolConfig struct {
 type WriteToolConfig struct {
 	Enabled         bool  `yaml:"enabled"`
 	RequireApproval *bool `yaml:"require_approval,omitempty"`
+}
+
+// DeleteToolConfig contains delete-specific tool settings
+type DeleteToolConfig struct {
+	Enabled           bool     `yaml:"enabled"`
+	RequireApproval   *bool    `yaml:"require_approval,omitempty"`
+	ProtectedPaths    []string `yaml:"protected_paths"`
+	AllowWildcards    bool     `yaml:"allow_wildcards"`
+	RestrictToWorkDir bool     `yaml:"restrict_to_workdir"`
 }
 
 // FileSearchToolConfig contains file search-specific tool settings
@@ -178,6 +188,13 @@ func DefaultConfig() *Config {
 			Write: WriteToolConfig{
 				Enabled:         true,
 				RequireApproval: &[]bool{true}[0],
+			},
+			Delete: DeleteToolConfig{
+				Enabled:           true,
+				RequireApproval:   &[]bool{true}[0],
+				ProtectedPaths:    []string{".infer/", ".infer/*", ".git/", ".git/*"},
+				AllowWildcards:    true,
+				RestrictToWorkDir: true,
 			},
 			FileSearch: FileSearchToolConfig{
 				Enabled:         true,
@@ -329,6 +346,10 @@ func (c *Config) IsApprovalRequired(toolName string) bool {
 	case "Write":
 		if c.Tools.Write.RequireApproval != nil {
 			return *c.Tools.Write.RequireApproval
+		}
+	case "Delete":
+		if c.Tools.Delete.RequireApproval != nil {
+			return *c.Tools.Delete.RequireApproval
 		}
 	case "FileSearch":
 		if c.Tools.FileSearch.RequireApproval != nil {

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -237,3 +237,14 @@ type TreeToolResult struct {
 	UsingNativeTree bool     `json:"using_native_tree"`
 	Truncated       bool     `json:"truncated"`
 }
+
+// DeleteToolResult represents the result of a delete operation
+type DeleteToolResult struct {
+	Path              string   `json:"path"`
+	DeletedFiles      []string `json:"deleted_files"`
+	DeletedDirs       []string `json:"deleted_dirs"`
+	TotalFilesDeleted int      `json:"total_files_deleted"`
+	TotalDirsDeleted  int      `json:"total_dirs_deleted"`
+	WildcardExpanded  bool     `json:"wildcard_expanded"`
+	Errors            []string `json:"errors,omitempty"`
+}

--- a/internal/services/tools/delete.go
+++ b/internal/services/tools/delete.go
@@ -269,23 +269,35 @@ func (t *DeleteTool) deleteSinglePath(path string, recursive bool, result *Delet
 	}
 
 	if info.IsDir() {
-		if recursive {
-			if err := os.RemoveAll(path); err != nil {
-				return fmt.Errorf("failed to delete directory %s: %w", path, err)
-			}
-			result.DeletedDirs = append(result.DeletedDirs, path)
-			result.TotalDirsDeleted++
-		} else {
-			return fmt.Errorf("path %s is a directory, use recursive=true to delete directories", path)
-		}
-	} else {
-		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("failed to delete file %s: %w", path, err)
-		}
-		result.DeletedFiles = append(result.DeletedFiles, path)
-		result.TotalFilesDeleted++
+		return t.deleteDirectory(path, recursive, result)
 	}
 
+	return t.deleteFile(path, result)
+}
+
+// deleteDirectory handles directory deletion with recursive option
+func (t *DeleteTool) deleteDirectory(path string, recursive bool, result *DeleteResult) error {
+	if !recursive {
+		return fmt.Errorf("path %s is a directory, use recursive=true to delete directories", path)
+	}
+
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("failed to delete directory %s: %w", path, err)
+	}
+
+	result.DeletedDirs = append(result.DeletedDirs, path)
+	result.TotalDirsDeleted++
+	return nil
+}
+
+// deleteFile handles single file deletion
+func (t *DeleteTool) deleteFile(path string, result *DeleteResult) error {
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("failed to delete file %s: %w", path, err)
+	}
+
+	result.DeletedFiles = append(result.DeletedFiles, path)
+	result.TotalFilesDeleted++
 	return nil
 }
 

--- a/internal/services/tools/delete.go
+++ b/internal/services/tools/delete.go
@@ -188,7 +188,6 @@ func (t *DeleteTool) executeDelete(path string, recursive, force bool) (*DeleteR
 		Errors:       []string{},
 	}
 
-	// Check if wildcards are enabled and if the path contains wildcards
 	if t.containsWildcards(path) {
 		if !t.config.Tools.Delete.AllowWildcards {
 			return nil, fmt.Errorf("wildcard patterns are not enabled in the configuration")
@@ -197,7 +196,6 @@ func (t *DeleteTool) executeDelete(path string, recursive, force bool) (*DeleteR
 		return t.executeWildcardDelete(path, recursive, force, result)
 	}
 
-	// Single file/directory deletion
 	return t.executeSingleDelete(path, recursive, force, result)
 }
 
@@ -263,7 +261,7 @@ func (t *DeleteTool) deleteSinglePath(path string, recursive bool, result *Delet
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil // File doesn't exist, consider it already deleted
+			return nil
 		}
 		return fmt.Errorf("failed to stat path %s: %w", path, err)
 	}
@@ -303,7 +301,6 @@ func (t *DeleteTool) deleteFile(path string, result *DeleteResult) error {
 
 // validatePathSecurity checks if a path is allowed for deletion
 func (t *DeleteTool) validatePathSecurity(path string) error {
-	// Ensure absolute path resolves within current working directory
 	if t.config.Tools.Delete.RestrictToWorkDir {
 		wd, err := os.Getwd()
 		if err != nil {
@@ -320,7 +317,6 @@ func (t *DeleteTool) validatePathSecurity(path string) error {
 		}
 	}
 
-	// Check against general excluded paths
 	for _, excludePath := range t.config.Tools.ExcludePaths {
 		if strings.HasPrefix(path, excludePath) {
 			return fmt.Errorf("access to path '%s' is excluded for security", path)
@@ -331,7 +327,6 @@ func (t *DeleteTool) validatePathSecurity(path string) error {
 		}
 	}
 
-	// Check against delete-specific protected paths
 	for _, protectedPath := range t.config.Tools.Delete.ProtectedPaths {
 		if strings.HasPrefix(path, protectedPath) {
 			return fmt.Errorf("path '%s' is protected from deletion", path)

--- a/internal/services/tools/delete.go
+++ b/internal/services/tools/delete.go
@@ -1,0 +1,334 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/inference-gateway/cli/config"
+	"github.com/inference-gateway/cli/internal/domain"
+)
+
+// DeleteTool handles file and directory deletion operations
+type DeleteTool struct {
+	config  *config.Config
+	enabled bool
+}
+
+// NewDeleteTool creates a new delete tool
+func NewDeleteTool(cfg *config.Config) *DeleteTool {
+	return &DeleteTool{
+		config:  cfg,
+		enabled: cfg.Tools.Enabled && cfg.Tools.Delete.Enabled,
+	}
+}
+
+// Definition returns the tool definition for the LLM
+func (t *DeleteTool) Definition() domain.ToolDefinition {
+	return domain.ToolDefinition{
+		Name:        "Delete",
+		Description: "Delete files or directories from the filesystem. Supports wildcard patterns for batch operations. Restricted to current working directory for security.",
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{
+					"type":        "string",
+					"description": "The path to the file or directory to delete. Supports wildcard patterns like '*.txt' or 'temp/*' when wildcards are enabled.",
+				},
+				"recursive": map[string]interface{}{
+					"type":        "boolean",
+					"description": "Whether to delete directories recursively",
+					"default":     false,
+				},
+				"force": map[string]interface{}{
+					"type":        "boolean",
+					"description": "Whether to force deletion (ignore non-existent files)",
+					"default":     false,
+				},
+				"format": map[string]interface{}{
+					"type":        "string",
+					"description": "Output format (text or json)",
+					"enum":        []string{"text", "json"},
+					"default":     "text",
+				},
+			},
+			"required": []string{"path"},
+		},
+	}
+}
+
+// Execute runs the delete tool with given arguments
+func (t *DeleteTool) Execute(ctx context.Context, args map[string]interface{}) (*domain.ToolExecutionResult, error) {
+	start := time.Now()
+	if !t.config.Tools.Enabled {
+		return nil, fmt.Errorf("delete tool is not enabled")
+	}
+
+	path, ok := args["path"].(string)
+	if !ok {
+		return &domain.ToolExecutionResult{
+			ToolName:  "Delete",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(start),
+			Error:     "path parameter is required and must be a string",
+		}, nil
+	}
+
+	recursive := false
+	if recursiveVal, exists := args["recursive"]; exists {
+		if val, ok := recursiveVal.(bool); ok {
+			recursive = val
+		}
+	}
+
+	force := false
+	if forceVal, exists := args["force"]; exists {
+		if val, ok := forceVal.(bool); ok {
+			force = val
+		}
+	}
+
+	deleteResult, err := t.executeDelete(path, recursive, force)
+	if err != nil {
+		return nil, err
+	}
+
+	var toolData *domain.DeleteToolResult
+	if deleteResult != nil {
+		toolData = &domain.DeleteToolResult{
+			Path:              deleteResult.Path,
+			DeletedFiles:      deleteResult.DeletedFiles,
+			DeletedDirs:       deleteResult.DeletedDirs,
+			TotalFilesDeleted: deleteResult.TotalFilesDeleted,
+			TotalDirsDeleted:  deleteResult.TotalDirsDeleted,
+			WildcardExpanded:  deleteResult.WildcardExpanded,
+			Errors:            deleteResult.Errors,
+		}
+	}
+
+	result := &domain.ToolExecutionResult{
+		ToolName:  "Delete",
+		Arguments: args,
+		Success:   true,
+		Duration:  time.Since(start),
+		Data:      toolData,
+	}
+
+	return result, nil
+}
+
+// Validate checks if the delete tool arguments are valid
+func (t *DeleteTool) Validate(args map[string]interface{}) error {
+	if !t.config.Tools.Enabled {
+		return fmt.Errorf("delete tool is not enabled")
+	}
+
+	path, ok := args["path"].(string)
+	if !ok {
+		return fmt.Errorf("path parameter is required and must be a string")
+	}
+
+	if path == "" {
+		return fmt.Errorf("path cannot be empty")
+	}
+
+	if err := t.validatePathSecurity(path); err != nil {
+		return err
+	}
+
+	if recursive, exists := args["recursive"]; exists {
+		if _, ok := recursive.(bool); !ok {
+			return fmt.Errorf("recursive parameter must be a boolean")
+		}
+	}
+
+	if force, exists := args["force"]; exists {
+		if _, ok := force.(bool); !ok {
+			return fmt.Errorf("force parameter must be a boolean")
+		}
+	}
+
+	if format, ok := args["format"].(string); ok {
+		if format != "text" && format != "json" {
+			return fmt.Errorf("format must be 'text' or 'json'")
+		}
+	} else if args["format"] != nil {
+		return fmt.Errorf("format parameter must be a string")
+	}
+
+	return nil
+}
+
+// IsEnabled returns whether the delete tool is enabled
+func (t *DeleteTool) IsEnabled() bool {
+	return t.enabled
+}
+
+// DeleteResult represents the result of a delete operation
+type DeleteResult struct {
+	Path              string   `json:"path"`
+	DeletedFiles      []string `json:"deleted_files"`
+	DeletedDirs       []string `json:"deleted_dirs"`
+	TotalFilesDeleted int      `json:"total_files_deleted"`
+	TotalDirsDeleted  int      `json:"total_dirs_deleted"`
+	WildcardExpanded  bool     `json:"wildcard_expanded"`
+	Errors            []string `json:"errors,omitempty"`
+}
+
+// executeDelete performs the actual deletion operation
+func (t *DeleteTool) executeDelete(path string, recursive, force bool) (*DeleteResult, error) {
+	result := &DeleteResult{
+		Path:         path,
+		DeletedFiles: []string{},
+		DeletedDirs:  []string{},
+		Errors:       []string{},
+	}
+
+	// Check if wildcards are enabled and if the path contains wildcards
+	if t.containsWildcards(path) {
+		if !t.config.Tools.Delete.AllowWildcards {
+			return nil, fmt.Errorf("wildcard patterns are not enabled in the configuration")
+		}
+		result.WildcardExpanded = true
+		return t.executeWildcardDelete(path, recursive, force, result)
+	}
+
+	// Single file/directory deletion
+	return t.executeSingleDelete(path, recursive, force, result)
+}
+
+// containsWildcards checks if a path contains wildcard characters
+func (t *DeleteTool) containsWildcards(path string) bool {
+	return strings.Contains(path, "*") || strings.Contains(path, "?") || strings.Contains(path, "[")
+}
+
+// executeWildcardDelete handles deletion with wildcard patterns
+func (t *DeleteTool) executeWildcardDelete(pattern string, recursive, force bool, result *DeleteResult) (*DeleteResult, error) {
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid wildcard pattern: %w", err)
+	}
+
+	if len(matches) == 0 {
+		if !force {
+			return nil, fmt.Errorf("no files or directories match the pattern: %s", pattern)
+		}
+		return result, nil
+	}
+
+	for _, match := range matches {
+		if err := t.validatePathSecurity(match); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("Path %s: %v", match, err))
+			continue
+		}
+
+		if err := t.deleteSinglePath(match, recursive, result); err != nil {
+			if !force {
+				return nil, err
+			}
+			result.Errors = append(result.Errors, fmt.Sprintf("Path %s: %v", match, err))
+		}
+	}
+
+	return result, nil
+}
+
+// executeSingleDelete handles deletion of a single file or directory
+func (t *DeleteTool) executeSingleDelete(path string, recursive, force bool, result *DeleteResult) (*DeleteResult, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) && force {
+			return result, nil
+		}
+		return nil, fmt.Errorf("failed to stat path %s: %w", path, err)
+	}
+
+	if info.IsDir() && !recursive {
+		return nil, fmt.Errorf("path %s is a directory, use recursive=true to delete directories", path)
+	}
+
+	if err := t.deleteSinglePath(path, recursive, result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// deleteSinglePath deletes a single file or directory and updates the result
+func (t *DeleteTool) deleteSinglePath(path string, recursive bool, result *DeleteResult) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // File doesn't exist, consider it already deleted
+		}
+		return fmt.Errorf("failed to stat path %s: %w", path, err)
+	}
+
+	if info.IsDir() {
+		if recursive {
+			if err := os.RemoveAll(path); err != nil {
+				return fmt.Errorf("failed to delete directory %s: %w", path, err)
+			}
+			result.DeletedDirs = append(result.DeletedDirs, path)
+			result.TotalDirsDeleted++
+		} else {
+			return fmt.Errorf("path %s is a directory, use recursive=true to delete directories", path)
+		}
+	} else {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("failed to delete file %s: %w", path, err)
+		}
+		result.DeletedFiles = append(result.DeletedFiles, path)
+		result.TotalFilesDeleted++
+	}
+
+	return nil
+}
+
+// validatePathSecurity checks if a path is allowed for deletion
+func (t *DeleteTool) validatePathSecurity(path string) error {
+	// Ensure absolute path resolves within current working directory
+	if t.config.Tools.Delete.RestrictToWorkDir {
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current working directory: %w", err)
+		}
+
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return fmt.Errorf("failed to resolve absolute path for %s: %w", path, err)
+		}
+
+		if !strings.HasPrefix(absPath, wd) {
+			return fmt.Errorf("path '%s' is outside the current working directory", path)
+		}
+	}
+
+	// Check against general excluded paths
+	for _, excludePath := range t.config.Tools.ExcludePaths {
+		if strings.HasPrefix(path, excludePath) {
+			return fmt.Errorf("access to path '%s' is excluded for security", path)
+		}
+
+		if strings.Contains(excludePath, "*") && matchesPattern(path, excludePath) {
+			return fmt.Errorf("access to path '%s' is excluded for security", path)
+		}
+	}
+
+	// Check against delete-specific protected paths
+	for _, protectedPath := range t.config.Tools.Delete.ProtectedPaths {
+		if strings.HasPrefix(path, protectedPath) {
+			return fmt.Errorf("path '%s' is protected from deletion", path)
+		}
+
+		if strings.Contains(protectedPath, "*") && matchesPattern(path, protectedPath) {
+			return fmt.Errorf("path '%s' is protected from deletion", path)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/tools/delete_test.go
+++ b/internal/services/tools/delete_test.go
@@ -133,12 +133,25 @@ func TestDeleteTool_Execute_SingleFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
 
 	// Change to temp directory
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(tempDir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to restore working directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
 
 	// Create a test file
 	testFile := "test.txt"
@@ -190,12 +203,25 @@ func TestDeleteTool_Execute_Directory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
 
 	// Change to temp directory
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(tempDir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to restore working directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
 
 	// Create a test directory
 	testDir := "testdir"
@@ -212,14 +238,14 @@ func TestDeleteTool_Execute_Directory(t *testing.T) {
 		"path": testDir,
 	}
 
-	result, err := tool.Execute(context.Background(), args)
+	_, err = tool.Execute(context.Background(), args)
 	if err == nil {
 		t.Error("Expected error when deleting directory without recursive flag")
 	}
 
 	// Test with recursive flag
 	args["recursive"] = true
-	result, err = tool.Execute(context.Background(), args)
+	result, err := tool.Execute(context.Background(), args)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -250,12 +276,25 @@ func TestDeleteTool_Execute_Wildcard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
 
 	// Change to temp directory
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(tempDir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to restore working directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
 
 	// Create test files
 	testFiles := []string{"test1.txt", "test2.txt", "other.log"}
@@ -330,12 +369,25 @@ func TestDeleteTool_Execute_NonExistentFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
 
 	// Change to temp directory
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(tempDir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to restore working directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
 
 	cfg := config.DefaultConfig()
 	tool := NewDeleteTool(cfg)
@@ -345,14 +397,14 @@ func TestDeleteTool_Execute_NonExistentFile(t *testing.T) {
 		"path": "nonexistent.txt",
 	}
 
-	result, err := tool.Execute(context.Background(), args)
+	_, err = tool.Execute(context.Background(), args)
 	if err == nil {
 		t.Error("Expected error when deleting non-existent file without force flag")
 	}
 
 	// Test with force flag (should succeed)
 	args["force"] = true
-	result, err = tool.Execute(context.Background(), args)
+	result, err := tool.Execute(context.Background(), args)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -368,12 +420,25 @@ func TestDeleteTool_SecurityRestrictions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
 
 	// Change to temp directory
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(tempDir)
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("Failed to restore working directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
 
 	cfg := config.DefaultConfig()
 	cfg.Tools.Delete.RestrictToWorkDir = true

--- a/internal/services/tools/delete_test.go
+++ b/internal/services/tools/delete_test.go
@@ -1,0 +1,427 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/inference-gateway/cli/config"
+	"github.com/inference-gateway/cli/internal/domain"
+)
+
+func TestDeleteTool_Definition(t *testing.T) {
+	cfg := config.DefaultConfig()
+	tool := NewDeleteTool(cfg)
+
+	def := tool.Definition()
+	if def.Name != "Delete" {
+		t.Errorf("Expected tool name 'Delete', got '%s'", def.Name)
+	}
+
+	if def.Description == "" {
+		t.Error("Expected non-empty description")
+	}
+
+	if def.Parameters == nil {
+		t.Error("Expected non-nil parameters")
+	}
+}
+
+func TestDeleteTool_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name            string
+		toolsEnabled    bool
+		deleteEnabled   bool
+		expectedEnabled bool
+	}{
+		{"tools enabled and delete enabled", true, true, true},
+		{"tools disabled and delete enabled", false, true, false},
+		{"tools enabled and delete disabled", true, false, false},
+		{"tools disabled and delete disabled", false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.Tools.Enabled = tt.toolsEnabled
+			cfg.Tools.Delete.Enabled = tt.deleteEnabled
+
+			tool := NewDeleteTool(cfg)
+			if tool.IsEnabled() != tt.expectedEnabled {
+				t.Errorf("Expected IsEnabled() to return %v, got %v", tt.expectedEnabled, tool.IsEnabled())
+			}
+		})
+	}
+}
+
+func TestDeleteTool_Validate(t *testing.T) {
+	cfg := config.DefaultConfig()
+	tool := NewDeleteTool(cfg)
+
+	tests := []struct {
+		name      string
+		args      map[string]interface{}
+		expectErr bool
+	}{
+		{
+			name:      "valid args",
+			args:      map[string]interface{}{"path": "test.txt"},
+			expectErr: false,
+		},
+		{
+			name:      "missing path",
+			args:      map[string]interface{}{},
+			expectErr: true,
+		},
+		{
+			name:      "empty path",
+			args:      map[string]interface{}{"path": ""},
+			expectErr: true,
+		},
+		{
+			name:      "invalid recursive type",
+			args:      map[string]interface{}{"path": "test.txt", "recursive": "true"},
+			expectErr: true,
+		},
+		{
+			name:      "invalid force type",
+			args:      map[string]interface{}{"path": "test.txt", "force": "true"},
+			expectErr: true,
+		},
+		{
+			name:      "invalid format",
+			args:      map[string]interface{}{"path": "test.txt", "format": "xml"},
+			expectErr: true,
+		},
+		{
+			name:      "protected path .infer",
+			args:      map[string]interface{}{"path": ".infer/config.yaml"},
+			expectErr: true,
+		},
+		{
+			name:      "protected path .git",
+			args:      map[string]interface{}{"path": ".git/config"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tool.Validate(tt.args)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Expected error: %v, got: %v", tt.expectErr, err)
+			}
+		})
+	}
+}
+
+func TestDeleteTool_ValidateDisabled(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Enabled = false
+	tool := NewDeleteTool(cfg)
+
+	args := map[string]interface{}{"path": "test.txt"}
+	err := tool.Validate(args)
+	if err == nil {
+		t.Error("Expected error when tools are disabled")
+	}
+}
+
+func TestDeleteTool_Execute_SingleFile(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "delete-tool-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to temp directory
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	// Create a test file
+	testFile := "test.txt"
+	content := "test content"
+	err = os.WriteFile(testFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	tool := NewDeleteTool(cfg)
+
+	args := map[string]interface{}{
+		"path": testFile,
+	}
+
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success, got: %s", result.Error)
+	}
+
+	// Verify file was deleted
+	if _, err := os.Stat(testFile); !os.IsNotExist(err) {
+		t.Error("Expected file to be deleted")
+	}
+
+	// Check result data
+	deleteResult, ok := result.Data.(*domain.DeleteToolResult)
+	if !ok {
+		t.Fatal("Expected DeleteToolResult in result data")
+	}
+
+	if deleteResult.TotalFilesDeleted != 1 {
+		t.Errorf("Expected 1 file deleted, got %d", deleteResult.TotalFilesDeleted)
+	}
+
+	if len(deleteResult.DeletedFiles) != 1 || deleteResult.DeletedFiles[0] != testFile {
+		t.Errorf("Expected deleted files to contain %s, got %v", testFile, deleteResult.DeletedFiles)
+	}
+}
+
+func TestDeleteTool_Execute_Directory(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "delete-tool-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to temp directory
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	// Create a test directory
+	testDir := "testdir"
+	err = os.Mkdir(testDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test dir: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	tool := NewDeleteTool(cfg)
+
+	// Test without recursive flag (should fail)
+	args := map[string]interface{}{
+		"path": testDir,
+	}
+
+	result, err := tool.Execute(context.Background(), args)
+	if err == nil {
+		t.Error("Expected error when deleting directory without recursive flag")
+	}
+
+	// Test with recursive flag
+	args["recursive"] = true
+	result, err = tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success, got: %s", result.Error)
+	}
+
+	// Verify directory was deleted
+	if _, err := os.Stat(testDir); !os.IsNotExist(err) {
+		t.Error("Expected directory to be deleted")
+	}
+
+	// Check result data
+	deleteResult, ok := result.Data.(*domain.DeleteToolResult)
+	if !ok {
+		t.Fatal("Expected DeleteToolResult in result data")
+	}
+
+	if deleteResult.TotalDirsDeleted != 1 {
+		t.Errorf("Expected 1 directory deleted, got %d", deleteResult.TotalDirsDeleted)
+	}
+}
+
+func TestDeleteTool_Execute_Wildcard(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "delete-tool-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to temp directory
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	// Create test files
+	testFiles := []string{"test1.txt", "test2.txt", "other.log"}
+	for _, file := range testFiles {
+		err = os.WriteFile(file, []byte("content"), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file %s: %v", file, err)
+		}
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Tools.Delete.AllowWildcards = true
+	tool := NewDeleteTool(cfg)
+
+	args := map[string]interface{}{
+		"path": "*.txt",
+	}
+
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success, got: %s", result.Error)
+	}
+
+	// Verify only .txt files were deleted
+	if _, err := os.Stat("test1.txt"); !os.IsNotExist(err) {
+		t.Error("Expected test1.txt to be deleted")
+	}
+	if _, err := os.Stat("test2.txt"); !os.IsNotExist(err) {
+		t.Error("Expected test2.txt to be deleted")
+	}
+	if _, err := os.Stat("other.log"); os.IsNotExist(err) {
+		t.Error("Expected other.log to remain")
+	}
+
+	// Check result data
+	deleteResult, ok := result.Data.(*domain.DeleteToolResult)
+	if !ok {
+		t.Fatal("Expected DeleteToolResult in result data")
+	}
+
+	if deleteResult.TotalFilesDeleted != 2 {
+		t.Errorf("Expected 2 files deleted, got %d", deleteResult.TotalFilesDeleted)
+	}
+
+	if !deleteResult.WildcardExpanded {
+		t.Error("Expected WildcardExpanded to be true")
+	}
+}
+
+func TestDeleteTool_Execute_WildcardDisabled(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Delete.AllowWildcards = false
+	tool := NewDeleteTool(cfg)
+
+	args := map[string]interface{}{
+		"path": "*.txt",
+	}
+
+	_, err := tool.Execute(context.Background(), args)
+	if err == nil {
+		t.Error("Expected error when wildcards are disabled")
+	}
+}
+
+func TestDeleteTool_Execute_NonExistentFile(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "delete-tool-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to temp directory
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	cfg := config.DefaultConfig()
+	tool := NewDeleteTool(cfg)
+
+	// Test without force flag (should fail)
+	args := map[string]interface{}{
+		"path": "nonexistent.txt",
+	}
+
+	result, err := tool.Execute(context.Background(), args)
+	if err == nil {
+		t.Error("Expected error when deleting non-existent file without force flag")
+	}
+
+	// Test with force flag (should succeed)
+	args["force"] = true
+	result, err = tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Expected success with force flag, got: %s", result.Error)
+	}
+}
+
+func TestDeleteTool_SecurityRestrictions(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "delete-tool-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Change to temp directory
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	cfg := config.DefaultConfig()
+	cfg.Tools.Delete.RestrictToWorkDir = true
+	tool := NewDeleteTool(cfg)
+
+	// Test path outside working directory
+	args := map[string]interface{}{
+		"path": "../outside.txt",
+	}
+
+	err = tool.Validate(args)
+	if err == nil {
+		t.Error("Expected validation error for path outside working directory")
+	}
+
+	// Test absolute path outside working directory
+	args = map[string]interface{}{
+		"path": "/etc/passwd",
+	}
+
+	err = tool.Validate(args)
+	if err == nil {
+		t.Error("Expected validation error for absolute path outside working directory")
+	}
+}
+
+func TestDeleteTool_ProtectedPaths(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Tools.Delete.ProtectedPaths = []string{"protected/", "*.secret"}
+	tool := NewDeleteTool(cfg)
+
+	tests := []struct {
+		name      string
+		path      string
+		expectErr bool
+	}{
+		{"protected directory", "protected/file.txt", true},
+		{"protected pattern", "config.secret", true},
+		{"allowed file", "normal.txt", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := map[string]interface{}{"path": tt.path}
+			err := tool.Validate(args)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Expected error: %v, got: %v", tt.expectErr, err)
+			}
+		})
+	}
+}

--- a/internal/services/tools/registry.go
+++ b/internal/services/tools/registry.go
@@ -29,6 +29,7 @@ func (r *Registry) registerTools() {
 	r.tools["Bash"] = NewBashTool(r.config)
 	r.tools["Read"] = NewReadTool(r.config)
 	r.tools["Write"] = NewWriteTool(r.config)
+	r.tools["Delete"] = NewDeleteTool(r.config)
 	r.tools["FileSearch"] = NewFileSearchTool(r.config)
 	r.tools["Tree"] = NewTreeTool(r.config)
 


### PR DESCRIPTION
This PR implements the Delete Tool feature as requested in issue #47.

## Summary

Adds a new Delete Tool that allows LLMs to safely delete files and directories with improved security restrictions.

## Features

- ✅ Restricted to current working directory only
- ✅ Protected paths configuration (.infer/, .git/ by default)
- ✅ Wildcard pattern support (*.txt, temp/*)
- ✅ Cannot delete .infer directory by default
- ✅ Comprehensive test coverage (11 test functions)
- ✅ Complete documentation in CLAUDE.md

## Security Measures

- User approval required by default
- Path traversal attack prevention
- Configurable protected paths with wildcard support
- Working directory restriction enforcement

## Testing

All tests pass including:
- Security restriction validation
- Wildcard pattern functionality
- Protected path enforcement
- Error handling scenarios

Closes #47

Generated with [Claude Code](https://claude.ai/code)