### PR TITLE
feat: Implement centralized sandbox configuration

### DIFF
--- a/internal/services/tools/delete.go
+++ b/internal/services/tools/delete.go
@@ -299,43 +299,7 @@ func (t *DeleteTool) deleteFile(path string, result *DeleteResult) error {
 	return nil
 }
 
-// validatePathSecurity checks if a path is allowed for deletion
+// validatePathSecurity checks if a path is allowed for deletion within the sandbox
 func (t *DeleteTool) validatePathSecurity(path string) error {
-	if t.config.Tools.Delete.RestrictToWorkDir {
-		wd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("failed to get current working directory: %w", err)
-		}
-
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			return fmt.Errorf("failed to resolve absolute path for %s: %w", path, err)
-		}
-
-		if !strings.HasPrefix(absPath, wd) {
-			return fmt.Errorf("path '%s' is outside the current working directory", path)
-		}
-	}
-
-	for _, excludePath := range t.config.Tools.ExcludePaths {
-		if strings.HasPrefix(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-
-		if strings.Contains(excludePath, "*") && matchesPattern(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-	}
-
-	for _, protectedPath := range t.config.Tools.Delete.ProtectedPaths {
-		if strings.HasPrefix(path, protectedPath) {
-			return fmt.Errorf("path '%s' is protected from deletion", path)
-		}
-
-		if strings.Contains(protectedPath, "*") && matchesPattern(path, protectedPath) {
-			return fmt.Errorf("path '%s' is protected from deletion", path)
-		}
-	}
-
-	return nil
+	return t.config.ValidatePathInSandbox(path)
 }

--- a/internal/services/tools/edit.go
+++ b/internal/services/tools/edit.go
@@ -367,18 +367,9 @@ func appendBothLinesDiff(diff *strings.Builder, lineNum int, oldLine, newLine st
 	}
 }
 
