### PR TITLE
feat: Display version information in chat interface

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -85,6 +85,7 @@ func StartChatSession(cfg *config.Config, v *viper.Viper) error {
 	agentManager := services.GetAgentManager()
 	conversationOptimizer := services.GetConversationOptimizer()
 
+	versionInfo := GetVersionInfo()
 	application := app.NewChatApplication(
 		models,
 		defaultModel,
@@ -106,6 +107,7 @@ func StartChatSession(cfg *config.Config, v *viper.Viper) error {
 		backgroundTaskService,
 		agentManager,
 		getEffectiveConfigPath(),
+		versionInfo,
 	)
 
 	program := tea.NewProgram(

--- a/cmd/version_info.go
+++ b/cmd/version_info.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "github.com/inference-gateway/cli/internal/domain"
+
+// GetVersionInfo returns the current version information
+func GetVersionInfo() domain.VersionInfo {
+	return domain.VersionInfo{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+	}
+}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -111,6 +111,7 @@ func NewChatApplication(
 	backgroundTaskService domain.BackgroundTaskService,
 	agentManager domain.AgentManager,
 	configPath string,
+	versionInfo domain.VersionInfo,
 ) *ChatApplication {
 	initialView := domain.ViewStateModelSelection
 	if defaultModel != "" {
@@ -151,6 +152,7 @@ func NewChatApplication(
 	if cv, ok := app.conversationView.(*components.ConversationView); ok {
 		cv.SetToolFormatter(toolFormatterService)
 		cv.SetConfigPath(configPath)
+		cv.SetVersionInfo(versionInfo)
 		cv.SetToolCallRenderer(app.toolCallRenderer)
 		cv.SetStateManager(app.stateManager)
 	}

--- a/internal/domain/version.go
+++ b/internal/domain/version.go
@@ -1,0 +1,8 @@
+package domain
+
+// VersionInfo contains build-time version information
+type VersionInfo struct {
+	Version string
+	Commit  string
+	Date    string
+}


### PR DESCRIPTION
Adds version information to the chat welcome screen. Shows version number in both full and compact layouts. This helps users identify which version of the CLI they're running.

## Changes:
- Added `VersionInfo` struct to domain package
- Created `GetVersionInfo()` function to retrieve build-time version data
- Modified `ChatApplication` to accept version info parameter
- Updated `ConversationView` to display version in welcome message (both full and compact layouts)
- Version appears as "• Version: x.x.x" in full layout or just the version number in compact layout
- Refactored `renderWelcome()` function to reduce nesting complexity and fix linting issues

## Testing:
- All linting checks pass
- Code formatting is correct
- No breaking changes to existing functionality