### PR TITLE
feat(grep): Add gitignore support and excluded_patterns parameter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,9 +111,10 @@ type DeleteToolConfig struct {
 
 // GrepToolConfig contains grep-specific tool settings
 type GrepToolConfig struct {
-	Enabled         bool   `yaml:"enabled" mapstructure:"enabled"`
-	Backend         string `yaml:"backend" mapstructure:"backend"`
-	RequireApproval *bool  `yaml:"require_approval,omitempty" mapstructure:"require_approval,omitempty"`
+	Enabled          bool     `yaml:"enabled" mapstructure:"enabled"`
+	Backend          string   `yaml:"backend" mapstructure:"backend"`
+	ExcludedPatterns []string `yaml:"excluded_patterns" mapstructure:"excluded_patterns"`
+	RequireApproval  *bool    `yaml:"require_approval,omitempty" mapstructure:"require_approval,omitempty"`
 }
 
 // TreeToolConfig contains tree-specific tool settings

--- a/internal/services/tools/grep_test.go
+++ b/internal/services/tools/grep_test.go
@@ -65,7 +65,7 @@ func TestGrepTool_Definition(t *testing.T) {
 		t.Errorf("Expected required to be ['pattern'], got %v", required)
 	}
 
-	essentialParams := []string{"pattern", "output_mode", "glob", "type", "-i", "-n", "-A", "-B", "-C", "multiline", "head_limit"}
+	essentialParams := []string{"pattern", "output_mode", "glob", "type", "-i", "-n", "-A", "-B", "-C", "multiline", "head_limit", "excluded_patterns"}
 	for _, param := range essentialParams {
 		if _, exists := properties[param]; !exists {
 			t.Errorf("Expected parameter '%s' to exist", param)
@@ -137,6 +137,10 @@ func TestGrepTool_Validate(t *testing.T) {
 
 	t.Run("boolean flags validation", func(t *testing.T) {
 		testGrepValidationCases(t, tool, getBooleanFlagsTestCases())
+	})
+
+	t.Run("excluded patterns validation", func(t *testing.T) {
+		testGrepValidationCases(t, tool, getExcludedPatternsTestCases())
 	})
 }
 
@@ -318,6 +322,45 @@ func getBooleanFlagsTestCases() []grepValidationTestCase {
 				"-i":        true,
 				"-n":        false,
 				"multiline": true,
+			},
+			expectError: false,
+		},
+	}
+}
+
+func getExcludedPatternsTestCases() []grepValidationTestCase {
+	return []grepValidationTestCase{
+		{
+			name: "invalid excluded_patterns type",
+			args: map[string]any{
+				"pattern":           "test",
+				"excluded_patterns": "not_array",
+			},
+			expectError: true,
+			errorMsg:    "excluded_patterns must be an array",
+		},
+		{
+			name: "invalid pattern in array",
+			args: map[string]any{
+				"pattern":           "test",
+				"excluded_patterns": []interface{}{"valid", 123},
+			},
+			expectError: true,
+			errorMsg:    "excluded_patterns[1] must be a string",
+		},
+		{
+			name: "valid excluded_patterns",
+			args: map[string]any{
+				"pattern":           "test",
+				"excluded_patterns": []interface{}{"*.tmp", "build/*", "node_modules"},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty excluded_patterns",
+			args: map[string]any{
+				"pattern":           "test",
+				"excluded_patterns": []interface{}{},
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
Implements gitignore support for the Grep tool as requested in #120

## Features
- Automatically reads and respects .gitignore files
- New excluded_patterns parameter for custom exclusions
- Works with both ripgrep and Go implementations
- Comprehensive validation and test coverage

Closes #120

Generated with [Claude Code](https://claude.ai/code)