### PR TITLE
feat(system-reminders): Add dynamic system reminders feature

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -169,11 +169,19 @@ type OptimizationConfig struct {
 	SkipRedundantConfirmations bool `yaml:"skip_redundant_confirmations"`
 }
 
+// SystemRemindersConfig contains settings for dynamic system reminders
+type SystemRemindersConfig struct {
+	Enabled      bool   `yaml:"enabled"`
+	Interval     int    `yaml:"interval"`
+	ReminderText string `yaml:"reminder_text"`
+}
+
 // ChatConfig contains chat-related settings
 type ChatConfig struct {
-	DefaultModel string             `yaml:"default_model"`
-	SystemPrompt string             `yaml:"system_prompt"`
-	Optimization OptimizationConfig `yaml:"optimization"`
+	DefaultModel    string                `yaml:"default_model"`
+	SystemPrompt    string                `yaml:"system_prompt"`
+	Optimization    OptimizationConfig    `yaml:"optimization"`
+	SystemReminders SystemRemindersConfig `yaml:"system_reminders"`
 }
 
 // FetchSafetyConfig contains safety settings for fetch operations
@@ -349,6 +357,13 @@ EXAMPLE:
 				CompactThreshold:           20,
 				TruncateLargeOutputs:       true,
 				SkipRedundantConfirmations: true,
+			},
+			SystemReminders: SystemRemindersConfig{
+				Enabled:  true,
+				Interval: 4,
+				ReminderText: `<system-reminder>
+This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.
+</system-reminder>`,
 			},
 		},
 	}

