### PR TITLE
test: Add table-driven tests for edit tools

### DIFF
--- a/internal/services/tools/edit_test.go
+++ b/internal/services/tools/edit_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/inference-gateway/cli/config"
-	"github.com/inference-gateway/cli/internal/domain"
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 // MockReadToolTracker for testing read tool usage tracking
@@ -711,6 +711,730 @@ func TestEditTool_ShouldCollapseArg(t *testing.T) {
 			result := tool.ShouldCollapseArg(tt.arg)
 			if result != tt.expected {
 				t.Errorf("ShouldCollapseArg(%s) = %v, expected %v", tt.arg, result, tt.expected)
+			}
+		})
+	}
+}
+
+type editExecuteTestCase struct {
+	name             string
+	initialContent   string
+	args             map[string]any
+	expectedContent  string
+	expectedSuccess  bool
+	expectedReplaced int
+	expectedModified bool
+	errorContains    string
+}
+
+func getEditExecuteBasicTestCases() []editExecuteTestCase {
+	return []editExecuteTestCase{
+		{
+			name:           "single word replacement",
+			initialContent: "hello world",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "hello",
+				"new_string": "hi",
+			},
+			expectedContent:  "hi world",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "multi-line replacement",
+			initialContent: "line1\nline2\nline3",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "line2",
+				"new_string": "replaced_line",
+			},
+			expectedContent:  "line1\nreplaced_line\nline3",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "replace with multi-line content",
+			initialContent: "start\nmiddle\nend",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "middle",
+				"new_string": "line1\nline2\nline3",
+			},
+			expectedContent:  "start\nline1\nline2\nline3\nend",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "replace all occurrences",
+			initialContent: "test test test",
+			args: map[string]any{
+				"file_path":   "",
+				"old_string":  "test",
+				"new_string":  "example",
+				"replace_all": true,
+			},
+			expectedContent:  "example example example",
+			expectedSuccess:  true,
+			expectedReplaced: 3,
+			expectedModified: true,
+		},
+		{
+			name:           "delete content (replace with empty)",
+			initialContent: "keep this remove_this keep that",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": " remove_this",
+				"new_string": "",
+			},
+			expectedContent:  "keep this keep that",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "whitespace-only changes",
+			initialContent: "no  spaces",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "  ",
+				"new_string": " ",
+			},
+			expectedContent:  "no spaces",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "unicode content replacement",
+			initialContent: "Hello 世界! emoji: 🎉",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "世界",
+				"new_string": "World",
+			},
+			expectedContent:  "Hello World! emoji: 🎉",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "preserve indentation",
+			initialContent: "func test() {\n\treturn nil\n}",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "\treturn nil",
+				"new_string": "\treturn true",
+			},
+			expectedContent:  "func test() {\n\treturn true\n}",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+	}
+}
+
+func getEditExecuteAdvancedTestCases() []editExecuteTestCase {
+	return []editExecuteTestCase{
+		{
+			name:           "fail on non-unique string without replace_all",
+			initialContent: "duplicate duplicate",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "duplicate",
+				"new_string": "unique",
+			},
+			expectedContent: "duplicate duplicate",
+			expectedSuccess: false,
+			errorContains:   "is not unique in file",
+		},
+		{
+			name:           "fail when old_string not found",
+			initialContent: "hello world",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "nonexistent",
+				"new_string": "replacement",
+			},
+			expectedContent: "hello world",
+			expectedSuccess: false,
+			errorContains:   "old_string not found in file",
+		},
+		{
+			name:           "special regex characters in content",
+			initialContent: "path/to/file.go (line 10)",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "(line 10)",
+				"new_string": "(line 20)",
+			},
+			expectedContent:  "path/to/file.go (line 20)",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "replace at start of file",
+			initialContent: "START middle end",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "START",
+				"new_string": "BEGIN",
+			},
+			expectedContent:  "BEGIN middle end",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "replace at end of file",
+			initialContent: "start middle END",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "END",
+				"new_string": "FINISH",
+			},
+			expectedContent:  "start middle FINISH",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "newline handling - add newlines",
+			initialContent: "single line",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "single line",
+				"new_string": "first line\nsecond line\nthird line",
+			},
+			expectedContent:  "first line\nsecond line\nthird line",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+		{
+			name:           "newline handling - remove newlines",
+			initialContent: "line1\nline2\nline3",
+			args: map[string]any{
+				"file_path":  "",
+				"old_string": "line1\nline2\nline3",
+				"new_string": "single line",
+			},
+			expectedContent:  "single line",
+			expectedSuccess:  true,
+			expectedReplaced: 1,
+			expectedModified: true,
+		},
+	}
+}
+
+func getEditExecuteTestCases() []editExecuteTestCase {
+	cases := getEditExecuteBasicTestCases()
+	return append(cases, getEditExecuteAdvancedTestCases()...)
+}
+
+func runEditExecuteTest(t *testing.T, tt editExecuteTestCase, tempDir string, cfg *config.Config) {
+	t.Helper()
+	testFile := filepath.Join(tempDir, fmt.Sprintf("test_%s.txt", strings.ReplaceAll(tt.name, " ", "_")))
+	err := os.WriteFile(testFile, []byte(tt.initialContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	tt.args["file_path"] = testFile
+
+	mockTracker := &MockReadToolTracker{readToolUsed: true}
+	tool := NewEditToolWithRegistry(cfg, mockTracker)
+
+	result, err := tool.Execute(context.Background(), tt.args)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+
+	if result.Success != tt.expectedSuccess {
+		t.Errorf("Expected success=%v, got %v. Error: %s", tt.expectedSuccess, result.Success, result.Error)
+	}
+
+	if tt.expectedSuccess {
+		editResult, ok := result.Data.(*domain.EditToolResult)
+		if !ok {
+			t.Fatal("Expected EditToolResult in result data")
+		}
+		if editResult.ReplacedCount != tt.expectedReplaced {
+			t.Errorf("Expected %d replacements, got %d", tt.expectedReplaced, editResult.ReplacedCount)
+		}
+		if editResult.FileModified != tt.expectedModified {
+			t.Errorf("Expected FileModified=%v, got %v", tt.expectedModified, editResult.FileModified)
+		}
+	}
+
+	if tt.errorContains != "" && !strings.Contains(result.Error, tt.errorContains) {
+		t.Errorf("Expected error containing '%s', got '%s'", tt.errorContains, result.Error)
+	}
+
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("Failed to read test file: %v", err)
+	}
+	if string(content) != tt.expectedContent {
+		t.Errorf("Expected file content:\n%q\nGot:\n%q", tt.expectedContent, string(content))
+	}
+}
+
+func TestEditTool_Execute_TableDriven(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Sandbox: config.SandboxConfig{
+				Directories: []string{tempDir},
+			},
+			Edit: config.EditToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	for _, tt := range getEditExecuteTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			runEditExecuteTest(t, tt, tempDir, cfg)
+		})
+	}
+}
+
+func TestEditTool_CleanString_TableDriven(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Sandbox: config.SandboxConfig{
+				Directories: []string{"."},
+			},
+			Edit: config.EditToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	tool := NewEditTool(cfg)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "tab-separated line number single line",
+			input:    "  10\tfunc main() {",
+			expected: "func main() {",
+		},
+		{
+			name:     "arrow-separated line number single line",
+			input:    "  10→func main() {",
+			expected: "func main() {",
+		},
+		{
+			name:     "multi-line with tab prefixes",
+			input:    "   5\tpackage main\n   6\t\n   7\timport \"fmt\"",
+			expected: "package main\n\nimport \"fmt\"",
+		},
+		{
+			name:     "multi-line with arrow prefixes",
+			input:    "   5→package main\n   6→\n   7→import \"fmt\"",
+			expected: "package main\n\nimport \"fmt\"",
+		},
+		{
+			name:     "no line number prefix - unchanged",
+			input:    "regular content without prefix",
+			expected: "regular content without prefix",
+		},
+		{
+			name:     "line starting with number but no separator",
+			input:    "10 items in stock",
+			expected: "10 items in stock",
+		},
+		{
+			name:     "mixed content - some with prefixes",
+			input:    "  1\tline one\nregular line\n  3\tline three",
+			expected: "line one\nregular line\nline three",
+		},
+		{
+			name:     "high line numbers",
+			input:    "  999\tsome code\n 1000\tmore code",
+			expected: "some code\nmore code",
+		},
+		{
+			name:     "single digit line number",
+			input:    "1\tcode",
+			expected: "code",
+		},
+		{
+			name:     "empty line with number prefix",
+			input:    "  5\t",
+			expected: "",
+		},
+		{
+			name:     "content with tabs inside",
+			input:    "  1\tvar x\t= 10",
+			expected: "var x\t= 10",
+		},
+		{
+			name:     "preserve leading spaces in content",
+			input:    "  5\t    indented content",
+			expected: "    indented content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tool.cleanString(tt.input)
+			if result != tt.expected {
+				t.Errorf("cleanString(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEditTool_FormatResult_TableDriven(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Edit: config.EditToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	tool := NewEditTool(cfg)
+
+	tests := []struct {
+		name       string
+		result     *domain.ToolExecutionResult
+		formatType domain.FormatterType
+		contains   []string
+	}{
+		{
+			name: "FormatPreview - successful single edit",
+			result: &domain.ToolExecutionResult{
+				ToolName: "Edit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path":  "/path/to/file.go",
+					"old_string": "old",
+					"new_string": "new",
+				},
+				Data: &domain.EditToolResult{
+					FilePath:        "/path/to/file.go",
+					ReplacedCount:   1,
+					FileModified:    true,
+					BytesDifference: 5,
+					LinesDifference: 0,
+				},
+			},
+			formatType: domain.FormatterShort,
+			contains:   []string{"Updated", "file.go"},
+		},
+		{
+			name: "FormatPreview - replace all",
+			result: &domain.ToolExecutionResult{
+				ToolName: "Edit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path":   "/path/to/file.go",
+					"old_string":  "old",
+					"new_string":  "new",
+					"replace_all": true,
+				},
+				Data: &domain.EditToolResult{
+					FilePath:        "/path/to/file.go",
+					ReplacedCount:   5,
+					ReplaceAll:      true,
+					FileModified:    true,
+					BytesDifference: 10,
+					LinesDifference: 0,
+				},
+			},
+			formatType: domain.FormatterShort,
+			contains:   []string{"Replaced", "5", "occurrences"},
+		},
+		{
+			name: "FormatPreview - no changes",
+			result: &domain.ToolExecutionResult{
+				ToolName: "Edit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path":  "/path/to/file.go",
+					"old_string": "old",
+					"new_string": "old",
+				},
+				Data: &domain.EditToolResult{
+					FilePath:     "/path/to/file.go",
+					FileModified: false,
+				},
+			},
+			formatType: domain.FormatterShort,
+			contains:   []string{"No changes"},
+		},
+		{
+			name: "FormatUI - successful edit",
+			result: &domain.ToolExecutionResult{
+				ToolName: "Edit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path":  "/path/to/file.go",
+					"old_string": "old",
+					"new_string": "new",
+				},
+				Data: &domain.EditToolResult{
+					FilePath:        "/path/to/file.go",
+					ReplacedCount:   1,
+					FileModified:    true,
+					BytesDifference: 3,
+					LinesDifference: 0,
+				},
+			},
+			formatType: domain.FormatterUI,
+			contains:   []string{"Edit(", "file_path"},
+		},
+		{
+			name: "FormatUI - failed edit",
+			result: &domain.ToolExecutionResult{
+				ToolName: "Edit",
+				Success:  false,
+				Error:    "old_string not found",
+				Arguments: map[string]any{
+					"file_path":  "/path/to/file.go",
+					"old_string": "missing",
+					"new_string": "new",
+				},
+			},
+			formatType: domain.FormatterUI,
+			contains:   []string{"Edit("},
+		},
+		{
+			name:       "FormatResult - nil result",
+			result:     nil,
+			formatType: domain.FormatterUI,
+			contains:   []string{"unavailable"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := tool.FormatResult(tt.result, tt.formatType)
+			for _, expected := range tt.contains {
+				if !strings.Contains(output, expected) {
+					t.Errorf("FormatResult output should contain '%s', got:\n%s", expected, output)
+				}
+			}
+		})
+	}
+}
+
+func testEditEdgeCaseEmptyFile(t *testing.T, tempDir string, tool *EditTool) {
+	t.Helper()
+	testFile := filepath.Join(tempDir, "empty.txt")
+	if err := os.WriteFile(testFile, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	args := map[string]any{"file_path": testFile, "old_string": "nonexistent", "new_string": "new content"}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected failure when searching in empty file")
+	}
+}
+
+func testEditEdgeCaseLongReplacement(t *testing.T, tempDir string, tool *EditTool) {
+	t.Helper()
+	testFile := filepath.Join(tempDir, "long.txt")
+	if err := os.WriteFile(testFile, []byte("MARKER"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	longContent := strings.Repeat("a", 10000)
+	args := map[string]any{"file_path": testFile, "old_string": "MARKER", "new_string": longContent}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+	content, _ := os.ReadFile(testFile)
+	if len(content) != 10000 {
+		t.Errorf("Expected content length 10000, got %d", len(content))
+	}
+}
+
+func testEditEdgeCaseBinaryContent(t *testing.T, tempDir string, tool *EditTool) {
+	t.Helper()
+	testFile := filepath.Join(tempDir, "binary.txt")
+	if err := os.WriteFile(testFile, []byte("start\x00middle\x00end"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	args := map[string]any{"file_path": testFile, "old_string": "middle", "new_string": "replaced"}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+}
+
+func testEditEdgeCaseDuplicates(t *testing.T, tempDir string, tool *EditTool) {
+	t.Helper()
+	testFile := filepath.Join(tempDir, "introduce_dup.txt")
+	if err := os.WriteFile(testFile, []byte("unique value"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	args := map[string]any{"file_path": testFile, "old_string": "unique", "new_string": "value"}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+	content, _ := os.ReadFile(testFile)
+	if string(content) != "value value" {
+		t.Errorf("Expected 'value value', got '%s'", string(content))
+	}
+}
+
+func testEditEdgeCaseCRLF(t *testing.T, tempDir string, tool *EditTool) {
+	t.Helper()
+	testFile := filepath.Join(tempDir, "crlf.txt")
+	if err := os.WriteFile(testFile, []byte("line1\r\nline2\r\nline3"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	args := map[string]any{"file_path": testFile, "old_string": "line2", "new_string": "replaced"}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+}
+
+func testEditEdgeCaseOverlapping(t *testing.T, tempDir string, tool *EditTool) {
+	t.Helper()
+	testFile := filepath.Join(tempDir, "overlap.txt")
+	if err := os.WriteFile(testFile, []byte("abc-abc-abc"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	args := map[string]any{"file_path": testFile, "old_string": "abc", "new_string": "XYZ", "replace_all": true}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+	content, _ := os.ReadFile(testFile)
+	if string(content) != "XYZ-XYZ-XYZ" {
+		t.Errorf("Expected 'XYZ-XYZ-XYZ', got '%s'", string(content))
+	}
+}
+
+func TestEditTool_Execute_EdgeCases(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Sandbox: config.SandboxConfig{Directories: []string{tempDir}},
+			Edit:    config.EditToolConfig{Enabled: true},
+		},
+	}
+	mockTracker := &MockReadToolTracker{readToolUsed: true}
+	tool := NewEditToolWithRegistry(cfg, mockTracker)
+
+	t.Run("empty file editing", func(t *testing.T) { testEditEdgeCaseEmptyFile(t, tempDir, tool) })
+	t.Run("very long replacement", func(t *testing.T) { testEditEdgeCaseLongReplacement(t, tempDir, tool) })
+	t.Run("binary-like content", func(t *testing.T) { testEditEdgeCaseBinaryContent(t, tempDir, tool) })
+	t.Run("introduces duplicates", func(t *testing.T) { testEditEdgeCaseDuplicates(t, tempDir, tool) })
+	t.Run("CRLF handling", func(t *testing.T) { testEditEdgeCaseCRLF(t, tempDir, tool) })
+	t.Run("overlapping pattern", func(t *testing.T) { testEditEdgeCaseOverlapping(t, tempDir, tool) })
+}
+
+func TestEditTool_GetDiffInfo(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Edit: config.EditToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	tool := NewEditTool(cfg)
+
+	tests := []struct {
+		name         string
+		args         map[string]any
+		expectedFile string
+		expectedOld  string
+		expectedNew  string
+	}{
+		{
+			name: "basic diff info",
+			args: map[string]any{
+				"file_path":  "/path/to/file.go",
+				"old_string": "old content",
+				"new_string": "new content",
+			},
+			expectedFile: "/path/to/file.go",
+			expectedOld:  "old content",
+			expectedNew:  "new content",
+		},
+		{
+			name: "multi-line diff info",
+			args: map[string]any{
+				"file_path":  "/path/to/file.go",
+				"old_string": "line1\nline2",
+				"new_string": "newline1\nnewline2\nnewline3",
+			},
+			expectedFile: "/path/to/file.go",
+			expectedOld:  "line1\nline2",
+			expectedNew:  "newline1\nnewline2\nnewline3",
+		},
+		{
+			name: "empty strings",
+			args: map[string]any{
+				"file_path":  "/path/to/file.go",
+				"old_string": "",
+				"new_string": "new content",
+			},
+			expectedFile: "/path/to/file.go",
+			expectedOld:  "",
+			expectedNew:  "new content",
+		},
+		{
+			name:         "missing arguments",
+			args:         map[string]any{},
+			expectedFile: "",
+			expectedOld:  "",
+			expectedNew:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diffInfo := tool.GetDiffInfo(tt.args)
+
+			if diffInfo.FilePath != tt.expectedFile {
+				t.Errorf("Expected FilePath=%q, got %q", tt.expectedFile, diffInfo.FilePath)
+			}
+			if diffInfo.OldContent != tt.expectedOld {
+				t.Errorf("Expected OldContent=%q, got %q", tt.expectedOld, diffInfo.OldContent)
+			}
+			if diffInfo.NewContent != tt.expectedNew {
+				t.Errorf("Expected NewContent=%q, got %q", tt.expectedNew, diffInfo.NewContent)
 			}
 		})
 	}

--- a/internal/services/tools/multiedit_test.go
+++ b/internal/services/tools/multiedit_test.go
@@ -2,13 +2,14 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/inference-gateway/cli/config"
-	"github.com/inference-gateway/cli/internal/domain"
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 func TestMultiEditTool_Definition(t *testing.T) {
@@ -1182,6 +1183,613 @@ func TestMultiEditTool_EdgeCases(t *testing.T) {
 		expected := "package main\n\nfunc main() {}"
 		if string(content) != expected {
 			t.Errorf("Expected: %s, Got: %s", expected, string(content))
+		}
+	})
+}
+
+type multiEditValidateTestCase struct {
+	name      string
+	args      map[string]any
+	wantError bool
+	errMsg    string
+}
+
+func getMultiEditValidateTestCases() []multiEditValidateTestCase {
+	return []multiEditValidateTestCase{
+		{name: "valid single edit", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"old_string": "old", "new_string": "new"}}}, wantError: false},
+		{name: "valid multiple edits", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"old_string": "old1", "new_string": "new1"}, map[string]any{"old_string": "old2", "new_string": "new2"}}}, wantError: false},
+		{name: "valid with replace_all", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"old_string": "old", "new_string": "new", "replace_all": true}}}, wantError: false},
+		{name: "missing file_path", args: map[string]any{"edits": []any{map[string]any{"old_string": "old", "new_string": "new"}}}, wantError: true, errMsg: "file_path parameter is required"},
+		{name: "empty file_path", args: map[string]any{"file_path": "", "edits": []any{map[string]any{"old_string": "old", "new_string": "new"}}}, wantError: true, errMsg: "file_path cannot be empty"},
+		{name: "file_path wrong type", args: map[string]any{"file_path": 123, "edits": []any{map[string]any{"old_string": "old", "new_string": "new"}}}, wantError: true, errMsg: "file_path parameter is required and must be a string"},
+		{name: "missing edits", args: map[string]any{"file_path": "/tmp/test.txt"}, wantError: true, errMsg: "edits parameter is required"},
+		{name: "edits wrong type", args: map[string]any{"file_path": "/tmp/test.txt", "edits": "not an array"}, wantError: true, errMsg: "edits parameter must be an array"},
+		{name: "empty edits array", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{}}, wantError: true, errMsg: "edits array must contain at least one edit operation"},
+		{name: "edit missing old_string", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"new_string": "new"}}}, wantError: true, errMsg: "old_string parameter is required"},
+		{name: "edit missing new_string", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"old_string": "old"}}}, wantError: true, errMsg: "new_string parameter is required"},
+		{name: "edit old_string wrong type", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"old_string": 123, "new_string": "new"}}}, wantError: true, errMsg: "old_string parameter is required and must be a string"},
+		{name: "edit new_string wrong type", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"old_string": "old", "new_string": 123}}}, wantError: true, errMsg: "new_string parameter is required and must be a string"},
+		{name: "edit old and new string same", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"old_string": "same", "new_string": "same"}}}, wantError: true, errMsg: "new_string must be different from old_string"},
+		{name: "edit not an object", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{"not an object"}}, wantError: true, errMsg: "edit at index 0 must be an object"},
+		{name: "second edit invalid", args: map[string]any{"file_path": "/tmp/test.txt", "edits": []any{map[string]any{"old_string": "old1", "new_string": "new1"}, map[string]any{"old_string": "same", "new_string": "same"}}}, wantError: true, errMsg: "new_string must be different from old_string at edit index 1"},
+	}
+}
+
+func runMultiEditValidateTest(t *testing.T, tt multiEditValidateTestCase, tool *MultiEditTool) {
+	t.Helper()
+	err := tool.Validate(tt.args)
+	if tt.wantError {
+		if err == nil {
+			t.Error("Expected error but got none")
+			return
+		}
+		if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+			t.Errorf("Expected error containing '%s', got '%s'", tt.errMsg, err.Error())
+		}
+	} else if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestMultiEditTool_Validate_TableDriven(t *testing.T) {
+	wd, _ := os.Getwd()
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Sandbox: config.SandboxConfig{Directories: []string{wd, "/tmp"}},
+			Edit:    config.EditToolConfig{Enabled: true},
+		},
+	}
+	tool := NewMultiEditTool(cfg)
+
+	for _, tt := range getMultiEditValidateTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			runMultiEditValidateTest(t, tt, tool)
+		})
+	}
+}
+
+func TestMultiEditTool_CleanString_TableDriven(t *testing.T) {
+	wd, _ := os.Getwd()
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Sandbox: config.SandboxConfig{
+				Directories: []string{wd},
+			},
+			Edit: config.EditToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	tool := NewMultiEditTool(cfg)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "tab-separated line number",
+			input:    "  10\tfunc main() {",
+			expected: "func main() {",
+		},
+		{
+			name:     "arrow-separated line number",
+			input:    "  10→func main() {",
+			expected: "func main() {",
+		},
+		{
+			name:     "multi-line with tab prefixes",
+			input:    "   5\tpackage main\n   6\t\n   7\timport \"fmt\"",
+			expected: "package main\n\nimport \"fmt\"",
+		},
+		{
+			name:     "multi-line with arrow prefixes",
+			input:    "   5→package main\n   6→\n   7→import \"fmt\"",
+			expected: "package main\n\nimport \"fmt\"",
+		},
+		{
+			name:     "no prefix - unchanged",
+			input:    "regular content",
+			expected: "regular content",
+		},
+		{
+			name:     "number without separator",
+			input:    "10 items",
+			expected: "10 items",
+		},
+		{
+			name:     "preserve content tabs",
+			input:    "  1\tvar x\t= 10",
+			expected: "var x\t= 10",
+		},
+		{
+			name:     "high line numbers",
+			input:    " 1234\tsome code",
+			expected: "some code",
+		},
+		{
+			name:     "empty content after prefix",
+			input:    "  5\t",
+			expected: "",
+		},
+		{
+			name:     "preserve indentation in content",
+			input:    "  5\t    indented",
+			expected: "    indented",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tool.cleanString(tt.input)
+			if result != tt.expected {
+				t.Errorf("cleanString(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+type multiEditExecuteTestCase struct {
+	name                   string
+	initialContent         string
+	edits                  []any
+	expectedContent        string
+	expectedSuccess        bool
+	expectedSuccessfulEdit int
+	expectedModified       bool
+	errorContains          string
+}
+
+func getMultiEditExecuteTestCases() []multiEditExecuteTestCase {
+	return []multiEditExecuteTestCase{
+		{name: "single edit success", initialContent: "hello world", edits: []any{map[string]any{"old_string": "hello", "new_string": "hi"}}, expectedContent: "hi world", expectedSuccess: true, expectedSuccessfulEdit: 1, expectedModified: true},
+		{name: "multiple sequential edits", initialContent: "aaa bbb ccc", edits: []any{map[string]any{"old_string": "aaa", "new_string": "AAA"}, map[string]any{"old_string": "bbb", "new_string": "BBB"}, map[string]any{"old_string": "ccc", "new_string": "CCC"}}, expectedContent: "AAA BBB CCC", expectedSuccess: true, expectedSuccessfulEdit: 3, expectedModified: true},
+		{name: "replace all in one edit", initialContent: "foo foo foo", edits: []any{map[string]any{"old_string": "foo", "new_string": "bar", "replace_all": true}}, expectedContent: "bar bar bar", expectedSuccess: true, expectedSuccessfulEdit: 1, expectedModified: true},
+		{name: "chained edits", initialContent: "step1", edits: []any{map[string]any{"old_string": "step1", "new_string": "step2"}, map[string]any{"old_string": "step2", "new_string": "step3"}}, expectedContent: "step3", expectedSuccess: true, expectedSuccessfulEdit: 2, expectedModified: true},
+		{name: "unicode content", initialContent: "Hello 世界", edits: []any{map[string]any{"old_string": "世界", "new_string": "World 🌍"}}, expectedContent: "Hello World 🌍", expectedSuccess: true, expectedSuccessfulEdit: 1, expectedModified: true},
+		{name: "multi-line content", initialContent: "line1\nline2\nline3", edits: []any{map[string]any{"old_string": "line1\nline2", "new_string": "newline1\nnewline2"}}, expectedContent: "newline1\nnewline2\nline3", expectedSuccess: true, expectedSuccessfulEdit: 1, expectedModified: true},
+		{name: "delete content", initialContent: "keep remove keep", edits: []any{map[string]any{"old_string": " remove", "new_string": ""}}, expectedContent: "keep keep", expectedSuccess: true, expectedSuccessfulEdit: 1, expectedModified: true},
+		{name: "fail old_string not found", initialContent: "hello world", edits: []any{map[string]any{"old_string": "nonexistent", "new_string": "replacement"}}, expectedContent: "hello world", expectedSuccess: false, errorContains: "old_string not found"},
+		{name: "fail non-unique", initialContent: "dup dup dup", edits: []any{map[string]any{"old_string": "dup", "new_string": "unique"}}, expectedContent: "dup dup dup", expectedSuccess: false, errorContains: "is not unique"},
+		{name: "fail second edit atomic", initialContent: "first second", edits: []any{map[string]any{"old_string": "first", "new_string": "FIRST"}, map[string]any{"old_string": "nonexistent", "new_string": "replacement"}}, expectedContent: "first second", expectedSuccess: false, errorContains: "old_string not found"},
+		{name: "preserve whitespace", initialContent: "  indented\n\tTabbed", edits: []any{map[string]any{"old_string": "  indented", "new_string": "    more indented"}}, expectedContent: "    more indented\n\tTabbed", expectedSuccess: true, expectedSuccessfulEdit: 1, expectedModified: true},
+	}
+}
+
+func runMultiEditExecuteTest(t *testing.T, tt multiEditExecuteTestCase, tmpDir string, cfg *config.Config) {
+	t.Helper()
+	testFile := filepath.Join(tmpDir, strings.ReplaceAll(tt.name, " ", "_")+".txt")
+	if err := os.WriteFile(testFile, []byte(tt.initialContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	mockTracker := &MockReadToolTracker{readToolUsed: true}
+	tool := NewMultiEditToolWithRegistry(cfg, mockTracker)
+	args := map[string]any{"file_path": testFile, "edits": tt.edits}
+
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned unexpected error: %v", err)
+	}
+
+	if result.Success != tt.expectedSuccess {
+		t.Errorf("Expected success=%v, got %v. Error: %s", tt.expectedSuccess, result.Success, result.Error)
+	}
+
+	if tt.expectedSuccess {
+		multiEditResult, ok := result.Data.(*domain.MultiEditToolResult)
+		if !ok {
+			t.Fatal("Expected MultiEditToolResult in result data")
+		}
+		if multiEditResult.SuccessfulEdits != tt.expectedSuccessfulEdit {
+			t.Errorf("Expected %d successful edits, got %d", tt.expectedSuccessfulEdit, multiEditResult.SuccessfulEdits)
+		}
+		if multiEditResult.FileModified != tt.expectedModified {
+			t.Errorf("Expected FileModified=%v, got %v", tt.expectedModified, multiEditResult.FileModified)
+		}
+	}
+
+	if tt.errorContains != "" && !strings.Contains(result.Error, tt.errorContains) {
+		t.Errorf("Expected error containing '%s', got '%s'", tt.errorContains, result.Error)
+	}
+
+	content, err := os.ReadFile(testFile)
+	if err != nil {
+		t.Fatalf("Failed to read test file: %v", err)
+	}
+	if string(content) != tt.expectedContent {
+		t.Errorf("Expected file content:\n%q\nGot:\n%q", tt.expectedContent, string(content))
+	}
+}
+
+func TestMultiEditTool_Execute_TableDriven(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Sandbox: config.SandboxConfig{Directories: []string{tmpDir}},
+			Edit:    config.EditToolConfig{Enabled: true},
+		},
+	}
+
+	for _, tt := range getMultiEditExecuteTestCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			runMultiEditExecuteTest(t, tt, tmpDir, cfg)
+		})
+	}
+}
+
+func TestMultiEditTool_FormatResult_TableDriven(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Edit: config.EditToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	tool := NewMultiEditTool(cfg)
+
+	tests := []struct {
+		name       string
+		result     *domain.ToolExecutionResult
+		formatType domain.FormatterType
+		contains   []string
+	}{
+		{
+			name: "FormatPreview - successful multiple edits",
+			result: &domain.ToolExecutionResult{
+				ToolName: "MultiEdit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path": "/path/to/file.go",
+					"edits": []any{
+						map[string]any{"old_string": "a", "new_string": "b"},
+						map[string]any{"old_string": "c", "new_string": "d"},
+					},
+				},
+				Data: &domain.MultiEditToolResult{
+					FilePath:        "/path/to/file.go",
+					TotalEdits:      2,
+					SuccessfulEdits: 2,
+					FileModified:    true,
+					BytesDifference: 10,
+				},
+			},
+			formatType: domain.FormatterShort,
+			contains:   []string{"Applied", "2/2", "edits"},
+		},
+		{
+			name: "FormatPreview - no changes",
+			result: &domain.ToolExecutionResult{
+				ToolName: "MultiEdit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path": "/path/to/file.go",
+					"edits":     []any{},
+				},
+				Data: &domain.MultiEditToolResult{
+					FilePath:     "/path/to/file.go",
+					FileModified: false,
+				},
+			},
+			formatType: domain.FormatterShort,
+			contains:   []string{"No changes"},
+		},
+		{
+			name: "FormatUI - collapsed view with edit count",
+			result: &domain.ToolExecutionResult{
+				ToolName: "MultiEdit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path": "/path/to/file.go",
+					"edits": []any{
+						map[string]any{"old_string": "a", "new_string": "b"},
+						map[string]any{"old_string": "c", "new_string": "d"},
+						map[string]any{"old_string": "e", "new_string": "f"},
+					},
+				},
+				Data: &domain.MultiEditToolResult{
+					FilePath:        "/path/to/file.go",
+					TotalEdits:      3,
+					SuccessfulEdits: 3,
+					FileModified:    true,
+				},
+			},
+			formatType: domain.FormatterUI,
+			contains:   []string{"MultiEdit(", "3 edits", "file.go"},
+		},
+		{
+			name: "FormatUI - failed edit",
+			result: &domain.ToolExecutionResult{
+				ToolName: "MultiEdit",
+				Success:  false,
+				Error:    "old_string not found",
+				Arguments: map[string]any{
+					"file_path": "/path/to/file.go",
+					"edits": []any{
+						map[string]any{"old_string": "missing", "new_string": "new"},
+					},
+				},
+			},
+			formatType: domain.FormatterUI,
+			contains:   []string{"MultiEdit(", "✗"},
+		},
+		{
+			name:       "FormatResult - nil result",
+			result:     nil,
+			formatType: domain.FormatterUI,
+			contains:   []string{"unavailable"},
+		},
+		{
+			name: "FormatLLM - successful with details",
+			result: &domain.ToolExecutionResult{
+				ToolName: "MultiEdit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path": "/path/to/file.go",
+					"edits": []any{
+						map[string]any{"old_string": "old", "new_string": "new"},
+					},
+				},
+				Data: &domain.MultiEditToolResult{
+					FilePath:        "/path/to/file.go",
+					TotalEdits:      1,
+					SuccessfulEdits: 1,
+					FileModified:    true,
+					BytesDifference: 5,
+				},
+			},
+			formatType: domain.FormatterLLM,
+			contains:   []string{"MultiEdit"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := tool.FormatResult(tt.result, tt.formatType)
+			for _, expected := range tt.contains {
+				if !strings.Contains(output, expected) {
+					t.Errorf("FormatResult output should contain '%s', got:\n%s", expected, output)
+				}
+			}
+		})
+	}
+}
+
+func testMultiEditEdgeCaseLargeEdits(t *testing.T, tmpDir string, tool *MultiEditTool) {
+	t.Helper()
+	testFile := filepath.Join(tmpDir, "many_edits.txt")
+	if err := os.WriteFile(testFile, []byte("[a1] [a2] [a3] [a4] [a5] [a6] [a7] [a8] [a9] [a10]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	edits := make([]any, 10)
+	for i := range 10 {
+		edits[i] = map[string]any{"old_string": fmt.Sprintf("[a%d]", i+1), "new_string": fmt.Sprintf("[b%d]", i+1)}
+	}
+	result, err := tool.Execute(context.Background(), map[string]any{"file_path": testFile, "edits": edits})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+	newContent, _ := os.ReadFile(testFile)
+	if string(newContent) != "[b1] [b2] [b3] [b4] [b5] [b6] [b7] [b8] [b9] [b10]" {
+		t.Errorf("Unexpected content: %q", string(newContent))
+	}
+}
+
+func testMultiEditEdgeCaseCancelEdits(t *testing.T, tmpDir string, tool *MultiEditTool) {
+	t.Helper()
+	testFile := filepath.Join(tmpDir, "cancel_edits.txt")
+	if err := os.WriteFile(testFile, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	args := map[string]any{"file_path": testFile, "edits": []any{map[string]any{"old_string": "original", "new_string": "modified"}, map[string]any{"old_string": "modified", "new_string": "original"}}}
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+	newContent, _ := os.ReadFile(testFile)
+	if string(newContent) != "original" {
+		t.Errorf("Expected 'original', got %q", string(newContent))
+	}
+}
+
+func testMultiEditEdgeCaseBinary(t *testing.T, tmpDir string, tool *MultiEditTool) {
+	t.Helper()
+	testFile := filepath.Join(tmpDir, "binary.txt")
+	if err := os.WriteFile(testFile, []byte("start\x00middle\x00end"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := tool.Execute(context.Background(), map[string]any{"file_path": testFile, "edits": []any{map[string]any{"old_string": "middle", "new_string": "replaced"}}})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+}
+
+func testMultiEditEdgeCaseCRLF(t *testing.T, tmpDir string, tool *MultiEditTool) {
+	t.Helper()
+	testFile := filepath.Join(tmpDir, "crlf.txt")
+	if err := os.WriteFile(testFile, []byte("line1\r\nline2\r\nline3"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := tool.Execute(context.Background(), map[string]any{"file_path": testFile, "edits": []any{map[string]any{"old_string": "line2", "new_string": "replaced"}}})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("Expected success, got error: %s", result.Error)
+	}
+	newContent, _ := os.ReadFile(testFile)
+	if !strings.Contains(string(newContent), "replaced") {
+		t.Errorf("Expected content to contain 'replaced', got %q", string(newContent))
+	}
+}
+
+func testMultiEditEdgeCaseDirectory(t *testing.T, tmpDir string, tool *MultiEditTool) {
+	t.Helper()
+	result, err := tool.Execute(context.Background(), map[string]any{"file_path": tmpDir, "edits": []any{map[string]any{"old_string": "old", "new_string": "new"}}})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if result.Success {
+		t.Error("Expected failure when path is a directory")
+	}
+	if !strings.Contains(result.Error, "is a directory") {
+		t.Errorf("Expected error about directory, got: %s", result.Error)
+	}
+}
+
+func TestMultiEditTool_AdditionalEdgeCases(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Sandbox: config.SandboxConfig{Directories: []string{tmpDir}},
+			Edit:    config.EditToolConfig{Enabled: true},
+		},
+	}
+	mockTracker := &MockReadToolTracker{readToolUsed: true}
+	tool := NewMultiEditToolWithRegistry(cfg, mockTracker)
+
+	t.Run("large number of edits", func(t *testing.T) { testMultiEditEdgeCaseLargeEdits(t, tmpDir, tool) })
+	t.Run("cancel edits", func(t *testing.T) { testMultiEditEdgeCaseCancelEdits(t, tmpDir, tool) })
+	t.Run("binary content", func(t *testing.T) { testMultiEditEdgeCaseBinary(t, tmpDir, tool) })
+	t.Run("CRLF", func(t *testing.T) { testMultiEditEdgeCaseCRLF(t, tmpDir, tool) })
+	t.Run("directory path", func(t *testing.T) { testMultiEditEdgeCaseDirectory(t, tmpDir, tool) })
+}
+
+func TestMultiEditTool_ShouldCollapseArg(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Edit: config.EditToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	tool := NewMultiEditTool(cfg)
+
+	tests := []struct {
+		arg      string
+		expected bool
+	}{
+		{"edits", true},
+		{"file_path", false},
+		{"other_param", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			result := tool.ShouldCollapseArg(tt.arg)
+			if result != tt.expected {
+				t.Errorf("ShouldCollapseArg(%s) = %v, expected %v", tt.arg, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMultiEditTool_GetDiffInfo(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "multiedit_diffinfo_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
+
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Edit: config.EditToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	tool := NewMultiEditTool(cfg)
+
+	t.Run("valid edits simulation", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "test.txt")
+		err := os.WriteFile(testFile, []byte("hello world"), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		args := map[string]any{
+			"file_path": testFile,
+			"edits": []any{
+				map[string]any{
+					"old_string": "hello",
+					"new_string": "hi",
+				},
+			},
+		}
+
+		diffInfo := tool.GetDiffInfo(args)
+
+		if diffInfo.FilePath != testFile {
+			t.Errorf("Expected FilePath=%q, got %q", testFile, diffInfo.FilePath)
+		}
+
+		if diffInfo.OldContent != "hello world" {
+			t.Errorf("Expected OldContent='hello world', got %q", diffInfo.OldContent)
+		}
+
+		if diffInfo.NewContent != "hi world" {
+			t.Errorf("Expected NewContent='hi world', got %q", diffInfo.NewContent)
+		}
+	})
+
+	t.Run("invalid edits format", func(t *testing.T) {
+		args := map[string]any{
+			"file_path": "/path/to/file.go",
+			"edits":     "not an array",
+		}
+
+		diffInfo := tool.GetDiffInfo(args)
+
+		if !strings.Contains(diffInfo.NewContent, "Invalid") {
+			t.Errorf("Expected error message about invalid format, got: %s", diffInfo.NewContent)
+		}
+	})
+
+	t.Run("edit would fail - old_string not found", func(t *testing.T) {
+		testFile := filepath.Join(tmpDir, "notfound.txt")
+		err := os.WriteFile(testFile, []byte("hello world"), 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		args := map[string]any{
+			"file_path": testFile,
+			"edits": []any{
+				map[string]any{
+					"old_string": "nonexistent",
+					"new_string": "new",
+				},
+			},
+		}
+
+		diffInfo := tool.GetDiffInfo(args)
+
+		if !strings.Contains(diffInfo.NewContent, "failed") || !strings.Contains(diffInfo.NewContent, "not found") {
+			t.Errorf("Expected failure message, got: %s", diffInfo.NewContent)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive table-driven tests for the Edit and MultiEdit tools to improve test coverage and maintainability.

## Changes

- Added table-driven test structure for Edit tool functionality
- Added table-driven test structure for MultiEdit tool functionality  
- Improved test organization and maintainability
- Added test cases covering various edit scenarios

## Testing

- All tests pass successfully
- Test coverage improved for edit operations
- Maintains backward compatibility