### PR TITLE
fix: Serialize SQLite writes to prevent lock contention

### DIFF
--- a/internal/infra/storage/sqlite.go
+++ b/internal/infra/storage/sqlite.go
@@ -27,13 +27,13 @@ func NewSQLiteStorage(config SQLiteConfig) (*SQLiteStorage, error) {
 		return nil, fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
-	db, err := sql.Open("sqlite", config.Path+"?_journal_mode=WAL&_synchronous=NORMAL&_cache_size=1000&_timeout=5000")
+	db, err := sql.Open("sqlite", config.Path+"?_journal_mode=WAL&_synchronous=NORMAL&_cache_size=1000&_timeout=30000&_busy_timeout=30000")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open SQLite database: %w", err)
 	}
 
-	db.SetMaxOpenConns(10)
-	db.SetMaxIdleConns(5)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	db.SetConnMaxLifetime(time.Hour)
 
 	storage := &SQLiteStorage{

--- a/internal/services/persistent_conversation.go
+++ b/internal/services/persistent_conversation.go
@@ -320,6 +320,9 @@ func (r *PersistentConversationRepository) SetOptimizedMessages(ctx context.Cont
 		return fmt.Errorf("no active conversation to store optimized messages")
 	}
 
+	r.autoSaveMutex.Lock()
+	defer r.autoSaveMutex.Unlock()
+
 	conversationEntries := make([]domain.ConversationEntry, 0, len(optimizedMessages))
 	now := time.Now()
 


### PR DESCRIPTION
Prevents database lock errors by ensuring only one write operation happens at a time.
Changes include limiting SQLite to a single connection and protecting the `SetOptimizedMessages` function with the existing auto-save mutex.