### PR TITLE
feat(agent): Add parallel tool execution support

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -40,6 +40,7 @@ export INFER_GATEWAY_TIMEOUT=300
 # Agent configuration
 export INFER_AGENT_MODEL="anthropic/claude-4.1"
 export INFER_AGENT_MAX_TURNS=100
+export INFER_AGENT_MAX_CONCURRENT_TOOLS=3
 export INFER_AGENT_VERBOSE_TOOLS=true
 
 # Tools configuration
@@ -95,6 +96,7 @@ agent:
   verbose_tools: false
   max_turns: 50
   max_tokens: 4096
+  max_concurrent_tools: 5  # Maximum number of tools that can run in parallel
   optimization:
     enabled: false
     max_history: 10

--- a/README.md
+++ b/README.md
@@ -438,8 +438,10 @@ until the task is considered complete. Particularly useful for SCM tickets like 
 - **Autonomous execution**: Agent works independently to complete tasks
 - **Iterative processing**: Continues until task completion criteria are met
 - **Tool integration**: Full access to all available tools (Bash, Read, Write, etc.)
+- **Parallel tool execution**: Executes multiple tool calls simultaneously for improved efficiency
 - **Background operation**: Runs without interactive user input
 - **Task completion detection**: Automatically detects when tasks are complete
+- **Configurable concurrency**: Control the maximum number of parallel tool executions (default: 5)
 - **JSON output**: Structured JSON output for easy parsing and integration
 
 **Options:**

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	"github.com/inference-gateway/cli/tests/mocks/generated"
 	sdk "github.com/inference-gateway/sdk"
 )
 
