### PR TITLE
fix(agent): Persist reasoning_content across non-streaming agent path

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -61,17 +61,18 @@ Examples:
 
 // ConversationMessage represents a message in the JSON output conversation
 type ConversationMessage struct {
-	Role          string                               `json:"role"`
-	Content       string                               `json:"content"`
-	ToolCalls     *[]sdk.ChatCompletionMessageToolCall `json:"tool_calls,omitempty"`
-	Tools         []string                             `json:"tools,omitempty"`
-	ToolCallID    string                               `json:"tool_call_id,omitempty"`
-	ToolExecution *domain.ToolExecutionResult          `json:"-"`
-	TokenUsage    *sdk.CompletionUsage                 `json:"token_usage,omitempty"`
-	Timestamp     time.Time                            `json:"timestamp"`
-	RequestID     string                               `json:"request_id,omitempty"`
-	Internal      bool                                 `json:"-"`
-	Images        []domain.ImageAttachment             `json:"images,omitempty"`
+	Role             string                               `json:"role"`
+	Content          string                               `json:"content"`
+	ReasoningContent string                               `json:"reasoning_content,omitempty"`
+	ToolCalls        *[]sdk.ChatCompletionMessageToolCall `json:"tool_calls,omitempty"`
+	Tools            []string                             `json:"tools,omitempty"`
+	ToolCallID       string                               `json:"tool_call_id,omitempty"`
+	ToolExecution    *domain.ToolExecutionResult          `json:"-"`
+	TokenUsage       *sdk.CompletionUsage                 `json:"token_usage,omitempty"`
+	Timestamp        time.Time                            `json:"timestamp"`
+	RequestID        string                               `json:"request_id,omitempty"`
+	Internal         bool                                 `json:"-"`
+	Images           []domain.ImageAttachment             `json:"images,omitempty"`
 }
 
 // AgentSession manages the background execution session
@@ -469,6 +470,12 @@ func (s *AgentSession) buildSDKMessages() []sdk.Message {
 			Content: content,
 		}
 
+		if msg.ReasoningContent != "" {
+			reasoning := msg.ReasoningContent
+			sdkMsg.Reasoning = &reasoning
+			sdkMsg.ReasoningContent = &reasoning
+		}
+
 		if msg.ToolCalls != nil && len(*msg.ToolCalls) > 0 {
 			sdkMsg.ToolCalls = msg.ToolCalls
 		}
@@ -524,11 +531,12 @@ func (s *AgentSession) processSyncResponse(response *domain.ChatSyncResponse, re
 	}
 
 	assistantMsg := ConversationMessage{
-		Role:       "assistant",
-		Content:    response.Content,
-		TokenUsage: response.Usage,
-		Timestamp:  time.Now(),
-		RequestID:  requestID,
+		Role:             "assistant",
+		Content:          response.Content,
+		ReasoningContent: response.ReasoningContent,
+		TokenUsage:       response.Usage,
+		Timestamp:        time.Now(),
+		RequestID:        requestID,
 	}
 
 	if len(response.ToolCalls) > 0 {
@@ -832,6 +840,12 @@ func (s *AgentSession) convertToConversationEntry(msg ConversationMessage) domai
 	sdkMsg.Role = sdk.MessageRole(msg.Role)
 	sdkMsg.Content = sdk.NewMessageContent(msg.Content)
 
+	if msg.ReasoningContent != "" {
+		reasoning := msg.ReasoningContent
+		sdkMsg.Reasoning = &reasoning
+		sdkMsg.ReasoningContent = &reasoning
+	}
+
 	if msg.ToolCalls != nil && len(*msg.ToolCalls) > 0 {
 		sdkMsg.ToolCalls = msg.ToolCalls
 	}
@@ -841,12 +855,13 @@ func (s *AgentSession) convertToConversationEntry(msg ConversationMessage) domai
 	}
 
 	entry := domain.ConversationEntry{
-		Message:       sdkMsg,
-		Model:         s.model,
-		Time:          msg.Timestamp,
-		Images:        msg.Images,
-		Hidden:        msg.Internal,
-		ToolExecution: msg.ToolExecution,
+		Message:          sdkMsg,
+		Model:            s.model,
+		Time:             msg.Timestamp,
+		Images:           msg.Images,
+		Hidden:           msg.Internal,
+		ReasoningContent: msg.ReasoningContent,
+		ToolExecution:    msg.ToolExecution,
 	}
 
 	return entry
