### PR TITLE
refactor(params): Simplify WriteParams structure and related extraction logic

### DIFF
--- a/internal/services/tools/params.go
+++ b/internal/services/tools/params.go
@@ -8,15 +8,8 @@ import (
 
 // WriteParams represents extracted parameters for write operations
 type WriteParams struct {
-	FilePath    string
-	Content     string
-	Append      bool
-	Overwrite   bool
-	Backup      bool
-	ChunkIndex  int
-	TotalChunks int
-	SessionID   string
-	IsChunked   bool
+	FilePath string
+	Content  string
 }
 
 // ParameterExtractor handles centralized parameter extraction and validation
@@ -29,47 +22,20 @@ func NewParameterExtractor() *ParameterExtractor {
 
 // ExtractWriteParams extracts and validates write operation parameters
 func (p *ParameterExtractor) ExtractWriteParams(params map[string]interface{}) (*WriteParams, error) {
-	result := &WriteParams{}
-
 	filePath, err := p.extractString(params, "file_path", true)
 	if err != nil {
 		return nil, err
 	}
-	result.FilePath = filePath
 
 	content, err := p.extractString(params, "content", true)
 	if err != nil {
 		return nil, err
 	}
-	result.Content = content
 
-	result.Append = p.extractBool(params, "append", false)
-	result.Overwrite = p.extractBool(params, "overwrite", true)
-	result.Backup = p.extractBool(params, "backup", false)
-
-	chunkIndex := p.extractInt(params, "chunk_index", -1)
-	totalChunks := p.extractInt(params, "total_chunks", -1)
-	sessionID, _ := p.extractString(params, "session_id", false)
-
-	result.IsChunked = chunkIndex >= 0 || totalChunks > 0 || sessionID != ""
-
-	if result.IsChunked {
-		if chunkIndex < 0 {
-			return nil, fmt.Errorf("chunk_index is required for chunked operations")
-		}
-		if sessionID == "" {
-			return nil, fmt.Errorf("session_id is required for chunked operations")
-		}
-		result.ChunkIndex = chunkIndex
-		result.TotalChunks = totalChunks
-		result.SessionID = sessionID
-	}
-
-	if err := p.validateParamCombinations(result); err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return &WriteParams{
+		FilePath: filePath,
+		Content:  content,
+	}, nil
 }
 
 // ToWriteRequest converts WriteParams to a filewriter.WriteRequest
@@ -77,19 +43,8 @@ func (p *ParameterExtractor) ToWriteRequest(params *WriteParams) filewriter.Writ
 	return filewriter.WriteRequest{
 		Path:      params.FilePath,
 		Content:   params.Content,
-		Overwrite: params.Overwrite,
-		Backup:    params.Backup,
-	}
-}
-
-// ToChunkWriteRequest converts WriteParams to a filewriter.ChunkWriteRequest
-func (p *ParameterExtractor) ToChunkWriteRequest(params *WriteParams) filewriter.ChunkWriteRequest {
-	isLast := params.TotalChunks > 0 && params.ChunkIndex == params.TotalChunks-1
-	return filewriter.ChunkWriteRequest{
-		SessionID:  params.SessionID,
-		ChunkIndex: params.ChunkIndex,
-		Data:       []byte(params.Content),
-		IsLast:     isLast,
+		Overwrite: true,
+		Backup:    false,
 	}
 }
 
@@ -113,76 +68,4 @@ func (p *ParameterExtractor) extractString(params map[string]interface{}, key st
 	}
 
 	return str, nil
-}
-
-// extractBool extracts a boolean parameter
-func (p *ParameterExtractor) extractBool(params map[string]interface{}, key string, defaultValue bool) bool {
-	value, exists := params[key]
-	if !exists {
-		return defaultValue
-	}
-
-	if b, ok := value.(bool); ok {
-		return b
-	}
-
-	if str, ok := value.(string); ok {
-		switch str {
-		case "true", "1", "yes":
-			return true
-		case "false", "0", "no":
-			return false
-		}
-	}
-
-	return defaultValue
-}
-
-// extractInt extracts an integer parameter
-func (p *ParameterExtractor) extractInt(params map[string]interface{}, key string, defaultValue int) int {
-	value, exists := params[key]
-	if !exists {
-		return defaultValue
-	}
-
-	// Handle different numeric types
-	switch v := value.(type) {
-	case int:
-		return v
-	case int64:
-		return int(v)
-	case float64:
-		return int(v)
-	case string:
-		if v == "" {
-			return defaultValue
-		}
-		result := 0
-		for _, r := range v {
-			if r < '0' || r > '9' {
-				return defaultValue
-			}
-			result = result*10 + int(r-'0')
-		}
-		return result
-	}
-
-	return defaultValue
-}
-
-// validateParamCombinations validates parameter combinations
-func (p *ParameterExtractor) validateParamCombinations(params *WriteParams) error {
-	if params.Append && params.IsChunked {
-		return fmt.Errorf("append mode is not supported with chunked operations")
-	}
-
-	if params.IsChunked && params.ChunkIndex < 0 {
-		return fmt.Errorf("chunk_index must be non-negative")
-	}
-
-	if params.TotalChunks > 0 && params.ChunkIndex >= params.TotalChunks {
-		return fmt.Errorf("chunk_index (%d) must be less than total_chunks (%d)", params.ChunkIndex, params.TotalChunks)
-	}
-
-	return nil
 }

