### PR TITLE
feat(a2a): Add A2A agent listing functionality

### DIFF
--- a/cmd/a2a.go
+++ b/cmd/a2a.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/inference-gateway/cli/config"
+	"github.com/inference-gateway/cli/internal/container"
+	"github.com/inference-gateway/cli/internal/domain"
+	"github.com/inference-gateway/cli/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+var a2aCmd = &cobra.Command{
+	Use:   "a2a",
+	Short: "List A2A (Agent-to-Agent) connections",
+	Long: `Display the current A2A agents connected to the inference gateway including:
+- Agent IDs and names
+- Connection status (unknown, available, degraded)
+- Endpoint information
+- Version details`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger.Debug("Starting a2a command")
+		fmt.Println("Fetching A2A agents...")
+
+		configPath, _ := cmd.Flags().GetString("config")
+		format, _ := cmd.Flags().GetString("format")
+
+		logger.Debug("A2A command flags", "config_path", configPath, "format", format)
+
+		cfg, err := config.LoadConfig(configPath)
+		if err != nil {
+			logger.Error("Failed to load config in a2a command", "error", err)
+			return fmt.Errorf("failed to load config: %w", err)
+		}
+
+		logger.Debug("Fetching A2A agents from gateway", "gateway_url", cfg.Gateway.URL)
+		agents, err := fetchA2AAgents(cfg)
+		if err != nil {
+			logger.Warn("Gateway unreachable", "error", err)
+			fmt.Printf("Gateway Status: Unreachable (%v)\n", err)
+			fmt.Println("A2A Agents: Unable to connect")
+			return nil
+		}
+
+		agentCount := len(agents)
+		logger.Debug("Successfully fetched A2A agents", "count", agentCount)
+
+		if format == "json" {
+			return displayA2AAgentsJSON(agents)
+		}
+
+		return displayA2AAgentsText(agents)
+	},
+}
+
+// fetchA2AAgents retrieves the list of available A2A agents from the gateway
+func fetchA2AAgents(cfg *config.Config) ([]domain.A2AAgent, error) {
+	logger.Debug("Creating service container")
+	services := container.NewServiceContainer(cfg)
+
+	timeout := time.Duration(cfg.Gateway.Timeout) * time.Second
+	logger.Debug("Creating request context", "timeout", timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	logger.Debug("Calling ListAgents API")
+	agents, err := services.GetA2AService().ListAgents(ctx)
+	if err != nil {
+		logger.Error("ListAgents API call failed", "error", err)
+		return nil, err
+	}
+
+	logger.Debug("ListAgents API call succeeded", "agents", agents)
+	return agents, nil
+}
+
+// displayA2AAgentsText displays the agents in human-readable text format
+func displayA2AAgentsText(agents []domain.A2AAgent) error {
+	fmt.Printf("A2A Agents: %d connected\n\n", len(agents))
+
+	if len(agents) == 0 {
+		fmt.Println("No A2A agents are currently connected.")
+		return nil
+	}
+
+	for i, agent := range agents {
+		fmt.Printf("Agent %d:\n", i+1)
+		fmt.Printf("  ID:       %s\n", agent.ID)
+		fmt.Printf("  Name:     %s\n", agent.Name)
+		fmt.Printf("  Status:   %s\n", formatAgentStatus(agent.Status))
+		if agent.Endpoint != "" {
+			fmt.Printf("  Endpoint: %s\n", agent.Endpoint)
+		}
+		if agent.Version != "" {
+			fmt.Printf("  Version:  %s\n", agent.Version)
+		}
+		if i < len(agents)-1 {
+			fmt.Println()
+		}
+	}
+
+	return nil
+}
+
+// displayA2AAgentsJSON displays the agents in JSON format
+func displayA2AAgentsJSON(agents []domain.A2AAgent) error {
+	fmt.Printf("{\n")
+	fmt.Printf("  \"total\": %d,\n", len(agents))
+	fmt.Printf("  \"agents\": [\n")
+
+	for i, agent := range agents {
+		fmt.Printf("    {\n")
+		fmt.Printf("      \"id\": \"%s\",\n", agent.ID)
+		fmt.Printf("      \"name\": \"%s\",\n", agent.Name)
+		fmt.Printf("      \"status\": \"%s\"", agent.Status)
+		if agent.Endpoint != "" {
+			fmt.Printf(",\n      \"endpoint\": \"%s\"", agent.Endpoint)
+		}
+		if agent.Version != "" {
+			fmt.Printf(",\n      \"version\": \"%s\"", agent.Version)
+		}
+		fmt.Printf("\n    }")
+		if i < len(agents)-1 {
+			fmt.Printf(",")
+		}
+		fmt.Printf("\n")
+	}
+
+	fmt.Printf("  ]\n")
+	fmt.Printf("}\n")
+	return nil
+}
+
+// formatAgentStatus returns a colored/formatted version of the agent status
+func formatAgentStatus(status domain.A2AAgentStatus) string {
+	switch status {
+	case domain.A2AAgentStatusAvailable:
+		return "✓ Available"
+	case domain.A2AAgentStatusDegraded:
+		return "⚠ Degraded"
+	case domain.A2AAgentStatusUnknown:
+		return "? Unknown"
+	default:
+		return string(status)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(a2aCmd)
+
+	a2aCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
+}

--- a/internal/commands/a2a_test.go
+++ b/internal/commands/a2a_test.go
@@ -1,0 +1,237 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/inference-gateway/cli/internal/domain"
+)
+
+// MockA2AService implements domain.A2AService for testing
+type MockA2AService struct {
+	agents []domain.A2AAgent
+	err    error
+}
+
+func (m *MockA2AService) ListAgents(ctx context.Context) ([]domain.A2AAgent, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.agents, nil
+}
+
+func TestA2ACommand_GetMethods(t *testing.T) {
+	service := &MockA2AService{}
+	cmd := NewA2ACommand(service)
+
+	if cmd.GetName() != "a2a" {
+		t.Errorf("Expected name 'a2a', got %q", cmd.GetName())
+	}
+
+	if cmd.GetDescription() != "Show A2A agents" {
+		t.Errorf("Expected description 'Show A2A agents', got %q", cmd.GetDescription())
+	}
+
+	if cmd.GetUsage() != "/a2a" {
+		t.Errorf("Expected usage '/a2a', got %q", cmd.GetUsage())
+	}
+}
+
+func TestA2ACommand_CanExecute(t *testing.T) {
+	service := &MockA2AService{}
+	cmd := NewA2ACommand(service)
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{"no args", []string{}, true},
+		{"one arg", []string{"arg1"}, false},
+		{"multiple args", []string{"arg1", "arg2"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cmd.CanExecute(tt.args)
+			if result != tt.expected {
+				t.Errorf("CanExecute(%v) = %v, expected %v", tt.args, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestA2ACommand_Execute_Success(t *testing.T) {
+	agents := []domain.A2AAgent{
+		{
+			ID:       "agent-1",
+			Name:     "Test Agent 1",
+			Status:   domain.A2AAgentStatusAvailable,
+			Endpoint: "http://agent1.example.com",
+			Version:  "1.0.0",
+		},
+		{
+			ID:       "agent-2",
+			Name:     "Test Agent 2",
+			Status:   domain.A2AAgentStatusDegraded,
+			Endpoint: "http://agent2.example.com",
+			Version:  "1.1.0",
+		},
+		{
+			ID:     "agent-3",
+			Name:   "Test Agent 3",
+			Status: domain.A2AAgentStatusUnknown,
+		},
+	}
+
+	service := &MockA2AService{agents: agents}
+	cmd := NewA2ACommand(service)
+
+	result, err := cmd.Execute(context.Background(), []string{})
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected command to succeed")
+	}
+
+	output := result.Output
+	if !strings.Contains(output, "A2A Agents: 3 connected") {
+		t.Errorf("Expected output to contain '3 connected', got: %s", output)
+	}
+
+	// Check for agent names
+	for _, agent := range agents {
+		if !strings.Contains(output, agent.Name) {
+			t.Errorf("Expected output to contain agent name %q, got: %s", agent.Name, output)
+		}
+		if !strings.Contains(output, agent.ID) {
+			t.Errorf("Expected output to contain agent ID %q, got: %s", agent.ID, output)
+		}
+	}
+
+	// Check for status indicators
+	if !strings.Contains(output, "✅") {
+		t.Errorf("Expected output to contain available status indicator ✅, got: %s", output)
+	}
+	if !strings.Contains(output, "⚠️") {
+		t.Errorf("Expected output to contain degraded status indicator ⚠️, got: %s", output)
+	}
+	if !strings.Contains(output, "❓") {
+		t.Errorf("Expected output to contain unknown status indicator ❓, got: %s", output)
+	}
+}
+
+func TestA2ACommand_Execute_EmptyAgents(t *testing.T) {
+	service := &MockA2AService{agents: []domain.A2AAgent{}}
+	cmd := NewA2ACommand(service)
+
+	result, err := cmd.Execute(context.Background(), []string{})
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if !result.Success {
+		t.Error("Expected command to succeed")
+	}
+
+	output := result.Output
+	if !strings.Contains(output, "A2A Agents: 0 connected") {
+		t.Errorf("Expected output to contain '0 connected', got: %s", output)
+	}
+
+	if !strings.Contains(output, "No A2A agents are currently connected") {
+		t.Errorf("Expected output to contain no agents message, got: %s", output)
+	}
+}
+
+func TestA2ACommand_Execute_Error(t *testing.T) {
+	service := &MockA2AService{err: errors.New("connection failed")}
+	cmd := NewA2ACommand(service)
+
+	result, err := cmd.Execute(context.Background(), []string{})
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if result.Success {
+		t.Error("Expected command to fail")
+	}
+
+	output := result.Output
+	if !strings.Contains(output, "Failed to fetch A2A agents") {
+		t.Errorf("Expected output to contain error message, got: %s", output)
+	}
+
+	if !strings.Contains(output, "connection failed") {
+		t.Errorf("Expected output to contain specific error, got: %s", output)
+	}
+}
+
+func TestA2ACommand_Execute_StatusFormatting(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         domain.A2AAgentStatus
+		expectedEmoji  string
+		expectedStatus string
+	}{
+		{
+			name:           "available status",
+			status:         domain.A2AAgentStatusAvailable,
+			expectedEmoji:  "✅",
+			expectedStatus: "available",
+		},
+		{
+			name:           "degraded status",
+			status:         domain.A2AAgentStatusDegraded,
+			expectedEmoji:  "⚠️",
+			expectedStatus: "degraded",
+		},
+		{
+			name:           "unknown status",
+			status:         domain.A2AAgentStatusUnknown,
+			expectedEmoji:  "❓",
+			expectedStatus: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agents := []domain.A2AAgent{
+				{
+					ID:     "test-agent",
+					Name:   "Test Agent",
+					Status: tt.status,
+				},
+			}
+
+			service := &MockA2AService{agents: agents}
+			cmd := NewA2ACommand(service)
+
+			result, err := cmd.Execute(context.Background(), []string{})
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !result.Success {
+				t.Error("Expected command to succeed")
+			}
+
+			output := result.Output
+			if !strings.Contains(output, tt.expectedEmoji) {
+				t.Errorf("Expected output to contain emoji %q, got: %s", tt.expectedEmoji, output)
+			}
+
+			if !strings.Contains(output, tt.expectedStatus) {
+				t.Errorf("Expected output to contain status %q, got: %s", tt.expectedStatus, output)
+			}
+		})
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -21,6 +21,7 @@ type ServiceContainer struct {
 	chatService      domain.ChatService
 	toolService      domain.ToolService
 	fileService      domain.FileService
+	a2aService       domain.A2AService
 
 	// UI components
 	theme ui.Theme
@@ -56,6 +57,11 @@ func (c *ServiceContainer) initializeDomainServices() {
 	)
 
 	c.fileService = services.NewFileService()
+
+	c.a2aService = services.NewHTTPA2AService(
+		c.config.Gateway.URL,
+		c.config.Gateway.APIKey,
+	)
 
 	c.toolRegistry = tools.NewRegistry(c.config)
 
@@ -96,6 +102,7 @@ func (c *ServiceContainer) registerDefaultCommands() {
 	c.commandRegistry.Register(commands.NewHistoryCommand(c.conversationRepo))
 	c.commandRegistry.Register(commands.NewModelsCommand(c.modelService))
 	c.commandRegistry.Register(commands.NewSwitchCommand(c.modelService))
+	c.commandRegistry.Register(commands.NewA2ACommand(c.a2aService))
 }
 
 // registerMessageHandlers registers the message handlers
@@ -143,6 +150,10 @@ func (c *ServiceContainer) GetToolRegistry() *tools.Registry {
 
 func (c *ServiceContainer) GetFileService() domain.FileService {
 	return c.fileService
+}
+
+func (c *ServiceContainer) GetA2AService() domain.A2AService {
+	return c.a2aService
 }
 
 func (c *ServiceContainer) GetTheme() ui.Theme {

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -160,6 +160,29 @@ type WebSearchService interface {
 	SetEnabled(enabled bool)
 }
 
+// A2AAgentStatus represents the possible statuses of an A2A agent
+type A2AAgentStatus string
+
+const (
+	A2AAgentStatusUnknown   A2AAgentStatus = "unknown"
+	A2AAgentStatusAvailable A2AAgentStatus = "available"
+	A2AAgentStatusDegraded  A2AAgentStatus = "degraded"
+)
+
+// A2AAgent represents an Agent-to-Agent connection
+type A2AAgent struct {
+	ID       string         `json:"id"`
+	Name     string         `json:"name"`
+	Status   A2AAgentStatus `json:"status"`
+	Endpoint string         `json:"endpoint,omitempty"`
+	Version  string         `json:"version,omitempty"`
+}
+
+// A2AService handles Agent-to-Agent operations
+type A2AService interface {
+	ListAgents(ctx context.Context) ([]A2AAgent, error)
+}
+
 // Tool represents a single tool with its definition, handler, and validator
 type Tool interface {
 	// Definition returns the tool definition for the LLM

--- a/internal/services/a2a.go
+++ b/internal/services/a2a.go
@@ -1,0 +1,94 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/inference-gateway/cli/internal/domain"
+)
+
+// HTTPA2AService implements A2AService using HTTP API calls
+type HTTPA2AService struct {
+	baseURL string
+	apiKey  string
+	client  *http.Client
+}
+
+// A2AAgentsResponse represents the API response for listing A2A agents
+type A2AAgentsResponse struct {
+	Data []struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Status   string `json:"status"`
+		Endpoint string `json:"endpoint,omitempty"`
+		Version  string `json:"version,omitempty"`
+	} `json:"data"`
+}
+
+// NewHTTPA2AService creates a new HTTP-based A2A service
+func NewHTTPA2AService(baseURL, apiKey string) *HTTPA2AService {
+	return &HTTPA2AService{
+		baseURL: strings.TrimSuffix(baseURL, "/"),
+		apiKey:  apiKey,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (s *HTTPA2AService) ListAgents(ctx context.Context) ([]domain.A2AAgent, error) {
+	url := fmt.Sprintf("%s/v1/a2a/agents", s.baseURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if s.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch A2A agents: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var agentsResp A2AAgentsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&agentsResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	agents := make([]domain.A2AAgent, len(agentsResp.Data))
+	for i, agent := range agentsResp.Data {
+		agents[i] = domain.A2AAgent{
+			ID:       agent.ID,
+			Name:     agent.Name,
+			Status:   mapAgentStatus(agent.Status),
+			Endpoint: agent.Endpoint,
+			Version:  agent.Version,
+		}
+	}
+
+	return agents, nil
+}
+
+// mapAgentStatus maps string status to domain status type
+func mapAgentStatus(status string) domain.A2AAgentStatus {
+	switch strings.ToLower(status) {
+	case "available":
+		return domain.A2AAgentStatusAvailable
+	case "degraded":
+		return domain.A2AAgentStatusDegraded
+	default:
+		return domain.A2AAgentStatusUnknown
+	}
+}

--- a/internal/services/a2a_test.go
+++ b/internal/services/a2a_test.go
@@ -1,0 +1,266 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/inference-gateway/cli/internal/domain"
+)
+
+func TestHTTPA2AService_ListAgents(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverResponse string
+		statusCode     int
+		expectedAgents []domain.A2AAgent
+		expectError    bool
+	}{
+		{
+			name:       "successful response with agents",
+			statusCode: http.StatusOK,
+			serverResponse: `{
+				"data": [
+					{
+						"id": "agent-1",
+						"name": "Test Agent 1",
+						"status": "available",
+						"endpoint": "http://agent1.example.com",
+						"version": "1.0.0"
+					},
+					{
+						"id": "agent-2",
+						"name": "Test Agent 2",
+						"status": "degraded",
+						"endpoint": "http://agent2.example.com",
+						"version": "1.1.0"
+					}
+				]
+			}`,
+			expectedAgents: []domain.A2AAgent{
+				{
+					ID:       "agent-1",
+					Name:     "Test Agent 1",
+					Status:   domain.A2AAgentStatusAvailable,
+					Endpoint: "http://agent1.example.com",
+					Version:  "1.0.0",
+				},
+				{
+					ID:       "agent-2",
+					Name:     "Test Agent 2",
+					Status:   domain.A2AAgentStatusDegraded,
+					Endpoint: "http://agent2.example.com",
+					Version:  "1.1.0",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:       "empty response",
+			statusCode: http.StatusOK,
+			serverResponse: `{
+				"data": []
+			}`,
+			expectedAgents: []domain.A2AAgent{},
+			expectError:    false,
+		},
+		{
+			name:           "server error",
+			statusCode:     http.StatusInternalServerError,
+			serverResponse: `{"error": "Internal server error"}`,
+			expectedAgents: nil,
+			expectError:    true,
+		},
+		{
+			name:       "unknown status mapping",
+			statusCode: http.StatusOK,
+			serverResponse: `{
+				"data": [
+					{
+						"id": "agent-3",
+						"name": "Test Agent 3",
+						"status": "offline",
+						"endpoint": "http://agent3.example.com"
+					}
+				]
+			}`,
+			expectedAgents: []domain.A2AAgent{
+				{
+					ID:       "agent-3",
+					Name:     "Test Agent 3",
+					Status:   domain.A2AAgentStatusUnknown,
+					Endpoint: "http://agent3.example.com",
+					Version:  "",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/a2a/agents" {
+					t.Errorf("Expected path '/v1/a2a/agents', got %q", r.URL.Path)
+				}
+				if r.Method != "GET" {
+					t.Errorf("Expected method GET, got %s", r.Method)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			service := NewHTTPA2AService(server.URL, "test-api-key")
+			agents, err := service.ListAgents(context.Background())
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !tt.expectError {
+				if len(agents) != len(tt.expectedAgents) {
+					t.Errorf("Expected %d agents, got %d", len(tt.expectedAgents), len(agents))
+				}
+
+				for i, expected := range tt.expectedAgents {
+					if i >= len(agents) {
+						t.Errorf("Missing agent at index %d", i)
+						continue
+					}
+					actual := agents[i]
+
+					if actual.ID != expected.ID {
+						t.Errorf("Agent %d: expected ID %q, got %q", i, expected.ID, actual.ID)
+					}
+					if actual.Name != expected.Name {
+						t.Errorf("Agent %d: expected name %q, got %q", i, expected.Name, actual.Name)
+					}
+					if actual.Status != expected.Status {
+						t.Errorf("Agent %d: expected status %q, got %q", i, expected.Status, actual.Status)
+					}
+					if actual.Endpoint != expected.Endpoint {
+						t.Errorf("Agent %d: expected endpoint %q, got %q", i, expected.Endpoint, actual.Endpoint)
+					}
+					if actual.Version != expected.Version {
+						t.Errorf("Agent %d: expected version %q, got %q", i, expected.Version, actual.Version)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestHTTPA2AService_ListAgents_WithAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer test-api-key" {
+			t.Errorf("Expected Authorization header 'Bearer test-api-key', got %q", authHeader)
+		}
+
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("Expected Content-Type 'application/json', got %q", contentType)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data": []}`))
+	}))
+	defer server.Close()
+
+	service := NewHTTPA2AService(server.URL, "test-api-key")
+	_, err := service.ListAgents(context.Background())
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestHTTPA2AService_ListAgents_WithoutAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "" {
+			t.Errorf("Expected no Authorization header, got %q", authHeader)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data": []}`))
+	}))
+	defer server.Close()
+
+	service := NewHTTPA2AService(server.URL, "")
+	_, err := service.ListAgents(context.Background())
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestHTTPA2AService_ListAgents_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`invalid json`))
+	}))
+	defer server.Close()
+
+	service := NewHTTPA2AService(server.URL, "")
+	_, err := service.ListAgents(context.Background())
+
+	if err == nil {
+		t.Error("Expected error for invalid JSON but got none")
+	}
+	if !strings.Contains(err.Error(), "failed to parse response") {
+		t.Errorf("Expected error to contain 'failed to parse response', got: %v", err)
+	}
+}
+
+func TestMapAgentStatus(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected domain.A2AAgentStatus
+	}{
+		{"available", domain.A2AAgentStatusAvailable},
+		{"Available", domain.A2AAgentStatusAvailable},
+		{"AVAILABLE", domain.A2AAgentStatusAvailable},
+		{"degraded", domain.A2AAgentStatusDegraded},
+		{"Degraded", domain.A2AAgentStatusDegraded},
+		{"DEGRADED", domain.A2AAgentStatusDegraded},
+		{"unknown", domain.A2AAgentStatusUnknown},
+		{"offline", domain.A2AAgentStatusUnknown},
+		{"invalid", domain.A2AAgentStatusUnknown},
+		{"", domain.A2AAgentStatusUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := mapAgentStatus(tt.input)
+			if result != tt.expected {
+				t.Errorf("mapAgentStatus(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHTTPA2AService_ListAgents_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Don't respond to simulate timeout
+		select {}
+	}))
+	defer server.Close()
+
+	service := NewHTTPA2AService(server.URL, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately to trigger timeout
+
+	_, err := service.ListAgents(ctx)
+
+	if err == nil {
+		t.Error("Expected error for cancelled context but got none")
+	}
+}


### PR DESCRIPTION
Implements the A2A agent listing feature as requested in # 37.

## Changes
- Add new `infer a2a` command to list Agent-to-Agent connections
- Implement HTTPA2AService for /v1/a2a/agents API endpoint
- Add domain models for A2AAgent with status support
- Create interactive chat command `/a2a` for TUI sessions
- Support both text and JSON output formats
- Include comprehensive test coverage
- Add proper status indicator formatting with emojis

Resolves # 37

🤖 Generated with [Claude Code](https://claude.ai/code)