### PR TITLE
refactor: Use 'any' type alias instead of interface{}

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -482,7 +482,7 @@ var configToolsWebFetchCacheClearCmd = &cobra.Command{
 }
 
 // resolveViperEnvironmentVariables recursively resolves environment variables for all string fields using Viper
-func resolveViperEnvironmentVariables(cfg interface{}, keyPrefix string) {
+func resolveViperEnvironmentVariables(cfg any, keyPrefix string) {
 	rv := reflect.ValueOf(cfg)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {
 		return

--- a/internal/domain/ui_events.go
+++ b/internal/domain/ui_events.go
@@ -137,7 +137,7 @@ type HideHelpBarEvent struct{}
 
 // ConversationsLoadedEvent indicates conversations have been loaded
 type ConversationsLoadedEvent struct {
-	Conversations []interface{}
+	Conversations []any
 	Error         error
 }
 
@@ -145,8 +145,8 @@ type ConversationsLoadedEvent struct {
 
 // TasksLoadedEvent indicates tasks have been loaded
 type TasksLoadedEvent struct {
-	ActiveTasks    []interface{}
-	CompletedTasks []interface{}
+	ActiveTasks    []any
+	CompletedTasks []any
 	Error          error
 }
 

--- a/internal/services/agent_utils.go
+++ b/internal/services/agent_utils.go
@@ -239,7 +239,7 @@ func isCompleteJSON(s string) bool {
 		return false
 	}
 
-	var js interface{}
+	var js any
 	return json.Unmarshal([]byte(s), &js) == nil
 }
 

--- a/internal/services/tokenizer_test.go
+++ b/internal/services/tokenizer_test.go
@@ -271,8 +271,8 @@ func TestCalculateUsagePolyfill(t *testing.T) {
 					Description: &description,
 					Parameters: &sdk.FunctionParameters{
 						"type": "object",
-						"properties": map[string]interface{}{
-							"path": map[string]interface{}{
+						"properties": map[string]any{
+							"path": map[string]any{
 								"type":        "string",
 								"description": "The file path to read",
 							},

--- a/internal/services/tools/a2a_query_agent.go
+++ b/internal/services/tools/a2a_query_agent.go
@@ -46,8 +46,8 @@ func (t *A2AQueryAgentTool) Definition() sdk.ChatCompletionTool {
 			Description: &description,
 			Parameters: &sdk.FunctionParameters{
 				"type": "object",
-				"properties": map[string]interface{}{
-					"agent_url": map[string]interface{}{
+				"properties": map[string]any{
+					"agent_url": map[string]any{
 						"type":        "string",
 						"description": "URL of the A2A agent to retrieve metadata from",
 					},

--- a/internal/services/tools/a2a_query_task.go
+++ b/internal/services/tools/a2a_query_task.go
@@ -50,16 +50,16 @@ func (t *A2AQueryTaskTool) Definition() sdk.ChatCompletionTool {
 			Description: &description,
 			Parameters: &sdk.FunctionParameters{
 				"type": "object",
-				"properties": map[string]interface{}{
-					"agent_url": map[string]interface{}{
+				"properties": map[string]any{
+					"agent_url": map[string]any{
 						"type":        "string",
 						"description": "URL of the A2A agent server",
 					},
-					"context_id": map[string]interface{}{
+					"context_id": map[string]any{
 						"type":        "string",
 						"description": "Context ID for the task",
 					},
-					"task_id": map[string]interface{}{
+					"task_id": map[string]any{
 						"type":        "string",
 						"description": "ID of the task to query",
 					},

--- a/internal/services/tools/a2a_task.go
+++ b/internal/services/tools/a2a_task.go
@@ -106,12 +106,12 @@ func (t *A2ASubmitTaskTool) Definition() sdk.ChatCompletionTool {
 			Description: &description,
 			Parameters: &sdk.FunctionParameters{
 				"type": "object",
-				"properties": map[string]interface{}{
-					"agent_url": map[string]interface{}{
+				"properties": map[string]any{
+					"agent_url": map[string]any{
 						"type":        "string",
 						"description": "URL of the A2A agent server",
 					},
-					"task_description": map[string]interface{}{
+					"task_description": map[string]any{
 						"type":        "string",
 						"description": "The question to ask or work to perform. Can be a question, task, action, or continuation of existing work",
 					},

--- a/internal/services/tools/params.go
+++ b/internal/services/tools/params.go
@@ -21,7 +21,7 @@ func NewParameterExtractor() *ParameterExtractor {
 }
 
 // ExtractWriteParams extracts and validates write operation parameters
-func (p *ParameterExtractor) ExtractWriteParams(params map[string]interface{}) (*WriteParams, error) {
+func (p *ParameterExtractor) ExtractWriteParams(params map[string]any) (*WriteParams, error) {
 	filePath, err := p.extractString(params, "file_path", true)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (p *ParameterExtractor) ToWriteRequest(params *WriteParams) filewriter.Writ
 }
 
 // extractString extracts a string parameter
-func (p *ParameterExtractor) extractString(params map[string]interface{}, key string, required bool) (string, error) {
+func (p *ParameterExtractor) extractString(params map[string]any, key string, required bool) (string, error) {
 	value, exists := params[key]
 	if !exists {
 		if required {

--- a/internal/services/tools/params_test.go
+++ b/internal/services/tools/params_test.go
@@ -8,7 +8,7 @@ import (
 
 type writeParamsTestCase struct {
 	name      string
-	params    map[string]interface{}
+	params    map[string]any
 	expected  *WriteParams
 	wantError bool
 	errorMsg  string
@@ -18,7 +18,7 @@ func getWriteParamsTestCases() []writeParamsTestCase {
 	return []writeParamsTestCase{
 		{
 			name: "valid basic params",
-			params: map[string]interface{}{
+			params: map[string]any{
 				"file_path": "/test/file.txt",
 				"content":   "test content",
 			},
@@ -29,7 +29,7 @@ func getWriteParamsTestCases() []writeParamsTestCase {
 		},
 		{
 			name: "missing file_path",
-			params: map[string]interface{}{
+			params: map[string]any{
 				"content": "test content",
 			},
 			wantError: true,
@@ -37,7 +37,7 @@ func getWriteParamsTestCases() []writeParamsTestCase {
 		},
 		{
 			name: "missing content",
-			params: map[string]interface{}{
+			params: map[string]any{
 				"file_path": "/test/file.txt",
 			},
 			wantError: true,
@@ -45,7 +45,7 @@ func getWriteParamsTestCases() []writeParamsTestCase {
 		},
 		{
 			name: "empty file_path",
-			params: map[string]interface{}{
+			params: map[string]any{
 				"file_path": "",
 				"content":   "test content",
 			},
@@ -54,7 +54,7 @@ func getWriteParamsTestCases() []writeParamsTestCase {
 		},
 		{
 			name: "invalid file_path type",
-			params: map[string]interface{}{
+			params: map[string]any{
 				"file_path": 123,
 				"content":   "test content",
 			},

--- a/internal/shortcuts/config.go
+++ b/internal/shortcuts/config.go
@@ -200,7 +200,7 @@ func (c *ConfigShortcut) executeReload() (ShortcutResult, error) {
 }
 
 // getConfigValue retrieves a config value using dot notation (e.g., "agent.model")
-func (c *ConfigShortcut) getConfigValue(key string) (interface{}, error) {
+func (c *ConfigShortcut) getConfigValue(key string) (any, error) {
 	parts := strings.Split(key, ".")
 	if len(parts) == 0 {
 		return nil, fmt.Errorf("empty key")
@@ -262,7 +262,7 @@ func (c *ConfigShortcut) findField(structValue reflect.Value, fieldName string) 
 }
 
 // formatValue formats a reflect.Value for display
-func (c *ConfigShortcut) formatValue(value reflect.Value) interface{} {
+func (c *ConfigShortcut) formatValue(value reflect.Value) any {
 	switch value.Kind() {
 	case reflect.String:
 		return value.String()

--- a/internal/ui/components/conversation_selection_view.go
+++ b/internal/ui/components/conversation_selection_view.go
@@ -65,7 +65,7 @@ func (c *ConversationSelectorImpl) loadConversationsCmd() tea.Cmd {
 
 		conversations, err := c.repo.ListSavedConversations(ctx, 50, 0)
 
-		interfaceConversations := make([]interface{}, len(conversations))
+		interfaceConversations := make([]any, len(conversations))
 		for i, conv := range conversations {
 			interfaceConversations[i] = conv
 		}

--- a/internal/ui/components/task_management_view.go
+++ b/internal/ui/components/task_management_view.go
@@ -108,8 +108,8 @@ func (t *TaskManagerImpl) loadTasksCmd() tea.Cmd {
 	return func() tea.Msg {
 		if t.backgroundTaskService == nil {
 			return domain.TasksLoadedEvent{
-				ActiveTasks:    []interface{}{},
-				CompletedTasks: []interface{}{},
+				ActiveTasks:    []any{},
+				CompletedTasks: []any{},
 				Error:          fmt.Errorf("background task service not available"),
 			}
 		}
@@ -159,12 +159,12 @@ func (t *TaskManagerImpl) loadTasksCmd() tea.Cmd {
 			completedTasks = append(completedTasks, taskInfo)
 		}
 
-		interfaceActiveTasks := make([]interface{}, len(activeTasks))
+		interfaceActiveTasks := make([]any, len(activeTasks))
 		for i, task := range activeTasks {
 			interfaceActiveTasks[i] = task
 		}
 
-		interfaceCompletedTasks := make([]interface{}, len(completedTasks))
+		interfaceCompletedTasks := make([]any, len(completedTasks))
 		for i, task := range completedTasks {
 			interfaceCompletedTasks[i] = task
 		}


### PR DESCRIPTION
Replaces `interface{}` with `any` type alias throughout the codebase. This improves readability and aligns with Go 1.18+ conventions. Changes are purely syntactic and maintain backward compatibility.

## Changes Made

Systematic replacement of `interface{}` with `any` across multiple files:

### Configuration Handling
- `cmd/config.go`: Function parameters and return types
- `internal/shortcuts/config.go`: JSON unmarshaling and event payload structures

### UI Components
- `internal/ui/components/conversation_selection_view.go`: Event payload structures
- `internal/ui/components/task_management_view.go`: Event payload structures

### Domain Models
- `internal/domain/ui_events.go`: Event payload type definitions

### Service Layer
- `internal/services/agent_utils.go`: Function parameters and return types
- `internal/services/tokenizer_test.go`: Test data structures

### Tool Definitions
- `internal/services/tools/a2a_query_agent.go`: Tool parameter definitions
- `internal/services/tools/a2a_query_task.go`: Tool parameter definitions
- `internal/services/tools/a2a_task.go`: Tool parameter definitions
- `internal/services/tools/params.go`: Tool parameter type definitions
- `internal/services/tools/params_test.go`: Test data structures

## Benefits
1. **Improved Readability**: `any` is more concise and clearer than `interface{}`
2. **Modern Go Conventions**: Aligns with Go 1.18+ best practices
3. **Type Safety**: Maintains the same type safety guarantees as `interface{}`
4. **Backward Compatible**: No functional changes - purely syntactic improvement

## Testing
- All existing tests continue to pass
- No behavior changes introduced
- Code compiles successfully with Go 1.18+