### PR TITLE
refactor: Separate autocomplete component from input view

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -225,9 +225,11 @@ tasks:
       - go run github.com/maxbrunsfeld/counterfeiter/v6 -o tests/mocks/ui internal/ui SelectionComponent
       - go run github.com/maxbrunsfeld/counterfeiter/v6 -o tests/mocks/ui internal/ui Theme
       - go run github.com/maxbrunsfeld/counterfeiter/v6 -o tests/mocks/ui internal/ui/autocomplete ShortcutRegistry
-      - go run github.com/maxbrunsfeld/counterfeiter/v6 -o tests/mocks/ui internal/ui AutocompleteInterface
+      - go run github.com/maxbrunsfeld/counterfeiter/v6 -o tests/mocks/ui internal/ui AutocompleteComponent
       - mkdir -p tests/mocks/history
       - go run github.com/maxbrunsfeld/counterfeiter/v6 -o tests/mocks/history internal/ui/history ShellHistoryProvider
+      - mkdir -p tests/mocks/keybinding
+      - go run github.com/maxbrunsfeld/counterfeiter/v6 -o tests/mocks/keybinding internal/ui/keybinding KeyHandlerContext
     sources:
       - "internal/domain/interfaces.go"
       - "internal/domain/agent.go"

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -111,6 +111,7 @@ func StartChatSession(cfg *config.Config, v *viper.Viper) error {
 	program := tea.NewProgram(
 		application,
 		tea.WithMouseCellMotion(),
+		tea.WithReportFocus(),
 	)
 
 	if _, err := program.Run(); err != nil {

--- a/internal/domain/ui_events.go
+++ b/internal/domain/ui_events.go
@@ -49,6 +49,25 @@ type SetInputEvent struct {
 	Text string
 }
 
+// AutocompleteUpdateEvent is fired when input text changes and autocomplete should update
+type AutocompleteUpdateEvent struct {
+	Text      string
+	CursorPos int
+}
+
+// AutocompleteHideEvent is fired when autocomplete should be hidden
+type AutocompleteHideEvent struct{}
+
+// AutocompleteCompleteEvent is fired when a completion is selected
+type AutocompleteCompleteEvent struct {
+	Completion string
+}
+
+// AutocompleteVisibilityCheckEvent requests autocomplete visibility state
+type AutocompleteVisibilityCheckEvent struct {
+	ResponseChan chan bool
+}
+
 // UserInputEvent represents user input submission
 type UserInputEvent struct {
 	Content string

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -767,9 +767,14 @@ func isUIOnlyEvent(msg tea.Msg) bool {
 		domain.ThemeSelectedEvent,
 		domain.ShowPlanApprovalEvent,
 		domain.RefreshAutocompleteEvent,
+		domain.AutocompleteUpdateEvent,
+		domain.AutocompleteHideEvent,
+		domain.AutocompleteCompleteEvent,
 		tea.KeyMsg,
 		tea.WindowSizeMsg,
 		tea.MouseMsg,
+		tea.FocusMsg,
+		tea.BlurMsg,
 		spinner.TickMsg:
 		return true
 	}

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -271,25 +271,34 @@ func (cv *ConversationView) updateViewportContentFull() {
 }
 
 func (cv *ConversationView) renderWelcome() string {
-	wd, err := os.Getwd()
-	if err != nil {
-		wd = "unknown"
-	}
-
 	statusColor := cv.styleProvider.GetThemeColor("status")
 	successColor := cv.styleProvider.GetThemeColor("success")
 	dimColor := cv.styleProvider.GetThemeColor("dim")
-	headerColor := cv.getHeaderColor()
 
 	headerLine := cv.styleProvider.RenderWithColor("✨ Inference Gateway CLI", statusColor)
 	readyLine := cv.styleProvider.RenderWithColor("🚀 Ready to chat!", successColor)
-	workingLinePrefix := cv.styleProvider.RenderWithColor("📂 Working in: ", dimColor)
-	workingLinePath := cv.styleProvider.RenderWithColor(wd, headerColor)
-	workingLine := workingLinePrefix + workingLinePath
 
-	configLine := cv.buildConfigLine()
+	var content string
 
-	content := headerLine + "\n\n" + readyLine + "\n\n" + workingLine + "\n\n" + configLine
+	if cv.height >= 20 {
+		wd, err := os.Getwd()
+		if err != nil {
+			wd = "unknown"
+		}
+
+		headerColor := cv.getHeaderColor()
+
+		workingLinePrefix := cv.styleProvider.RenderWithColor("📂 Working in: ", dimColor)
+		workingLinePath := cv.styleProvider.RenderWithColor(wd, headerColor)
+		workingLine := workingLinePrefix + workingLinePath
+
+		configLine := cv.buildConfigLine()
+
+		content = headerLine + "\n\n" + readyLine + "\n\n" + workingLine + "\n\n" + configLine
+	} else {
+		separator := cv.styleProvider.RenderWithColor("  •  ", dimColor)
+		content = headerLine + separator + readyLine
+	}
 
 	return cv.styleProvider.RenderBorderedBox(content, cv.styleProvider.GetThemeColor("accent"), 1, 1)
 }

--- a/internal/ui/components/factory/factory.go
+++ b/internal/ui/components/factory/factory.go
@@ -16,32 +16,26 @@ func CreateConversationView(themeService domain.ThemeService) ui.ConversationRen
 }
 
 // CreateInputView creates a new input view component
-func CreateInputView(modelService domain.ModelService, shortcutRegistry *shortcuts.Registry) ui.InputComponent {
-	iv := components.NewInputView(modelService)
-
-	if shortcutRegistry != nil {
-		iv.Autocomplete = autocomplete.NewAutocomplete(ui.NewDefaultTheme(), shortcutRegistry)
-	}
-	return iv
+func CreateInputView(modelService domain.ModelService) ui.InputComponent {
+	return components.NewInputView(modelService)
 }
 
-// CreateInputViewWithToolService creates a new input view component with tool service
-func CreateInputViewWithToolService(modelService domain.ModelService, shortcutRegistry *shortcuts.Registry, toolService domain.ToolService) ui.InputComponent {
-	return CreateInputViewWithToolServiceAndConfigDir(modelService, shortcutRegistry, toolService, "")
+// CreateInputViewWithConfigDir creates a new input view component with config directory
+func CreateInputViewWithConfigDir(modelService domain.ModelService, configDir string) ui.InputComponent {
+	return components.NewInputViewWithConfigDir(modelService, configDir)
 }
 
-// CreateInputViewWithToolServiceAndConfigDir creates a new input view component with tool service and config directory
-func CreateInputViewWithToolServiceAndConfigDir(modelService domain.ModelService, shortcutRegistry *shortcuts.Registry, toolService domain.ToolService, configDir string) ui.InputComponent {
-	iv := components.NewInputViewWithConfigDir(modelService, configDir)
-
-	if shortcutRegistry != nil {
-		autocomplete := autocomplete.NewAutocomplete(ui.NewDefaultTheme(), shortcutRegistry)
-		if toolService != nil {
-			autocomplete.SetToolService(toolService)
-		}
-		iv.Autocomplete = autocomplete
+// CreateAutocomplete creates a new autocomplete component
+func CreateAutocomplete(shortcutRegistry *shortcuts.Registry, toolService domain.ToolService) ui.AutocompleteComponent {
+	if shortcutRegistry == nil {
+		return nil
 	}
-	return iv
+
+	ac := autocomplete.NewAutocomplete(ui.NewDefaultTheme(), shortcutRegistry)
+	if toolService != nil {
+		ac.SetToolService(toolService)
+	}
+	return ac
 }
 
 // CreateStatusView creates a new status view component

--- a/internal/ui/components/factory/factory_test.go
+++ b/internal/ui/components/factory/factory_test.go
@@ -28,7 +28,7 @@ func TestCreateInputView(t *testing.T) {
 	mockModelService.ValidateModelReturns(nil)
 	mockModelService.IsVisionModelReturns(false)
 
-	iv := CreateInputView(mockModelService, nil)
+	iv := CreateInputView(mockModelService)
 
 	if iv == nil {
 		t.Fatal("Expected CreateInputView to return non-nil component")

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -72,7 +72,7 @@ func (isb *InputStatusBar) SetHeight(height int) {
 func (isb *InputStatusBar) Render() string {
 	renderedLeft := isb.buildLeftText()
 	modeIndicator := isb.getAgentModeIndicator()
-	availableWidth := isb.width - 4 - 2
+	availableWidth := isb.width - 2 - 2
 	return isb.combineLeftAndRight(renderedLeft, modeIndicator, availableWidth)
 }
 
@@ -228,34 +228,43 @@ func (isb *InputStatusBar) getAgentModeIndicator() string {
 
 // combineLeftAndRight combines the left text and right mode indicator with appropriate spacing
 func (isb *InputStatusBar) combineLeftAndRight(renderedLeft string, modeIndicator string, availableWidth int) string {
-	// Add left padding to match input field alignment
-	leftPadding := "  "
+	const leftPadding = "  "
 
-	if renderedLeft != "" && modeIndicator != "" {
-		leftWidth := isb.styleProvider.GetWidth(renderedLeft)
-		rightWidth := isb.styleProvider.GetWidth(modeIndicator)
-		spacingWidth := availableWidth - leftWidth - rightWidth
-
-		if spacingWidth > 0 {
-			return leftPadding + renderedLeft + strings.Repeat(" ", spacingWidth) + modeIndicator
-		}
-		return leftPadding + renderedLeft + " " + modeIndicator
+	if renderedLeft == "" && modeIndicator == "" {
+		return leftPadding + "\u00A0"
 	}
 
-	if renderedLeft != "" {
+	if renderedLeft == "" {
+		return leftPadding + isb.formatRightOnly(modeIndicator, availableWidth)
+	}
+
+	if modeIndicator == "" {
 		return leftPadding + renderedLeft
 	}
 
-	if modeIndicator != "" {
-		rightWidth := isb.styleProvider.GetWidth(modeIndicator)
-		spacingWidth := availableWidth - rightWidth
-		if spacingWidth > 0 {
-			return leftPadding + strings.Repeat(" ", spacingWidth) + modeIndicator
-		}
-		return leftPadding + modeIndicator
-	}
+	return leftPadding + isb.formatBothSides(renderedLeft, modeIndicator, availableWidth)
+}
 
-	return leftPadding + "\u00A0"
+// formatBothSides formats content when both left and right text are present
+func (isb *InputStatusBar) formatBothSides(renderedLeft, modeIndicator string, availableWidth int) string {
+	leftWidth := isb.styleProvider.GetWidth(renderedLeft)
+	rightWidth := isb.styleProvider.GetWidth(modeIndicator)
+	spacingWidth := availableWidth - leftWidth - rightWidth
+
+	if spacingWidth > 0 {
+		return renderedLeft + strings.Repeat(" ", spacingWidth) + modeIndicator
+	}
+	return renderedLeft + " " + modeIndicator
+}
+
+// formatRightOnly formats content when only right text is present
+func (isb *InputStatusBar) formatRightOnly(modeIndicator string, availableWidth int) string {
+	rightWidth := isb.styleProvider.GetWidth(modeIndicator)
+	spacingWidth := availableWidth - rightWidth
+	if spacingWidth > 0 {
+		return strings.Repeat(" ", spacingWidth) + modeIndicator
+	}
+	return modeIndicator
 }
 
 // Bubble Tea interface

--- a/internal/ui/components/input_view_test.go
+++ b/internal/ui/components/input_view_test.go
@@ -32,7 +32,6 @@ func createInputViewWithTheme(modelService domain.ModelService) *InputView {
 		width:            80,
 		height:           5,
 		modelService:     modelService,
-		Autocomplete:     nil,
 		historyManager:   history.NewMemoryOnlyHistoryManager(5),
 		themeService:     nil,
 		imageAttachments: []domain.ImageAttachment{},

--- a/internal/ui/components/todo_box_view.go
+++ b/internal/ui/components/todo_box_view.go
@@ -164,7 +164,8 @@ func (tv *TodoBoxView) renderCollapsed() string {
 	indicatorStyled := tv.styleProvider.RenderWithColor(indicator, accentColor)
 	hintStyled := tv.styleProvider.RenderWithColor(hint, dimColor)
 
-	return fmt.Sprintf("%s %s", indicatorStyled, hintStyled)
+	leftPadding := "  "
+	return fmt.Sprintf("%s%s %s", leftPadding, indicatorStyled, hintStyled)
 }
 
 // renderExpanded renders the full expanded view

--- a/internal/ui/interfaces.go
+++ b/internal/ui/interfaces.go
@@ -22,12 +22,13 @@ const (
 	ScrollToBottom
 )
 
-// AutocompleteInterface defines the interface for autocomplete functionality
-type AutocompleteInterface interface {
+// AutocompleteComponent defines the interface for autocomplete functionality
+type AutocompleteComponent interface {
 	Update(inputText string, cursorPos int)
 	HandleKey(key tea.KeyMsg) (bool, string)
 	IsVisible() bool
 	SetWidth(width int)
+	SetHeight(height int)
 	Render() string
 	GetSelectedShortcut() string
 	Hide()
@@ -79,8 +80,6 @@ type InputComponent interface {
 	CanHandle(key tea.KeyMsg) bool
 	NavigateHistoryUp()
 	NavigateHistoryDown()
-	IsAutocompleteVisible() bool
-	TryHandleAutocomplete(key tea.KeyMsg) (handled bool, completion string)
 	AddImageAttachment(image domain.ImageAttachment)
 	GetImageAttachments() []domain.ImageAttachment
 	ClearImageAttachments()

--- a/internal/ui/keybinding/registry_test.go
+++ b/internal/ui/keybinding/registry_test.go
@@ -16,26 +16,21 @@ import (
 func newTestContext(currentView domain.ViewState, inputText string) *keybindingmocks.FakeKeyHandlerContext {
 	fake := &keybindingmocks.FakeKeyHandlerContext{}
 
-	// Setup state manager
 	stateManager := services.NewStateManager(false)
 	_ = stateManager.TransitionToView(currentView)
 	fake.GetStateManagerReturns(stateManager)
 
-	// Setup input component
 	fakeInput := &uimocks.FakeInputComponent{}
 	fakeInput.GetInputReturns(inputText)
 	fakeInput.GetCursorReturns(0)
 	fake.GetInputViewReturns(fakeInput)
 
-	// Setup conversation view
 	fakeConversation := &uimocks.FakeConversationRenderer{}
 	fake.GetConversationViewReturns(fakeConversation)
 
-	// Setup status view
 	fakeStatus := &uimocks.FakeStatusComponent{}
 	fake.GetStatusViewReturns(fakeStatus)
 
-	// Setup other defaults
 	fake.GetPageSizeReturns(20)
 	fake.GetMouseEnabledReturns(false)
 	fake.GetConfigReturns(nil)

--- a/internal/ui/keybinding/types.go
+++ b/internal/ui/keybinding/types.go
@@ -25,6 +25,7 @@ type KeyHandlerContext interface {
 	GetConversationView() ui.ConversationRenderer
 	GetInputView() ui.InputComponent
 	GetStatusView() ui.StatusComponent
+	GetAutocomplete() ui.AutocompleteComponent
 
 	// Actions
 	ToggleToolResultExpansion()

--- a/internal/ui/styles/provider.go
+++ b/internal/ui/styles/provider.go
@@ -599,3 +599,8 @@ func (p *Provider) GetSpinnerStyle() lipgloss.Style {
 func (p *Provider) GetThemeService() domain.ThemeService {
 	return p.themeService
 }
+
+// RenderStatusLine renders a status line with no padding
+func (p *Provider) RenderStatusLine(content string) string {
+	return content
+}

--- a/tests/mocks/keybinding/fake_key_handler_context.go
+++ b/tests/mocks/keybinding/fake_key_handler_context.go
@@ -22,6 +22,16 @@ type FakeKeyHandlerContext struct {
 	getAgentServiceReturnsOnCall map[int]struct {
 		result1 domain.AgentService
 	}
+	GetAutocompleteStub        func() ui.AutocompleteComponent
+	getAutocompleteMutex       sync.RWMutex
+	getAutocompleteArgsForCall []struct {
+	}
+	getAutocompleteReturns struct {
+		result1 ui.AutocompleteComponent
+	}
+	getAutocompleteReturnsOnCall map[int]struct {
+		result1 ui.AutocompleteComponent
+	}
 	GetConfigStub        func() *config.Config
 	getConfigMutex       sync.RWMutex
 	getConfigArgsForCall []struct {
@@ -189,6 +199,59 @@ func (fake *FakeKeyHandlerContext) GetAgentServiceReturnsOnCall(i int, result1 d
 	}
 	fake.getAgentServiceReturnsOnCall[i] = struct {
 		result1 domain.AgentService
+	}{result1}
+}
+
+func (fake *FakeKeyHandlerContext) GetAutocomplete() ui.AutocompleteComponent {
+	fake.getAutocompleteMutex.Lock()
+	ret, specificReturn := fake.getAutocompleteReturnsOnCall[len(fake.getAutocompleteArgsForCall)]
+	fake.getAutocompleteArgsForCall = append(fake.getAutocompleteArgsForCall, struct {
+	}{})
+	stub := fake.GetAutocompleteStub
+	fakeReturns := fake.getAutocompleteReturns
+	fake.recordInvocation("GetAutocomplete", []interface{}{})
+	fake.getAutocompleteMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeKeyHandlerContext) GetAutocompleteCallCount() int {
+	fake.getAutocompleteMutex.RLock()
+	defer fake.getAutocompleteMutex.RUnlock()
+	return len(fake.getAutocompleteArgsForCall)
+}
+
+func (fake *FakeKeyHandlerContext) GetAutocompleteCalls(stub func() ui.AutocompleteComponent) {
+	fake.getAutocompleteMutex.Lock()
+	defer fake.getAutocompleteMutex.Unlock()
+	fake.GetAutocompleteStub = stub
+}
+
+func (fake *FakeKeyHandlerContext) GetAutocompleteReturns(result1 ui.AutocompleteComponent) {
+	fake.getAutocompleteMutex.Lock()
+	defer fake.getAutocompleteMutex.Unlock()
+	fake.GetAutocompleteStub = nil
+	fake.getAutocompleteReturns = struct {
+		result1 ui.AutocompleteComponent
+	}{result1}
+}
+
+func (fake *FakeKeyHandlerContext) GetAutocompleteReturnsOnCall(i int, result1 ui.AutocompleteComponent) {
+	fake.getAutocompleteMutex.Lock()
+	defer fake.getAutocompleteMutex.Unlock()
+	fake.GetAutocompleteStub = nil
+	if fake.getAutocompleteReturnsOnCall == nil {
+		fake.getAutocompleteReturnsOnCall = make(map[int]struct {
+			result1 ui.AutocompleteComponent
+		})
+	}
+	fake.getAutocompleteReturnsOnCall[i] = struct {
+		result1 ui.AutocompleteComponent
 	}{result1}
 }
 

--- a/tests/mocks/ui/fake_autocomplete_component.go
+++ b/tests/mocks/ui/fake_autocomplete_component.go
@@ -8,7 +8,7 @@ import (
 	"github.com/inference-gateway/cli/internal/ui"
 )
 
-type FakeAutocompleteInterface struct {
+type FakeAutocompleteComponent struct {
 	GetSelectedShortcutStub        func() string
 	getSelectedShortcutMutex       sync.RWMutex
 	getSelectedShortcutArgsForCall []struct {
@@ -56,6 +56,11 @@ type FakeAutocompleteInterface struct {
 	renderReturnsOnCall map[int]struct {
 		result1 string
 	}
+	SetHeightStub        func(int)
+	setHeightMutex       sync.RWMutex
+	setHeightArgsForCall []struct {
+		arg1 int
+	}
 	SetWidthStub        func(int)
 	setWidthMutex       sync.RWMutex
 	setWidthArgsForCall []struct {
@@ -71,7 +76,7 @@ type FakeAutocompleteInterface struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAutocompleteInterface) GetSelectedShortcut() string {
+func (fake *FakeAutocompleteComponent) GetSelectedShortcut() string {
 	fake.getSelectedShortcutMutex.Lock()
 	ret, specificReturn := fake.getSelectedShortcutReturnsOnCall[len(fake.getSelectedShortcutArgsForCall)]
 	fake.getSelectedShortcutArgsForCall = append(fake.getSelectedShortcutArgsForCall, struct {
@@ -89,19 +94,19 @@ func (fake *FakeAutocompleteInterface) GetSelectedShortcut() string {
 	return fakeReturns.result1
 }
 
-func (fake *FakeAutocompleteInterface) GetSelectedShortcutCallCount() int {
+func (fake *FakeAutocompleteComponent) GetSelectedShortcutCallCount() int {
 	fake.getSelectedShortcutMutex.RLock()
 	defer fake.getSelectedShortcutMutex.RUnlock()
 	return len(fake.getSelectedShortcutArgsForCall)
 }
 
-func (fake *FakeAutocompleteInterface) GetSelectedShortcutCalls(stub func() string) {
+func (fake *FakeAutocompleteComponent) GetSelectedShortcutCalls(stub func() string) {
 	fake.getSelectedShortcutMutex.Lock()
 	defer fake.getSelectedShortcutMutex.Unlock()
 	fake.GetSelectedShortcutStub = stub
 }
 
-func (fake *FakeAutocompleteInterface) GetSelectedShortcutReturns(result1 string) {
+func (fake *FakeAutocompleteComponent) GetSelectedShortcutReturns(result1 string) {
 	fake.getSelectedShortcutMutex.Lock()
 	defer fake.getSelectedShortcutMutex.Unlock()
 	fake.GetSelectedShortcutStub = nil
@@ -110,7 +115,7 @@ func (fake *FakeAutocompleteInterface) GetSelectedShortcutReturns(result1 string
 	}{result1}
 }
 
-func (fake *FakeAutocompleteInterface) GetSelectedShortcutReturnsOnCall(i int, result1 string) {
+func (fake *FakeAutocompleteComponent) GetSelectedShortcutReturnsOnCall(i int, result1 string) {
 	fake.getSelectedShortcutMutex.Lock()
 	defer fake.getSelectedShortcutMutex.Unlock()
 	fake.GetSelectedShortcutStub = nil
@@ -124,7 +129,7 @@ func (fake *FakeAutocompleteInterface) GetSelectedShortcutReturnsOnCall(i int, r
 	}{result1}
 }
 
-func (fake *FakeAutocompleteInterface) HandleKey(arg1 tea.KeyMsg) (bool, string) {
+func (fake *FakeAutocompleteComponent) HandleKey(arg1 tea.KeyMsg) (bool, string) {
 	fake.handleKeyMutex.Lock()
 	ret, specificReturn := fake.handleKeyReturnsOnCall[len(fake.handleKeyArgsForCall)]
 	fake.handleKeyArgsForCall = append(fake.handleKeyArgsForCall, struct {
@@ -143,26 +148,26 @@ func (fake *FakeAutocompleteInterface) HandleKey(arg1 tea.KeyMsg) (bool, string)
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeAutocompleteInterface) HandleKeyCallCount() int {
+func (fake *FakeAutocompleteComponent) HandleKeyCallCount() int {
 	fake.handleKeyMutex.RLock()
 	defer fake.handleKeyMutex.RUnlock()
 	return len(fake.handleKeyArgsForCall)
 }
 
-func (fake *FakeAutocompleteInterface) HandleKeyCalls(stub func(tea.KeyMsg) (bool, string)) {
+func (fake *FakeAutocompleteComponent) HandleKeyCalls(stub func(tea.KeyMsg) (bool, string)) {
 	fake.handleKeyMutex.Lock()
 	defer fake.handleKeyMutex.Unlock()
 	fake.HandleKeyStub = stub
 }
 
-func (fake *FakeAutocompleteInterface) HandleKeyArgsForCall(i int) tea.KeyMsg {
+func (fake *FakeAutocompleteComponent) HandleKeyArgsForCall(i int) tea.KeyMsg {
 	fake.handleKeyMutex.RLock()
 	defer fake.handleKeyMutex.RUnlock()
 	argsForCall := fake.handleKeyArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeAutocompleteInterface) HandleKeyReturns(result1 bool, result2 string) {
+func (fake *FakeAutocompleteComponent) HandleKeyReturns(result1 bool, result2 string) {
 	fake.handleKeyMutex.Lock()
 	defer fake.handleKeyMutex.Unlock()
 	fake.HandleKeyStub = nil
@@ -172,7 +177,7 @@ func (fake *FakeAutocompleteInterface) HandleKeyReturns(result1 bool, result2 st
 	}{result1, result2}
 }
 
-func (fake *FakeAutocompleteInterface) HandleKeyReturnsOnCall(i int, result1 bool, result2 string) {
+func (fake *FakeAutocompleteComponent) HandleKeyReturnsOnCall(i int, result1 bool, result2 string) {
 	fake.handleKeyMutex.Lock()
 	defer fake.handleKeyMutex.Unlock()
 	fake.HandleKeyStub = nil
@@ -188,7 +193,7 @@ func (fake *FakeAutocompleteInterface) HandleKeyReturnsOnCall(i int, result1 boo
 	}{result1, result2}
 }
 
-func (fake *FakeAutocompleteInterface) Hide() {
+func (fake *FakeAutocompleteComponent) Hide() {
 	fake.hideMutex.Lock()
 	fake.hideArgsForCall = append(fake.hideArgsForCall, struct {
 	}{})
@@ -200,19 +205,19 @@ func (fake *FakeAutocompleteInterface) Hide() {
 	}
 }
 
-func (fake *FakeAutocompleteInterface) HideCallCount() int {
+func (fake *FakeAutocompleteComponent) HideCallCount() int {
 	fake.hideMutex.RLock()
 	defer fake.hideMutex.RUnlock()
 	return len(fake.hideArgsForCall)
 }
 
-func (fake *FakeAutocompleteInterface) HideCalls(stub func()) {
+func (fake *FakeAutocompleteComponent) HideCalls(stub func()) {
 	fake.hideMutex.Lock()
 	defer fake.hideMutex.Unlock()
 	fake.HideStub = stub
 }
 
-func (fake *FakeAutocompleteInterface) IsVisible() bool {
+func (fake *FakeAutocompleteComponent) IsVisible() bool {
 	fake.isVisibleMutex.Lock()
 	ret, specificReturn := fake.isVisibleReturnsOnCall[len(fake.isVisibleArgsForCall)]
 	fake.isVisibleArgsForCall = append(fake.isVisibleArgsForCall, struct {
@@ -230,19 +235,19 @@ func (fake *FakeAutocompleteInterface) IsVisible() bool {
 	return fakeReturns.result1
 }
 
-func (fake *FakeAutocompleteInterface) IsVisibleCallCount() int {
+func (fake *FakeAutocompleteComponent) IsVisibleCallCount() int {
 	fake.isVisibleMutex.RLock()
 	defer fake.isVisibleMutex.RUnlock()
 	return len(fake.isVisibleArgsForCall)
 }
 
-func (fake *FakeAutocompleteInterface) IsVisibleCalls(stub func() bool) {
+func (fake *FakeAutocompleteComponent) IsVisibleCalls(stub func() bool) {
 	fake.isVisibleMutex.Lock()
 	defer fake.isVisibleMutex.Unlock()
 	fake.IsVisibleStub = stub
 }
 
-func (fake *FakeAutocompleteInterface) IsVisibleReturns(result1 bool) {
+func (fake *FakeAutocompleteComponent) IsVisibleReturns(result1 bool) {
 	fake.isVisibleMutex.Lock()
 	defer fake.isVisibleMutex.Unlock()
 	fake.IsVisibleStub = nil
@@ -251,7 +256,7 @@ func (fake *FakeAutocompleteInterface) IsVisibleReturns(result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeAutocompleteInterface) IsVisibleReturnsOnCall(i int, result1 bool) {
+func (fake *FakeAutocompleteComponent) IsVisibleReturnsOnCall(i int, result1 bool) {
 	fake.isVisibleMutex.Lock()
 	defer fake.isVisibleMutex.Unlock()
 	fake.IsVisibleStub = nil
@@ -265,7 +270,7 @@ func (fake *FakeAutocompleteInterface) IsVisibleReturnsOnCall(i int, result1 boo
 	}{result1}
 }
 
-func (fake *FakeAutocompleteInterface) Render() string {
+func (fake *FakeAutocompleteComponent) Render() string {
 	fake.renderMutex.Lock()
 	ret, specificReturn := fake.renderReturnsOnCall[len(fake.renderArgsForCall)]
 	fake.renderArgsForCall = append(fake.renderArgsForCall, struct {
@@ -283,19 +288,19 @@ func (fake *FakeAutocompleteInterface) Render() string {
 	return fakeReturns.result1
 }
 
-func (fake *FakeAutocompleteInterface) RenderCallCount() int {
+func (fake *FakeAutocompleteComponent) RenderCallCount() int {
 	fake.renderMutex.RLock()
 	defer fake.renderMutex.RUnlock()
 	return len(fake.renderArgsForCall)
 }
 
-func (fake *FakeAutocompleteInterface) RenderCalls(stub func() string) {
+func (fake *FakeAutocompleteComponent) RenderCalls(stub func() string) {
 	fake.renderMutex.Lock()
 	defer fake.renderMutex.Unlock()
 	fake.RenderStub = stub
 }
 
-func (fake *FakeAutocompleteInterface) RenderReturns(result1 string) {
+func (fake *FakeAutocompleteComponent) RenderReturns(result1 string) {
 	fake.renderMutex.Lock()
 	defer fake.renderMutex.Unlock()
 	fake.RenderStub = nil
@@ -304,7 +309,7 @@ func (fake *FakeAutocompleteInterface) RenderReturns(result1 string) {
 	}{result1}
 }
 
-func (fake *FakeAutocompleteInterface) RenderReturnsOnCall(i int, result1 string) {
+func (fake *FakeAutocompleteComponent) RenderReturnsOnCall(i int, result1 string) {
 	fake.renderMutex.Lock()
 	defer fake.renderMutex.Unlock()
 	fake.RenderStub = nil
@@ -318,7 +323,39 @@ func (fake *FakeAutocompleteInterface) RenderReturnsOnCall(i int, result1 string
 	}{result1}
 }
 
-func (fake *FakeAutocompleteInterface) SetWidth(arg1 int) {
+func (fake *FakeAutocompleteComponent) SetHeight(arg1 int) {
+	fake.setHeightMutex.Lock()
+	fake.setHeightArgsForCall = append(fake.setHeightArgsForCall, struct {
+		arg1 int
+	}{arg1})
+	stub := fake.SetHeightStub
+	fake.recordInvocation("SetHeight", []interface{}{arg1})
+	fake.setHeightMutex.Unlock()
+	if stub != nil {
+		fake.SetHeightStub(arg1)
+	}
+}
+
+func (fake *FakeAutocompleteComponent) SetHeightCallCount() int {
+	fake.setHeightMutex.RLock()
+	defer fake.setHeightMutex.RUnlock()
+	return len(fake.setHeightArgsForCall)
+}
+
+func (fake *FakeAutocompleteComponent) SetHeightCalls(stub func(int)) {
+	fake.setHeightMutex.Lock()
+	defer fake.setHeightMutex.Unlock()
+	fake.SetHeightStub = stub
+}
+
+func (fake *FakeAutocompleteComponent) SetHeightArgsForCall(i int) int {
+	fake.setHeightMutex.RLock()
+	defer fake.setHeightMutex.RUnlock()
+	argsForCall := fake.setHeightArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeAutocompleteComponent) SetWidth(arg1 int) {
 	fake.setWidthMutex.Lock()
 	fake.setWidthArgsForCall = append(fake.setWidthArgsForCall, struct {
 		arg1 int
@@ -331,26 +368,26 @@ func (fake *FakeAutocompleteInterface) SetWidth(arg1 int) {
 	}
 }
 
-func (fake *FakeAutocompleteInterface) SetWidthCallCount() int {
+func (fake *FakeAutocompleteComponent) SetWidthCallCount() int {
 	fake.setWidthMutex.RLock()
 	defer fake.setWidthMutex.RUnlock()
 	return len(fake.setWidthArgsForCall)
 }
 
-func (fake *FakeAutocompleteInterface) SetWidthCalls(stub func(int)) {
+func (fake *FakeAutocompleteComponent) SetWidthCalls(stub func(int)) {
 	fake.setWidthMutex.Lock()
 	defer fake.setWidthMutex.Unlock()
 	fake.SetWidthStub = stub
 }
 
-func (fake *FakeAutocompleteInterface) SetWidthArgsForCall(i int) int {
+func (fake *FakeAutocompleteComponent) SetWidthArgsForCall(i int) int {
 	fake.setWidthMutex.RLock()
 	defer fake.setWidthMutex.RUnlock()
 	argsForCall := fake.setWidthArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeAutocompleteInterface) Update(arg1 string, arg2 int) {
+func (fake *FakeAutocompleteComponent) Update(arg1 string, arg2 int) {
 	fake.updateMutex.Lock()
 	fake.updateArgsForCall = append(fake.updateArgsForCall, struct {
 		arg1 string
@@ -364,26 +401,26 @@ func (fake *FakeAutocompleteInterface) Update(arg1 string, arg2 int) {
 	}
 }
 
-func (fake *FakeAutocompleteInterface) UpdateCallCount() int {
+func (fake *FakeAutocompleteComponent) UpdateCallCount() int {
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	return len(fake.updateArgsForCall)
 }
 
-func (fake *FakeAutocompleteInterface) UpdateCalls(stub func(string, int)) {
+func (fake *FakeAutocompleteComponent) UpdateCalls(stub func(string, int)) {
 	fake.updateMutex.Lock()
 	defer fake.updateMutex.Unlock()
 	fake.UpdateStub = stub
 }
 
-func (fake *FakeAutocompleteInterface) UpdateArgsForCall(i int) (string, int) {
+func (fake *FakeAutocompleteComponent) UpdateArgsForCall(i int) (string, int) {
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
 	argsForCall := fake.updateArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeAutocompleteInterface) Invocations() map[string][][]interface{} {
+func (fake *FakeAutocompleteComponent) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
@@ -393,7 +430,7 @@ func (fake *FakeAutocompleteInterface) Invocations() map[string][][]interface{} 
 	return copiedInvocations
 }
 
-func (fake *FakeAutocompleteInterface) recordInvocation(key string, args []interface{}) {
+func (fake *FakeAutocompleteComponent) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
@@ -405,4 +442,4 @@ func (fake *FakeAutocompleteInterface) recordInvocation(key string, args []inter
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ ui.AutocompleteInterface = new(FakeAutocompleteInterface)
+var _ ui.AutocompleteComponent = new(FakeAutocompleteComponent)

--- a/tests/mocks/ui/fake_input_component.go
+++ b/tests/mocks/ui/fake_input_component.go
@@ -88,16 +88,6 @@ type FakeInputComponent struct {
 		result1 tea.Model
 		result2 tea.Cmd
 	}
-	IsAutocompleteVisibleStub        func() bool
-	isAutocompleteVisibleMutex       sync.RWMutex
-	isAutocompleteVisibleArgsForCall []struct {
-	}
-	isAutocompleteVisibleReturns struct {
-		result1 bool
-	}
-	isAutocompleteVisibleReturnsOnCall map[int]struct {
-		result1 bool
-	}
 	NavigateHistoryDownStub        func()
 	navigateHistoryDownMutex       sync.RWMutex
 	navigateHistoryDownArgsForCall []struct {
@@ -140,19 +130,6 @@ type FakeInputComponent struct {
 	setWidthMutex       sync.RWMutex
 	setWidthArgsForCall []struct {
 		arg1 int
-	}
-	TryHandleAutocompleteStub        func(tea.KeyMsg) (bool, string)
-	tryHandleAutocompleteMutex       sync.RWMutex
-	tryHandleAutocompleteArgsForCall []struct {
-		arg1 tea.KeyMsg
-	}
-	tryHandleAutocompleteReturns struct {
-		result1 bool
-		result2 string
-	}
-	tryHandleAutocompleteReturnsOnCall map[int]struct {
-		result1 bool
-		result2 string
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -583,59 +560,6 @@ func (fake *FakeInputComponent) HandleKeyReturnsOnCall(i int, result1 tea.Model,
 	}{result1, result2}
 }
 
-func (fake *FakeInputComponent) IsAutocompleteVisible() bool {
-	fake.isAutocompleteVisibleMutex.Lock()
-	ret, specificReturn := fake.isAutocompleteVisibleReturnsOnCall[len(fake.isAutocompleteVisibleArgsForCall)]
-	fake.isAutocompleteVisibleArgsForCall = append(fake.isAutocompleteVisibleArgsForCall, struct {
-	}{})
-	stub := fake.IsAutocompleteVisibleStub
-	fakeReturns := fake.isAutocompleteVisibleReturns
-	fake.recordInvocation("IsAutocompleteVisible", []interface{}{})
-	fake.isAutocompleteVisibleMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeInputComponent) IsAutocompleteVisibleCallCount() int {
-	fake.isAutocompleteVisibleMutex.RLock()
-	defer fake.isAutocompleteVisibleMutex.RUnlock()
-	return len(fake.isAutocompleteVisibleArgsForCall)
-}
-
-func (fake *FakeInputComponent) IsAutocompleteVisibleCalls(stub func() bool) {
-	fake.isAutocompleteVisibleMutex.Lock()
-	defer fake.isAutocompleteVisibleMutex.Unlock()
-	fake.IsAutocompleteVisibleStub = stub
-}
-
-func (fake *FakeInputComponent) IsAutocompleteVisibleReturns(result1 bool) {
-	fake.isAutocompleteVisibleMutex.Lock()
-	defer fake.isAutocompleteVisibleMutex.Unlock()
-	fake.IsAutocompleteVisibleStub = nil
-	fake.isAutocompleteVisibleReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *FakeInputComponent) IsAutocompleteVisibleReturnsOnCall(i int, result1 bool) {
-	fake.isAutocompleteVisibleMutex.Lock()
-	defer fake.isAutocompleteVisibleMutex.Unlock()
-	fake.IsAutocompleteVisibleStub = nil
-	if fake.isAutocompleteVisibleReturnsOnCall == nil {
-		fake.isAutocompleteVisibleReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isAutocompleteVisibleReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
 func (fake *FakeInputComponent) NavigateHistoryDown() {
 	fake.navigateHistoryDownMutex.Lock()
 	fake.navigateHistoryDownArgsForCall = append(fake.navigateHistoryDownArgsForCall, struct {
@@ -895,70 +819,6 @@ func (fake *FakeInputComponent) SetWidthArgsForCall(i int) int {
 	defer fake.setWidthMutex.RUnlock()
 	argsForCall := fake.setWidthArgsForCall[i]
 	return argsForCall.arg1
-}
-
-func (fake *FakeInputComponent) TryHandleAutocomplete(arg1 tea.KeyMsg) (bool, string) {
-	fake.tryHandleAutocompleteMutex.Lock()
-	ret, specificReturn := fake.tryHandleAutocompleteReturnsOnCall[len(fake.tryHandleAutocompleteArgsForCall)]
-	fake.tryHandleAutocompleteArgsForCall = append(fake.tryHandleAutocompleteArgsForCall, struct {
-		arg1 tea.KeyMsg
-	}{arg1})
-	stub := fake.TryHandleAutocompleteStub
-	fakeReturns := fake.tryHandleAutocompleteReturns
-	fake.recordInvocation("TryHandleAutocomplete", []interface{}{arg1})
-	fake.tryHandleAutocompleteMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeInputComponent) TryHandleAutocompleteCallCount() int {
-	fake.tryHandleAutocompleteMutex.RLock()
-	defer fake.tryHandleAutocompleteMutex.RUnlock()
-	return len(fake.tryHandleAutocompleteArgsForCall)
-}
-
-func (fake *FakeInputComponent) TryHandleAutocompleteCalls(stub func(tea.KeyMsg) (bool, string)) {
-	fake.tryHandleAutocompleteMutex.Lock()
-	defer fake.tryHandleAutocompleteMutex.Unlock()
-	fake.TryHandleAutocompleteStub = stub
-}
-
-func (fake *FakeInputComponent) TryHandleAutocompleteArgsForCall(i int) tea.KeyMsg {
-	fake.tryHandleAutocompleteMutex.RLock()
-	defer fake.tryHandleAutocompleteMutex.RUnlock()
-	argsForCall := fake.tryHandleAutocompleteArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeInputComponent) TryHandleAutocompleteReturns(result1 bool, result2 string) {
-	fake.tryHandleAutocompleteMutex.Lock()
-	defer fake.tryHandleAutocompleteMutex.Unlock()
-	fake.TryHandleAutocompleteStub = nil
-	fake.tryHandleAutocompleteReturns = struct {
-		result1 bool
-		result2 string
-	}{result1, result2}
-}
-
-func (fake *FakeInputComponent) TryHandleAutocompleteReturnsOnCall(i int, result1 bool, result2 string) {
-	fake.tryHandleAutocompleteMutex.Lock()
-	defer fake.tryHandleAutocompleteMutex.Unlock()
-	fake.TryHandleAutocompleteStub = nil
-	if fake.tryHandleAutocompleteReturnsOnCall == nil {
-		fake.tryHandleAutocompleteReturnsOnCall = make(map[int]struct {
-			result1 bool
-			result2 string
-		})
-	}
-	fake.tryHandleAutocompleteReturnsOnCall[i] = struct {
-		result1 bool
-		result2 string
-	}{result1, result2}
 }
 
 func (fake *FakeInputComponent) Invocations() map[string][][]interface{} {


### PR DESCRIPTION
Decouples autocomplete functionality from the InputView component. Autocomplete is now a separate component managed by the main application, with its own event handling and rendering logic. This improves component separation and makes both components more maintainable.

Key changes:
- Created separate AutocompleteComponent interface and implementation
- Moved autocomplete event handling to ChatApplication
- Updated keybindings to work with separate autocomplete
- Refactored rendering to position autocomplete below input field
- Updated factory methods to create components independently

## Summary of Changes:
1. **Component Separation:** Autocomplete is now a standalone component instead of being embedded in InputView
2. **Event-Driven Architecture:** Autocomplete events are handled centrally in ChatApplication
3. **Improved Rendering:** Autocomplete renders below input field with proper positioning
4. **Cleaner Interfaces:** Removed autocomplete-specific methods from InputComponent interface
5. **Better Focus Management:** Added focus/blur handling for input components
6. **Updated Tests:** Modified factory tests and mocks to reflect new structure

The refactoring improves code organization by adhering to the Single Responsibility Principle - InputView handles text input, while AutocompleteComponent handles suggestion display and selection.