-// validatePathSecurity checks if a path is allowed for editing (reuses the same logic as other tools)
+// validatePathSecurity checks if a path is allowed for editing within the sandbox
 func (t *EditTool) validatePathSecurity(path string) error {
-	for _, excludePath := range t.config.Tools.ExcludePaths {
-		if strings.HasPrefix(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-
-		if strings.Contains(excludePath, "*") && matchesPattern(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-	}
-	return nil
+	return t.config.ValidatePathInSandbox(path)
 }
 
 // validateFile checks if a file path is valid and exists (only works with existing files)

--- a/internal/services/tools/edit_test.go
+++ b/internal/services/tools/edit_test.go
@@ -143,12 +143,11 @@ func getTestConfig() *config.Config {
 	return &config.Config{
 		Tools: config.ToolsConfig{
 			Enabled: true,
+			Sandbox: config.SandboxConfig{
+				Directories: []string{"."},
+			},
 			Edit: config.EditToolConfig{
 				Enabled: true,
-			},
-			ExcludePaths: []string{
-				".infer/",
-				"*.secret",
 			},
 		},
 	}

--- a/internal/services/tools/grep.go
+++ b/internal/services/tools/grep.go
@@ -921,34 +921,9 @@ func (t *GrepTool) isPathExcluded(path string) bool {
 		return true
 	}
 
-	cleanPath := filepath.Clean(path)
-	normalizedPath := filepath.ToSlash(cleanPath)
-
-	for _, excludePattern := range t.config.Tools.ExcludePaths {
-		cleanPattern := filepath.Clean(excludePattern)
-		normalizedPattern := filepath.ToSlash(cleanPattern)
-
-		if normalizedPath == normalizedPattern {
-			return true
-		}
-
-		if strings.HasSuffix(normalizedPattern, "/*") {
-			dirPattern := strings.TrimSuffix(normalizedPattern, "/*")
-			if strings.HasPrefix(normalizedPath, dirPattern+"/") || normalizedPath == dirPattern {
-				return true
-			}
-		}
-
-		if strings.HasSuffix(normalizedPattern, "/") {
-			dirPattern := strings.TrimSuffix(normalizedPattern, "/")
-			if strings.HasPrefix(normalizedPath, dirPattern+"/") || normalizedPath == dirPattern {
-				return true
-			}
-		}
-
-		if strings.HasPrefix(normalizedPath, normalizedPattern) {
-			return true
-		}
+	// Check if path is outside sandbox directories
+	if err := t.config.ValidatePathInSandbox(path); err != nil {
+		return true
 	}
 
 	return false

--- a/internal/services/tools/grep_test.go
+++ b/internal/services/tools/grep_test.go
@@ -402,8 +402,10 @@ func TestGrepTool_Execute(t *testing.T) {
 func TestGrepTool_PathExclusion(t *testing.T) {
 	cfg := &config.Config{
 		Tools: config.ToolsConfig{
-			Enabled:      true,
-			ExcludePaths: []string{".git/", ".infer/", "secret/*"},
+			Enabled: true,
+			Sandbox: config.SandboxConfig{
+				Directories: []string{"."},
+			},
 			Grep: config.GrepToolConfig{
 				Enabled: true,
 			},

--- a/internal/services/tools/multiedit.go
+++ b/internal/services/tools/multiedit.go
@@ -402,18 +402,9 @@ func (t *MultiEditTool) executeMultiEdit(filePath string, edits []EditOperation)
 	return result, nil
 }
 
-// validatePathSecurity checks if a path is allowed for editing (reuses the same logic as other tools)
+// validatePathSecurity checks if a path is allowed for editing within the sandbox
 func (t *MultiEditTool) validatePathSecurity(path string) error {
-	for _, excludePath := range t.config.Tools.ExcludePaths {
-		if strings.HasPrefix(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-
-		if strings.Contains(excludePath, "*") && matchesPattern(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-	}
-	return nil
+	return t.config.ValidatePathInSandbox(path)
 }
 
 // validateFile checks if a file path is valid - supports both existing files and new file creation

--- a/internal/services/tools/read.go
+++ b/internal/services/tools/read.go
@@ -390,29 +390,7 @@ func (t *ReadTool) validateParameter(args map[string]interface{}, paramName stri
 	return nil
 }
 
-// validatePathSecurity checks if a path is allowed (no file existence check)
+// validatePathSecurity checks if a path is allowed within the sandbox
 func (t *ReadTool) validatePathSecurity(path string) error {
-	for _, excludePath := range t.config.Tools.ExcludePaths {
-		if strings.HasPrefix(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-
-		if strings.Contains(excludePath, "*") && matchesPattern(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-	}
-	return nil
-}
-
-// matchesPattern checks if a path matches a simple glob pattern
-func matchesPattern(path, pattern string) bool {
-	if strings.HasSuffix(pattern, "*") {
-		prefix := strings.TrimSuffix(pattern, "*")
-		return strings.HasPrefix(path, prefix)
-	}
-	if strings.HasPrefix(pattern, "*") {
-		suffix := strings.TrimPrefix(pattern, "*")
-		return strings.HasSuffix(path, suffix)
-	}
-	return path == pattern
+	return t.config.ValidatePathInSandbox(path)
 }

--- a/internal/services/tools/read_test.go
+++ b/internal/services/tools/read_test.go
@@ -131,12 +131,11 @@ func TestReadTool_Validate(t *testing.T) {
 	cfg := &config.Config{
 		Tools: config.ToolsConfig{
 			Enabled: true,
+			Sandbox: config.SandboxConfig{
+				Directories: []string{"."},
+			},
 			Read: config.ReadToolConfig{
 				Enabled: true,
-			},
-			ExcludePaths: []string{
-				"/.infer/",
-				"*.secret",
 			},
 		},
 	}

--- a/internal/services/tools/tree.go
+++ b/internal/services/tools/tree.go
@@ -475,16 +475,7 @@ func (t *TreeTool) shouldExclude(name string, excludePatterns []string) bool {
 
 // validatePathSecurity checks if a path is allowed (no file existence check)
 func (t *TreeTool) validatePathSecurity(path string) error {
-	for _, excludePath := range t.config.Tools.ExcludePaths {
-		if strings.HasPrefix(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-
-		if strings.Contains(excludePath, "*") && matchesPattern(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-	}
-	return nil
+	return t.config.ValidatePathInSandbox(path)
 }
 
 // validatePath checks if a path exists and is accessible

--- a/internal/services/tools/tree_test.go
+++ b/internal/services/tools/tree_test.go
@@ -61,10 +61,12 @@ func TestTreeTool_Validate(t *testing.T) {
 	cfg := &config.Config{
 		Tools: config.ToolsConfig{
 			Enabled: true,
+			Sandbox: config.SandboxConfig{
+				Directories: []string{"."},
+			},
 			Tree: config.TreeToolConfig{
 				Enabled: true,
 			},
-			ExcludePaths: []string{".infer/"},
 		},
 	}
 
@@ -587,8 +589,10 @@ func TestTreeTool_ValidatePath(t *testing.T) {
 
 	cfg := &config.Config{
 		Tools: config.ToolsConfig{
-			Enabled:      true,
-			ExcludePaths: []string{".infer/"},
+			Enabled: true,
+			Sandbox: config.SandboxConfig{
+				Directories: []string{"."},
+			},
 			Tree: config.TreeToolConfig{
 				Enabled: true,
 			},

--- a/internal/services/tools/write.go
+++ b/internal/services/tools/write.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/inference-gateway/cli/config"
@@ -292,18 +291,9 @@ func (t *WriteTool) createParentDirs(filePath string, createDirs bool, result *d
 	return nil
 }
 
-// validatePathSecurity checks if a path is allowed for writing (no file existence check)
+// validatePathSecurity checks if a path is allowed for writing within the sandbox
 func (t *WriteTool) validatePathSecurity(path string) error {
-	for _, excludePath := range t.config.Tools.ExcludePaths {
-		if strings.HasPrefix(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-
-		if strings.Contains(excludePath, "*") && matchesPattern(path, excludePath) {
-			return fmt.Errorf("access to path '%s' is excluded for security", path)
-		}
-	}
-	return nil
+	return t.config.ValidatePathInSandbox(path)
 }
 
 // executeAppendWrite handles writing in append mode


### PR DESCRIPTION
Resolves #82

This PR implements centralized sandbox configuration to replace the current tool-specific sandboxing approach.

## Changes
- Add `SandboxConfig` with `Directories` field to replace tool-specific path configs
- Implement `ValidatePathInSandbox()` method for centralized validation
- Update all tools to use sandbox validation
- Remove `ExcludePaths`, `RestrictToWorkDir`, and `ProtectedPaths` configurations
- Add CLI commands: `infer config tools sandbox [list|add|remove]`
- Replace exclude-path commands with sandbox commands
- Set default sandbox to current directory in DefaultConfig
- Update tests and documentation

## Breaking Changes
As requested, this removes tool-level path configurations without maintaining backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)