### PR TITLE
fix: Improve bash output formatting and truncation limits

### DIFF
--- a/internal/services/tools/bash.go
+++ b/internal/services/tools/bash.go
@@ -341,7 +341,15 @@ func (t *BashTool) FormatPreview(result *domain.ToolExecutionResult) string {
 	}
 
 	if bashResult.ExitCode == 0 && bashResult.Output != "" {
-		return t.formatter.TruncateText(strings.TrimSpace(bashResult.Output), 60)
+		output := strings.TrimSpace(bashResult.Output)
+		lines := strings.Split(output, "\n")
+
+		if len(lines) <= 4 {
+			return output
+		}
+
+		preview := strings.Join(lines[:4], "\n")
+		return preview + "\n..."
 	} else if bashResult.ExitCode != 0 {
 		return fmt.Sprintf("Exit code: %d", bashResult.ExitCode)
 	}
@@ -360,7 +368,15 @@ func (t *BashTool) FormatForUI(result *domain.ToolExecutionResult) string {
 
 	var output strings.Builder
 	output.WriteString(fmt.Sprintf("%s\n", toolCall))
-	output.WriteString(fmt.Sprintf("└─ %s %s", statusIcon, preview))
+
+	previewLines := strings.Split(preview, "\n")
+	for i, line := range previewLines {
+		if i == 0 {
+			output.WriteString(fmt.Sprintf("└─ %s %s", statusIcon, line))
+		} else {
+			output.WriteString(fmt.Sprintf("\n     %s", line))
+		}
+	}
 
 	return output.String()
 }
@@ -395,7 +411,6 @@ func (t *BashTool) formatBashData(data any) string {
 	}
 
 	var output strings.Builder
-	output.WriteString(fmt.Sprintf("Command: %s\n", bashResult.Command))
 	output.WriteString(fmt.Sprintf("Exit Code: %d\n", bashResult.ExitCode))
 	if bashResult.Error != "" {
 		output.WriteString(fmt.Sprintf("Error: %s\n", bashResult.Error))

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -515,10 +515,10 @@ func (cv *ConversationView) formatCompactContent(entry domain.ConversationEntry)
 func (cv *ConversationView) formatToolContentCompact(content string) string {
 	if cv.toolFormatter == nil {
 		lines := strings.Split(content, "\n")
-		if len(lines) <= 3 {
+		if len(lines) <= 4 {
 			return content
 		}
-		return strings.Join(lines[:3], "\n") + "\n... (truncated)"
+		return strings.Join(lines[:4], "\n") + "\n... (truncated)"
 	}
 
 	lines := strings.Split(content, "\n")
@@ -534,10 +534,10 @@ func (cv *ConversationView) formatToolContentCompact(content string) string {
 		}
 	}
 
-	if len(result) <= 3 {
+	if len(result) <= 4 {
 		return strings.Join(result, "\n")
 	}
-	return strings.Join(result[:3], "\n") + "\n... (truncated)"
+	return strings.Join(result[:4], "\n") + "\n... (truncated)"
 }
 
 type ToolCallInfo struct {


### PR DESCRIPTION
Updates bash tool output formatting to show up to 4 lines instead of truncating at 60 characters. Improves multi-line display in the UI and increases truncation limits for tool content from 3 to 4 lines for better readability.

## Changes
- **bash.go**: Enhanced output formatting to display up to 4 lines of command output instead of truncating at 60 characters
- **conversation_view.go**: Increased truncation limit from 3 to 4 lines for tool content display

## Benefits
- Better visibility of command outputs in the UI
- Improved readability for multi-line command results
- More context shown while maintaining clean truncation for longer outputs