### PR TITLE
refactor(gitignore): Integrate gitignore support in GrepTool and TreeTool

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -71,7 +71,6 @@ tools:
   grep:
     enabled: true
     backend: auto
-    excluded_patterns: []
     require_approval: false
   tree:
     enabled: true

--- a/README.md
+++ b/README.md
@@ -452,16 +452,16 @@ implementation when the native `tree` command is unavailable.
 
 - `path` (optional): Directory path to display tree structure for (default: current directory)
 - `max_depth` (optional): Maximum depth to traverse (unlimited by default)
-- `exclude_patterns` (optional): Array of glob patterns to exclude from the tree (e.g., `["*.log", "node_modules"]`)
 - `show_hidden` (optional): Whether to show hidden files and directories (default: false)
+- `respect_gitignore` (optional): Whether to exclude patterns from .gitignore (default: true)
 - `format` (optional): Output format - "text" or "json" (default: "text")
 
 **Examples:**
 
 - Basic tree: Uses current directory with default settings
 - Tree with depth limit: `max_depth: 2` - Shows only 2 levels deep
-- Tree excluding patterns: `exclude_patterns: ["*.log", "node_modules", ".git"]`
 - Tree with hidden files: `show_hidden: true`
+- Tree ignoring gitignore: `respect_gitignore: false` - Shows all files including those in .gitignore
 - JSON output: `format: "json"` - Returns structured data
 
 **Features:**
@@ -738,21 +738,6 @@ A powerful search tool with configurable backend (ripgrep or Go implementation).
   - Cache and temp files (.cache, \*.tmp, \*.log, etc.)
   - Security-sensitive files (.env, secrets, etc.)
 - **Gitignore Integration**: Automatically reads and respects .gitignore patterns
-- **User Configuration**: Users can add custom exclusion patterns in the configuration file:
-
-  ```yaml
-  tools:
-    grep:
-      enabled: true
-      backend: auto  # "auto", "ripgrep", or "go"
-      excluded_patterns:  # Additional patterns to exclude (user-configured only)
-        - "*.generated.go"
-        - "test_data/*"
-        - "vendor/*"
-  ```
-
-  **Note**: The `excluded_patterns` configuration is only available to users via the config file.
-  The LLM cannot set exclusion patterns at runtime for security reasons.
 - **Validation**: Validates search patterns and file access
 - **Performance Limits**: Configurable result limits to prevent overwhelming output
 
@@ -921,7 +906,6 @@ tools:
   grep:
     enabled: true
     backend: auto # "auto", "ripgrep", or "go"
-    excluded_patterns: [] # User-configured exclusion patterns (not settable by LLM)
     require_approval: false
   tree:
     enabled: true

