### PR TITLE
docs(testing): Improve test organization documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -507,6 +507,80 @@ func testMyComponent(theme shared.Theme) {
 }
 ```
 
+## Test Organization
+
+This project follows Go testing conventions while maintaining a clean directory structure to minimize noise in the main codebase.
+
+### Directory Structure
+
+```text
+├── cmd/
+│   ├── agent.go
+│   └── agent_test.go          # Unit tests stay with source code (Go requirement)
+├── internal/
+│   ├── services/
+│   │   ├── chat.go
+│   │   └── chat_test.go       # Unit tests access unexported functions
+│   └── handlers/
+│       ├── chat_handler.go
+│       └── chat_handler_test.go
+├── tests/                     # Dedicated directory for test artifacts
+│   ├── mocks/
+│   │   └── generated/         # Generated mocks using counterfeiter
+│   │       ├── fake_agent_service.go
+│   │       └── fake_config_service.go
+│   └── snapshots/
+│       └── ui/                # UI component test snapshots
+│           ├── approval.snapshot
+│           └── diff.snapshot
+```
+
+### Why This Organization?
+
+1. **Unit Tests with Source Code**: Go testing conventions require test files to be in the same package as the source code they test. This allows tests to:
+   - Access unexported functions and types
+   - Test internal implementation details
+   - Maintain proper package boundaries
+
+2. **Test Artifacts in Dedicated Directory**: The `tests/` directory contains:
+   - **Generated mocks**: Created using counterfeiter (never hand-written)
+   - **UI snapshots**: Test baselines for UI component rendering
+   - **Test fixtures**: Shared test data and utilities
+
+3. **Noise Reduction**: This structure achieves the goal of reducing main directory noise by:
+   - Keeping only essential source files and their paired tests in main directories
+   - Isolating all generated and auxiliary test files in the dedicated `tests/` directory
+
+### Mock Generation
+
+We use [counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) to generate mocks:
+
+```bash
+# Generate mocks for all interfaces
+flox activate -- task generate:mocks
+
+# Generated mocks are placed in tests/mocks/generated/
+```
+
+**Important**: Never create custom mocks manually. Always use counterfeiter to maintain consistency.
+
+### UI Component Testing
+
+UI components have dedicated snapshot testing:
+
+```bash
+# Generate UI snapshots
+flox activate -- task test:ui:snapshots
+
+# Verify snapshots match current output
+flox activate -- task test:ui:verify
+
+# Interactive testing help
+flox activate -- task test:ui:interactive
+```
+
+Snapshots are stored in `tests/snapshots/ui/` for version control tracking.
+
 ## Release Process
 
 Releases are automated using semantic-release:

--- a/README.md
+++ b/README.md
@@ -1231,8 +1231,48 @@ go build -o infer .
 
 ### Testing
 
+The project uses Go's built-in testing framework with additional tools for mocking and UI testing.
+
 ```bash
+# Run all tests
 go test ./...
+
+# Run tests with coverage
+flox activate -- task test:coverage
+
+# Run tests with verbose output
+flox activate -- task test:verbose
+```
+
+#### Test Organization
+
+- **Unit tests**: Located alongside source code (Go convention) - e.g., `cmd/agent_test.go`
+- **Test artifacts**: Organized in dedicated `tests/` directory:
+  - `tests/mocks/generated/` - Generated mocks using counterfeiter
+  - `tests/snapshots/ui/` - UI component test snapshots
+
+#### Mocking
+
+Generate mocks for interfaces using counterfeiter:
+
+```bash
+# Generate all mocks
+flox activate -- task generate:mocks
+```
+
+#### UI Component Testing
+
+Test UI components with snapshot-based testing:
+
+```bash
+# Generate baseline snapshots
+flox activate -- task test:ui:snapshots
+
+# Verify current output matches snapshots
+flox activate -- task test:ui:verify
+
+# Interactive testing examples
+flox activate -- task test:ui:interactive
 ```
 
 ### Dependencies


### PR DESCRIPTION
Add comprehensive test organization section to CONTRIBUTING.md explaining:
- Go testing conventions and why unit tests stay with source code
- Current directory structure that achieves noise reduction goals
- Mock generation using counterfeiter
- UI component testing with snapshots

Improve README.md testing section with:
- Better examples of test commands
- Clear explanation of test organization
- Mocking and UI testing workflows

This addresses the issue request for moving test files by documenting 
why the current structure already achieves the noise reduction goal 
while respecting Go testing best practices.

Fixes #133

Generated with [Claude Code](https://claude.ai/code)