--- a/internal/services/tools/params_test.go
+++ b/internal/services/tools/params_test.go
@@ -23,49 +23,8 @@ func getWriteParamsTestCases() []writeParamsTestCase {
 				"content":   "test content",
 			},
 			expected: &WriteParams{
-				FilePath:  "/test/file.txt",
-				Content:   "test content",
-				Overwrite: true,
-				Append:    false,
-				Backup:    false,
-				IsChunked: false,
-			},
-		},
-		{
-			name: "valid params with all options",
-			params: map[string]interface{}{
-				"file_path": "/test/file.txt",
-				"content":   "test content",
-				"append":    true,
-				"overwrite": false,
-				"backup":    true,
-			},
-			expected: &WriteParams{
-				FilePath:  "/test/file.txt",
-				Content:   "test content",
-				Append:    true,
-				Overwrite: false,
-				Backup:    true,
-				IsChunked: false,
-			},
-		},
-		{
-			name: "valid chunked params",
-			params: map[string]interface{}{
-				"file_path":    "/test/file.txt",
-				"content":      "chunk content",
-				"session_id":   "session123",
-				"chunk_index":  0,
-				"total_chunks": 3,
-			},
-			expected: &WriteParams{
-				FilePath:    "/test/file.txt",
-				Content:     "chunk content",
-				Overwrite:   true,
-				SessionID:   "session123",
-				ChunkIndex:  0,
-				TotalChunks: 3,
-				IsChunked:   true,
+				FilePath: "/test/file.txt",
+				Content:  "test content",
 			},
 		},
 		{
@@ -102,39 +61,6 @@ func getWriteParamsTestCases() []writeParamsTestCase {
 			wantError: true,
 			errorMsg:  "parameter file_path must be a string",
 		},
-		{
-			name: "chunked with missing session_id",
-			params: map[string]interface{}{
-				"file_path":   "/test/file.txt",
-				"content":     "chunk content",
-				"chunk_index": 0,
-			},
-			wantError: true,
-			errorMsg:  "session_id is required for chunked operations",
-		},
-		{
-			name: "chunked with negative chunk_index",
-			params: map[string]interface{}{
-				"file_path":   "/test/file.txt",
-				"content":     "chunk content",
-				"session_id":  "session123",
-				"chunk_index": -1,
-			},
-			wantError: true,
-			errorMsg:  "chunk_index is required for chunked operations",
-		},
-		{
-			name: "append with chunked (invalid combination)",
-			params: map[string]interface{}{
-				"file_path":   "/test/file.txt",
-				"content":     "chunk content",
-				"append":      true,
-				"session_id":  "session123",
-				"chunk_index": 0,
-			},
-			wantError: true,
-			errorMsg:  "append mode is not supported with chunked operations",
-		},
 	}
 }
 
@@ -144,33 +70,6 @@ func validateWriteParamsResult(t *testing.T, result, expected *WriteParams) {
 	}
 	if result.Content != expected.Content {
 		t.Errorf("Content = %v, want %v", result.Content, expected.Content)
-	}
-	if result.Append != expected.Append {
-		t.Errorf("Append = %v, want %v", result.Append, expected.Append)
-	}
-	if result.Overwrite != expected.Overwrite {
-		t.Errorf("Overwrite = %v, want %v", result.Overwrite, expected.Overwrite)
-	}
-	if result.Backup != expected.Backup {
-		t.Errorf("Backup = %v, want %v", result.Backup, expected.Backup)
-	}
-	if result.IsChunked != expected.IsChunked {
-		t.Errorf("IsChunked = %v, want %v", result.IsChunked, expected.IsChunked)
-	}
-	if result.IsChunked {
-		validateChunkedParams(t, result, expected)
-	}
-}
-
-func validateChunkedParams(t *testing.T, result, expected *WriteParams) {
-	if result.SessionID != expected.SessionID {
-		t.Errorf("SessionID = %v, want %v", result.SessionID, expected.SessionID)
-	}
-	if result.ChunkIndex != expected.ChunkIndex {
-		t.Errorf("ChunkIndex = %v, want %v", result.ChunkIndex, expected.ChunkIndex)
-	}
-	if result.TotalChunks != expected.TotalChunks {
-		t.Errorf("TotalChunks = %v, want %v", result.TotalChunks, expected.TotalChunks)
 	}
 }
 
