### PR TITLE
feat(a2a): Implement QueryTask tool and rename Query to QueryAgent

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,7 @@ type ToolsConfig struct {
 	TodoWrite TodoWriteToolConfig `yaml:"todo_write" mapstructure:"todo_write"`
 	Query     QueryToolConfig     `yaml:"query" mapstructure:"query"`
 	Task      TaskToolConfig      `yaml:"task" mapstructure:"task"`
+	QueryTask QueryTaskToolConfig `yaml:"query_task" mapstructure:"query_task"`
 
 	Safety SafetyConfig `yaml:"safety" mapstructure:"safety"`
 }
@@ -160,6 +161,12 @@ type QueryToolConfig struct {
 
 // TaskToolConfig contains Task-specific tool settings
 type TaskToolConfig struct {
+	Enabled         bool  `yaml:"enabled" mapstructure:"enabled"`
+	RequireApproval *bool `yaml:"require_approval,omitempty" mapstructure:"require_approval,omitempty"`
+}
+
+// QueryTaskToolConfig contains QueryTask-specific tool settings
+type QueryTaskToolConfig struct {
 	Enabled         bool  `yaml:"enabled" mapstructure:"enabled"`
 	RequireApproval *bool `yaml:"require_approval,omitempty" mapstructure:"require_approval,omitempty"`
 }
@@ -462,6 +469,18 @@ func DefaultConfig() *Config { //nolint:funlen
 				Repo:  "",
 			},
 			TodoWrite: TodoWriteToolConfig{
+				Enabled:         true,
+				RequireApproval: &[]bool{false}[0],
+			},
+			Query: QueryToolConfig{
+				Enabled:         true,
+				RequireApproval: &[]bool{false}[0],
+			},
+			Task: TaskToolConfig{
+				Enabled:         true,
+				RequireApproval: &[]bool{false}[0],
+			},
+			QueryTask: QueryTaskToolConfig{
 				Enabled:         true,
 				RequireApproval: &[]bool{false}[0],
 			},

--- a/internal/services/tools/a2a_query_agent.go
+++ b/internal/services/tools/a2a_query_agent.go
@@ -1,0 +1,199 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	client "github.com/inference-gateway/adk/client"
+	adk "github.com/inference-gateway/adk/types"
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	logger "github.com/inference-gateway/cli/internal/logger"
+	sdk "github.com/inference-gateway/sdk"
+)
+
+type A2AQueryAgentTool struct {
+	config    *config.Config
+	formatter domain.CustomFormatter
+}
+
+type A2AQueryAgentResult struct {
+	AgentName string         `json:"agent_name"`
+	Query     string         `json:"query"`
+	Response  *adk.AgentCard `json:"response"`
+	Success   bool           `json:"success"`
+	Message   string         `json:"message"`
+	Duration  time.Duration  `json:"duration"`
+}
+
+func NewA2AQueryAgentTool(cfg *config.Config) *A2AQueryAgentTool {
+	return &A2AQueryAgentTool{
+		config: cfg,
+		formatter: domain.NewCustomFormatter("QueryAgent", func(key string) bool {
+			return key == "metadata"
+		}),
+	}
+}
+
+func (t *A2AQueryAgentTool) Definition() sdk.ChatCompletionTool {
+	description := "Retrieve an A2A agent's metadata card showing its capabilities and configuration. Use ONLY for discovering what an agent can do. For asking questions or requesting work from an agent, use the Task tool instead."
+	return sdk.ChatCompletionTool{
+		Type: sdk.Function,
+		Function: sdk.FunctionObject{
+			Name:        "QueryAgent",
+			Description: &description,
+			Parameters: &sdk.FunctionParameters{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent_url": map[string]interface{}{
+						"type":        "string",
+						"description": "URL of the A2A agent to retrieve metadata from",
+					},
+				},
+				"required": []string{"agent_url"},
+			},
+		},
+	}
+}
+
+func (t *A2AQueryAgentTool) Execute(ctx context.Context, args map[string]any) (*domain.ToolExecutionResult, error) {
+	startTime := time.Now()
+
+	if !t.IsEnabled() {
+		return &domain.ToolExecutionResult{
+			ToolName:  "QueryAgent",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(startTime),
+			Error:     "A2A connections are disabled in configuration",
+			Data: A2AQueryAgentResult{
+				Success: false,
+				Message: "A2A connections are disabled",
+			},
+		}, nil
+	}
+
+	agentURL, ok := args["agent_url"].(string)
+	if !ok {
+		return t.errorResult(args, startTime, "agent_url parameter is required and must be a string")
+	}
+
+	adkClient := client.NewClient(agentURL)
+	response, err := adkClient.GetAgentCard(ctx)
+	if err != nil {
+		logger.Error("Failed to fetch agent card", "agent_url", agentURL, "error", err)
+		return t.errorResult(args, startTime, fmt.Sprintf("Failed to fetch agent card: %v", err))
+	}
+
+	return &domain.ToolExecutionResult{
+		ToolName:  "QueryAgent",
+		Arguments: args,
+		Success:   true,
+		Duration:  time.Since(startTime),
+		Data: A2AQueryAgentResult{
+			AgentName: agentURL,
+			Query:     "card",
+			Response:  response,
+			Success:   true,
+			Message:   fmt.Sprintf("QueryAgent sent to agent at %s successfully", agentURL),
+			Duration:  time.Since(startTime),
+		},
+	}, nil
+}
+
+func (t *A2AQueryAgentTool) errorResult(args map[string]any, startTime time.Time, errorMsg string) (*domain.ToolExecutionResult, error) {
+	return &domain.ToolExecutionResult{
+		ToolName:  "QueryAgent",
+		Arguments: args,
+		Success:   false,
+		Duration:  time.Since(startTime),
+		Error:     errorMsg,
+		Data: A2AQueryAgentResult{
+			Success: false,
+			Message: errorMsg,
+		},
+	}, nil
+}
+
+func (t *A2AQueryAgentTool) Validate(args map[string]any) error {
+	if _, ok := args["agent_url"].(string); !ok {
+		return fmt.Errorf("agent_url parameter is required and must be a string")
+	}
+	return nil
+}
+
+func (t *A2AQueryAgentTool) FormatResult(result *domain.ToolExecutionResult, formatType domain.FormatterType) string {
+	switch formatType {
+	case domain.FormatterUI:
+		return t.FormatForUI(result)
+	case domain.FormatterLLM:
+		return t.FormatForLLM(result)
+	case domain.FormatterShort:
+		return t.FormatPreview(result)
+	default:
+		return t.FormatForUI(result)
+	}
+}
+
+func (t *A2AQueryAgentTool) FormatForLLM(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return "Tool execution result unavailable"
+	}
+
+	var output strings.Builder
+
+	output.WriteString(t.formatter.FormatExpandedHeader(result))
+
+	if result.Data != nil {
+		dataContent := t.formatter.FormatAsJSON(result.Data)
+		hasMetadata := len(result.Metadata) > 0
+		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+	}
+
+	hasDataSection := result.Data != nil
+	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
+
+	return output.String()
+}
+
+func (t *A2AQueryAgentTool) FormatForUI(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return "Tool execution result unavailable"
+	}
+
+	toolCall := t.formatter.FormatToolCall(result.Arguments, false)
+	statusIcon := t.formatter.FormatStatusIcon(result.Success)
+	preview := t.FormatPreview(result)
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("%s\n", toolCall))
+	output.WriteString(fmt.Sprintf("└─ %s %s", statusIcon, preview))
+
+	return output.String()
+}
+
+func (t *A2AQueryAgentTool) FormatPreview(result *domain.ToolExecutionResult) string {
+	if result.Data == nil {
+		return result.Error
+	}
+
+	if data, ok := result.Data.(A2AQueryAgentResult); ok {
+		return fmt.Sprintf("A2A QueryAgent: %s", data.Message)
+	}
+
+	return "A2A query agent operation completed"
+}
+
+func (t *A2AQueryAgentTool) ShouldCollapseArg(key string) bool {
+	return t.formatter.ShouldCollapseArg(key)
+}
+
+func (t *A2AQueryAgentTool) ShouldAlwaysExpand() bool {
+	return false
+}
+
+func (t *A2AQueryAgentTool) IsEnabled() bool {
+	return t.config.Tools.Query.Enabled
+}

