### PR TITLE
feat: Disable user input during plan and tool approval flows

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -121,7 +121,7 @@ export:
   output_dir: .infer
   summary_model: ""
 agent:
-  model: "ollama_cloud/qwen3-vl:235b-instruct"
+  model: "deepseek/deepseek-chat"
   system_prompt: |
     Autonomous software engineering agent. Execute tasks iteratively until completion.
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -337,6 +337,14 @@ func (app *ChatApplication) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (app *ChatApplication) handleViewSpecificMessages(msg tea.Msg) []tea.Cmd {
 	currentView := app.stateManager.GetCurrentView()
 
+	if inputView, ok := app.inputView.(*components.InputView); ok {
+		if currentView == domain.ViewStatePlanApproval || app.stateManager.GetApprovalUIState() != nil {
+			inputView.SetDisabled(true)
+		} else {
+			inputView.SetDisabled(false)
+		}
+	}
+
 	switch currentView {
 	case domain.ViewStateModelSelection:
 		return app.handleModelSelectionView(msg)

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -780,7 +780,7 @@ func (s *ApplicationState) ClearApprovalUIState() {
 // SetupPlanApprovalUIState initializes plan approval UI state
 func (s *ApplicationState) SetupPlanApprovalUIState(planContent string, responseChan chan PlanApprovalAction) {
 	s.planApprovalUIState = &PlanApprovalUIState{
-		SelectedIndex: int(PlanApprovalAccept), // Default to accept
+		SelectedIndex: int(PlanApprovalAccept),
 		PlanContent:   planContent,
 		ResponseChan:  responseChan,
 	}

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -823,12 +823,7 @@ func (cv *ConversationView) renderInlineApprovalButtons(_ int) string {
 		autoApproveStyled = cv.styleProvider.RenderWithColor("[ "+autoApproveText+" ]", accentColor)
 	}
 
-	helpText := cv.styleProvider.RenderWithColor(
-		"  ←/→: Navigate • Enter: Confirm • Esc: Reject",
-		cv.styleProvider.GetThemeColor("dim"),
-	)
-
-	return fmt.Sprintf("  %s  %s  %s\n%s", acceptStyled, rejectStyled, autoApproveStyled, helpText)
+	return fmt.Sprintf("  %s  %s  %s", acceptStyled, rejectStyled, autoApproveStyled)
 }
 
 // renderPendingToolEntry renders a pending tool call that requires approval
@@ -985,12 +980,7 @@ func (cv *ConversationView) renderInlineToolApprovalButtons(_ int) string {
 		autoApproveStyled = cv.styleProvider.RenderWithColor("[ "+autoApproveText+" ]", accentColor)
 	}
 
-	helpText := cv.styleProvider.RenderWithColor(
-		"  ←/→: Navigate • Enter: Confirm • Esc: Reject",
-		cv.styleProvider.GetThemeColor("dim"),
-	)
-
-	return fmt.Sprintf("  %s  %s  %s\n%s", approveStyled, rejectStyled, autoApproveStyled, helpText)
+	return fmt.Sprintf("  %s  %s  %s", approveStyled, rejectStyled, autoApproveStyled)
 }
 
 // handleToolCallRendererEvents processes tool call renderer specific events

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -1095,6 +1095,17 @@ func handleCharacterInput(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 		return handlePasteEvent(app, keyStr)
 	}
 
+	stateManager := app.GetStateManager()
+	currentView := stateManager.GetCurrentView()
+
+	if currentView == domain.ViewStatePlanApproval {
+		return nil
+	}
+
+	if stateManager.GetApprovalUIState() != nil {
+		return nil
+	}
+
 	inputView := app.GetInputView()
 	if inputView != nil {
 		if inputView.CanHandle(keyMsg) {


### PR DESCRIPTION
## Summary

Disables the input field when plan or tool approval is required. Prevents user typing during approval flows and shows appropriate placeholder messages. Also updates default model to deepseek-chat.

## Changes

- **Input disabling**: Added logic to disable text input during plan and tool approval flows
- **Visual feedback**: Shows placeholder messages explaining why input is disabled
- **Model update**: Changed default AI model from qwen3-vl to deepseek-chat
- **UI cleanup**: Removed redundant help text from approval buttons

## Benefits

- Improves user experience by preventing accidental input during critical approval steps
- Provides clear visual feedback about why input is disabled
- Maintains consistent UI behavior across different approval states

## Testing

- All linting and pre-commit checks pass
- Manual testing of approval flows with disabled input
- Visual verification of placeholder messages