@@ -216,10 +115,8 @@ func TestParameterExtractor_ToWriteRequest(t *testing.T) {
 	extractor := NewParameterExtractor()
 
 	params := &WriteParams{
-		FilePath:  "/test/file.txt",
-		Content:   "test content",
-		Overwrite: true,
-		Backup:    true,
+		FilePath: "/test/file.txt",
+		Content:  "test content",
 	}
 
 	result := extractor.ToWriteRequest(params)
@@ -228,7 +125,7 @@ func TestParameterExtractor_ToWriteRequest(t *testing.T) {
 		Path:      "/test/file.txt",
 		Content:   "test content",
 		Overwrite: true,
-		Backup:    true,
+		Backup:    false,
 	}
 
 	if result.Path != expected.Path {
@@ -242,61 +139,6 @@ func TestParameterExtractor_ToWriteRequest(t *testing.T) {
 	}
 	if result.Backup != expected.Backup {
 		t.Errorf("Backup = %v, want %v", result.Backup, expected.Backup)
-	}
-}
-
-func TestParameterExtractor_ToChunkWriteRequest(t *testing.T) {
-	extractor := NewParameterExtractor()
-
-	params := &WriteParams{
-		Content:     "chunk content",
-		SessionID:   "session123",
-		ChunkIndex:  2,
-		TotalChunks: 3,
-	}
-
-	result := extractor.ToChunkWriteRequest(params)
-
-	if result.SessionID != "session123" {
-		t.Errorf("SessionID = %v, want %v", result.SessionID, "session123")
-	}
-	if result.ChunkIndex != 2 {
-		t.Errorf("ChunkIndex = %v, want %v", result.ChunkIndex, 2)
-	}
-	if string(result.Data) != "chunk content" {
-		t.Errorf("Data = %v, want %v", string(result.Data), "chunk content")
-	}
-	if !result.IsLast {
-		t.Errorf("IsLast = %v, want %v", result.IsLast, true)
-	}
-}
-
-func TestParameterExtractor_BooleanConversions(t *testing.T) {
-	extractor := NewParameterExtractor()
-
-	tests := []struct {
-		name     string
-		params   map[string]interface{}
-		key      string
-		expected bool
-	}{
-		{"true string", map[string]interface{}{"key": "true"}, "key", true},
-		{"false string", map[string]interface{}{"key": "false"}, "key", false},
-		{"1 string", map[string]interface{}{"key": "1"}, "key", true},
-		{"0 string", map[string]interface{}{"key": "0"}, "key", false},
-		{"yes string", map[string]interface{}{"key": "yes"}, "key", true},
-		{"no string", map[string]interface{}{"key": "no"}, "key", false},
-		{"true bool", map[string]interface{}{"key": true}, "key", true},
-		{"false bool", map[string]interface{}{"key": false}, "key", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractor.extractBool(tt.params, tt.key, false)
-			if result != tt.expected {
-				t.Errorf("extractBool() = %v, want %v", result, tt.expected)
-			}
-		})
 	}
 }
 

--- a/internal/services/tools/tree.go
+++ b/internal/services/tools/tree.go
@@ -106,7 +106,6 @@ func (t *TreeTool) Execute(ctx context.Context, args map[string]any) (*domain.To
 		maxFiles = int(maxFilesFloat)
 	}
 
-
 	showHidden := false
 	if showHiddenArg, ok := args["show_hidden"].(bool); ok {
 		showHidden = showHiddenArg
@@ -186,7 +185,6 @@ func (t *TreeTool) Validate(args map[string]any) error {
 		}
 	}
 
