### PR TITLE
refactor: Simplify export shortcut functionality

### DIFF
--- a/.infer/shortcuts/export.yaml
+++ b/.infer/shortcuts/export.yaml
@@ -1,0 +1,14 @@
+---
+# Export Shortcuts
+# Export conversations to markdown files
+#
+# Usage:
+# - /export - Export the current active conversation
+
+shortcuts:
+  - name: export
+    description: "Export current conversation to markdown"
+    command: infer
+    args:
+      - export
+    pass_session_id: true

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	storage "github.com/inference-gateway/cli/internal/infra/storage"
+	services "github.com/inference-gateway/cli/internal/services"
+	tools "github.com/inference-gateway/cli/internal/services/tools"
+	cobra "github.com/spf13/cobra"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export <session-id>",
+	Short: "Export conversation to markdown",
+	Long:  `Export a conversation session to a markdown file.`,
+	Args:  cobra.RangeArgs(0, 1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("session ID required. Provide as argument: infer export <session-id>")
+		}
+		if args[0] == "" {
+			return fmt.Errorf("no conversation to export. Send at least one message first, then use /export")
+		}
+		return runExport(args[0])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(exportCmd)
+}
+
+func runExport(sessionID string) error {
+	cfg, err := getConfigFromViper()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	storageConfig := storage.NewStorageFromConfig(cfg)
+	storageBackend, err := storage.NewStorage(storageConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize storage: %w", err)
+	}
+
+	toolRegistry := tools.NewRegistry(cfg, nil, nil, nil)
+	toolFormatterService := services.NewToolFormatterService(toolRegistry)
+	persistentRepo := services.NewPersistentConversationRepository(toolFormatterService, storageBackend)
+
+	ctx := context.Background()
+	if err := persistentRepo.LoadConversation(ctx, sessionID); err != nil {
+		return fmt.Errorf("failed to load session %s: %w", sessionID, err)
+	}
+
+	if persistentRepo.GetMessageCount() == 0 {
+		return fmt.Errorf("no conversation to export - conversation history is empty")
+	}
+
+	data, err := persistentRepo.Export(domain.ExportMarkdown)
+	if err != nil {
+		return fmt.Errorf("failed to export conversation: %w", err)
+	}
+
+	outputDir := cfg.Export.OutputDir
+	if outputDir == "" {
+		outputDir = ".infer"
+	}
+
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	filename := fmt.Sprintf("chat_export_%s.md", time.Now().Format("20060102_150405"))
+	filePath := filepath.Join(outputDir, filename)
+
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write export file: %w", err)
+	}
+
+	fmt.Printf("• Conversation exported to: %s\n", filePath)
+	return nil
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,7 +37,7 @@ func initializeProject(cmd *cobra.Command) error {
 	overwrite, _ := cmd.Flags().GetBool("overwrite")
 	userspace, _ := cmd.Flags().GetBool("userspace")
 
-	var configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, mcpPath string
+	var configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, mcpPath string
 
 	if userspace {
 		homeDir, err := os.UserHomeDir()
@@ -50,6 +50,7 @@ func initializeProject(cmd *cobra.Command) error {
 		gitShortcutsPath = filepath.Join(homeDir, config.ConfigDirName, "shortcuts", "git.yaml")
 		mcpShortcutsPath = filepath.Join(homeDir, config.ConfigDirName, "shortcuts", "mcp.yaml")
 		shellsShortcutsPath = filepath.Join(homeDir, config.ConfigDirName, "shortcuts", "shells.yaml")
+		exportShortcutsPath = filepath.Join(homeDir, config.ConfigDirName, "shortcuts", "export.yaml")
 		mcpPath = filepath.Join(homeDir, config.ConfigDirName, config.MCPFileName)
 	} else {
 		configPath = config.DefaultConfigPath
@@ -58,11 +59,12 @@ func initializeProject(cmd *cobra.Command) error {
 		gitShortcutsPath = filepath.Join(config.ConfigDirName, "shortcuts", "git.yaml")
 		mcpShortcutsPath = filepath.Join(config.ConfigDirName, "shortcuts", "mcp.yaml")
 		shellsShortcutsPath = filepath.Join(config.ConfigDirName, "shortcuts", "shells.yaml")
+		exportShortcutsPath = filepath.Join(config.ConfigDirName, "shortcuts", "export.yaml")
 		mcpPath = filepath.Join(config.ConfigDirName, config.MCPFileName)
 	}
 
 	if !overwrite {
-		if err := validateFilesNotExist(configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, mcpPath); err != nil {
+		if err := validateFilesNotExist(configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, mcpPath); err != nil {
 			return err
 		}
 	}
@@ -99,6 +101,10 @@ bin/
 		return fmt.Errorf("failed to create Shells shortcuts file: %w", err)
 	}
 
+	if err := createExportShortcutsFile(exportShortcutsPath); err != nil {
+		return fmt.Errorf("failed to create Export shortcuts file: %w", err)
+	}
+
 	if err := createMCPConfigFile(mcpPath); err != nil {
 		return fmt.Errorf("failed to create MCP config file: %w", err)
 	}
@@ -117,6 +123,7 @@ bin/
 	fmt.Printf("   Created: %s\n", gitShortcutsPath)
 	fmt.Printf("   Created: %s\n", mcpShortcutsPath)
 	fmt.Printf("   Created: %s\n", shellsShortcutsPath)
+	fmt.Printf("   Created: %s\n", exportShortcutsPath)
 	fmt.Printf("   Created: %s\n", mcpPath)
 	fmt.Println("")
 	if userspace {
@@ -524,4 +531,29 @@ shortcuts:
 `
 
 	return os.WriteFile(path, []byte(shellsShortcutsContent), 0644)
+}
+
+// createExportShortcutsFile creates the Export shortcuts YAML file
+func createExportShortcutsFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create shortcuts directory: %w", err)
+	}
+
+	exportShortcutsContent := `---
+# Export Shortcuts
+# Export conversations to markdown files
+#
+# Usage:
+# - /export - Export the current active conversation
+
+shortcuts:
+  - name: export
+    description: "Export current conversation to markdown"
+    command: infer
+    args:
+      - export
+    pass_session_id: true
+`
+
+	return os.WriteFile(path, []byte(exportShortcutsContent), 0644)
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -325,7 +325,6 @@ func (c *ServiceContainer) initializeExtensibility() {
 // registerDefaultCommands registers the built-in commands
 func (c *ServiceContainer) registerDefaultCommands() {
 	c.shortcutRegistry.Register(shortcuts.NewClearShortcut(c.conversationRepo, c.taskTrackerService))
-	c.shortcutRegistry.Register(shortcuts.NewExportShortcut(c.conversationRepo, c.config))
 	c.shortcutRegistry.Register(shortcuts.NewCompactShortcut(c.conversationRepo))
 	c.shortcutRegistry.Register(shortcuts.NewContextShortcut(c.conversationRepo, c.modelService))
 	c.shortcutRegistry.Register(shortcuts.NewExitShortcut())

--- a/internal/domain/context.go
+++ b/internal/domain/context.go
@@ -24,3 +24,7 @@ const BashDetachChannelKey ContextKey = "bash_detach_channel"
 // ChatHandlerKey is the context key for passing the ChatHandler reference
 // This allows the agent service to access ChatHandler for setting up the detach channel
 const ChatHandlerKey ContextKey = "chat_handler"
+
+// SessionIDKey is the context key for the current conversation session ID
+// This allows shortcuts to access the session ID when they need it (e.g., /export)
+const SessionIDKey ContextKey = "session_id"

--- a/internal/handlers/chat_shortcut_handler.go
+++ b/internal/handlers/chat_shortcut_handler.go
@@ -107,6 +107,16 @@ func (s *ChatShortcutHandler) tryExecuteFromRegistry(shortcut string, args []str
 // executeRegistryShortcut executes a shortcut from the registry and handles results
 func (s *ChatShortcutHandler) executeRegistryShortcut(shortcut shortcuts.Shortcut, args []string) tea.Msg {
 	ctx := context.Background()
+
+	sessionID := ""
+	if persistentRepo, ok := s.handler.conversationRepo.(*services.PersistentConversationRepository); ok {
+		sessionID = persistentRepo.GetCurrentConversationID()
+		logger.Debug("Adding session ID to shortcut context", "session_id", sessionID, "shortcut", shortcut.GetName())
+	} else {
+		logger.Debug("ConversationRepo is not PersistentConversationRepository", "type", fmt.Sprintf("%T", s.handler.conversationRepo))
+	}
+	ctx = context.WithValue(ctx, domain.SessionIDKey, sessionID)
+
 	result, err := shortcut.Execute(ctx, args)
 	if err != nil {
 		return domain.SetStatusEvent{
@@ -160,8 +170,6 @@ func (s *ChatShortcutHandler) handleShortcutSideEffect(sideEffect shortcuts.Side
 		return s.handleSwitchThemeSideEffect()
 	case shortcuts.SideEffectClearConversation:
 		return s.handleClearConversationSideEffect()
-	case shortcuts.SideEffectExportConversation:
-		return s.handleExportConversationSideEffect()
 	case shortcuts.SideEffectReloadConfig:
 		return s.handleReloadConfigSideEffect()
 	case shortcuts.SideEffectShowHelp:
@@ -246,97 +254,6 @@ func (s *ChatShortcutHandler) handleClearConversationSideEffect() tea.Msg {
 			}
 		},
 	)()
-}
-
-func (s *ChatShortcutHandler) handleExportConversationSideEffect() tea.Msg {
-	return tea.Batch(
-		func() tea.Msg {
-			return domain.SetStatusEvent{
-				Message:    "📝 Generating summary and exporting conversation...",
-				Spinner:    true,
-				StatusType: domain.StatusWorking,
-			}
-		},
-		s.performExportAsync(),
-	)()
-}
-
-func (s *ChatShortcutHandler) performExportAsync() tea.Cmd {
-	return tea.Sequence(
-		func() tea.Msg {
-			return domain.SetStatusEvent{
-				Message:    "🤖 Generating AI summary...",
-				Spinner:    true,
-				StatusType: domain.StatusGenerating,
-			}
-		},
-		s.performSummaryGeneration(),
-	)
-}
-
-func (s *ChatShortcutHandler) performSummaryGeneration() tea.Cmd {
-	return func() tea.Msg {
-		ctx := context.Background()
-
-		shortcut, exists := s.handler.shortcutRegistry.Get("export")
-		if !exists {
-			return domain.SetStatusEvent{
-				Message:    "Export command not found",
-				Spinner:    false,
-				StatusType: domain.StatusError,
-			}
-		}
-
-		exportShortcut, ok := shortcut.(*shortcuts.ExportShortcut)
-		if !ok {
-			return domain.SetStatusEvent{
-				Message:    "Invalid export command type",
-				Spinner:    false,
-				StatusType: domain.StatusError,
-			}
-		}
-
-		exportResult, err := exportShortcut.PerformExport(ctx)
-		if err != nil {
-			return domain.SetStatusEvent{
-				Message:    fmt.Sprintf("Export failed: %v", err),
-				Spinner:    false,
-				StatusType: domain.StatusError,
-			}
-		}
-
-		if clearErr := s.handler.conversationRepo.ClearExceptFirstUserMessage(); clearErr != nil {
-			logger.Error("failed to clear conversation except first message", "error", clearErr)
-		}
-
-		summaryEntry := domain.ConversationEntry{
-			Message: sdk.Message{
-				Role:    sdk.Assistant,
-				Content: sdk.NewMessageContent(fmt.Sprintf("• Conversation exported to: %s", exportResult.FilePath)),
-			},
-			Model: "",
-			Time:  time.Now(),
-		}
-
-		if addErr := s.handler.conversationRepo.AddMessage(summaryEntry); addErr != nil {
-			logger.Error("failed to add summary message", "error", addErr)
-		}
-
-		return tea.Batch(
-			func() tea.Msg {
-				return domain.UpdateHistoryEvent{
-					History: s.handler.conversationRepo.GetMessages(),
-				}
-			},
-			func() tea.Msg {
-				return domain.SetStatusEvent{
-					Message:    fmt.Sprintf("Conversation exported to: %s", exportResult.FilePath),
-					Spinner:    false,
-					StatusType: domain.StatusDefault,
-				}
-			},
-		)()
-	}
 }
 
 func (s *ChatShortcutHandler) handleReloadConfigSideEffect() tea.Msg {

--- a/internal/shortcuts/custom.go
+++ b/internal/shortcuts/custom.go
@@ -25,14 +25,15 @@ type SnippetConfig struct {
 
 // CustomShortcutConfig represents a user-defined shortcut configuration
 type CustomShortcutConfig struct {
-	Name        string         `yaml:"name"`
-	Description string         `yaml:"description"`
-	Command     string         `yaml:"command,omitempty"`
-	Args        []string       `yaml:"args,omitempty"`
-	WorkingDir  string         `yaml:"working_dir,omitempty"`
-	Tool        string         `yaml:"tool,omitempty"`
-	ToolArgs    map[string]any `yaml:"tool_args,omitempty"`
-	Snippet     *SnippetConfig `yaml:"snippet,omitempty"`
+	Name          string         `yaml:"name"`
+	Description   string         `yaml:"description"`
+	Command       string         `yaml:"command,omitempty"`
+	Args          []string       `yaml:"args,omitempty"`
+	WorkingDir    string         `yaml:"working_dir,omitempty"`
+	Tool          string         `yaml:"tool,omitempty"`
+	ToolArgs      map[string]any `yaml:"tool_args,omitempty"`
+	Snippet       *SnippetConfig `yaml:"snippet,omitempty"`
+	PassSessionID bool           `yaml:"pass_session_id,omitempty"`
 }
 
 // CustomShortcutsConfig represents the structure of a custom shortcuts YAML file
@@ -172,6 +173,14 @@ func (c *CustomShortcut) Execute(ctx context.Context, args []string) (ShortcutRe
 
 	command := c.config.Command
 	cmdArgs := append([]string{}, c.config.Args...)
+
+	if c.config.PassSessionID {
+		if sessionID := ctx.Value(domain.SessionIDKey); sessionID != nil {
+			if sessionIDStr, ok := sessionID.(string); ok {
+				args = append(args, sessionIDStr)
+			}
+		}
+	}
 
 	if command == "bash" && len(cmdArgs) >= 2 && cmdArgs[0] == "-c" {
 		cmdArgs = append(cmdArgs, "bash")

--- a/internal/shortcuts/interfaces.go
+++ b/internal/shortcuts/interfaces.go
@@ -29,7 +29,6 @@ type SideEffectType int
 const (
 	SideEffectNone SideEffectType = iota
 	SideEffectClearConversation
-	SideEffectExportConversation
 	SideEffectExit
 	SideEffectSwitchModel
 	SideEffectSwitchTheme


### PR DESCRIPTION
Removed AI-powered summary generation from the export shortcut. The export now saves only the raw conversation data without generating summaries. This simplifies the codebase by removing dependencies on agent and model services.