--- a/internal/services/tools/a2a_query_agent_test.go
+++ b/internal/services/tools/a2a_query_agent_test.go
@@ -1,0 +1,208 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	adk "github.com/inference-gateway/adk/types"
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+)
+
+func TestA2AQueryAgentTool_Definition(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Query: config.QueryToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+	tool := NewA2AQueryAgentTool(cfg)
+
+	def := tool.Definition()
+
+	assert.Equal(t, "QueryAgent", def.Function.Name)
+	assert.NotNil(t, def.Function.Description)
+	assert.Contains(t, *def.Function.Description, "A2A agent")
+	assert.Contains(t, *def.Function.Description, "metadata card")
+}
+
+func TestA2AQueryAgentTool_Execute_MissingAgentURL(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Query: config.QueryToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+	tool := NewA2AQueryAgentTool(cfg)
+
+	args := map[string]any{}
+
+	result, err := tool.Execute(context.Background(), args)
+
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, result.Error, "agent_url parameter is required")
+}
+
+func TestA2AQueryAgentTool_Validate(t *testing.T) {
+	cfg := &config.Config{}
+	tool := NewA2AQueryAgentTool(cfg)
+
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid args",
+			args: map[string]any{
+				"agent_url": "http://test-agent.example.com",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "missing agent_url",
+			args:    map[string]any{},
+			wantErr: true,
+			errMsg:  "agent_url parameter is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tool.Validate(tt.args)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestA2AQueryAgentTool_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected bool
+	}{
+		{
+			name:     "enabled when A2A is enabled",
+			enabled:  true,
+			expected: true,
+		},
+		{
+			name:     "disabled when A2A is disabled",
+			enabled:  false,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Tools: config.ToolsConfig{
+					Query: config.QueryToolConfig{
+						Enabled: tt.enabled,
+					},
+				},
+			}
+			tool := NewA2AQueryAgentTool(cfg)
+
+			assert.Equal(t, tt.expected, tool.IsEnabled())
+		})
+	}
+}
+
+func TestA2AQueryAgentTool_FormatResult(t *testing.T) {
+	cfg := &config.Config{}
+	tool := NewA2AQueryAgentTool(cfg)
+
+	queryResult := A2AQueryAgentResult{
+		AgentName: "test-agent",
+		Query:     "card",
+		Response:  &adk.AgentCard{Name: "test-agent", Description: "Test agent"},
+		Success:   true,
+		Message:   "QueryAgent sent successfully",
+		Duration:  time.Second,
+	}
+
+	result := &domain.ToolExecutionResult{
+		ToolName: "QueryAgent",
+		Success:  true,
+		Data:     queryResult,
+	}
+
+	tests := []struct {
+		name       string
+		formatType domain.FormatterType
+		contains   []string
+	}{
+		{
+			name:       "LLM format",
+			formatType: domain.FormatterLLM,
+			contains:   []string{"QueryAgent()", "✓ Success", "📄 Result:", "agent_name", "test-agent", "query", "card"},
+		},
+		{
+			name:       "UI format",
+			formatType: domain.FormatterUI,
+			contains:   []string{"QueryAgent()", "✓ A2A QueryAgent", "QueryAgent sent successfully"},
+		},
+		{
+			name:       "Short format",
+			formatType: domain.FormatterShort,
+			contains:   []string{"QueryAgent sent successfully"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted := tool.FormatResult(result, tt.formatType)
+			for _, expectedContent := range tt.contains {
+				assert.Contains(t, formatted, expectedContent)
+			}
+		})
+	}
+}
+
+func TestA2AQueryAgentTool_FormatPreview(t *testing.T) {
+	cfg := &config.Config{}
+	tool := NewA2AQueryAgentTool(cfg)
+
+	queryResult := A2AQueryAgentResult{
+		Success: true,
+		Message: "QueryAgent sent successfully",
+	}
+
+	result := &domain.ToolExecutionResult{
+		ToolName: "QueryAgent",
+		Success:  true,
+		Data:     queryResult,
+	}
+
+	preview := tool.FormatPreview(result)
+	assert.Contains(t, preview, "A2A QueryAgent")
+	assert.Contains(t, preview, "QueryAgent sent successfully")
+}
+
+func TestA2AQueryAgentTool_ShouldCollapseArg(t *testing.T) {
+	cfg := &config.Config{}
+	tool := NewA2AQueryAgentTool(cfg)
+
+	assert.False(t, tool.ShouldCollapseArg("agent_url"))
+}
+
+func TestA2AQueryAgentTool_ShouldAlwaysExpand(t *testing.T) {
+	cfg := &config.Config{}
+	tool := NewA2AQueryAgentTool(cfg)
+
+	assert.False(t, tool.ShouldAlwaysExpand())
+}

