### PR TITLE
feat(chat): Add config file path to welcome message

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -25,6 +25,7 @@ and have a conversational interface with the inference gateway.`,
 
 // startChatSession starts a chat session using the SOLID architecture
 func startChatSession() error {
+	configPath := config.GetConfigPath("")
 	cfg, err := config.LoadConfig("")
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
@@ -75,6 +76,7 @@ func startChatSession() error {
 		toolOrchestrator,
 		theme,
 		toolRegistry,
+		configPath,
 	)
 
 	program := tea.NewProgram(application)

--- a/config/config.go
+++ b/config/config.go
@@ -490,6 +490,14 @@ func getDefaultConfigPath() string {
 	return filepath.Join(wd, ".infer/config.yaml")
 }
 
+// GetConfigPath returns the config path that would be used, either default or provided
+func GetConfigPath(configPath string) string {
+	if configPath == "" {
+		return getDefaultConfigPath()
+	}
+	return configPath
+}
+
 // IsApprovalRequired checks if approval is required for a specific tool
 // It returns true if tool-specific approval is set to true, or if global approval is true and tool-specific is not set to false
 // ConfigService interface implementation

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -77,6 +77,7 @@ func NewChatApplication(
 	toolOrchestrator *services.ToolExecutionOrchestrator,
 	theme ui.Theme,
 	toolRegistry *tools.Registry,
+	configPath string,
 ) *ChatApplication {
 	initialView := domain.ViewStateModelSelection
 	if defaultModel != "" {
@@ -106,6 +107,7 @@ func NewChatApplication(
 	toolFormatterService := services.NewToolFormatterService(app.toolRegistry)
 	if cv, ok := app.conversationView.(*components.ConversationView); ok {
 		cv.SetToolFormatter(toolFormatterService)
+		cv.SetConfigPath(configPath)
 	}
 	app.inputView = ui.CreateInputViewWithToolService(app.modelService, app.commandRegistry, app.toolService)
 	app.statusView = ui.CreateStatusView()

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -25,6 +25,7 @@ type ConversationView struct {
 	toolFormatter       domain.ToolFormatter
 	lineFormatter       *shared.ConversationLineFormatter
 	plainTextLines      []string
+	configPath          string
 }
 
 func NewConversationView() *ConversationView {
@@ -46,6 +47,11 @@ func NewConversationView() *ConversationView {
 func (cv *ConversationView) SetToolFormatter(formatter domain.ToolFormatter) {
 	cv.toolFormatter = formatter
 	cv.lineFormatter = shared.NewConversationLineFormatter(cv.width, formatter)
+}
+
+// SetConfigPath sets the config path for the welcome message
+func (cv *ConversationView) SetConfigPath(configPath string) {
+	cv.configPath = configPath
 }
 
 func (cv *ConversationView) SetConversation(conversation []domain.ConversationEntry) {
@@ -160,7 +166,12 @@ func (cv *ConversationView) renderWelcome() string {
 	readyLine := colors.SuccessColor.ANSI + "🚀 Ready to chat!" + colors.Reset
 	workingLine := colors.DimColor.ANSI + "📂 Working in: " + colors.Reset + colors.HeaderColor.ANSI + wd + colors.Reset
 
-	content := headerLine + "\n" + readyLine + "\n" + workingLine
+	configLine := ""
+	if cv.configPath != "" {
+		configLine = "\n" + colors.DimColor.ANSI + "⚙️ Config: " + colors.Reset + colors.AccentColor.ANSI + cv.configPath + colors.Reset
+	}
+
+	content := headerLine + "\n" + readyLine + "\n" + workingLine + configLine
 
 	style := styles.NewCommonStyles().Border.
 		Border(styles.RoundedBorder(), true).


### PR DESCRIPTION
Display the loaded config file path in the interactive chat welcome message
to improve developer experience by showing where configuration is loaded from.

## Changes
- Add GetConfigPath() function to config package
- Add SetConfigPath() method to ConversationView
- Update welcome message to display config file location with gear emoji
- Pass config path through chat application initialization

Fixes #109

Generated with [Claude Code](https://claude.ai/code)