### PR TITLE
feat(cli): Add --version flag support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,10 @@ var rootCmd = &cobra.Command{
 the Inference Gateway. This CLI provides tools for configuration,
 deployment, monitoring, and management of inference services.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if cmd.Flags().Changed("version") {
+			versionCmd.Run(cmd, args)
+			return
+		}
 		if len(args) == 0 && !cmd.Flags().Changed("help") {
 			fmt.Println("Welcome to the Inference Gateway CLI!")
 			fmt.Println("Use 'infer chat' to start interactive chat or --help to see available commands.")
@@ -43,6 +47,7 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
+	rootCmd.Flags().BoolP("version", "", false, "print version information")
 
 	cobra.OnInitialize(initConfig)
 }


### PR DESCRIPTION
## Summary
- Add support for `--version` flag to match standard CLI conventions
- Both `infer --version` and `infer version` now work identically

## Changes
- Added `--version` flag definition in root command initialization
- Added version flag check in root command's Run function to invoke version subcommand

## Test Plan
- [x] Build and install binary using `task install`
- [x] Verify `infer --version` displays version information
- [x] Verify `infer version` still works as before
- [x] Pre-commit hooks passed (formatting, linting)

## Motivation
Previously, users expecting standard CLI behavior with `--version` would get an "unknown flag" error. This change improves UX by supporting the conventional `--version` flag alongside the existing `version` subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)