@@ -864,6 +879,15 @@ func (s *AgentSession) convertFromConversationEntry(entry domain.ConversationEnt
 
 	if contentStr, err := entry.Message.Content.AsMessageContent0(); err == nil {
 		msg.Content = contentStr
+	}
+
+	switch {
+	case entry.ReasoningContent != "":
+		msg.ReasoningContent = entry.ReasoningContent
+	case entry.Message.ReasoningContent != nil && *entry.Message.ReasoningContent != "":
+		msg.ReasoningContent = *entry.Message.ReasoningContent
+	case entry.Message.Reasoning != nil && *entry.Message.Reasoning != "":
+		msg.ReasoningContent = *entry.Message.Reasoning
 	}
 
 	if entry.Message.ToolCalls != nil && len(*entry.Message.ToolCalls) > 0 {

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -356,6 +356,10 @@ func TestConvertFromConversationEntry(t *testing.T) {
 				t.Errorf("ToolCallID = %v, want %v", result.ToolCallID, tt.expected.ToolCallID)
 			}
 
+			if result.ReasoningContent != tt.expected.ReasoningContent {
+				t.Errorf("ReasoningContent = %q, want %q", result.ReasoningContent, tt.expected.ReasoningContent)
+			}
+
 			if len(result.Images) != len(tt.expected.Images) {
 				t.Errorf("Images length = %v, want %v", len(result.Images), len(tt.expected.Images))
 			}
@@ -624,4 +628,111 @@ func validateToolExecution(t *testing.T, actual, expected *domain.ToolExecutionR
 
 func stringPtr(s string) *string {
 	return &s
+}
+
+// TestReasoningContentRoundTripSyncPath is a regression test for issue #428:
+// the non-streaming agent path used to drop reasoning_content end-to-end,
+// which broke multi-turn DeepSeek v4-pro requests after a tool call.
+//
+// This test exercises three layers of the fix:
+//  1. processSyncResponse persists reasoning_content from ChatSyncResponse
+//     onto the assistant ConversationMessage.
+//  2. buildSDKMessages emits both `reasoning` and `reasoning_content` on the
+//     outbound sdk.Message (provider-agnostic).
+//  3. convertToConversationEntry / convertFromConversationEntry round-trip
+//     the field through storage so resumed sessions still carry it.
+func TestReasoningContentRoundTripSyncPath(t *testing.T) {
+	const reasoning = "The user asked me to echo, so I'll call Bash."
+
+	t.Run("processSyncResponse persists reasoning_content on assistant message", func(t *testing.T) {
+		session := &AgentSession{
+			toolService:  &domainmocks.FakeToolService{},
+			config:       &config.Config{Agent: config.AgentConfig{MaxConcurrentTools: 1}},
+			conversation: []ConversationMessage{},
+		}
+
+		resp := &domain.ChatSyncResponse{
+			RequestID:        "req_1",
+			Content:          "",
+			ReasoningContent: reasoning,
+			ToolCalls: []sdk.ChatCompletionMessageToolCall{{
+				Id: "call_1",
+				Function: sdk.ChatCompletionMessageToolCallFunction{
+					Name:      "Bash",
+					Arguments: `{"command":"echo hi"}`,
+				},
+			}},
+		}
+
+		if err := session.processSyncResponse(resp, "req_1"); err != nil {
+			t.Fatalf("processSyncResponse: %v", err)
+		}
+
+		if len(session.conversation) == 0 {
+			t.Fatal("expected conversation to contain assistant message")
+		}
+		assistant := session.conversation[0]
+		if assistant.Role != "assistant" {
+			t.Fatalf("expected first message to be assistant, got %q", assistant.Role)
+		}
+		if assistant.ReasoningContent != reasoning {
+			t.Errorf("assistant.ReasoningContent = %q, want %q", assistant.ReasoningContent, reasoning)
+		}
+	})
+
+	t.Run("buildSDKMessages emits reasoning and reasoning_content on outbound", func(t *testing.T) {
+		session := &AgentSession{
+			conversation: []ConversationMessage{
+				{Role: "user", Content: "echo hi"},
+				{
+					Role:             "assistant",
+					Content:          "",
+					ReasoningContent: reasoning,
+					ToolCalls: &[]sdk.ChatCompletionMessageToolCall{{
+						Id: "call_1",
+						Function: sdk.ChatCompletionMessageToolCallFunction{
+							Name: "Bash", Arguments: `{"command":"echo hi"}`,
+						},
+					}},
+				},
+			},
+		}
+
+		msgs := session.buildSDKMessages()
+		if len(msgs) != 2 {
+			t.Fatalf("expected 2 sdk messages, got %d", len(msgs))
+		}
+
+		out := msgs[1]
+		if out.Reasoning == nil || *out.Reasoning != reasoning {
+			t.Errorf("outbound Reasoning = %v, want pointer to %q", out.Reasoning, reasoning)
+		}
+		if out.ReasoningContent == nil || *out.ReasoningContent != reasoning {
+			t.Errorf("outbound ReasoningContent = %v, want pointer to %q", out.ReasoningContent, reasoning)
+		}
+	})
+
+	t.Run("convertTo/From round-trips reasoning_content through storage", func(t *testing.T) {
+		session := &AgentSession{model: "deepseek/deepseek-v4-pro"}
+
+		original := ConversationMessage{
+			Role:             "assistant",
+			Content:          "",
+			ReasoningContent: reasoning,
+			Timestamp:        mockTime(),
+		}
+
+		entry := session.convertToConversationEntry(original)
+		if entry.ReasoningContent != reasoning {
+			t.Errorf("entry.ReasoningContent = %q, want %q", entry.ReasoningContent, reasoning)
+		}
+		if entry.Message.ReasoningContent == nil || *entry.Message.ReasoningContent != reasoning {
+			t.Errorf("entry.Message.ReasoningContent = %v, want pointer to %q", entry.Message.ReasoningContent, reasoning)
+		}
+
+		restored := session.convertFromConversationEntry(entry)
+		if restored.ReasoningContent != reasoning {
+			t.Errorf("restored.ReasoningContent = %q, want %q", restored.ReasoningContent, reasoning)
+		}
+	})
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -325,29 +325,47 @@ func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*
 
 	duration := time.Since(startTime)
 
-	var content string
-	var toolCalls []sdk.ChatCompletionMessageToolCall
-
-	if len(response.Choices) > 0 {
-		choice := response.Choices[0]
-		contentStr, err := choice.Message.Content.AsMessageContent0()
-		if err != nil {
-			contentStr = ""
-		}
-		content = contentStr
-
-		if choice.Message.ToolCalls != nil {
-			toolCalls = *choice.Message.ToolCalls
-		}
-	}
+	content, reasoningContent, toolCalls := extractFirstChoice(response)
 
 	return &domain.ChatSyncResponse{
-		RequestID: req.RequestID,
-		Content:   content,
-		ToolCalls: toolCalls,
-		Usage:     response.Usage,
-		Duration:  duration,
+		RequestID:        req.RequestID,
+		Content:          content,
+		ReasoningContent: reasoningContent,
+		ToolCalls:        toolCalls,
+		Usage:            response.Usage,
+		Duration:         duration,
 	}, nil
+}
+
+// extractFirstChoice pulls content, reasoning, and tool calls from the first
+// choice of a non-streaming response. Reasoning preference matches the
+// streaming path in agent_streaming.go.
+func extractFirstChoice(response *sdk.CreateChatCompletionResponse) (string, string, []sdk.ChatCompletionMessageToolCall) {
+	if len(response.Choices) == 0 {
+		return "", "", nil
+	}
+
+	choice := response.Choices[0]
+
+	content, err := choice.Message.Content.AsMessageContent0()
+	if err != nil {
+		content = ""
+	}
+
+	reasoning := ""
+	switch {
+	case choice.Message.Reasoning != nil && *choice.Message.Reasoning != "":
+		reasoning = *choice.Message.Reasoning
+	case choice.Message.ReasoningContent != nil && *choice.Message.ReasoningContent != "":
+		reasoning = *choice.Message.ReasoningContent
+	}
+
+	var toolCalls []sdk.ChatCompletionMessageToolCall
+	if choice.Message.ToolCalls != nil {
+		toolCalls = *choice.Message.ToolCalls
+	}
+
+	return content, reasoning, toolCalls
 }
 
 // batchDrainQueue drains all queued messages and adds them to conversation

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -230,11 +230,12 @@ type ChatMetrics struct {
 
 // ChatSyncResponse represents a synchronous chat completion response
 type ChatSyncResponse struct {
-	RequestID string                              `json:"request_id"`
-	Content   string                              `json:"content"`
-	ToolCalls []sdk.ChatCompletionMessageToolCall `json:"tool_calls,omitempty"`
-	Usage     *sdk.CompletionUsage                `json:"usage,omitempty"`
-	Duration  time.Duration                       `json:"duration"`
+	RequestID        string                              `json:"request_id"`
+	Content          string                              `json:"content"`
+	ReasoningContent string                              `json:"reasoning_content,omitempty"`
+	ToolCalls        []sdk.ChatCompletionMessageToolCall `json:"tool_calls,omitempty"`
+	Usage            *sdk.CompletionUsage                `json:"usage,omitempty"`
+	Duration         time.Duration                       `json:"duration"`
 }
 
 // ChatService handles chat completion operations


### PR DESCRIPTION
## Summary

- Fixes #428: `infer agent` (the subprocess channels-manager spawns per inbound message) was silently dropping the assistant message's `reasoning_content` end-to-end. With `deepseek/deepseek-v4-pro` — whose API now requires `reasoning_content` to be passed back on assistant messages produced in thinking mode — this caused the next iteration after a tool call to fail with HTTP 400.
- Threads `reasoning_content` through the six layers of the non-streaming path that previously lost it: `domain.ChatSyncResponse`, `AgentServiceImpl.Run` extraction, `cmd.ConversationMessage`, `processSyncResponse`, `buildSDKMessages` outbound, and `convertTo/FromConversationEntry` storage round-trip.
- Outbound assistant messages set **both** `sdk.Message.Reasoning` and `sdk.Message.ReasoningContent` to the same value — provider-agnostic, mirrors what the streaming path already does at `agent_streaming.go:281-285`. The OpenAPI documents the two fields as semantically identical.
- Streaming path (`chat` mode / `RunWithStream`) was already correct and is untouched.

## Verification

End-to-end against the running gateway with `deepseek/deepseek-v4-pro`:

```
{"role":"assistant","content":"","reasoning_content":"The user wants me to echo \"hello world\"...","tools":["Bash"],...}
{"role":"tool","content":"...echo 'hello world' → hello world","...}
{"role":"assistant","content":"I ran `echo 'hello world'` and got back: ...","reasoning_content":"The command executed successfully...",...}
```

Previously the second assistant turn returned HTTP 400 (`reasoning_content ... must be passed back to the API`).