@@ -74,6 +78,243 @@ func TestBuildSDKMessages(t *testing.T) {
 
 	if messages[0].Content != "Hello" {
 		t.Errorf("Expected first message content to be 'Hello', got %s", messages[0].Content)
+	}
+}
+
+func TestExecuteToolCallsParallel(t *testing.T) {
+	tests := []struct {
+		name              string
+		toolCalls         []sdk.ChatCompletionMessageToolCall
+		maxConcurrentTool int
+		mockResults       []*domain.ToolExecutionResult
+		mockErrors        []error
+		expectedCount     int
+		expectedRoles     []string
+	}{
+		{
+			name:              "empty tool calls",
+			toolCalls:         []sdk.ChatCompletionMessageToolCall{},
+			maxConcurrentTool: 5,
+			mockResults:       []*domain.ToolExecutionResult{},
+			mockErrors:        []error{},
+			expectedCount:     0,
+			expectedRoles:     []string{},
+		},
+		{
+			name: "single tool call",
+			toolCalls: []sdk.ChatCompletionMessageToolCall{
+				{
+					Id: "call_1",
+					Function: sdk.ChatCompletionMessageToolCallFunction{
+						Name:      "Read",
+						Arguments: `{"file_path": "test.txt"}`,
+					},
+				},
+			},
+			maxConcurrentTool: 5,
+			mockResults: []*domain.ToolExecutionResult{
+				{
+					ToolName: "Read",
+					Success:  true,
+					Data:     "file content",
+				},
+			},
+			mockErrors:    []error{nil},
+			expectedCount: 1,
+			expectedRoles: []string{"tool"},
+		},
+		{
+			name: "multiple tool calls",
+			toolCalls: []sdk.ChatCompletionMessageToolCall{
+				{
+					Id: "call_1",
+					Function: sdk.ChatCompletionMessageToolCallFunction{
+						Name:      "Read",
+						Arguments: `{"file_path": "test1.txt"}`,
+					},
+				},
+				{
+					Id: "call_2",
+					Function: sdk.ChatCompletionMessageToolCallFunction{
+						Name:      "Grep",
+						Arguments: `{"pattern": "func"}`,
+					},
+				},
+				{
+					Id: "call_3",
+					Function: sdk.ChatCompletionMessageToolCallFunction{
+						Name:      "Write",
+						Arguments: `{"file_path": "output.txt", "content": "hello"}`,
+					},
+				},
+			},
+			maxConcurrentTool: 2,
+			mockResults: []*domain.ToolExecutionResult{
+				{ToolName: "Read", Success: true, Data: "content1"},
+				{ToolName: "Grep", Success: true, Data: "matches"},
+				{ToolName: "Write", Success: true, Data: "written"},
+			},
+			mockErrors:    []error{nil, nil, nil},
+			expectedCount: 3,
+			expectedRoles: []string{"tool", "tool", "tool"},
+		},
+		{
+			name: "tool call with error",
+			toolCalls: []sdk.ChatCompletionMessageToolCall{
+				{
+					Id: "call_1",
+					Function: sdk.ChatCompletionMessageToolCallFunction{
+						Name:      "Read",
+						Arguments: `{"file_path": "nonexistent.txt"}`,
+					},
+				},
+			},
+			maxConcurrentTool: 5,
+			mockResults:       []*domain.ToolExecutionResult{nil},
+			mockErrors:        []error{errors.New("file not found")},
+			expectedCount:     1,
+			expectedRoles:     []string{"tool"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockToolService := &generated.FakeToolService{}
+
+			for i := range tt.toolCalls {
+				if i < len(tt.mockErrors) && tt.mockErrors[i] != nil {
+					mockToolService.ExecuteToolReturns(tt.mockResults[i], tt.mockErrors[i])
+				} else if i < len(tt.mockResults) {
+					mockToolService.ExecuteToolReturns(tt.mockResults[i], nil)
+				}
+			}
+
+			cfg := &config.Config{
+				Agent: config.AgentConfig{
+					MaxConcurrentTools: tt.maxConcurrentTool,
+				},
+			}
+
+			session := &AgentSession{
+				toolService: mockToolService,
+				config:      cfg,
+			}
+
+			results := session.executeToolCallsParallel(tt.toolCalls)
+
+			if len(results) != tt.expectedCount {
+				t.Errorf("Expected %d results, got %d", tt.expectedCount, len(results))
+			}
+
+			for i, result := range results {
+				if i < len(tt.expectedRoles) && result.Role != tt.expectedRoles[i] {
+					t.Errorf("Expected result[%d].Role to be %s, got %s", i, tt.expectedRoles[i], result.Role)
+				}
+			}
+
+			if len(tt.toolCalls) > 0 {
+				expectedCallCount := len(tt.toolCalls)
+				if mockToolService.ExecuteToolCallCount() != expectedCallCount {
+					t.Errorf("Expected ExecuteTool to be called %d times, got %d", expectedCallCount, mockToolService.ExecuteToolCallCount())
+				}
+			}
+		})
+	}
+}
+
+func TestProcessSyncResponseParallel(t *testing.T) {
+	tests := []struct {
+		name                  string
+		response              *domain.ChatSyncResponse
+		maxConcurrentTools    int
+		expectedMessageCount  int
+		expectedToolCallCount int
+	}{
+		{
+			name: "response with content only",
+			response: &domain.ChatSyncResponse{
+				RequestID: "req_1",
+				Content:   "Hello, world!",
+				ToolCalls: []sdk.ChatCompletionMessageToolCall{},
+			},
+			maxConcurrentTools:    5,
+			expectedMessageCount:  1,
+			expectedToolCallCount: 0,
+		},
+		{
+			name: "response with tool calls",
+			response: &domain.ChatSyncResponse{
+				RequestID: "req_1",
+				Content:   "I'll help you with that.",
+				ToolCalls: []sdk.ChatCompletionMessageToolCall{
+					{
+						Id: "call_1",
+						Function: sdk.ChatCompletionMessageToolCallFunction{
+							Name:      "Read",
+							Arguments: `{"file_path": "test.txt"}`,
+						},
+					},
+					{
+						Id: "call_2",
+						Function: sdk.ChatCompletionMessageToolCallFunction{
+							Name:      "Grep",
+							Arguments: `{"pattern": "test"}`,
+						},
+					},
+				},
+			},
+			maxConcurrentTools:    2,
+			expectedMessageCount:  4,
+			expectedToolCallCount: 2,
+		},
+		{
+			name: "empty response",
+			response: &domain.ChatSyncResponse{
+				RequestID: "req_1",
+				Content:   "",
+				ToolCalls: []sdk.ChatCompletionMessageToolCall{},
+			},
+			maxConcurrentTools:    5,
+			expectedMessageCount:  0,
+			expectedToolCallCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockToolService := &generated.FakeToolService{}
+			mockToolService.ExecuteToolReturns(&domain.ToolExecutionResult{
+				ToolName: "TestTool",
+				Success:  true,
+				Data:     "test result",
+			}, nil)
+
+			cfg := &config.Config{
+				Agent: config.AgentConfig{
+					MaxConcurrentTools: tt.maxConcurrentTools,
+				},
+			}
+
+			session := &AgentSession{
+				toolService:  mockToolService,
+				config:       cfg,
+				conversation: []ConversationMessage{},
+			}
+
+			err := session.processSyncResponse(tt.response, "request_123")
+
+			if err != nil {
+				t.Errorf("processSyncResponse() returned error: %v", err)
+			}
+
+			if len(session.conversation) != tt.expectedMessageCount {
+				t.Errorf("Expected %d messages in conversation, got %d", tt.expectedMessageCount, len(session.conversation))
+			}
+
+			if mockToolService.ExecuteToolCallCount() != tt.expectedToolCallCount {
+				t.Errorf("Expected ExecuteTool to be called %d times, got %d", tt.expectedToolCallCount, mockToolService.ExecuteToolCallCount())
+			}
+		})
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -488,7 +488,14 @@ RULES:
 - Code: Follow existing patterns, check deps, no secrets
 - Tasks: Use TodoWrite, mark progress immediately
 - Chat exports: Read only "## Summary" to "---" section
-- Tools: Batch calls, prefer Grep for search
+- Tools: ALWAYS use parallel execution when possible - batch multiple tool calls in a single response to improve efficiency
+- Tools: Prefer Grep for search, Read for specific files
+
+PARALLEL TOOL EXECUTION:
+- When you need to perform multiple operations, make ALL tool calls in a single response
+- Examples: Read multiple files, search multiple patterns, execute multiple commands
+- The system supports up to 5 concurrent tool executions by default
+- This reduces back-and-forth communication and significantly improves performance
 
 WORKFLOW:
 When asked to implement features or fix issues:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -117,7 +117,14 @@ RULES:
 - Code: Follow existing patterns, check deps, no secrets
 - Tasks: Use TodoWrite, mark progress immediately
 - Chat exports: Read only "## Summary" to "---" section
-- Tools: Batch calls, prefer Grep for search
+- Tools: ALWAYS use parallel execution when possible - batch multiple tool calls in a single response to improve efficiency
+- Tools: Prefer Grep for search, Read for specific files
+
+PARALLEL TOOL EXECUTION:
+- When you need to perform multiple operations, make ALL tool calls in a single response
+- Examples: Read multiple files, search multiple patterns, execute multiple commands
+- The system supports up to 5 concurrent tool executions by default
+- This reduces back-and-forth communication and significantly improves performance
 
 WORKFLOW:
 When asked to implement features or fix issues:


### PR DESCRIPTION
Closes #156

Refactors the `infer agent` command to support batched and parallel tool execution for improved efficiency.

## Changes
- ✅ Implement parallel tool execution in agent command
- ✅ Leverage existing `max_concurrent_tools` configuration (default: 5)
- ✅ Update system prompts to encourage parallel execution
- ✅ Add comprehensive table-driven tests
- ✅ Update documentation (README.md, CONFIG.md)

## Performance Benefits
- **Reduced Latency**: Multiple tools execute simultaneously
- **Fewer Round-trips**: Batched tool calls reduce back-and-forth communication
- **Configurable Concurrency**: Adjustable via configuration

## Testing
- All existing tests continue to pass
- New parallel execution tests added
- Code formatting and linting checks pass

Generated with [Claude Code](https://claude.ai/code)