### PR TITLE
fix: Skip migrations for JSONL storage in infer init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -151,14 +151,7 @@ tmp/
 	fmt.Println("Tip: Use /init in chat mode to generate an AGENTS.md file interactively")
 
 	if !skipMigrations {
-		fmt.Println("")
-		fmt.Println("Running database migrations...")
-		if err := runMigrations(); err != nil {
-			fmt.Printf("%s Warning: Failed to run migrations: %v\n", icons.CrossMarkStyle.Render(icons.CrossMark), err)
-			fmt.Println("   You can run migrations manually with: infer migrate")
-		} else {
-			fmt.Printf("%s Database migrations completed successfully\n", icons.CheckMarkStyle.Render(icons.CheckMark))
-		}
+		handleMigrations()
 	}
 
 	return nil
@@ -546,4 +539,25 @@ shortcuts:
 `
 
 	return os.WriteFile(path, []byte(a2aShortcutsContent), 0644)
+}
+
+// handleMigrations handles the migration logic for the init command
+func handleMigrations() {
+	defaultConfig := config.DefaultConfig()
+	requiresMigrations := defaultConfig.Storage.Type == config.StorageTypeSQLite || defaultConfig.Storage.Type == config.StorageTypePostgres
+
+	if !requiresMigrations {
+		fmt.Println("")
+		fmt.Printf("%s Storage type '%s' does not require migrations\n", icons.CheckMarkStyle.Render(icons.CheckMark), defaultConfig.Storage.Type)
+		return
+	}
+
+	fmt.Println("")
+	fmt.Println("Running database migrations...")
+	if err := runMigrations(); err != nil {
+		fmt.Printf("%s Warning: Failed to run migrations: %v\n", icons.CrossMarkStyle.Render(icons.CrossMark), err)
+		fmt.Println("   You can run migrations manually with: infer migrate")
+	} else {
+		fmt.Printf("%s Database migrations completed successfully\n", icons.CheckMarkStyle.Render(icons.CheckMark))
+	}
 }


### PR DESCRIPTION
## Description

Fixes #372

During `infer init`, the CLI was running database migrations even when JSONL storage was configured, despite the message stating that 'JSONL storage does not require migrations'.

## Changes

- Added `handleMigrations()` function that checks the storage type before running migrations
- Only executes migrations for SQLite/PostgreSQL backends
- For JSONL storage, shows appropriate message and skips migration step entirely

## Testing

The fix ensures that:
1. When JSONL storage is configured, migrations are skipped with appropriate message
2. When SQLite/PostgreSQL storage is configured, migrations run as expected
3. The `--skip-migrations` flag continues to work as before