### PR TITLE
fix(cli): Maintain spinner visibility when exiting task management view

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -526,6 +526,20 @@ func (app *ChatApplication) handleA2ATaskManagementCancelled(cmds []tea.Cmd) []t
 	}
 
 	app.focusedComponent = app.inputView
+
+	if app.backgroundTaskService != nil {
+		backgroundTasks := app.backgroundTaskService.GetBackgroundTasks()
+		if len(backgroundTasks) > 0 {
+			cmds = append(cmds, func() tea.Msg {
+				return domain.SetStatusEvent{
+					Message:    fmt.Sprintf("Background tasks running (%d)", len(backgroundTasks)),
+					Spinner:    true,
+					StatusType: domain.StatusDefault,
+				}
+			})
+		}
+	}
+
 	return cmds
 }
 

--- a/internal/handlers/chat_shortcut_handler.go
+++ b/internal/handlers/chat_shortcut_handler.go
@@ -570,9 +570,15 @@ func (s *ChatShortcutHandler) handleShowA2ATaskManagementSideEffect() tea.Msg {
 		}
 	}
 
+	hasBackgroundTasks := false
+	if s.handler.backgroundTaskService != nil {
+		backgroundTasks := s.handler.backgroundTaskService.GetBackgroundTasks()
+		hasBackgroundTasks = len(backgroundTasks) > 0
+	}
+
 	return domain.SetStatusEvent{
 		Message:    "Task management interface",
-		Spinner:    false,
+		Spinner:    hasBackgroundTasks,
 		TokenUsage: s.handler.getCurrentTokenUsage(),
 		StatusType: domain.StatusDefault,
 	}

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -11,10 +11,6 @@ import (
 func TestNewConversationView(t *testing.T) {
 	cv := NewConversationView(nil)
 
-	if cv == nil {
-		t.Fatal("Expected ConversationView to be created, got nil")
-	}
-
 	if cv.width != 80 {
 		t.Errorf("Expected default width 80, got %d", cv.width)
 	}

--- a/internal/ui/components/help_bar_test.go
+++ b/internal/ui/components/help_bar_test.go
@@ -10,10 +10,6 @@ import (
 func TestNewHelpBar(t *testing.T) {
 	hb := NewHelpBar(nil)
 
-	if hb == nil {
-		t.Fatal("Expected HelpBar to be created, got nil")
-	}
-
 	if hb.width != 80 {
 		t.Errorf("Expected default width 80, got %d", hb.width)
 	}

--- a/internal/ui/components/input_view_test.go
+++ b/internal/ui/components/input_view_test.go
@@ -37,10 +37,6 @@ func TestNewInputView(t *testing.T) {
 	mockModelService := &mockModelService{}
 	iv := NewInputView(mockModelService)
 
-	if iv == nil {
-		t.Fatal("Expected InputView to be created, got nil")
-	}
-
 	if iv.text != "" {
 		t.Errorf("Expected empty text, got '%s'", iv.text)
 	}

--- a/internal/ui/components/status_view_test.go
+++ b/internal/ui/components/status_view_test.go
@@ -8,10 +8,6 @@ import (
 func TestNewStatusView(t *testing.T) {
 	sv := NewStatusView(nil)
 
-	if sv == nil {
-		t.Fatal("Expected StatusView to be created, got nil")
-	}
-
 	if sv.width != 0 {
 		t.Errorf("Expected default width 0, got %d", sv.width)
 	}

--- a/internal/ui/keybinding/registry_test.go
+++ b/internal/ui/keybinding/registry_test.go
@@ -265,16 +265,14 @@ func TestKeyResolution(t *testing.T) {
 	action := registry.Resolve("ctrl+c", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+c to resolve to an action")
-	}
-	if action.ID != "quit" {
+	} else if action.ID != "quit" {
 		t.Errorf("Expected ctrl+c to resolve to 'quit', got %s", action.ID)
 	}
 
 	action = registry.Resolve("ctrl+r", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+r to resolve to an action")
-	}
-	if action.ID != "toggle_tool_expansion" {
+	} else if action.ID != "toggle_tool_expansion" {
 		t.Errorf("Expected ctrl+r to resolve to 'toggle_tool_expansion', got %s", action.ID)
 	}
 
@@ -330,23 +328,23 @@ func TestActionHandlers(t *testing.T) {
 	action := registry.Resolve("ctrl+c", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+c to resolve to quit action")
-	}
-
-	cmd := action.Handler(mockContext, tea.KeyMsg{})
-	if cmd == nil {
-		t.Error("Expected quit handler to return a command")
+	} else {
+		cmd := action.Handler(mockContext, tea.KeyMsg{})
+		if cmd == nil {
+			t.Error("Expected quit handler to return a command")
+		}
 	}
 
 	action = registry.Resolve("ctrl+r", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+r to resolve to toggle action")
-	}
+	} else {
+		initialCallCount := mockContext.expandToggleCalls
+		_ = action.Handler(mockContext, tea.KeyMsg{})
 
-	initialCallCount := mockContext.expandToggleCalls
-	_ = action.Handler(mockContext, tea.KeyMsg{})
-
-	if mockContext.expandToggleCalls != initialCallCount+1 {
-		t.Error("Expected toggle handler to call ToggleToolResultExpansion()")
+		if mockContext.expandToggleCalls != initialCallCount+1 {
+			t.Error("Expected toggle handler to call ToggleToolResultExpansion()")
+		}
 	}
 }
 
@@ -391,8 +389,7 @@ func TestConditionalKeyBindings(t *testing.T) {
 	action := registry.Resolve("enter", emptyInputContext)
 	if action == nil {
 		t.Fatal("Expected enter key to resolve to enter_key_handler even when input is empty")
-	}
-	if action.ID != "enter_key_handler" {
+	} else if action.ID != "enter_key_handler" {
 		t.Errorf("Expected enter to resolve to 'enter_key_handler', got %s", action.ID)
 	}
 
@@ -403,8 +400,7 @@ func TestConditionalKeyBindings(t *testing.T) {
 	action = registry.Resolve("enter", nonEmptyInputContext)
 	if action == nil {
 		t.Fatal("Expected enter key to resolve to enter_key_handler when input has content")
-	}
-	if action.ID != "enter_key_handler" {
+	} else if action.ID != "enter_key_handler" {
 		t.Errorf("Expected enter to resolve to 'enter_key_handler', got %s", action.ID)
 	}
 }
@@ -451,8 +447,7 @@ func TestActionRegistration(t *testing.T) {
 	retrievedAction := registry.GetAction("test_action")
 	if retrievedAction == nil {
 		t.Fatal("Expected to retrieve registered action")
-	}
-	if retrievedAction.ID != "test_action" {
+	} else if retrievedAction.ID != "test_action" {
 		t.Errorf("Expected retrieved action ID to be 'test_action', got %s", retrievedAction.ID)
 	}
 
@@ -462,8 +457,7 @@ func TestActionRegistration(t *testing.T) {
 	resolvedAction := registry.Resolve("ctrl+t", mockContext)
 	if resolvedAction == nil {
 		t.Fatal("Expected custom action to be resolved")
-	}
-	if resolvedAction.ID != "test_action" {
+	} else if resolvedAction.ID != "test_action" {
 		t.Errorf("Expected resolved action to be 'test_action', got %s", resolvedAction.ID)
 	}
 }


### PR DESCRIPTION
## Summary
Fixes a UX issue where the spinner would disappear when pressing ESC to exit the `/tasks` view, even though background tasks were still running.

## Changes
- **Entry point fix**: When entering `/tasks` view, preserve spinner state if background tasks are running
- **Exit point fix**: When exiting `/tasks` view with ESC, check for active background tasks and restore spinner with task count
- **Test fixes**: Resolved staticcheck SA5011 false positives by restructuring test conditionals

## Technical Details
The issue occurred in two places:
1. `handleShowA2ATaskManagementSideEffect` - Set spinner to false unconditionally when entering task management
2. `handleA2ATaskManagementCancelled` - Did not restore spinner state when exiting back to chat

Now both functions check `backgroundTaskService.GetBackgroundTasks()` to determine if the spinner should remain visible.

## Test Plan
- [x] Run linter (all checks pass)
- [x] Build succeeds
- [ ] Manual testing: Start background tasks, press `/tasks`, press ESC, verify spinner remains visible

## Related
Addresses user-reported UX inconsistency with spinner visibility during task management operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)