### PR TITLE
fix(a2a): Enable A2A tools by default when A2A is enabled

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,18 @@ func initConfig() {
 	if a2aEnabled := os.Getenv("INFER_A2A_ENABLED"); a2aEnabled != "" {
 		enabled := a2aEnabled == "true"
 		v.Set("a2a.enabled", enabled)
+
+		if enabled {
+			if os.Getenv("INFER_A2A_TOOLS_QUERY_AGENT_ENABLED") == "" {
+				v.Set("a2a.tools.query_agent.enabled", true)
+			}
+			if os.Getenv("INFER_A2A_TOOLS_QUERY_TASK_ENABLED") == "" {
+				v.Set("a2a.tools.query_task.enabled", true)
+			}
+			if os.Getenv("INFER_A2A_TOOLS_SUBMIT_TASK_ENABLED") == "" {
+				v.Set("a2a.tools.submit_task.enabled", true)
+			}
+		}
 	}
 
 	if err := v.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose")); err != nil {

--- a/internal/services/tools/a2a_query_agent.go
+++ b/internal/services/tools/a2a_query_agent.go
@@ -195,5 +195,8 @@ func (t *A2AQueryAgentTool) ShouldAlwaysExpand() bool {
 }
 
 func (t *A2AQueryAgentTool) IsEnabled() bool {
-	return t.config.IsA2AToolsEnabled() && t.config.A2A.Tools.QueryAgent.Enabled
+	if !t.config.IsA2AToolsEnabled() {
+		return false
+	}
+	return t.config.A2A.Tools.QueryAgent.Enabled
 }

--- a/internal/services/tools/a2a_query_task.go
+++ b/internal/services/tools/a2a_query_task.go
@@ -242,5 +242,8 @@ func (t *A2AQueryTaskTool) ShouldAlwaysExpand() bool {
 }
 
 func (t *A2AQueryTaskTool) IsEnabled() bool {
-	return t.config.IsA2AToolsEnabled() && t.config.A2A.Tools.QueryTask.Enabled
+	if !t.config.IsA2AToolsEnabled() {
+		return false
+	}
+	return t.config.A2A.Tools.QueryTask.Enabled
 }

--- a/internal/services/tools/a2a_task.go
+++ b/internal/services/tools/a2a_task.go
@@ -287,7 +287,10 @@ func (t *A2ASubmitTaskTool) Validate(args map[string]any) error {
 
 // IsEnabled returns whether this tool is enabled
 func (t *A2ASubmitTaskTool) IsEnabled() bool {
-	return t.config.IsA2AToolsEnabled() && t.config.A2A.Tools.SubmitTask.Enabled
+	if !t.config.IsA2AToolsEnabled() {
+		return false
+	}
+	return t.config.A2A.Tools.SubmitTask.Enabled
 }
 
 // FormatResult formats tool execution results for different contexts


### PR DESCRIPTION
Fixes #174

This PR resolves the issue where A2A tools weren't available by default when `INFER_A2A_ENABLED=true` is set.

## Changes

- Added explicit configuration in viper setup to ensure A2A tools are enabled by default when A2A is enabled
- Updated A2A tool IsEnabled methods for consistency
- Ensures A2A tools (QueryAgent, QueryTask, SubmitTask) are available unless explicitly disabled

## Testing

With this change, users can now set `INFER_A2A_ENABLED=true` and have all A2A tools available immediately, without needing to set individual tool environment variables.

Generated with [Claude Code](https://claude.ai/code)