--- a/internal/services/tools/a2a_query_task.go
+++ b/internal/services/tools/a2a_query_task.go
@@ -1,0 +1,246 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	client "github.com/inference-gateway/adk/client"
+	adk "github.com/inference-gateway/adk/types"
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	logger "github.com/inference-gateway/cli/internal/logger"
+	sdk "github.com/inference-gateway/sdk"
+)
+
+type A2AQueryTaskTool struct {
+	config    *config.Config
+	formatter domain.CustomFormatter
+}
+
+type A2AQueryTaskResult struct {
+	AgentName string        `json:"agent_name"`
+	ContextID string        `json:"context_id"`
+	TaskID    string        `json:"task_id"`
+	Status    string        `json:"status"`
+	Result    string        `json:"result,omitempty"`
+	Success   bool          `json:"success"`
+	Message   string        `json:"message"`
+	Duration  time.Duration `json:"duration"`
+}
+
+func NewA2AQueryTaskTool(cfg *config.Config) *A2AQueryTaskTool {
+	return &A2AQueryTaskTool{
+		config: cfg,
+		formatter: domain.NewCustomFormatter("QueryTask", func(key string) bool {
+			return key == "metadata"
+		}),
+	}
+}
+
+func (t *A2AQueryTaskTool) Definition() sdk.ChatCompletionTool {
+	description := "Query the status and result of a specific A2A task. Returns task status and last message if completed/input-required, or current status if still working."
+	return sdk.ChatCompletionTool{
+		Type: sdk.Function,
+		Function: sdk.FunctionObject{
+			Name:        "QueryTask",
+			Description: &description,
+			Parameters: &sdk.FunctionParameters{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent_url": map[string]interface{}{
+						"type":        "string",
+						"description": "URL of the A2A agent server",
+					},
+					"context_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Context ID for the task",
+					},
+					"task_id": map[string]interface{}{
+						"type":        "string",
+						"description": "ID of the task to query",
+					},
+				},
+				"required": []string{"agent_url", "context_id", "task_id"},
+			},
+		},
+	}
+}
+
+func (t *A2AQueryTaskTool) Execute(ctx context.Context, args map[string]any) (*domain.ToolExecutionResult, error) {
+	startTime := time.Now()
+
+	if !t.IsEnabled() {
+		return &domain.ToolExecutionResult{
+			ToolName:  "QueryTask",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(startTime),
+			Error:     "A2A connections are disabled in configuration",
+			Data: A2AQueryTaskResult{
+				Success: false,
+				Message: "A2A connections are disabled",
+			},
+		}, nil
+	}
+
+	agentURL, ok := args["agent_url"].(string)
+	if !ok {
+		return t.errorResult(args, startTime, "agent_url parameter is required and must be a string")
+	}
+
+	contextID, ok := args["context_id"].(string)
+	if !ok {
+		return t.errorResult(args, startTime, "context_id parameter is required and must be a string")
+	}
+
+	taskID, ok := args["task_id"].(string)
+	if !ok {
+		return t.errorResult(args, startTime, "task_id parameter is required and must be a string")
+	}
+
+	adkClient := client.NewClient(agentURL)
+	queryParams := adk.TaskQueryParams{ID: taskID}
+	taskResponse, err := adkClient.GetTask(ctx, queryParams)
+	if err != nil {
+		logger.Error("Failed to query task", "agent_url", agentURL, "task_id", taskID, "error", err)
+		return t.errorResult(args, startTime, fmt.Sprintf("Failed to query task: %v", err))
+	}
+
+	var task adk.Task
+	if err := mapToStruct(taskResponse.Result, &task); err != nil {
+		return t.errorResult(args, startTime, "Failed to parse task response")
+	}
+
+	result := A2AQueryTaskResult{
+		AgentName: agentURL,
+		ContextID: contextID,
+		TaskID:    taskID,
+		Status:    string(task.Status.State),
+		Success:   true,
+		Duration:  time.Since(startTime),
+	}
+
+	if task.Status.State == adk.TaskStateCompleted || task.Status.State == "input-required" {
+		if task.Status.Message != nil {
+			result.Result = extractTextFromParts(task.Status.Message.Parts)
+		}
+		result.Message = fmt.Sprintf("Task %s is %s", taskID, task.Status.State)
+	} else {
+		result.Message = fmt.Sprintf("Task %s is %s", taskID, task.Status.State)
+	}
+
+	return &domain.ToolExecutionResult{
+		ToolName:  "QueryTask",
+		Arguments: args,
+		Success:   true,
+		Duration:  time.Since(startTime),
+		Data:      result,
+	}, nil
+}
+
+func (t *A2AQueryTaskTool) errorResult(args map[string]any, startTime time.Time, errorMsg string) (*domain.ToolExecutionResult, error) {
+	return &domain.ToolExecutionResult{
+		ToolName:  "QueryTask",
+		Arguments: args,
+		Success:   false,
+		Duration:  time.Since(startTime),
+		Error:     errorMsg,
+		Data: A2AQueryTaskResult{
+			Success: false,
+			Message: errorMsg,
+		},
+	}, nil
+}
+
+func (t *A2AQueryTaskTool) Validate(args map[string]any) error {
+	if _, ok := args["agent_url"].(string); !ok {
+		return fmt.Errorf("agent_url parameter is required and must be a string")
+	}
+	if _, ok := args["context_id"].(string); !ok {
+		return fmt.Errorf("context_id parameter is required and must be a string")
+	}
+	if _, ok := args["task_id"].(string); !ok {
+		return fmt.Errorf("task_id parameter is required and must be a string")
+	}
+	return nil
+}
+
+func (t *A2AQueryTaskTool) FormatResult(result *domain.ToolExecutionResult, formatType domain.FormatterType) string {
+	switch formatType {
+	case domain.FormatterUI:
+		return t.FormatForUI(result)
+	case domain.FormatterLLM:
+		return t.FormatForLLM(result)
+	case domain.FormatterShort:
+		return t.FormatPreview(result)
+	default:
+		return t.FormatForUI(result)
+	}
+}
+
+func (t *A2AQueryTaskTool) FormatForLLM(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return "Tool execution result unavailable"
+	}
+
+	var output strings.Builder
+
+	output.WriteString(t.formatter.FormatExpandedHeader(result))
+
+	if result.Data != nil {
+		dataContent := t.formatter.FormatAsJSON(result.Data)
+		hasMetadata := len(result.Metadata) > 0
+		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+	}
+
+	hasDataSection := result.Data != nil
+	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
+
+	return output.String()
+}
+
+func (t *A2AQueryTaskTool) FormatForUI(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return "Tool execution result unavailable"
+	}
+
+	toolCall := t.formatter.FormatToolCall(result.Arguments, false)
+	statusIcon := t.formatter.FormatStatusIcon(result.Success)
+	preview := t.FormatPreview(result)
+
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("%s\n", toolCall))
+	output.WriteString(fmt.Sprintf("└─ %s %s", statusIcon, preview))
+
+	return output.String()
+}
+
+func (t *A2AQueryTaskTool) FormatPreview(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return "Tool execution result unavailable"
+	}
+
+	if result.Data == nil {
+		return result.Error
+	}
+
+	if data, ok := result.Data.(A2AQueryTaskResult); ok {
+		return fmt.Sprintf("A2A Query Task: %s", data.Message)
+	}
+
+	return "A2A query task operation completed"
+}
+
+func (t *A2AQueryTaskTool) ShouldCollapseArg(key string) bool {
+	return t.formatter.ShouldCollapseArg(key)
+}
+
+func (t *A2AQueryTaskTool) ShouldAlwaysExpand() bool {
+	return false
+}
+
+func (t *A2AQueryTaskTool) IsEnabled() bool {
+	return t.config.Tools.QueryTask.Enabled
+}

