### PR TITLE
refactor: Format CLI listings as markdown tables

### DIFF
--- a/internal/shortcuts/custom.go
+++ b/internal/shortcuts/custom.go
@@ -220,6 +220,27 @@ func (c *CustomShortcut) Execute(ctx context.Context, args []string) (ShortcutRe
 		}
 	}
 
+	// Check if output looks like markdown (contains markdown table syntax)
+	isMarkdown := strings.Contains(outputStr, "| ") && strings.Contains(outputStr, " |") && strings.Contains(outputStr, "---")
+
+	if isMarkdown {
+		// Output raw markdown without code fences - will be rendered by chat
+		if len(imageAttachments) > 0 {
+			return ShortcutResult{
+				Output:     outputStr,
+				Success:    true,
+				SideEffect: SideEffectEmbedImages,
+				Data:       imageAttachments,
+			}, nil
+		}
+
+		return ShortcutResult{
+			Output:  outputStr,
+			Success: true,
+		}, nil
+	}
+
+	// For non-markdown output, wrap in code fences as before
 	formattedOutput := fmt.Sprintf("```json\n%s\n```", outputStr)
 
 	if len(imageAttachments) > 0 {


### PR DESCRIPTION
Converts plain text output for `list-agents`, `show-agent`, and `list-mcp` commands to formatted markdown tables. Uses glamour library for terminal rendering. Improves readability with status icons and structured data presentation.

## Summary of Changes:

1. **`cmd/agents.go`**: Replaced plain text listings with markdown tables for both `listAgents` and `showAgent` functions
2. **`cmd/mcp.go`**: Converted MCP server listing to markdown format with improved table structure
3. **Added `renderMarkdown` function** using the glamour library for terminal rendering
4. **`internal/shortcuts/custom.go`**: Added markdown detection to handle the new output format properly
5. **Uses status icons** (✓/✗) for enabled/disabled states instead of text
6. **Better data organization** with columns for key properties in tables

The refactoring maintains backward compatibility by falling back to raw markdown if rendering fails.

## Benefits:
- Improved visual presentation of CLI output
- Better readability with structured tables
- Status indicators using icons instead of plain text
- Consistent formatting across all listing commands
- Maintains backward compatibility

Closes #311 