--- a/config/config.go
+++ b/config/config.go
@@ -111,10 +111,9 @@ type DeleteToolConfig struct {
 
 // GrepToolConfig contains grep-specific tool settings
 type GrepToolConfig struct {
-	Enabled          bool     `yaml:"enabled" mapstructure:"enabled"`
-	Backend          string   `yaml:"backend" mapstructure:"backend"`
-	ExcludedPatterns []string `yaml:"excluded_patterns" mapstructure:"excluded_patterns"`
-	RequireApproval  *bool    `yaml:"require_approval,omitempty" mapstructure:"require_approval,omitempty"`
+	Enabled         bool   `yaml:"enabled" mapstructure:"enabled"`
+	Backend         string `yaml:"backend" mapstructure:"backend"`
+	RequireApproval *bool  `yaml:"require_approval,omitempty" mapstructure:"require_approval,omitempty"`
 }
 
 // TreeToolConfig contains tree-specific tool settings

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/inference-gateway/sdk v1.12.0
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/muesli/reflow v0.3.0
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/charmbracelet/x/cellbuf v0.0.13/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xU
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
@@ -75,6 +76,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
@@ -91,8 +94,10 @@ github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
@@ -126,5 +131,6 @@ golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -309,17 +309,16 @@ type EditToolResult struct {
 
 // TreeToolResult represents the result of a tree operation
 type TreeToolResult struct {
-	Path            string   `json:"path"`
-	Output          string   `json:"output"`
-	TotalFiles      int      `json:"total_files"`
-	TotalDirs       int      `json:"total_dirs"`
-	MaxDepth        int      `json:"max_depth"`
-	MaxFiles        int      `json:"max_files"`
-	ExcludePatterns []string `json:"exclude_patterns"`
-	ShowHidden      bool     `json:"show_hidden"`
-	Format          string   `json:"format"`
-	UsingNativeTree bool     `json:"using_native_tree"`
-	Truncated       bool     `json:"truncated"`
+	Path            string `json:"path"`
+	Output          string `json:"output"`
+	TotalFiles      int    `json:"total_files"`
+	TotalDirs       int    `json:"total_dirs"`
+	MaxDepth        int    `json:"max_depth"`
+	MaxFiles        int    `json:"max_files"`
+	ShowHidden      bool   `json:"show_hidden"`
+	Format          string `json:"format"`
+	UsingNativeTree bool   `json:"using_native_tree"`
+	Truncated       bool   `json:"truncated"`
 }
 
 // DeleteToolResult represents the result of a delete operation

--- a/internal/mocks/fake_autocomplete_interface.go
+++ b/internal/mocks/fake_autocomplete_interface.go
@@ -386,20 +386,6 @@ func (fake *FakeAutocompleteInterface) UpdateArgsForCall(i int) (string, int) {
 func (fake *FakeAutocompleteInterface) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getSelectedShortcutMutex.RLock()
-	defer fake.getSelectedShortcutMutex.RUnlock()
-	fake.handleKeyMutex.RLock()
-	defer fake.handleKeyMutex.RUnlock()
-	fake.hideMutex.RLock()
-	defer fake.hideMutex.RUnlock()
-	fake.isVisibleMutex.RLock()
-	defer fake.isVisibleMutex.RUnlock()
-	fake.renderMutex.RLock()
-	defer fake.renderMutex.RUnlock()
-	fake.setWidthMutex.RLock()
-	defer fake.setWidthMutex.RUnlock()
-	fake.updateMutex.RLock()
-	defer fake.updateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
@@ -412,6 +398,9 @@ func (fake *FakeAutocompleteInterface) recordInvocation(key string, args []inter
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
 		fake.invocations = map[string][][]interface{}{}
+	}
+	if fake.invocations[key] == nil {
+		fake.invocations[key] = [][]interface{}{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/internal/services/tools/tree.go
+++ b/internal/services/tools/tree.go
@@ -1,34 +1,38 @@
 package tools
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/inference-gateway/cli/config"
-	"github.com/inference-gateway/cli/internal/domain"
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	ignore "github.com/sabhiram/go-gitignore"
 )
 
 // TreeTool handles directory tree visualization operations
 type TreeTool struct {
-	config    *config.Config
-	enabled   bool
-	formatter domain.BaseFormatter
+	config         *config.Config
+	enabled        bool
+	gitignore      *ignore.GitIgnore
+	gitignoreCache map[string]*ignore.GitIgnore
+	formatter      domain.BaseFormatter
 }
 
 // NewTreeTool creates a new tree tool
 func NewTreeTool(cfg *config.Config) *TreeTool {
-	return &TreeTool{
-		config:    cfg,
-		enabled:   cfg.Tools.Enabled && cfg.Tools.Tree.Enabled,
-		formatter: domain.NewBaseFormatter("Tree"),
+	tool := &TreeTool{
+		config:         cfg,
+		enabled:        cfg.Tools.Enabled && cfg.Tools.Tree.Enabled,
+		formatter:      domain.NewBaseFormatter("Tree"),
+		gitignoreCache: make(map[string]*ignore.GitIgnore),
 	}
+	tool.loadGitignore()
+	return tool
 }
 
 // Definition returns the tool definition for the LLM
@@ -251,16 +255,20 @@ type TreeResult struct {
 
 // executeTree performs the tree operation
 func (t *TreeTool) executeTree(path string, maxDepth, maxFiles int, excludePatterns []string, showHidden, respectGitignore bool, format string) (*TreeResult, error) {
+	// Only apply gitignore patterns if respectGitignore is true
+	var allExcludePatterns []string
 	if respectGitignore {
-		gitignorePatterns := t.readGitignorePatterns(path)
-		excludePatterns = append(excludePatterns, gitignorePatterns...)
+		gitignorePatterns := t.getGitignorePatterns()
+		allExcludePatterns = append(gitignorePatterns, excludePatterns...)
+	} else {
+		allExcludePatterns = excludePatterns
 	}
 
 	result := &TreeResult{
 		Path:            path,
 		MaxDepth:        maxDepth,
 		MaxFiles:        maxFiles,
-		ExcludePatterns: excludePatterns,
+		ExcludePatterns: allExcludePatterns,
 		ShowHidden:      showHidden,
 		Format:          format,
 	}
@@ -269,15 +277,7 @@ func (t *TreeTool) executeTree(path string, maxDepth, maxFiles int, excludePatte
 		return nil, err
 	}
 
-	if format == "text" {
-		if nativeOutput, err := t.tryNativeTree(path, maxDepth, excludePatterns, showHidden); err == nil {
-			result.Output = nativeOutput
-			result.UsingNativeTree = true
-			return result, nil
-		}
-	}
-
-	output, files, dirs, truncated, err := t.buildTreeFallback(path, maxDepth, maxFiles, excludePatterns, showHidden, format)
+	output, files, dirs, truncated, err := t.buildTreeFallback(path, maxDepth, maxFiles, excludePatterns, showHidden, respectGitignore, format)
 	if err != nil {
 		return nil, err
 	}
@@ -291,41 +291,12 @@ func (t *TreeTool) executeTree(path string, maxDepth, maxFiles int, excludePatte
 	return result, nil
 }
 
-// tryNativeTree attempts to use the system's tree command
-func (t *TreeTool) tryNativeTree(path string, maxDepth int, excludePatterns []string, showHidden bool) (string, error) {
-	if _, err := exec.LookPath("tree"); err != nil {
-		return "", fmt.Errorf("native tree command not found")
-	}
-
-	args := []string{path}
-
-	if maxDepth > 0 {
-		args = append(args, "-L", fmt.Sprintf("%d", maxDepth))
-	}
-
-	if showHidden {
-		args = append(args, "-a")
-	}
-
-	for _, pattern := range excludePatterns {
-		args = append(args, "-I", pattern)
-	}
-
-	cmd := exec.Command("tree", args...)
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("native tree command failed: %w", err)
-	}
-
-	return string(output), nil
-}
-
 // buildTreeFallback builds a tree structure using our own implementation
-func (t *TreeTool) buildTreeFallback(rootPath string, maxDepth, maxFiles int, excludePatterns []string, showHidden bool, format string) (string, int, int, bool, error) {
+func (t *TreeTool) buildTreeFallback(rootPath string, maxDepth, maxFiles int, excludePatterns []string, showHidden, respectGitignore bool, format string) (string, int, int, bool, error) {
 	fileCounter := &fileCounter{max: maxFiles}
 
 	if format == "json" {
-		textOutput, files, dirs, truncated, err := t.buildTextTree(rootPath, maxDepth, excludePatterns, showHidden, "", 0, fileCounter)
+		textOutput, files, dirs, truncated, err := t.buildTextTree(rootPath, maxDepth, excludePatterns, showHidden, respectGitignore, "", 0, fileCounter)
 		if err != nil {
 			return "", 0, 0, false, err
 		}
@@ -333,7 +304,7 @@ func (t *TreeTool) buildTreeFallback(rootPath string, maxDepth, maxFiles int, ex
 		return jsonOutput, files, dirs, truncated, nil
 	}
 
-	output, files, dirs, truncated, err := t.buildTextTree(rootPath, maxDepth, excludePatterns, showHidden, "", 0, fileCounter)
+	output, files, dirs, truncated, err := t.buildTextTree(rootPath, maxDepth, excludePatterns, showHidden, respectGitignore, "", 0, fileCounter)
 	if err != nil {
 		return "", 0, 0, false, err
 	}
@@ -372,7 +343,7 @@ func (fc *fileCounter) isTruncated() bool {
 }
 
 // buildTextTree recursively builds a text tree representation
-func (t *TreeTool) buildTextTree(dirPath string, maxDepth int, excludePatterns []string, showHidden bool, prefix string, currentDepth int, fc *fileCounter) (string, int, int, bool, error) {
+func (t *TreeTool) buildTextTree(dirPath string, maxDepth int, excludePatterns []string, showHidden, respectGitignore bool, prefix string, currentDepth int, fc *fileCounter) (string, int, int, bool, error) {
 	if maxDepth > 0 && currentDepth >= maxDepth {
 		return "", 0, 0, false, nil
 	}
@@ -394,14 +365,14 @@ func (t *TreeTool) buildTextTree(dirPath string, maxDepth int, excludePatterns [
 			continue
 		}
 
-		if t.shouldExclude(name, excludePatterns) {
+		fullPath := filepath.Join(dirPath, name)
+		if t.shouldExclude(fullPath, name, excludePatterns, respectGitignore) {
 			continue
 		}
 
 		filteredEntries = append(filteredEntries, entry)
 	}
 
-	// Sort entries: directories first, then files, both alphabetically
 	sort.Slice(filteredEntries, func(i, j int) bool {
 		if filteredEntries[i].IsDir() != filteredEntries[j].IsDir() {
 			return filteredEntries[i].IsDir()
@@ -434,7 +405,7 @@ func (t *TreeTool) buildTextTree(dirPath string, maxDepth int, excludePatterns [
 
 		if entry.IsDir() {
 			totalDirs++
-			subFiles, subDirs, subTruncated := t.processDirectory(dirPath, entry.Name(), maxDepth, excludePatterns, showHidden, newPrefix, currentDepth, fc, &builder)
+			subFiles, subDirs, subTruncated := t.processDirectory(dirPath, entry.Name(), maxDepth, excludePatterns, showHidden, respectGitignore, newPrefix, currentDepth, fc, &builder)
 			totalFiles += subFiles
 			totalDirs += subDirs
 			if subTruncated {
@@ -455,9 +426,9 @@ func (t *TreeTool) buildTextTree(dirPath string, maxDepth int, excludePatterns [
 }
 
 // processDirectory handles directory processing to reduce complexity
-func (t *TreeTool) processDirectory(dirPath, entryName string, maxDepth int, excludePatterns []string, showHidden bool, newPrefix string, currentDepth int, fc *fileCounter, builder *strings.Builder) (int, int, bool) {
+func (t *TreeTool) processDirectory(dirPath, entryName string, maxDepth int, excludePatterns []string, showHidden, respectGitignore bool, newPrefix string, currentDepth int, fc *fileCounter, builder *strings.Builder) (int, int, bool) {
 	subPath := filepath.Join(dirPath, entryName)
-	subOutput, subFiles, subDirs, subTruncated, err := t.buildTextTree(subPath, maxDepth, excludePatterns, showHidden, newPrefix, currentDepth+1, fc)
+	subOutput, subFiles, subDirs, subTruncated, err := t.buildTextTree(subPath, maxDepth, excludePatterns, showHidden, respectGitignore, newPrefix, currentDepth+1, fc)
 	if err != nil {
 		return 0, 0, false
 	}
@@ -465,12 +436,40 @@ func (t *TreeTool) processDirectory(dirPath, entryName string, maxDepth int, exc
 	return subFiles, subDirs, subTruncated
 }
 
-// shouldExclude checks if a filename should be excluded based on patterns
-func (t *TreeTool) shouldExclude(name string, excludePatterns []string) bool {
+// shouldExclude checks if a filename should be excluded based on gitignore and additional patterns
+func (t *TreeTool) shouldExclude(fullPath string, name string, excludePatterns []string, respectGitignore bool) bool {
+	if respectGitignore && t.isPathExcludedByGitignore(fullPath) {
+		return true
+	}
+
 	for _, pattern := range excludePatterns {
 		if matched, _ := filepath.Match(pattern, name); matched {
 			return true
 		}
+	}
+	return false
+}
+
+// isPathExcludedByGitignore checks if a path is excluded by gitignore rules
+func (t *TreeTool) isPathExcludedByGitignore(fullPath string) bool {
+	if t.gitignore != nil && t.gitignore.MatchesPath(fullPath) {
+		return true
+	}
+
+	dirPath := filepath.Dir(fullPath)
+	for dirPath != "." && dirPath != "/" {
+		if dirIgnore := t.getOrLoadDirGitignore(dirPath); dirIgnore != nil {
+			relPath, err := filepath.Rel(dirPath, fullPath)
+			if err == nil && dirIgnore.MatchesPath(relPath) {
+				return true
+			}
+		}
+
+		parentDir := filepath.Dir(dirPath)
+		if parentDir == dirPath {
+			break
+		}
+		dirPath = parentDir
 	}
 	return false
 }
@@ -501,52 +500,75 @@ func (t *TreeTool) validatePath(path string) error {
 	return nil
 }
 
-// readGitignorePatterns reads and parses .gitignore files
-func (t *TreeTool) readGitignorePatterns(rootPath string) []string {
-	var patterns []string
-
-	defaultPatterns := []string{
-		"node_modules",
-		".git",
+// loadGitignore loads .gitignore patterns using the gitignore library
+func (t *TreeTool) loadGitignore() {
+	gitignore, err := ignore.CompileIgnoreFileAndLines(".gitignore",
+		".git/",
 		".DS_Store",
-		"*.log",
-		"dist",
-		"build",
-		"target",
-		".cache",
-		"coverage",
-		".nyc_output",
-		"*.tmp",
-		"*.temp",
-		".env",
-		".vscode",
-		".idea",
-	}
-	patterns = append(patterns, defaultPatterns...)
-
-	gitignorePath := filepath.Join(rootPath, ".gitignore")
-	file, err := os.Open(gitignorePath)
+		".infer/",
+	)
 	if err != nil {
-		return patterns
+		gitignore = ignore.CompileIgnoreLines(
+			".git/",
+			".DS_Store",
+			".infer/",
+		)
 	}
-	defer func() { _ = file.Close() }()
+	t.gitignore = gitignore
+}
 
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
+// getOrLoadDirGitignore loads and caches .gitignore for a specific directory
+func (t *TreeTool) getOrLoadDirGitignore(dirPath string) *ignore.GitIgnore {
+	if cached, exists := t.gitignoreCache[dirPath]; exists {
+		return cached
+	}
+
+	gitignorePath := filepath.Join(dirPath, ".gitignore")
+	if _, err := os.Stat(gitignorePath); err == nil {
+		gitignore, err := ignore.CompileIgnoreFile(gitignorePath)
+		if err == nil {
+			t.gitignoreCache[dirPath] = gitignore
+			return gitignore
 		}
+	}
 
-		pattern := strings.TrimPrefix(line, "/")
-		if pattern != "" && pattern != line {
-			patterns = append(patterns, pattern)
-		} else if pattern != "" {
-			patterns = append(patterns, pattern)
+	t.gitignoreCache[dirPath] = nil
+	return nil
+}
+
+// getGitignorePatterns returns gitignore patterns suitable for native tree command
+func (t *TreeTool) getGitignorePatterns() []string {
+	patterns := []string{}
+
+	patterns = append(patterns, ".git", ".DS_Store", ".infer")
+
+	if data, err := os.ReadFile(".gitignore"); err == nil {
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+
+			line = strings.TrimPrefix(line, "/")
+			line = strings.TrimSuffix(line, "/")
+			if line != "" && !containsString(patterns, line) {
+				patterns = append(patterns, line)
+			}
 		}
 	}
 
 	return patterns
+}
+
+// containsString checks if a slice contains a string
+func containsString(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
 }
 
 // FormatResult formats tool execution results for different contexts

--- a/internal/services/tools/tree_test.go
+++ b/internal/services/tools/tree_test.go
@@ -122,20 +122,6 @@ func TestTreeTool_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "valid exclude_patterns",
-			args: map[string]any{
-				"exclude_patterns": []any{"*.log", "node_modules"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "invalid exclude_patterns type",
-			args: map[string]any{
-				"exclude_patterns": "not_an_array",
-			},
-			wantErr: true,
-		},
-		{
 			name: "valid show_hidden",
 			args: map[string]any{
 				"show_hidden": true,
@@ -315,40 +301,6 @@ func TestTreeTool_ExecuteWithMaxDepth(t *testing.T) {
 	}
 }
 
-func TestTreeTool_ExecuteWithExcludePatterns(t *testing.T) {
-	tempDir := setupTestDirectory(t)
-	tool := createTestTreeTool(tempDir)
-	ctx := context.Background()
-
-	result, err := tool.Execute(ctx, map[string]any{
-		"path":              tempDir,
-		"exclude_patterns":  []any{"*.log"},
-		"respect_gitignore": false,
-	})
-
-	if err != nil {
-		t.Errorf("Execute() error = %v", err)
-		return
-	}
-
-	if !result.Success {
-		t.Error("Expected successful execution")
-	}
-
-	treeResult, ok := result.Data.(*domain.TreeToolResult)
-	if !ok {
-		t.Error("Expected TreeToolResult")
-		return
-	}
-
-	if len(treeResult.ExcludePatterns) != 1 || treeResult.ExcludePatterns[0] != "*.log" {
-		t.Errorf("Expected exclude patterns [*.log], got %v", treeResult.ExcludePatterns)
-	}
-
-	if strings.Contains(treeResult.Output, "file2.log") {
-		t.Error("Output should not contain excluded .log files")
-	}
-}
 
 func TestTreeTool_ExecuteWithShowHidden(t *testing.T) {
 	tempDir := setupTestDirectory(t)
@@ -531,55 +483,40 @@ func TestTreeTool_ShouldExclude(t *testing.T) {
 	tool := NewTreeTool(cfg)
 
 	tests := []struct {
-		name     string
-		filename string
-		patterns []string
-		expected bool
+		name             string
+		filename         string
+		fullPath         string
+		respectGitignore bool
+		expected         bool
 	}{
 		{
-			name:     "no patterns",
-			filename: "test.txt",
-			patterns: []string{},
-			expected: false,
+			name:             "regular file with gitignore respect",
+			filename:         "test.txt",
+			fullPath:         "/test/path/test.txt",
+			respectGitignore: true,
+			expected:         false,
 		},
 		{
-			name:     "exact match",
-			filename: "test.txt",
-			patterns: []string{"test.txt"},
-			expected: true,
+			name:             "git file should be excluded when respecting gitignore",
+			filename:         "config",
+			fullPath:         "/test/.git/config",
+			respectGitignore: true,
+			expected:         true,
 		},
 		{
-			name:     "glob pattern match",
-			filename: "test.log",
-			patterns: []string{"*.log"},
-			expected: true,
-		},
-		{
-			name:     "glob pattern no match",
-			filename: "test.txt",
-			patterns: []string{"*.log"},
-			expected: false,
-		},
-		{
-			name:     "multiple patterns with match",
-			filename: "node_modules",
-			patterns: []string{"*.log", "node_modules", "*.tmp"},
-			expected: true,
-		},
-		{
-			name:     "multiple patterns no match",
-			filename: "test.txt",
-			patterns: []string{"*.log", "node_modules", "*.tmp"},
-			expected: false,
+			name:             "git file should not be excluded when not respecting gitignore",
+			filename:         "config",
+			fullPath:         "/test/.git/config",
+			respectGitignore: false,
+			expected:         false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fullPath := "/test/path/" + tt.filename
-			result := tool.shouldExclude(fullPath, tt.filename, tt.patterns, true)
+			result := tool.shouldExclude(tt.fullPath, tt.filename, tt.respectGitignore)
 			if result != tt.expected {
-				t.Errorf("shouldExclude(%s, %s, %v) = %v, want %v", fullPath, tt.filename, tt.patterns, result, tt.expected)
+				t.Errorf("shouldExclude(%s, %s, %v) = %v, want %v", tt.fullPath, tt.filename, tt.respectGitignore, result, tt.expected)
 			}
 		})
 	}
@@ -618,9 +555,8 @@ func TestTreeTool_RespectGitignore(t *testing.T) {
 
 			fullPath := "/test/.git/config"
 			fileName := "config"
-			excludePatterns := []string{}
 
-			result := tool.shouldExclude(fullPath, fileName, excludePatterns, tt.respectGitignore)
+			result := tool.shouldExclude(fullPath, fileName, tt.respectGitignore)
 
 			if tt.expectGitignored && !result {
 				t.Errorf("Expected gitignored file to be excluded when respectGitignore=true, but it wasn't")


### PR DESCRIPTION
## Summary

Defining paths to exclude could be painful, instead the infer CLI will simply respect the gitignore files in a project - simple, efficient, less configurations to worry about.

Closes #123 