--- a/internal/services/tools/a2a_query_task_test.go
+++ b/internal/services/tools/a2a_query_task_test.go
@@ -1,0 +1,353 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+func TestA2AQueryTaskTool_Definition(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			QueryTask: config.QueryTaskToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+	tool := NewA2AQueryTaskTool(cfg)
+	def := tool.Definition()
+
+	if def.Function.Name != "QueryTask" {
+		t.Errorf("Expected function name to be 'QueryTask', got %s", def.Function.Name)
+	}
+
+	if def.Function.Description == nil {
+		t.Error("Expected function description to be non-nil")
+	}
+
+	if def.Function.Parameters == nil {
+		t.Error("Expected function parameters to be non-nil")
+	}
+}
+
+func TestA2AQueryTaskTool_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "valid arguments",
+			args: map[string]any{
+				"agent_url":  "http://example.com",
+				"context_id": "ctx123",
+				"task_id":    "task456",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing agent_url",
+			args: map[string]any{
+				"context_id": "ctx123",
+				"task_id":    "task456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing context_id",
+			args: map[string]any{
+				"agent_url": "http://example.com",
+				"task_id":   "task456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing task_id",
+			args: map[string]any{
+				"agent_url":  "http://example.com",
+				"context_id": "ctx123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid agent_url type",
+			args: map[string]any{
+				"agent_url":  123,
+				"context_id": "ctx123",
+				"task_id":    "task456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid context_id type",
+			args: map[string]any{
+				"agent_url":  "http://example.com",
+				"context_id": 123,
+				"task_id":    "task456",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid task_id type",
+			args: map[string]any{
+				"agent_url":  "http://example.com",
+				"context_id": "ctx123",
+				"task_id":    123,
+			},
+			wantErr: true,
+		},
+	}
+
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			QueryTask: config.QueryTaskToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+	tool := NewA2AQueryTaskTool(cfg)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tool.Validate(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestA2AQueryTaskTool_Execute_Disabled(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			QueryTask: config.QueryTaskToolConfig{
+				Enabled: false,
+			},
+		},
+	}
+	tool := NewA2AQueryTaskTool(cfg)
+
+	args := map[string]any{
+		"agent_url":  "http://example.com",
+		"context_id": "ctx123",
+		"task_id":    "task456",
+	}
+
+	result, err := tool.Execute(context.Background(), args)
+
+	if err != nil {
+		t.Errorf("Execute() returned unexpected error: %v", err)
+	}
+
+	if result.Success {
+		t.Error("Expected Execute() to fail when tool is disabled")
+	}
+
+	if result.Error != "A2A connections are disabled in configuration" {
+		t.Errorf("Expected specific error message, got: %s", result.Error)
+	}
+}
+
+func TestA2AQueryTaskTool_Execute_InvalidArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     map[string]any
+		wantErr  string
+		wantFail bool
+	}{
+		{
+			name: "missing agent_url",
+			args: map[string]any{
+				"context_id": "ctx123",
+				"task_id":    "task456",
+			},
+			wantErr:  "agent_url parameter is required and must be a string",
+			wantFail: true,
+		},
+		{
+			name: "missing context_id",
+			args: map[string]any{
+				"agent_url": "http://example.com",
+				"task_id":   "task456",
+			},
+			wantErr:  "context_id parameter is required and must be a string",
+			wantFail: true,
+		},
+		{
+			name: "missing task_id",
+			args: map[string]any{
+				"agent_url":  "http://example.com",
+				"context_id": "ctx123",
+			},
+			wantErr:  "task_id parameter is required and must be a string",
+			wantFail: true,
+		},
+	}
+
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			QueryTask: config.QueryTaskToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+	tool := NewA2AQueryTaskTool(cfg)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tool.Execute(context.Background(), tt.args)
+
+			if err != nil {
+				t.Errorf("Execute() returned unexpected error: %v", err)
+			}
+
+			if result.Success == tt.wantFail {
+				t.Errorf("Expected Success to be %v, got %v", !tt.wantFail, result.Success)
+			}
+
+			if result.Error != tt.wantErr {
+				t.Errorf("Expected error %q, got %q", tt.wantErr, result.Error)
+			}
+		})
+	}
+}
+
+func TestA2AQueryTaskTool_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		want    bool
+	}{
+		{
+			name:    "enabled",
+			enabled: true,
+			want:    true,
+		},
+		{
+			name:    "disabled",
+			enabled: false,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Tools: config.ToolsConfig{
+					QueryTask: config.QueryTaskToolConfig{
+						Enabled: tt.enabled,
+					},
+				},
+			}
+			tool := NewA2AQueryTaskTool(cfg)
+
+			if got := tool.IsEnabled(); got != tt.want {
+				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestA2AQueryTaskTool_FormatResult(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			QueryTask: config.QueryTaskToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+	tool := NewA2AQueryTaskTool(cfg)
+
+	result := &domain.ToolExecutionResult{
+		ToolName:  "QueryTask",
+		Arguments: map[string]any{"agent_url": "http://example.com"},
+		Success:   true,
+		Duration:  time.Second,
+		Data: A2AQueryTaskResult{
+			AgentName: "http://example.com",
+			ContextID: "ctx123",
+			TaskID:    "task456",
+			Status:    "completed",
+			Success:   true,
+			Message:   "Task task456 is completed",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		formatType domain.FormatterType
+	}{
+		{
+			name:       "UI format",
+			formatType: domain.FormatterUI,
+		},
+		{
+			name:       "LLM format",
+			formatType: domain.FormatterLLM,
+		},
+		{
+			name:       "Short format",
+			formatType: domain.FormatterShort,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := tool.FormatResult(result, tt.formatType)
+			if output == "" {
+				t.Error("FormatResult() returned empty string")
+			}
+		})
+	}
+}
+
+func TestA2AQueryTaskTool_FormatPreview(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			QueryTask: config.QueryTaskToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+	tool := NewA2AQueryTaskTool(cfg)
+
+	tests := []struct {
+		name   string
+		result *domain.ToolExecutionResult
+		want   string
+	}{
+		{
+			name: "successful result with data",
+			result: &domain.ToolExecutionResult{
+				Data: A2AQueryTaskResult{
+					Message: "Task completed successfully",
+				},
+			},
+			want: "A2A Query Task: Task completed successfully",
+		},
+		{
+			name: "failed result with error",
+			result: &domain.ToolExecutionResult{
+				Error: "Failed to connect",
+			},
+			want: "Failed to connect",
+		},
+		{
+			name:   "nil result",
+			result: nil,
+			want:   "Tool execution result unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tool.FormatPreview(tt.result)
+			if got != tt.want {
+				t.Errorf("FormatPreview() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/services/tools/registry.go
+++ b/internal/services/tools/registry.go
@@ -55,11 +55,15 @@ func (r *Registry) registerTools() {
 	}
 
 	if r.config.Tools.Query.Enabled {
-		r.tools["Query"] = NewA2AQueryTool(r.config)
+		r.tools["QueryAgent"] = NewA2AQueryAgentTool(r.config)
 	}
 
 	if r.config.Tools.Task.Enabled {
 		r.tools["Task"] = NewA2ATaskTool(r.config, r.taskTracker)
+	}
+
+	if r.config.Tools.QueryTask.Enabled {
+		r.tools["QueryTask"] = NewA2AQueryTaskTool(r.config)
 	}
 
 }


### PR DESCRIPTION
Closes #168

## Summary
- Implement new QueryTask tool for querying A2A task status and results
- Rename existing Query tool to QueryAgent for consistency
- Add comprehensive configuration and testing support

## Test plan
- [x] All unit tests pass
- [x] Quality checks pass (fmt, vet, test)
- [x] Tools can be enabled/disabled via configuration
- [x] QueryTask accepts required parameters and validates them
- [x] Task status checking logic implemented

🤖 Generated with [Claude Code](https://claude.ai/code)