--- a/internal/commands/core.go
+++ b/internal/commands/core.go
@@ -135,7 +135,7 @@ Keep the summary concise but informative, using bullet points where appropriate.
 	})
 
 	for _, entry := range entries {
-		if entry.Message.Role == sdk.User || entry.Message.Role == sdk.Assistant || entry.Message.Role == sdk.Tool {
+		if !entry.IsSystemReminder && (entry.Message.Role == sdk.User || entry.Message.Role == sdk.Assistant || entry.Message.Role == sdk.Tool) {
 			messages = append(messages, entry.Message)
 		}
 	}

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -9,10 +9,11 @@ import (
 
 // ConversationEntry represents a message in the conversation with metadata
 type ConversationEntry struct {
-	Message       sdk.Message          `json:"message"`
-	Model         string               `json:"model,omitempty"`
-	Time          time.Time            `json:"time"`
-	ToolExecution *ToolExecutionResult `json:"tool_execution,omitempty"`
+	Message          sdk.Message          `json:"message"`
+	Model            string               `json:"model,omitempty"`
+	Time             time.Time            `json:"time"`
+	ToolExecution    *ToolExecutionResult `json:"tool_execution,omitempty"`
+	IsSystemReminder bool                 `json:"is_system_reminder,omitempty"`
 }
 
 // ExportFormat defines the format for exporting conversations

--- a/internal/services/system_reminders_test.go
+++ b/internal/services/system_reminders_test.go
@@ -1,0 +1,185 @@
+package services
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/inference-gateway/cli/internal/domain"
+	sdk "github.com/inference-gateway/sdk"
+)
+
+func TestFilterSystemReminders(t *testing.T) {
+	repo := NewInMemoryConversationRepository(nil)
+
+	// Add regular messages
+	userMessage := domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:    sdk.User,
+			Content: "Hello, how are you?",
+		},
+	}
+	repo.AddMessage(userMessage)
+
+	assistantMessage := domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:    sdk.Assistant,
+			Content: "I'm doing well, thank you!",
+		},
+	}
+	repo.AddMessage(assistantMessage)
+
+	// Add system reminder
+	systemReminder := domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:    sdk.User,
+			Content: "<system-reminder>This is a reminder</system-reminder>",
+		},
+		IsSystemReminder: true,
+	}
+	repo.AddMessage(systemReminder)
+
+	// Add another regular message
+	userMessage2 := domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:    sdk.User,
+			Content: "What's the weather like?",
+		},
+	}
+	repo.AddMessage(userMessage2)
+
+	// Test that all messages are present before filtering
+	allMessages := repo.GetMessages()
+	if len(allMessages) != 4 {
+		t.Errorf("Expected 4 total messages, got %d", len(allMessages))
+	}
+
+	// Test JSON export filters system reminders
+	jsonData, err := repo.Export(domain.ExportJSON)
+	if err != nil {
+		t.Fatalf("Failed to export JSON: %v", err)
+	}
+
+	var exportedMessages []domain.ConversationEntry
+	if err := json.Unmarshal(jsonData, &exportedMessages); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if len(exportedMessages) != 3 {
+		t.Errorf("Expected 3 exported messages (system reminder filtered), got %d", len(exportedMessages))
+	}
+
+	// Verify system reminder is not in exported messages
+	for _, msg := range exportedMessages {
+		if msg.IsSystemReminder {
+			t.Error("System reminder found in exported messages, should be filtered out")
+		}
+		if msg.Message.Content == "<system-reminder>This is a reminder</system-reminder>" {
+			t.Error("System reminder content found in exported messages")
+		}
+	}
+
+	// Test markdown export filters system reminders
+	markdownData, err := repo.Export(domain.ExportMarkdown)
+	if err != nil {
+		t.Fatalf("Failed to export markdown: %v", err)
+	}
+
+	markdownContent := string(markdownData)
+	if len(markdownContent) == 0 {
+		t.Error("Markdown export is empty")
+	}
+
+	// System reminder should not appear in markdown
+	if contains(markdownContent, "<system-reminder>This is a reminder</system-reminder>") {
+		t.Error("System reminder content found in markdown export")
+	}
+
+	// Test text export filters system reminders
+	textData, err := repo.Export(domain.ExportText)
+	if err != nil {
+		t.Fatalf("Failed to export text: %v", err)
+	}
+
+	textContent := string(textData)
+	if len(textContent) == 0 {
+		t.Error("Text export is empty")
+	}
+
+	// System reminder should not appear in text
+	if contains(textContent, "<system-reminder>This is a reminder</system-reminder>") {
+		t.Error("System reminder content found in text export")
+	}
+}
+
+func TestFilterSystemRemindersEmpty(t *testing.T) {
+	repo := NewInMemoryConversationRepository(nil)
+
+	// Test with only system reminders
+	systemReminder1 := domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:    sdk.User,
+			Content: "<system-reminder>Reminder 1</system-reminder>",
+		},
+		IsSystemReminder: true,
+	}
+	repo.AddMessage(systemReminder1)
+
+	systemReminder2 := domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:    sdk.User,
+			Content: "<system-reminder>Reminder 2</system-reminder>",
+		},
+		IsSystemReminder: true,
+	}
+	repo.AddMessage(systemReminder2)
+
+	// Test that filtering results in empty slice
+	jsonData, err := repo.Export(domain.ExportJSON)
+	if err != nil {
+		t.Fatalf("Failed to export JSON: %v", err)
+	}
+
+	var exportedMessages []domain.ConversationEntry
+	if err := json.Unmarshal(jsonData, &exportedMessages); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if len(exportedMessages) != 0 {
+		t.Errorf("Expected 0 exported messages (all were system reminders), got %d", len(exportedMessages))
+	}
+}
+
+func TestFilterSystemRemindersWithEmptyRepo(t *testing.T) {
+	repo := NewInMemoryConversationRepository(nil)
+
+	// Test with empty repository
+	jsonData, err := repo.Export(domain.ExportJSON)
+	if err != nil {
+		t.Fatalf("Failed to export JSON: %v", err)
+	}
+
+	var exportedMessages []domain.ConversationEntry
+	if err := json.Unmarshal(jsonData, &exportedMessages); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if len(exportedMessages) != 0 {
+		t.Errorf("Expected 0 exported messages from empty repo, got %d", len(exportedMessages))
+	}
+}
+
+// Helper function to check if string contains substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
+		indexOfSubstring(s, substr) >= 0)
+}
+
+func indexOfSubstring(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Implements dynamic system reminders that inject helpful prompts every N assistant messages to keep LLM focused on task management.

## Changes
- Add IsSystemReminder field to ConversationEntry domain model
- Add SystemRemindersConfig to ChatConfig with configurable settings
- Implement injection logic in chat handler with counter tracking
- Filter system reminders from all export formats (JSON, Markdown, Text)
- Update summary generation to exclude system reminders
- Add comprehensive test coverage

## Configuration
```yaml
chat:
  system_reminders:
    enabled: true
    interval: 4
    reminder_text: "<system-reminder>...</system-reminder>"
```

Resolves #79

Generated with [Claude Code](https://claude.ai/code)