-
 	if showHidden, ok := args["show_hidden"]; ok {
 		if _, ok := showHidden.(bool); !ok {
 			return fmt.Errorf("show_hidden must be a boolean")
@@ -219,16 +217,16 @@ func (t *TreeTool) IsEnabled() bool {
 
 // TreeResult represents the internal result of a tree operation
 type TreeResult struct {
-	Path            string   `json:"path"`
-	Output          string   `json:"output"`
-	TotalFiles      int      `json:"total_files"`
-	TotalDirs       int      `json:"total_dirs"`
-	MaxDepth        int      `json:"max_depth"`
-	MaxFiles        int      `json:"max_files"`
-	ShowHidden      bool     `json:"show_hidden"`
-	Format          string   `json:"format"`
-	UsingNativeTree bool     `json:"using_native_tree"`
-	Truncated       bool     `json:"truncated"`
+	Path            string `json:"path"`
+	Output          string `json:"output"`
+	TotalFiles      int    `json:"total_files"`
+	TotalDirs       int    `json:"total_dirs"`
+	MaxDepth        int    `json:"max_depth"`
+	MaxFiles        int    `json:"max_files"`
+	ShowHidden      bool   `json:"show_hidden"`
+	Format          string `json:"format"`
+	UsingNativeTree bool   `json:"using_native_tree"`
+	Truncated       bool   `json:"truncated"`
 }
 
 // executeTree performs the tree operation
@@ -499,7 +497,6 @@ func (t *TreeTool) getOrLoadDirGitignore(dirPath string) *ignore.GitIgnore {
 	return nil
 }
 
-
 // FormatResult formats tool execution results for different contexts
 func (t *TreeTool) FormatResult(result *domain.ToolExecutionResult, formatType domain.FormatterType) string {
 	switch formatType {
@@ -606,7 +603,6 @@ func (t *TreeTool) formatTreeData(data any) string {
 	output.WriteString(fmt.Sprintf("Show Hidden: %t\n", treeResult.ShowHidden))
 	output.WriteString(fmt.Sprintf("Using Native Tree: %t\n", treeResult.UsingNativeTree))
 	output.WriteString(fmt.Sprintf("Truncated: %t\n", treeResult.Truncated))
-
 
 	if treeResult.Output != "" {
 		output.WriteString(fmt.Sprintf("\nTree Output:\n%s\n", treeResult.Output))

--- a/internal/services/tools/tree_test.go
+++ b/internal/services/tools/tree_test.go
@@ -301,7 +301,6 @@ func TestTreeTool_ExecuteWithMaxDepth(t *testing.T) {
 	}
 }
 
-
 func TestTreeTool_ExecuteWithShowHidden(t *testing.T) {
 	tempDir := setupTestDirectory(t)
 	tool := createTestTreeTool(tempDir)

--- a/internal/services/tools/write_test.go
+++ b/internal/services/tools/write_test.go
@@ -43,7 +43,7 @@ func TestWriteTool_Definition(t *testing.T) {
 		t.Errorf("Expected 2 required parameters, got %d", len(required))
 	}
 
-	expectedFields := []string{"file_path", "content", "append", "overwrite", "backup", "format"}
+	expectedFields := []string{"file_path", "content"}
 	for _, field := range expectedFields {
 		if _, exists := props[field]; !exists {
 			t.Errorf("Expected field '%s' in properties", field)
@@ -362,7 +362,6 @@ func testWriteFailNoOverwrite(t *testing.T, tempDir string, tool *WriteTool, ctx
 	args := map[string]any{
 		"file_path": filePath,
 		"content":   newContent,
-		"overwrite": false,
 	}
 
 	result, err := tool.Execute(ctx, args)
@@ -370,22 +369,17 @@ func testWriteFailNoOverwrite(t *testing.T, tempDir string, tool *WriteTool, ctx
 		t.Fatalf("Execute should not return error: %v", err)
 	}
 
-	if result.Success {
-		t.Error("Expected success=false when overwrite=false and file exists")
-	}
-
-	expectedErrorMsg := "file already exists and overwrite is false: " + filePath
-	if !strings.Contains(result.Error, expectedErrorMsg) {
-		t.Errorf("Expected error to contain '%s', got: %s", expectedErrorMsg, result.Error)
+	if !result.Success {
+		t.Errorf("Expected successful overwrite, got error: %s", result.Error)
 	}
 
 	writtenContent, err := os.ReadFile(filePath)
 	if err != nil {
-		t.Fatalf("Failed to read original file: %v", err)
+		t.Fatalf("Failed to read written file: %v", err)
 	}
 
-	if string(writtenContent) != originalContent {
-		t.Error("Original file should not have been modified")
+	if string(writtenContent) != newContent {
+		t.Errorf("Expected file content '%s', got '%s'", newContent, string(writtenContent))
 	}
 }
 


### PR DESCRIPTION
## Summary

Improve the description of the Write tool to ensure reliability and simplify arguments.

It only writes and overwrite content, for the other task the LLM can use the Edit tool.
