### PR TITLE
feat(chat): Add Ctrl+R support for expanding/collapsing all tool calls

### DIFF
--- a/internal/app/chat_application.go
+++ b/internal/app/chat_application.go
@@ -1301,17 +1301,9 @@ func (app *ChatApplication) getPageSize() int {
 	return max(1, conversationHeight-2)
 }
 
-// toggleToolResultExpansion toggles expansion of the most recent tool result
+// toggleToolResultExpansion toggles expansion of all tool results
 func (app *ChatApplication) toggleToolResultExpansion() {
-	conversationRepo := app.services.GetConversationRepository()
-	messages := conversationRepo.GetMessages()
-
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Message.Role == "tool" {
-			app.conversationView.ToggleToolResultExpansion(i)
-			break
-		}
-	}
+	app.conversationView.ToggleAllToolResultsExpansion()
 }
 
 // GetServices returns the service container (for testing or extensions)

--- a/internal/mocks/fake_conversation_renderer.go
+++ b/internal/mocks/fake_conversation_renderer.go
@@ -75,6 +75,10 @@ type FakeConversationRenderer struct {
 	setWidthArgsForCall []struct {
 		arg1 int
 	}
+	ToggleAllToolResultsExpansionStub        func()
+	toggleAllToolResultsExpansionMutex       sync.RWMutex
+	toggleAllToolResultsExpansionArgsForCall []struct {
+	}
 	ToggleToolResultExpansionStub        func(int)
 	toggleToolResultExpansionMutex       sync.RWMutex
 	toggleToolResultExpansionArgsForCall []struct {
@@ -456,6 +460,30 @@ func (fake *FakeConversationRenderer) SetWidthArgsForCall(i int) int {
 	defer fake.setWidthMutex.RUnlock()
 	argsForCall := fake.setWidthArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeConversationRenderer) ToggleAllToolResultsExpansion() {
+	fake.toggleAllToolResultsExpansionMutex.Lock()
+	fake.toggleAllToolResultsExpansionArgsForCall = append(fake.toggleAllToolResultsExpansionArgsForCall, struct {
+	}{})
+	stub := fake.ToggleAllToolResultsExpansionStub
+	fake.recordInvocation("ToggleAllToolResultsExpansion", []interface{}{})
+	fake.toggleAllToolResultsExpansionMutex.Unlock()
+	if stub != nil {
+		fake.ToggleAllToolResultsExpansionStub()
+	}
+}
+
+func (fake *FakeConversationRenderer) ToggleAllToolResultsExpansionCallCount() int {
+	fake.toggleAllToolResultsExpansionMutex.RLock()
+	defer fake.toggleAllToolResultsExpansionMutex.RUnlock()
+	return len(fake.toggleAllToolResultsExpansionArgsForCall)
+}
+
+func (fake *FakeConversationRenderer) ToggleAllToolResultsExpansionCalls(stub func()) {
+	fake.toggleAllToolResultsExpansionMutex.Lock()
+	defer fake.toggleAllToolResultsExpansionMutex.Unlock()
+	fake.ToggleAllToolResultsExpansionStub = stub
 }
 
 func (fake *FakeConversationRenderer) ToggleToolResultExpansion(arg1 int) {

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -152,24 +152,20 @@ func TestConversationView_ToggleAllToolResultsExpansion(t *testing.T) {
 	}
 	cv.SetConversation(conversation)
 
-	// Initially all should be collapsed
 	if cv.IsToolResultExpanded(0) || cv.IsToolResultExpanded(2) {
 		t.Error("Expected all tool results to be collapsed initially")
 	}
 
-	// Toggle all to expand
 	cv.ToggleAllToolResultsExpansion()
 
 	if !cv.IsToolResultExpanded(0) || !cv.IsToolResultExpanded(2) {
 		t.Error("Expected all tool results to be expanded after first toggle")
 	}
 
-	// User message should not be affected
 	if cv.IsToolResultExpanded(1) {
 		t.Error("Expected non-tool message to remain unaffected")
 	}
 
-	// Toggle all to collapse
 	cv.ToggleAllToolResultsExpansion()
 
 	if cv.IsToolResultExpanded(0) || cv.IsToolResultExpanded(2) {

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -23,12 +23,12 @@ func TestNewConversationView(t *testing.T) {
 		t.Errorf("Expected default height 20, got %d", cv.height)
 	}
 
-	if cv.expandedToolResult != -1 {
-		t.Errorf("Expected expandedToolResult to be -1, got %d", cv.expandedToolResult)
+	if cv.expandedToolResults == nil {
+		t.Error("Expected expandedToolResults to be initialized")
 	}
 
-	if cv.isToolExpanded {
-		t.Error("Expected isToolExpanded to be false")
+	if cv.allToolsExpanded {
+		t.Error("Expected allToolsExpanded to be false")
 	}
 
 	if len(cv.conversation) != 0 {
@@ -121,6 +121,59 @@ func TestConversationView_ToggleToolResultExpansion(t *testing.T) {
 
 	if cv.IsToolResultExpanded(0) {
 		t.Error("Expected tool result 0 to be collapsed after second toggle")
+	}
+}
+
+func TestConversationView_ToggleAllToolResultsExpansion(t *testing.T) {
+	cv := NewConversationView()
+
+	conversation := []domain.ConversationEntry{
+		{
+			Message: sdk.Message{
+				Role:    sdk.Tool,
+				Content: "Tool result 1",
+			},
+			Time: time.Now(),
+		},
+		{
+			Message: sdk.Message{
+				Role:    sdk.User,
+				Content: "User message",
+			},
+			Time: time.Now(),
+		},
+		{
+			Message: sdk.Message{
+				Role:    sdk.Tool,
+				Content: "Tool result 2",
+			},
+			Time: time.Now(),
+		},
+	}
+	cv.SetConversation(conversation)
+
+	// Initially all should be collapsed
+	if cv.IsToolResultExpanded(0) || cv.IsToolResultExpanded(2) {
+		t.Error("Expected all tool results to be collapsed initially")
+	}
+
+	// Toggle all to expand
+	cv.ToggleAllToolResultsExpansion()
+
+	if !cv.IsToolResultExpanded(0) || !cv.IsToolResultExpanded(2) {
+		t.Error("Expected all tool results to be expanded after first toggle")
+	}
+
+	// User message should not be affected
+	if cv.IsToolResultExpanded(1) {
+		t.Error("Expected non-tool message to remain unaffected")
+	}
+
+	// Toggle all to collapse
+	cv.ToggleAllToolResultsExpansion()
+
+	if cv.IsToolResultExpanded(0) || cv.IsToolResultExpanded(2) {
+		t.Error("Expected all tool results to be collapsed after second toggle")
 	}
 }
 

--- a/internal/ui/interfaces.go
+++ b/internal/ui/interfaces.go
@@ -40,6 +40,7 @@ type ConversationRenderer interface {
 	CanScrollUp() bool
 	CanScrollDown() bool
 	ToggleToolResultExpansion(index int)
+	ToggleAllToolResultsExpansion()
 	IsToolResultExpanded(index int) bool
 	SetWidth(width int)
 	SetHeight(height int)


### PR DESCRIPTION
Implements the ability to expand/collapse all tool calls using Ctrl+R as requested in #71.

## Changes
- Replace single tool expansion with multi-tool expansion support
- Add ToggleAllToolResultsExpansion method to ConversationRenderer interface
- Update ConversationView to use expandedToolResults map instead of single index
- Modify toggleToolResultExpansion to expand/collapse all tool calls
- Update help text to reflect new functionality
- Add comprehensive tests and regenerate mocks

## Testing
- All existing tests pass
- New tests verify toggle all functionality
- Code quality checks pass

Resolves #71

Generated with [Claude Code](https://claude.ai/code)