### PR TITLE
refactor: Move prompts to separate prompts.yaml config

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -57,6 +57,7 @@ tools:
       - .infer/agents.yaml
       - .infer/mcp.yaml
       - .infer/keybindings.yaml
+      - .infer/prompts.yaml
       - .git/
       - '*.env'
   bash:
@@ -159,97 +160,10 @@ export:
   summary_model: ""
 agent:
   model: ""
-  system_prompt: Autonomous software engineering agent. Execute tasks iteratively until completion.
   system_prompt_with_defaults: true
-  custom_instructions: ""
-  system_prompt_plan: |-
-    You are an AI planning assistant in PLAN MODE. Your role is to analyze user requests and create ACTIONABLE, EXECUTABLE plans WITHOUT executing them.
-
-    CRITICAL: Your plan MUST be actionable - if the user accepts it, you will be asked to execute it step-by-step. Plans that are not actionable are NOT plans.
-
-    CAPABILITIES IN PLAN MODE:
-    - Read, Grep, and Tree tools for gathering information
-    - TodoWrite for tracking planning progress
-    - RequestPlanApproval tool to submit your plan for user approval
-    - Analyze code structure and dependencies
-    - Break down complex tasks into concrete, executable steps
-    - Identify exact files and code locations that need changes
-
-    RESTRICTIONS IN PLAN MODE:
-    - DO NOT execute Write, Edit, Delete, Bash, or modification tools
-    - DO NOT make any changes to files or system
-    - DO NOT attempt to implement the plan
-    - Focus solely on creating an executable plan
-
-    PLANNING WORKFLOW:
-    1. Use Read/Grep/Tree to understand the codebase thoroughly
-    2. Analyze the user's request and identify ALL requirements
-    3. If you need clarification or more information, ASK the user - do NOT call RequestPlanApproval yet
-    4. Break down into specific, numbered action steps
-    5. For EACH step, specify:
-       - Exact file paths to modify
-       - Specific changes to make
-       - Tool calls that will be needed
-    6. Include testing and validation steps
-    7. When your plan is complete and actionable, call RequestPlanApproval tool
-
-    DECISION MAKING:
-    - Need more info? ASK questions instead of requesting approval
-    - Plan has gaps or uncertainties? ASK for clarification
-    - Plan is complete and specific? Call RequestPlanApproval tool
-
-    OUTPUT FORMAT - ACTIONABLE STEPS:
-    Structure your plan with concrete actions:
-    - Overview: What will be done and why
-    - Steps: Numbered steps with SPECIFIC actions
-      Example: "Step 1: Edit /path/to/file.go - Add function X at line Y"
-      Example: "Step 2: Run 'task test' to verify changes"
-    - Files: Exact list of files to be modified
-    - Testing: Specific commands to run and expected outcomes
-
-    REMEMBER:
-    - If accepted, YOU will execute this plan. Make it specific and actionable!
-    - Call RequestPlanApproval ONLY when your plan is complete and ready
-    - If you need clarification, ASK - don't guess!
-  system_prompt_remote: |-
-    Remote system administration agent. You are operating on a remote machine via SSH.
-
-    FOCUS: System operations, service management, monitoring, diagnostics, and infrastructure tasks.
-
-    CONTEXT: This is a shared system environment, not a project workspace. Users may be managing servers, containers, services, or general infrastructure.
-
-    COMPUTER USE TOOLS:
-    You have TWO ways to interact with the system:
-    1. Direct terminal tools (PRIMARY): Bash, Read, Write, Edit, Grep, etc.
-    2. GUI automation tools (FALLBACK): MouseMove, KeyboardType, MouseClick, GetLatestScreenshot
-
-    CRITICAL: ALWAYS prefer direct terminal tools over GUI automation when possible.
-
-    When to use DIRECT tools (preferred):
-    - Reading files: Use Read tool, NOT KeyboardType to open an editor
-    - Writing files: Use Write/Edit tools, NOT GUI text editor
-    - Running commands: Use Bash tool, NOT KeyboardType in a terminal window
-    - Searching code: Use Grep tool, NOT opening files via GUI
-    - System operations: Use Bash for systemctl, journalctl, docker, etc.
-
-    When to use GUI tools (only when necessary):
-    - Interacting with graphical applications that have no CLI equivalent
-    - Testing UI behavior or visual elements
-    - Remote desktop administration tasks that MUST be done through a GUI
-
-    Why prefer direct tools:
-    - 10-100x faster execution (no GUI rendering delays)
-    - More reliable (no window focus issues, no timing problems)
-    - Works over SSH without X11 forwarding
-    - Precise output (structured data, not visual interpretation)
-    - Lower resource usage (critical for remote systems)
   system_reminders:
     enabled: true
     interval: 4
-    reminder_text: |-
-      <system-reminder>
-      This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.
-      </system-reminder>
   context:
     git_context_enabled: true
     working_dir_enabled: true
@@ -261,31 +175,6 @@ agent:
 git:
   commit_message:
     model: ""
-    system_prompt: |-
-      Generate a concise git commit message following conventional commit format.
-
-      REQUIREMENTS:
-      - MUST use format: "type: Brief description"
-      - MUST be under 50 characters total
-      - MUST use imperative mood (e.g., "Add", "Fix", "Update")
-      - Types: feat, fix, docs, style, refactor, test, chore
-
-      EXAMPLES:
-      - "feat: Add git shortcut with AI commits"
-      - "fix: Resolve build error in container"
-      - "docs: Update README installation guide"
-      - "refactor: Simplify error handling"
-
-      Respond with ONLY the commit message, no quotes or explanation.
-scm:
-  pr_create:
-    prompt: ""
-    base_branch: main
-    branch_prefix: ""
-    model: ""
-  cleanup:
-    return_to_base: true
-    delete_local_branch: false
 storage:
   enabled: true
   type: jsonl
@@ -309,23 +198,6 @@ conversation:
   title_generation:
     enabled: true
     model: ""
-    system_prompt: |-
-      Generate a concise conversation title based on the messages provided.
-
-      REQUIREMENTS:
-      - MUST be under 50 characters total
-      - MUST be descriptive and capture the main topic
-      - MUST use title case
-      - NO quotes, colons, or special characters
-      - Focus on the primary subject or task discussed
-
-      EXAMPLES:
-      - "React Component Testing"
-      - "Database Migration Setup"
-      - "API Error Handling"
-      - "Docker Configuration"
-
-      Respond with ONLY the title, no quotes or explanation.
     batch_size: 10
     interval: 0
 chat:
@@ -381,22 +253,6 @@ pricing:
   enabled: true
   currency: USD
   custom_prices: {}
-init:
-  prompt: |-
-    Please analyze this project and generate a comprehensive AGENTS.md file. Start by using the Tree tool to understand the project structure.
-    Use your available tools to examine configuration files, documentation, build systems, and development workflow.
-    Focus on creating actionable documentation that will help other AI agents understand how to work effectively with this project.
-
-    The AGENTS.md file should include:
-    - Project overview and main technologies
-    - Architecture and structure
-    - Development environment setup
-    - Key commands (build, test, lint, run)
-    - Testing instructions
-    - Project conventions and coding standards
-    - Important files and configurations
-
-    Write the AGENTS.md file to the project root when you have gathered enough information.
 compact:
   enabled: true
   auto_at: 80

--- a/.infer/prompts.yaml
+++ b/.infer/prompts.yaml
@@ -1,0 +1,143 @@
+---
+agent:
+  system_prompt: Autonomous software engineering agent. Execute tasks iteratively until completion.
+  system_prompt_plan: |-
+    You are an AI planning assistant in PLAN MODE. Your role is to analyze user requests and create ACTIONABLE, EXECUTABLE plans WITHOUT executing them.
+
+    CRITICAL: Your plan MUST be actionable - if the user accepts it, you will be asked to execute it step-by-step. Plans that are not actionable are NOT plans.
+
+    CAPABILITIES IN PLAN MODE:
+    - Read, Grep, and Tree tools for gathering information
+    - TodoWrite for tracking planning progress
+    - RequestPlanApproval tool to submit your plan for user approval
+    - Analyze code structure and dependencies
+    - Break down complex tasks into concrete, executable steps
+    - Identify exact files and code locations that need changes
+
+    RESTRICTIONS IN PLAN MODE:
+    - DO NOT execute Write, Edit, Delete, Bash, or modification tools
+    - DO NOT make any changes to files or system
+    - DO NOT attempt to implement the plan
+    - Focus solely on creating an executable plan
+
+    PLANNING WORKFLOW:
+    1. Use Read/Grep/Tree to understand the codebase thoroughly
+    2. Analyze the user's request and identify ALL requirements
+    3. If you need clarification or more information, ASK the user - do NOT call RequestPlanApproval yet
+    4. Break down into specific, numbered action steps
+    5. For EACH step, specify:
+       - Exact file paths to modify
+       - Specific changes to make
+       - Tool calls that will be needed
+    6. Include testing and validation steps
+    7. When your plan is complete and actionable, call RequestPlanApproval tool
+
+    DECISION MAKING:
+    - Need more info? ASK questions instead of requesting approval
+    - Plan has gaps or uncertainties? ASK for clarification
+    - Plan is complete and specific? Call RequestPlanApproval tool
+
+    OUTPUT FORMAT - ACTIONABLE STEPS:
+    Structure your plan with concrete actions:
+    - Overview: What will be done and why
+    - Steps: Numbered steps with SPECIFIC actions
+      Example: "Step 1: Edit /path/to/file.go - Add function X at line Y"
+      Example: "Step 2: Run 'task test' to verify changes"
+    - Files: Exact list of files to be modified
+    - Testing: Specific commands to run and expected outcomes
+
+    REMEMBER:
+    - If accepted, YOU will execute this plan. Make it specific and actionable!
+    - Call RequestPlanApproval ONLY when your plan is complete and ready
+    - If you need clarification, ASK - don't guess!
+  system_prompt_remote: |-
+    Remote system administration agent. You are operating on a remote machine via SSH.
+
+    FOCUS: System operations, service management, monitoring, diagnostics, and infrastructure tasks.
+
+    CONTEXT: This is a shared system environment, not a project workspace. Users may be managing servers, containers, services, or general infrastructure.
+
+    COMPUTER USE TOOLS:
+    You have TWO ways to interact with the system:
+    1. Direct terminal tools (PRIMARY): Bash, Read, Write, Edit, Grep, etc.
+    2. GUI automation tools (FALLBACK): MouseMove, KeyboardType, MouseClick, GetLatestScreenshot
+
+    CRITICAL: ALWAYS prefer direct terminal tools over GUI automation when possible.
+
+    When to use DIRECT tools (preferred):
+    - Reading files: Use Read tool, NOT KeyboardType to open an editor
+    - Writing files: Use Write/Edit tools, NOT GUI text editor
+    - Running commands: Use Bash tool, NOT KeyboardType in a terminal window
+    - Searching code: Use Grep tool, NOT opening files via GUI
+    - System operations: Use Bash for systemctl, journalctl, docker, etc.
+
+    When to use GUI tools (only when necessary):
+    - Interacting with graphical applications that have no CLI equivalent
+    - Testing UI behavior or visual elements
+    - Remote desktop administration tasks that MUST be done through a GUI
+
+    Why prefer direct tools:
+    - 10-100x faster execution (no GUI rendering delays)
+    - More reliable (no window focus issues, no timing problems)
+    - Works over SSH without X11 forwarding
+    - Precise output (structured data, not visual interpretation)
+    - Lower resource usage (critical for remote systems)
+  custom_instructions: ""
+  system_reminders:
+    reminder_text: |-
+      <system-reminder>
+      This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.
+      </system-reminder>
+git:
+  commit_message:
+    system_prompt: |-
+      Generate a concise git commit message following conventional commit format.
+
+      REQUIREMENTS:
+      - MUST use format: "type: Brief description"
+      - MUST be under 50 characters total
+      - MUST use imperative mood (e.g., "Add", "Fix", "Update")
+      - Types: feat, fix, docs, style, refactor, test, chore
+
+      EXAMPLES:
+      - "feat: Add git shortcut with AI commits"
+      - "fix: Resolve build error in container"
+      - "docs: Update README installation guide"
+      - "refactor: Simplify error handling"
+
+      Respond with ONLY the commit message, no quotes or explanation.
+conversation:
+  title_generation:
+    system_prompt: |-
+      Generate a concise conversation title based on the messages provided.
+
+      REQUIREMENTS:
+      - MUST be under 50 characters total
+      - MUST be descriptive and capture the main topic
+      - MUST use title case
+      - NO quotes, colons, or special characters
+      - Focus on the primary subject or task discussed
+
+      EXAMPLES:
+      - "React Component Testing"
+      - "Database Migration Setup"
+      - "API Error Handling"
+      - "Docker Configuration"
+
+      Respond with ONLY the title, no quotes or explanation.
+init:
+  prompt: |-
+    Please analyze this project and generate a comprehensive AGENTS.md file. Start by using the Tree tool to understand the project structure.
+    Use your available tools to examine configuration files, documentation, build systems, and development workflow.
+    Focus on creating actionable documentation that will help other AI agents understand how to work effectively with this project.
+
+    The AGENTS.md file should include:
+    - Project overview and main technologies
+    - Architecture and structure
+    - Development environment setup
+    - Key commands (build, test, lint, run)
+    - Testing instructions
+    - Project conventions and coding standards
+    - Important files and configurations
+
+    Write the AGENTS.md file to the project root when you have gathered enough information.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -596,6 +596,27 @@ func getEffectiveKeybindingsConfigPath() string {
 	return config.DefaultKeybindingsPath
 }
 
+// getEffectivePromptsConfigPath returns the path to the prompts config file
+// Searches in this order: 1) project .infer/prompts.yaml, 2) user home ~/.infer/prompts.yaml
+func getEffectivePromptsConfigPath() string {
+	searchPaths := []string{
+		config.DefaultPromptsPath,
+	}
+
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		homePath := filepath.Join(homeDir, config.ConfigDirName, config.PromptsFileName)
+		searchPaths = append(searchPaths, homePath)
+	}
+
+	for _, path := range searchPaths {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	return config.DefaultPromptsPath
+}
+
 // getKeybindingsConfigWritePath returns the path to write keybindings to,
 // honouring the --userspace flag.
 func getKeybindingsConfigWritePath(userspace bool) (string, error) {
@@ -639,7 +660,64 @@ func getConfigFromViper() (*config.Config, error) {
 
 	applyKeybindingEnvOverrides(cfg)
 
+	promptsPath := getEffectivePromptsConfigPath()
+	promptsService := services.NewPromptsConfigService(promptsPath)
+	prompts, err := promptsService.Load()
+	if err != nil {
+		logger.Warn("Failed to load prompts config, using defaults", "error", err, "path", promptsPath)
+		prompts = config.DefaultPromptsConfig()
+	}
+	applyPromptsOverlay(cfg, prompts)
+	applyPromptsEnvOverrides(cfg)
+
 	return cfg, nil
+}
+
+// applyPromptsOverlay copies every prompt loaded from prompts.yaml into the
+// in-memory Config. Empty fields fall back to DefaultPromptsConfig() so a
+// user who blanks one entry doesn't lose every other prompt.
+func applyPromptsOverlay(cfg *config.Config, p *config.PromptsConfig) {
+	defaults := config.DefaultPromptsConfig()
+
+	pickString := func(loaded, fallback string) string {
+		if loaded != "" {
+			return loaded
+		}
+		return fallback
+	}
+
+	cfg.Agent.SystemPrompt = pickString(p.Agent.SystemPrompt, defaults.Agent.SystemPrompt)
+	cfg.Agent.SystemPromptPlan = pickString(p.Agent.SystemPromptPlan, defaults.Agent.SystemPromptPlan)
+	cfg.Agent.SystemPromptRemote = pickString(p.Agent.SystemPromptRemote, defaults.Agent.SystemPromptRemote)
+	cfg.Agent.CustomInstructions = p.Agent.CustomInstructions
+	cfg.Agent.SystemReminders.ReminderText = pickString(p.Agent.SystemReminders.ReminderText, defaults.Agent.SystemReminders.ReminderText)
+
+	cfg.Git.CommitMessage.SystemPrompt = pickString(p.Git.CommitMessage.SystemPrompt, defaults.Git.CommitMessage.SystemPrompt)
+	cfg.Conversation.TitleGeneration.SystemPrompt = pickString(p.Conversation.TitleGeneration.SystemPrompt, defaults.Conversation.TitleGeneration.SystemPrompt)
+	cfg.Init.Prompt = pickString(p.Init.Prompt, defaults.Init.Prompt)
+}
+
+// applyPromptsEnvOverrides lets users force a prompt from the environment.
+// Run AFTER applyPromptsOverlay so envs win over the YAML file. Only the
+// prompt fields exposed in PromptsConfig are checked, so an unrelated
+// INFER_PROMPTS_* var is silently ignored.
+func applyPromptsEnvOverrides(cfg *config.Config) {
+	envOverrides := map[string]*string{
+		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT":                         &cfg.Agent.SystemPrompt,
+		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT_PLAN":                    &cfg.Agent.SystemPromptPlan,
+		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT_REMOTE":                  &cfg.Agent.SystemPromptRemote,
+		"INFER_PROMPTS_AGENT_CUSTOM_INSTRUCTIONS":                   &cfg.Agent.CustomInstructions,
+		"INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_REMINDER_TEXT":        &cfg.Agent.SystemReminders.ReminderText,
+		"INFER_PROMPTS_GIT_COMMIT_MESSAGE_SYSTEM_PROMPT":            &cfg.Git.CommitMessage.SystemPrompt,
+		"INFER_PROMPTS_CONVERSATION_TITLE_GENERATION_SYSTEM_PROMPT": &cfg.Conversation.TitleGeneration.SystemPrompt,
+		"INFER_PROMPTS_INIT_PROMPT":                                 &cfg.Init.Prompt,
+	}
+
+	for envKey, target := range envOverrides {
+		if val, ok := os.LookupEnv(envKey); ok {
+			*target = val
+		}
+	}
 }
 
 // applyKeybindingEnvOverrides walks INFER_CHAT_KEYBINDINGS_BINDINGS_*

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -41,7 +41,7 @@ func initializeProject(cmd *cobra.Command) error {
 	userspace, _ := cmd.Flags().GetBool("userspace")
 	skipMigrations, _ := cmd.Flags().GetBool("skip-migrations")
 
-	var configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, a2aShortcutsPath, mcpPath, keybindingsPath string
+	var configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, a2aShortcutsPath, mcpPath, keybindingsPath, promptsPath string
 
 	if userspace {
 		homeDir, err := os.UserHomeDir()
@@ -58,6 +58,7 @@ func initializeProject(cmd *cobra.Command) error {
 		a2aShortcutsPath = filepath.Join(homeDir, config.ConfigDirName, "shortcuts", "a2a.yaml")
 		mcpPath = filepath.Join(homeDir, config.ConfigDirName, config.MCPFileName)
 		keybindingsPath = filepath.Join(homeDir, config.ConfigDirName, config.KeybindingsFileName)
+		promptsPath = filepath.Join(homeDir, config.ConfigDirName, config.PromptsFileName)
 	} else {
 		configPath = config.DefaultConfigPath
 		gitignorePath = filepath.Join(config.ConfigDirName, config.GitignoreFileName)
@@ -69,10 +70,11 @@ func initializeProject(cmd *cobra.Command) error {
 		a2aShortcutsPath = filepath.Join(config.ConfigDirName, "shortcuts", "a2a.yaml")
 		mcpPath = filepath.Join(config.ConfigDirName, config.MCPFileName)
 		keybindingsPath = config.DefaultKeybindingsPath
+		promptsPath = config.DefaultPromptsPath
 	}
 
 	if !overwrite {
-		if err := validateFilesNotExist(configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, a2aShortcutsPath, mcpPath, keybindingsPath); err != nil {
+		if err := validateFilesNotExist(configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, a2aShortcutsPath, mcpPath, keybindingsPath, promptsPath); err != nil {
 			return err
 		}
 	}
@@ -127,6 +129,10 @@ tmp/
 		return fmt.Errorf("failed to create keybindings config file: %w", err)
 	}
 
+	if err := createPromptsConfigFile(promptsPath); err != nil {
+		return fmt.Errorf("failed to create prompts config file: %w", err)
+	}
+
 	var scopeDesc string
 	if userspace {
 		scopeDesc = "userspace"
@@ -145,6 +151,7 @@ tmp/
 	fmt.Printf("   Created: %s\n", a2aShortcutsPath)
 	fmt.Printf("   Created: %s\n", mcpPath)
 	fmt.Printf("   Created: %s\n", keybindingsPath)
+	fmt.Printf("   Created: %s\n", promptsPath)
 	fmt.Println("")
 	if userspace {
 		fmt.Println("This userspace configuration will be used as a fallback for all projects.")
@@ -410,6 +417,18 @@ func createKeybindingsConfigFile(path string) error {
 
 	service := services.NewKeybindingsConfigService(path)
 	return service.Save(services.DefaultKeybindingsConfig())
+}
+
+// createPromptsConfigFile writes a fresh prompts.yaml seeded from the
+// in-code defaults so users can edit individual prompts without touching
+// config.yaml.
+func createPromptsConfigFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	service := services.NewPromptsConfigService(path)
+	return service.Save(config.DefaultPromptsConfig())
 }
 
 // createMCPConfigFile creates the MCP configuration YAML file

--- a/cmd/prompts_overlay_test.go
+++ b/cmd/prompts_overlay_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	require "github.com/stretchr/testify/require"
+
+	config "github.com/inference-gateway/cli/config"
+	services "github.com/inference-gateway/cli/internal/services"
+)
+
+// TestGetConfigFromViper_PromptsDefaultsWhenFileAbsent confirms the
+// overlay falls back to in-code defaults when no prompts.yaml exists,
+// so freshly-cloned repos still get a working agent prompt.
+func TestGetConfigFromViper_PromptsDefaultsWhenFileAbsent(t *testing.T) {
+	withHermeticEnv(t)
+	initConfig()
+
+	cfg, err := getConfigFromViper()
+	require.NoError(t, err)
+
+	defaults := config.DefaultPromptsConfig()
+	require.Equal(t, defaults.Agent.SystemPrompt, cfg.Agent.SystemPrompt)
+	require.Equal(t, defaults.Agent.SystemPromptPlan, cfg.Agent.SystemPromptPlan)
+	require.Equal(t, defaults.Agent.SystemPromptRemote, cfg.Agent.SystemPromptRemote)
+	require.Equal(t, defaults.Agent.SystemReminders.ReminderText, cfg.Agent.SystemReminders.ReminderText)
+	require.Equal(t, defaults.Git.CommitMessage.SystemPrompt, cfg.Git.CommitMessage.SystemPrompt)
+	require.Equal(t, defaults.Conversation.TitleGeneration.SystemPrompt, cfg.Conversation.TitleGeneration.SystemPrompt)
+	require.Equal(t, defaults.Init.Prompt, cfg.Init.Prompt)
+}
+
+// TestGetConfigFromViper_PromptsPartialFileFallsBackForUnsetFields
+// guards the partial-overlay rule: if a user blanks out (or never sets)
+// a single prompt key, the others must still resolve to defaults instead
+// of becoming empty strings. Empty prompts at runtime would cause the
+// LLM to receive no system instructions.
+func TestGetConfigFromViper_PromptsPartialFileFallsBackForUnsetFields(t *testing.T) {
+	withHermeticEnv(t)
+
+	homeDir := os.Getenv("HOME")
+	promptsPath := filepath.Join(homeDir, config.ConfigDirName, config.PromptsFileName)
+	custom := &config.PromptsConfig{
+		Agent: config.PromptsAgentConfig{
+			SystemPrompt: "USER OVERRIDE: only this is set",
+		},
+	}
+	require.NoError(t, services.NewPromptsConfigService(promptsPath).Save(custom))
+
+	initConfig()
+	cfg, err := getConfigFromViper()
+	require.NoError(t, err)
+
+	defaults := config.DefaultPromptsConfig()
+	require.Equal(t, "USER OVERRIDE: only this is set", cfg.Agent.SystemPrompt)
+	require.Equal(t, defaults.Agent.SystemPromptPlan, cfg.Agent.SystemPromptPlan, "unset plan prompt should fall back to default")
+	require.Equal(t, defaults.Git.CommitMessage.SystemPrompt, cfg.Git.CommitMessage.SystemPrompt, "unset git prompt should fall back to default")
+	require.Equal(t, defaults.Init.Prompt, cfg.Init.Prompt, "unset init prompt should fall back to default")
+}
+
+// TestGetConfigFromViper_PromptsEnvOverridesFile pins the precedence
+// order: env > file > in-code defaults. Without this guarantee, ops
+// teams cannot inject a prompt at deploy time without editing the file
+// inside the container image.
+func TestGetConfigFromViper_PromptsEnvOverridesFile(t *testing.T) {
+	withHermeticEnv(t)
+
+	homeDir := os.Getenv("HOME")
+	promptsPath := filepath.Join(homeDir, config.ConfigDirName, config.PromptsFileName)
+	require.NoError(t, services.NewPromptsConfigService(promptsPath).Save(&config.PromptsConfig{
+		Agent: config.PromptsAgentConfig{SystemPrompt: "from-file"},
+	}))
+	t.Setenv("INFER_PROMPTS_AGENT_SYSTEM_PROMPT", "from-env")
+
+	initConfig()
+	cfg, err := getConfigFromViper()
+	require.NoError(t, err)
+
+	require.Equal(t, "from-env", cfg.Agent.SystemPrompt)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -33,14 +33,13 @@ type Config struct {
 	Export           ExportConfig           `yaml:"export" mapstructure:"export"`
 	Agent            AgentConfig            `yaml:"agent" mapstructure:"agent"`
 	Git              GitConfig              `yaml:"git" mapstructure:"git"`
-	SCM              SCMConfig              `yaml:"scm" mapstructure:"scm"`
 	Storage          StorageConfig          `yaml:"storage" mapstructure:"storage"`
 	Conversation     ConversationConfig     `yaml:"conversation" mapstructure:"conversation"`
 	Chat             ChatConfig             `yaml:"chat" mapstructure:"chat"`
 	A2A              A2AConfig              `yaml:"a2a" mapstructure:"a2a"`
 	MCP              MCPConfig              `yaml:"mcp" mapstructure:"mcp"`
 	Pricing          PricingConfig          `yaml:"pricing" mapstructure:"pricing"`
-	Init             InitConfig             `yaml:"init" mapstructure:"init"`
+	Init             InitConfig             `yaml:"-" mapstructure:"-"`
 	Compact          CompactConfig          `yaml:"compact" mapstructure:"compact"`
 	Web              WebConfig              `yaml:"web" mapstructure:"web"`
 	ComputerUse      ComputerUseConfig      `yaml:"computer_use" mapstructure:"computer_use"`
@@ -410,11 +409,13 @@ type SSHServerConfig struct {
 	Tags        []string `yaml:"tags" mapstructure:"tags"`
 }
 
-// SystemRemindersConfig contains settings for dynamic system reminders
+// SystemRemindersConfig contains settings for dynamic system reminders.
+// ReminderText is sourced from prompts.yaml at runtime — it carries no
+// yaml/mapstructure tags so it never appears in config.yaml.
 type SystemRemindersConfig struct {
 	Enabled      bool   `yaml:"enabled" mapstructure:"enabled"`
 	Interval     int    `yaml:"interval" mapstructure:"interval"`
-	ReminderText string `yaml:"reminder_text" mapstructure:"reminder_text"`
+	ReminderText string `yaml:"-" mapstructure:"-"`
 }
 
 // AgentContextConfig contains settings for agent context enrichment
@@ -424,14 +425,17 @@ type AgentContextConfig struct {
 	GitContextRefreshTurns int  `yaml:"git_context_refresh_turns" mapstructure:"git_context_refresh_turns"`
 }
 
-// AgentConfig contains agent command-specific settings
+// AgentConfig contains agent command-specific settings.
+// The SystemPrompt*, CustomInstructions, and SystemReminders fields are
+// sourced from prompts.yaml at runtime — they carry no yaml/mapstructure
+// tags so they never appear in config.yaml.
 type AgentConfig struct {
 	Model                    string                `yaml:"model" mapstructure:"model"`
-	SystemPrompt             string                `yaml:"system_prompt" mapstructure:"system_prompt"`
+	SystemPrompt             string                `yaml:"-" mapstructure:"-"`
 	SystemPromptWithDefaults bool                  `yaml:"system_prompt_with_defaults" mapstructure:"system_prompt_with_defaults"`
-	CustomInstructions       string                `yaml:"custom_instructions" mapstructure:"custom_instructions"`
-	SystemPromptPlan         string                `yaml:"system_prompt_plan" mapstructure:"system_prompt_plan"`
-	SystemPromptRemote       string                `yaml:"system_prompt_remote" mapstructure:"system_prompt_remote"`
+	CustomInstructions       string                `yaml:"-" mapstructure:"-"`
+	SystemPromptPlan         string                `yaml:"-" mapstructure:"-"`
+	SystemPromptRemote       string                `yaml:"-" mapstructure:"-"`
 	SystemReminders          SystemRemindersConfig `yaml:"system_reminders" mapstructure:"system_reminders"`
 	Context                  AgentContextConfig    `yaml:"context" mapstructure:"context"`
 	VerboseTools             bool                  `yaml:"verbose_tools" mapstructure:"verbose_tools"`
@@ -466,17 +470,20 @@ type ConversationConfig struct {
 	TitleGeneration ConversationTitleConfig `yaml:"title_generation" mapstructure:"title_generation"`
 }
 
-// GitCommitMessageConfig contains settings for AI-generated commit messages
+// GitCommitMessageConfig contains settings for AI-generated commit
+// messages. SystemPrompt is sourced from prompts.yaml at runtime — it
+// carries no yaml/mapstructure tags so it never appears in config.yaml.
 type GitCommitMessageConfig struct {
 	Model        string `yaml:"model" mapstructure:"model"`
-	SystemPrompt string `yaml:"system_prompt" mapstructure:"system_prompt"`
+	SystemPrompt string `yaml:"-" mapstructure:"-"`
 }
 
-// ConversationTitleConfig contains settings for AI-generated conversation titles
+// ConversationTitleConfig contains settings for AI-generated conversation
+// titles. SystemPrompt is sourced from prompts.yaml at runtime.
 type ConversationTitleConfig struct {
 	Enabled      bool   `yaml:"enabled" mapstructure:"enabled"`
 	Model        string `yaml:"model" mapstructure:"model"`
-	SystemPrompt string `yaml:"system_prompt" mapstructure:"system_prompt"`
+	SystemPrompt string `yaml:"-" mapstructure:"-"`
 	BatchSize    int    `yaml:"batch_size" mapstructure:"batch_size"`
 	Interval     int    `yaml:"interval" mapstructure:"interval"`
 }
@@ -526,29 +533,10 @@ type StatusBarIndicators struct {
 	GitBranch        bool `yaml:"git_branch" mapstructure:"git_branch"`
 }
 
-// InitConfig contains settings for the /init shortcut
+// InitConfig contains settings for the /init shortcut. Prompt is sourced
+// from prompts.yaml at runtime.
 type InitConfig struct {
-	Prompt string `yaml:"prompt" mapstructure:"prompt"`
-}
-
-// SCMConfig contains settings for source control management shortcuts
-type SCMConfig struct {
-	PRCreate SCMPRCreateConfig `yaml:"pr_create" mapstructure:"pr_create"`
-	Cleanup  SCMCleanupConfig  `yaml:"cleanup" mapstructure:"cleanup"`
-}
-
-// SCMPRCreateConfig contains settings for the /scm pr create shortcut
-type SCMPRCreateConfig struct {
-	Prompt       string `yaml:"prompt" mapstructure:"prompt"`
-	BaseBranch   string `yaml:"base_branch" mapstructure:"base_branch"`
-	BranchPrefix string `yaml:"branch_prefix" mapstructure:"branch_prefix"`
-	Model        string `yaml:"model" mapstructure:"model"`
-}
-
-// SCMCleanupConfig contains settings for cleanup after PR creation
-type SCMCleanupConfig struct {
-	ReturnToBase      bool `yaml:"return_to_base" mapstructure:"return_to_base"`
-	DeleteLocalBranch bool `yaml:"delete_local_branch" mapstructure:"delete_local_branch"`
+	Prompt string `yaml:"-" mapstructure:"-"`
 }
 
 // FetchSafetyConfig contains safety settings for fetch operations
@@ -752,6 +740,8 @@ func DefaultConfig() *Config { //nolint:funlen
 					ConfigDirName + "/shortcuts/",
 					ConfigDirName + "/agents.yaml",
 					ConfigDirName + "/mcp.yaml",
+					ConfigDirName + "/keybindings.yaml",
+					ConfigDirName + "/prompts.yaml",
 					".git/",
 					"*.env",
 				},
@@ -874,94 +864,10 @@ func DefaultConfig() *Config { //nolint:funlen
 				WorkingDirEnabled:      true,
 				GitContextRefreshTurns: 10,
 			},
-			SystemPromptPlan: `You are an AI planning assistant in PLAN MODE. Your role is to analyze user requests and create ACTIONABLE, EXECUTABLE plans WITHOUT executing them.
-
-CRITICAL: Your plan MUST be actionable - if the user accepts it, you will be asked to execute it step-by-step. Plans that are not actionable are NOT plans.
-
-CAPABILITIES IN PLAN MODE:
-- Read, Grep, and Tree tools for gathering information
-- TodoWrite for tracking planning progress
-- RequestPlanApproval tool to submit your plan for user approval
-- Analyze code structure and dependencies
-- Break down complex tasks into concrete, executable steps
-- Identify exact files and code locations that need changes
-
-RESTRICTIONS IN PLAN MODE:
-- DO NOT execute Write, Edit, Delete, Bash, or modification tools
-- DO NOT make any changes to files or system
-- DO NOT attempt to implement the plan
-- Focus solely on creating an executable plan
-
-PLANNING WORKFLOW:
-1. Use Read/Grep/Tree to understand the codebase thoroughly
-2. Analyze the user's request and identify ALL requirements
-3. If you need clarification or more information, ASK the user - do NOT call RequestPlanApproval yet
-4. Break down into specific, numbered action steps
-5. For EACH step, specify:
-   - Exact file paths to modify
-   - Specific changes to make
-   - Tool calls that will be needed
-6. Include testing and validation steps
-7. When your plan is complete and actionable, call RequestPlanApproval tool
-
-DECISION MAKING:
-- Need more info? ASK questions instead of requesting approval
-- Plan has gaps or uncertainties? ASK for clarification
-- Plan is complete and specific? Call RequestPlanApproval tool
-
-OUTPUT FORMAT - ACTIONABLE STEPS:
-Structure your plan with concrete actions:
-- Overview: What will be done and why
-- Steps: Numbered steps with SPECIFIC actions
-  Example: "Step 1: Edit /path/to/file.go - Add function X at line Y"
-  Example: "Step 2: Run 'task test' to verify changes"
-- Files: Exact list of files to be modified
-- Testing: Specific commands to run and expected outcomes
-
-REMEMBER:
-- If accepted, YOU will execute this plan. Make it specific and actionable!
-- Call RequestPlanApproval ONLY when your plan is complete and ready
-- If you need clarification, ASK - don't guess!`,
-			SystemPrompt:             `Autonomous software engineering agent. Execute tasks iteratively until completion.`,
 			SystemPromptWithDefaults: true,
-			CustomInstructions:       ``,
-			SystemPromptRemote: `Remote system administration agent. You are operating on a remote machine via SSH.
-
-FOCUS: System operations, service management, monitoring, diagnostics, and infrastructure tasks.
-
-CONTEXT: This is a shared system environment, not a project workspace. Users may be managing servers, containers, services, or general infrastructure.
-
-COMPUTER USE TOOLS:
-You have TWO ways to interact with the system:
-1. Direct terminal tools (PRIMARY): Bash, Read, Write, Edit, Grep, etc.
-2. GUI automation tools (FALLBACK): MouseMove, KeyboardType, MouseClick, GetLatestScreenshot
-
-CRITICAL: ALWAYS prefer direct terminal tools over GUI automation when possible.
-
-When to use DIRECT tools (preferred):
-- Reading files: Use Read tool, NOT KeyboardType to open an editor
-- Writing files: Use Write/Edit tools, NOT GUI text editor
-- Running commands: Use Bash tool, NOT KeyboardType in a terminal window
-- Searching code: Use Grep tool, NOT opening files via GUI
-- System operations: Use Bash for systemctl, journalctl, docker, etc.
-
-When to use GUI tools (only when necessary):
-- Interacting with graphical applications that have no CLI equivalent
-- Testing UI behavior or visual elements
-- Remote desktop administration tasks that MUST be done through a GUI
-
-Why prefer direct tools:
-- 10-100x faster execution (no GUI rendering delays)
-- More reliable (no window focus issues, no timing problems)
-- Works over SSH without X11 forwarding
-- Precise output (structured data, not visual interpretation)
-- Lower resource usage (critical for remote systems)`,
 			SystemReminders: SystemRemindersConfig{
 				Enabled:  true,
 				Interval: 4,
-				ReminderText: `<system-reminder>
-This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.
-</system-reminder>`,
 			},
 			VerboseTools:       false,
 			MaxTurns:           50,
@@ -971,21 +877,6 @@ This is a reminder that your todo list is currently empty. DO NOT mention this t
 		Git: GitConfig{
 			CommitMessage: GitCommitMessageConfig{
 				Model: "",
-				SystemPrompt: `Generate a concise git commit message following conventional commit format.
-
-REQUIREMENTS:
-- MUST use format: "type: Brief description"
-- MUST be under 50 characters total
-- MUST use imperative mood (e.g., "Add", "Fix", "Update")
-- Types: feat, fix, docs, style, refactor, test, chore
-
-EXAMPLES:
-- "feat: Add git shortcut with AI commits"
-- "fix: Resolve build error in container"
-- "docs: Update README installation guide"
-- "refactor: Simplify error handling"
-
-Respond with ONLY the commit message, no quotes or explanation.`,
 			},
 		},
 		Storage: StorageConfig{
@@ -1017,22 +908,6 @@ Respond with ONLY the commit message, no quotes or explanation.`,
 				Enabled:   true,
 				Model:     "",
 				BatchSize: 10,
-				SystemPrompt: `Generate a concise conversation title based on the messages provided.
-
-REQUIREMENTS:
-- MUST be under 50 characters total
-- MUST be descriptive and capture the main topic
-- MUST use title case
-- NO quotes, colons, or special characters
-- Focus on the primary subject or task discussed
-
-EXAMPLES:
-- "React Component Testing"
-- "Database Migration Setup"
-- "API Error Handling"
-- "Docker Configuration"
-
-Respond with ONLY the title, no quotes or explanation.`,
 			},
 		},
 		Chat: ChatConfig{
@@ -1076,33 +951,7 @@ Respond with ONLY the title, no quotes or explanation.`,
 		},
 		MCP:     *DefaultMCPConfig(),
 		Pricing: GetDefaultPricingConfig(),
-		Init: InitConfig{
-			Prompt: `Please analyze this project and generate a comprehensive AGENTS.md file. Start by using the Tree tool to understand the project structure.
-Use your available tools to examine configuration files, documentation, build systems, and development workflow.
-Focus on creating actionable documentation that will help other AI agents understand how to work effectively with this project.
-
-The AGENTS.md file should include:
-- Project overview and main technologies
-- Architecture and structure
-- Development environment setup
-- Key commands (build, test, lint, run)
-- Testing instructions
-- Project conventions and coding standards
-- Important files and configurations
-
-Write the AGENTS.md file to the project root when you have gathered enough information.`,
-		},
-		SCM: SCMConfig{
-			PRCreate: SCMPRCreateConfig{
-				Prompt:       "",
-				BaseBranch:   "main",
-				BranchPrefix: "",
-			},
-			Cleanup: SCMCleanupConfig{
-				ReturnToBase:      true,
-				DeleteLocalBranch: false,
-			},
-		},
+		Init:    InitConfig{},
 		Compact: CompactConfig{
 			Enabled:               true,
 			AutoAt:                80,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,11 +105,12 @@ func testChatDefaults(t *testing.T, cfg *Config) {
 	if cfg.Agent.Model != "" {
 		t.Errorf("Expected default model to be empty, got %q", cfg.Agent.Model)
 	}
-	expectedSystemPrompt := `Autonomous software engineering agent. Execute tasks iteratively until completion.`
-	if cfg.Agent.SystemPrompt != expectedSystemPrompt {
-		t.Errorf("Expected system prompt to match default, got %q", cfg.Agent.SystemPrompt)
+	// Prompt defaults moved to prompts.yaml as of issue #439 — DefaultConfig
+	// leaves these fields empty so the runtime overlay (or env vars) fills
+	// them. See config/prompts.go for the live defaults.
+	if cfg.Agent.SystemPrompt != "" {
+		t.Errorf("Expected system prompt to be empty in main config (now sourced from prompts.yaml), got %q", cfg.Agent.SystemPrompt)
 	}
-
 	if cfg.Agent.CustomInstructions != "" {
 		t.Errorf("Expected custom instructions to be empty by default, got %q", cfg.Agent.CustomInstructions)
 	}
@@ -335,8 +336,12 @@ func TestSaveConfig(t *testing.T) {
 				if cfg.Agent.Model != "anthropic/claude-4" {
 					t.Errorf("Expected default model to be 'anthropic/claude-4', got %q", cfg.Agent.Model)
 				}
-				if cfg.Agent.SystemPrompt != "Be helpful" {
-					t.Errorf("Expected system prompt to be 'Be helpful', got %q", cfg.Agent.SystemPrompt)
+				// SystemPrompt is now sourced from prompts.yaml (issue #439)
+				// and tagged yaml:"-" — it intentionally does NOT round-trip
+				// through config.yaml. Asserting it is empty after save+load
+				// guards against accidentally re-tagging the field.
+				if cfg.Agent.SystemPrompt != "" {
+					t.Errorf("Expected system prompt to be empty after round-trip (it lives in prompts.yaml), got %q", cfg.Agent.SystemPrompt)
 				}
 				if cfg.Gateway.APIKey != "secret-key" {
 					t.Errorf("Expected API key to be 'secret-key', got %q", cfg.Gateway.APIKey)

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -1,0 +1,199 @@
+package config
+
+const (
+	PromptsFileName    = "prompts.yaml"
+	DefaultPromptsPath = ConfigDirName + "/" + PromptsFileName
+)
+
+// PromptsConfig holds every customisable LLM prompt the CLI ships with.
+// It mirrors the nested key structure those prompts had when they lived
+// under .infer/config.yaml so users can move existing values verbatim.
+type PromptsConfig struct {
+	Agent        PromptsAgentConfig        `yaml:"agent" mapstructure:"agent"`
+	Git          PromptsGitConfig          `yaml:"git" mapstructure:"git"`
+	Conversation PromptsConversationConfig `yaml:"conversation" mapstructure:"conversation"`
+	Init         PromptsInitConfig         `yaml:"init" mapstructure:"init"`
+}
+
+type PromptsAgentConfig struct {
+	SystemPrompt       string                      `yaml:"system_prompt" mapstructure:"system_prompt"`
+	SystemPromptPlan   string                      `yaml:"system_prompt_plan" mapstructure:"system_prompt_plan"`
+	SystemPromptRemote string                      `yaml:"system_prompt_remote" mapstructure:"system_prompt_remote"`
+	CustomInstructions string                      `yaml:"custom_instructions" mapstructure:"custom_instructions"`
+	SystemReminders    PromptsAgentRemindersConfig `yaml:"system_reminders" mapstructure:"system_reminders"`
+}
+
+type PromptsAgentRemindersConfig struct {
+	ReminderText string `yaml:"reminder_text" mapstructure:"reminder_text"`
+}
+
+type PromptsGitConfig struct {
+	CommitMessage PromptsGitCommitMessageConfig `yaml:"commit_message" mapstructure:"commit_message"`
+}
+
+type PromptsGitCommitMessageConfig struct {
+	SystemPrompt string `yaml:"system_prompt" mapstructure:"system_prompt"`
+}
+
+type PromptsConversationConfig struct {
+	TitleGeneration PromptsConversationTitleConfig `yaml:"title_generation" mapstructure:"title_generation"`
+}
+
+type PromptsConversationTitleConfig struct {
+	SystemPrompt string `yaml:"system_prompt" mapstructure:"system_prompt"`
+}
+
+type PromptsInitConfig struct {
+	Prompt string `yaml:"prompt" mapstructure:"prompt"`
+}
+
+// DefaultPromptsConfig returns the in-code default prompts. This is the
+// single source of truth — `infer init` seeds prompts.yaml from this and
+// the runtime overlay falls back to it when fields are missing.
+func DefaultPromptsConfig() *PromptsConfig {
+	return &PromptsConfig{
+		Agent: PromptsAgentConfig{
+			SystemPrompt: `Autonomous software engineering agent. Execute tasks iteratively until completion.`,
+			SystemPromptPlan: `You are an AI planning assistant in PLAN MODE. Your role is to analyze user requests and create ACTIONABLE, EXECUTABLE plans WITHOUT executing them.
+
+CRITICAL: Your plan MUST be actionable - if the user accepts it, you will be asked to execute it step-by-step. Plans that are not actionable are NOT plans.
+
+CAPABILITIES IN PLAN MODE:
+- Read, Grep, and Tree tools for gathering information
+- TodoWrite for tracking planning progress
+- RequestPlanApproval tool to submit your plan for user approval
+- Analyze code structure and dependencies
+- Break down complex tasks into concrete, executable steps
+- Identify exact files and code locations that need changes
+
+RESTRICTIONS IN PLAN MODE:
+- DO NOT execute Write, Edit, Delete, Bash, or modification tools
+- DO NOT make any changes to files or system
+- DO NOT attempt to implement the plan
+- Focus solely on creating an executable plan
+
+PLANNING WORKFLOW:
+1. Use Read/Grep/Tree to understand the codebase thoroughly
+2. Analyze the user's request and identify ALL requirements
+3. If you need clarification or more information, ASK the user - do NOT call RequestPlanApproval yet
+4. Break down into specific, numbered action steps
+5. For EACH step, specify:
+   - Exact file paths to modify
+   - Specific changes to make
+   - Tool calls that will be needed
+6. Include testing and validation steps
+7. When your plan is complete and actionable, call RequestPlanApproval tool
+
+DECISION MAKING:
+- Need more info? ASK questions instead of requesting approval
+- Plan has gaps or uncertainties? ASK for clarification
+- Plan is complete and specific? Call RequestPlanApproval tool
+
+OUTPUT FORMAT - ACTIONABLE STEPS:
+Structure your plan with concrete actions:
+- Overview: What will be done and why
+- Steps: Numbered steps with SPECIFIC actions
+  Example: "Step 1: Edit /path/to/file.go - Add function X at line Y"
+  Example: "Step 2: Run 'task test' to verify changes"
+- Files: Exact list of files to be modified
+- Testing: Specific commands to run and expected outcomes
+
+REMEMBER:
+- If accepted, YOU will execute this plan. Make it specific and actionable!
+- Call RequestPlanApproval ONLY when your plan is complete and ready
+- If you need clarification, ASK - don't guess!`,
+			SystemPromptRemote: `Remote system administration agent. You are operating on a remote machine via SSH.
+
+FOCUS: System operations, service management, monitoring, diagnostics, and infrastructure tasks.
+
+CONTEXT: This is a shared system environment, not a project workspace. Users may be managing servers, containers, services, or general infrastructure.
+
+COMPUTER USE TOOLS:
+You have TWO ways to interact with the system:
+1. Direct terminal tools (PRIMARY): Bash, Read, Write, Edit, Grep, etc.
+2. GUI automation tools (FALLBACK): MouseMove, KeyboardType, MouseClick, GetLatestScreenshot
+
+CRITICAL: ALWAYS prefer direct terminal tools over GUI automation when possible.
+
+When to use DIRECT tools (preferred):
+- Reading files: Use Read tool, NOT KeyboardType to open an editor
+- Writing files: Use Write/Edit tools, NOT GUI text editor
+- Running commands: Use Bash tool, NOT KeyboardType in a terminal window
+- Searching code: Use Grep tool, NOT opening files via GUI
+- System operations: Use Bash for systemctl, journalctl, docker, etc.
+
+When to use GUI tools (only when necessary):
+- Interacting with graphical applications that have no CLI equivalent
+- Testing UI behavior or visual elements
+- Remote desktop administration tasks that MUST be done through a GUI
+
+Why prefer direct tools:
+- 10-100x faster execution (no GUI rendering delays)
+- More reliable (no window focus issues, no timing problems)
+- Works over SSH without X11 forwarding
+- Precise output (structured data, not visual interpretation)
+- Lower resource usage (critical for remote systems)`,
+			CustomInstructions: ``,
+			SystemReminders: PromptsAgentRemindersConfig{
+				ReminderText: `<system-reminder>
+This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.
+</system-reminder>`,
+			},
+		},
+		Git: PromptsGitConfig{
+			CommitMessage: PromptsGitCommitMessageConfig{
+				SystemPrompt: `Generate a concise git commit message following conventional commit format.
+
+REQUIREMENTS:
+- MUST use format: "type: Brief description"
+- MUST be under 50 characters total
+- MUST use imperative mood (e.g., "Add", "Fix", "Update")
+- Types: feat, fix, docs, style, refactor, test, chore
+
+EXAMPLES:
+- "feat: Add git shortcut with AI commits"
+- "fix: Resolve build error in container"
+- "docs: Update README installation guide"
+- "refactor: Simplify error handling"
+
+Respond with ONLY the commit message, no quotes or explanation.`,
+			},
+		},
+		Conversation: PromptsConversationConfig{
+			TitleGeneration: PromptsConversationTitleConfig{
+				SystemPrompt: `Generate a concise conversation title based on the messages provided.
+
+REQUIREMENTS:
+- MUST be under 50 characters total
+- MUST be descriptive and capture the main topic
+- MUST use title case
+- NO quotes, colons, or special characters
+- Focus on the primary subject or task discussed
+
+EXAMPLES:
+- "React Component Testing"
+- "Database Migration Setup"
+- "API Error Handling"
+- "Docker Configuration"
+
+Respond with ONLY the title, no quotes or explanation.`,
+			},
+		},
+		Init: PromptsInitConfig{
+			Prompt: `Please analyze this project and generate a comprehensive AGENTS.md file. Start by using the Tree tool to understand the project structure.
+Use your available tools to examine configuration files, documentation, build systems, and development workflow.
+Focus on creating actionable documentation that will help other AI agents understand how to work effectively with this project.
+
+The AGENTS.md file should include:
+- Project overview and main technologies
+- Architecture and structure
+- Development environment setup
+- Key commands (build, test, lint, run)
+- Testing instructions
+- Project conventions and coding standards
+- Important files and configurations
+
+Write the AGENTS.md file to the project root when you have gathered enough information.`,
+		},
+	}
+}

--- a/config/prompts_test.go
+++ b/config/prompts_test.go
@@ -1,0 +1,37 @@
+package config
+
+import "testing"
+
+// Guards against accidental deletions of default prompts. Every prompt
+// field surfaced through prompts.yaml must ship a non-empty default so
+// the runtime overlay can fall back to it when a user blanks a key.
+func TestDefaultPromptsConfig_AllPromptsPopulated(t *testing.T) {
+	cfg := DefaultPromptsConfig()
+
+	cases := map[string]string{
+		"agent.system_prompt":                         cfg.Agent.SystemPrompt,
+		"agent.system_prompt_plan":                    cfg.Agent.SystemPromptPlan,
+		"agent.system_prompt_remote":                  cfg.Agent.SystemPromptRemote,
+		"agent.system_reminders.reminder_text":        cfg.Agent.SystemReminders.ReminderText,
+		"git.commit_message.system_prompt":            cfg.Git.CommitMessage.SystemPrompt,
+		"conversation.title_generation.system_prompt": cfg.Conversation.TitleGeneration.SystemPrompt,
+		"init.prompt":                                 cfg.Init.Prompt,
+	}
+
+	for key, val := range cases {
+		if val == "" {
+			t.Errorf("default prompt %q is empty", key)
+		}
+	}
+}
+
+// custom_instructions is intentionally empty - it's a user-supplied
+// opt-in. This guards it in the opposite direction so a future "fill in
+// a default" change is intentional.
+func TestDefaultPromptsConfig_OptionalPromptsBlank(t *testing.T) {
+	cfg := DefaultPromptsConfig()
+
+	if cfg.Agent.CustomInstructions != "" {
+		t.Errorf("agent.custom_instructions should ship empty, got %q", cfg.Agent.CustomInstructions)
+	}
+}

--- a/internal/services/prompts_config.go
+++ b/internal/services/prompts_config.go
@@ -1,0 +1,83 @@
+package services
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	config "github.com/inference-gateway/cli/config"
+	logger "github.com/inference-gateway/cli/internal/logger"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// PromptsConfigService manages the prompts.yaml configuration where every
+// LLM-facing prompt the CLI uses lives. It mirrors the keybindings and MCP
+// service contracts so callers can treat all sibling YAML configs the same
+// way.
+type PromptsConfigService struct {
+	configPath string
+}
+
+func NewPromptsConfigService(configPath string) *PromptsConfigService {
+	return &PromptsConfigService{configPath: configPath}
+}
+
+// Load reads prompts.yaml from disk. When the file is missing it returns
+// the in-code defaults so callers can treat absence as "use defaults"
+// without special-casing.
+func (s *PromptsConfigService) Load() (*config.PromptsConfig, error) {
+	if _, err := os.Stat(s.configPath); os.IsNotExist(err) {
+		logger.Info("Prompts config file does not exist, returning defaults", "path", s.configPath)
+		return config.DefaultPromptsConfig(), nil
+	}
+
+	data, err := os.ReadFile(s.configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read prompts config: %w", err)
+	}
+
+	var cfg config.PromptsConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse prompts config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// Save writes the prompts configuration to disk, creating any missing
+// parent directories.
+func (s *PromptsConfigService) Save(cfg *config.PromptsConfig) error {
+	var buf bytes.Buffer
+
+	buf.WriteString("---\n")
+
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+
+	if err := encoder.Encode(cfg); err != nil {
+		return fmt.Errorf("failed to marshal prompts config: %w", err)
+	}
+
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("failed to close encoder: %w", err)
+	}
+
+	configDir := filepath.Dir(s.configPath)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	if err := os.WriteFile(s.configPath, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write prompts config: %w", err)
+	}
+
+	logger.Info("Prompts config saved", "path", s.configPath)
+	return nil
+}
+
+// DefaultPromptsConfig exposes the default prompts config used when
+// no file exists. Callers (init, reset) use it to seed a fresh file.
+func DefaultPromptsConfig() *config.PromptsConfig {
+	return config.DefaultPromptsConfig()
+}

--- a/internal/services/prompts_config_test.go
+++ b/internal/services/prompts_config_test.go
@@ -1,0 +1,200 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+func TestPromptsConfigService_Load_NonExistentFile(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "non-existent.yaml")
+
+	service := NewPromptsConfigService(configPath)
+	cfg, err := service.Load()
+
+	if err != nil {
+		t.Fatalf("Load() should not error for non-existent file, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Load() returned nil config")
+	}
+	if cfg.Agent.SystemPrompt == "" {
+		t.Error("Default prompts config should populate agent.system_prompt")
+	}
+	if cfg.Agent.SystemPromptPlan == "" {
+		t.Error("Default prompts config should populate agent.system_prompt_plan")
+	}
+	if cfg.Git.CommitMessage.SystemPrompt == "" {
+		t.Error("Default prompts config should populate git.commit_message.system_prompt")
+	}
+}
+
+func TestPromptsConfigService_Load_ValidYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "prompts.yaml")
+
+	yamlContent := `---
+agent:
+  system_prompt: custom agent prompt
+  system_prompt_plan: custom plan prompt
+git:
+  commit_message:
+    system_prompt: custom commit prompt
+init:
+  prompt: custom init prompt
+`
+
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config file: %v", err)
+	}
+
+	service := NewPromptsConfigService(configPath)
+	cfg, err := service.Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.Agent.SystemPrompt != "custom agent prompt" {
+		t.Errorf("Expected custom system_prompt, got %q", cfg.Agent.SystemPrompt)
+	}
+	if cfg.Agent.SystemPromptPlan != "custom plan prompt" {
+		t.Errorf("Expected custom plan prompt, got %q", cfg.Agent.SystemPromptPlan)
+	}
+	if cfg.Git.CommitMessage.SystemPrompt != "custom commit prompt" {
+		t.Errorf("Expected custom commit prompt, got %q", cfg.Git.CommitMessage.SystemPrompt)
+	}
+	if cfg.Init.Prompt != "custom init prompt" {
+		t.Errorf("Expected custom init prompt, got %q", cfg.Init.Prompt)
+	}
+}
+
+func TestPromptsConfigService_Load_PartialYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "prompts.yaml")
+
+	yamlContent := `---
+agent:
+  system_prompt: only this field is set
+`
+
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write test config file: %v", err)
+	}
+
+	service := NewPromptsConfigService(configPath)
+	cfg, err := service.Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if cfg.Agent.SystemPrompt != "only this field is set" {
+		t.Errorf("Expected partial value, got %q", cfg.Agent.SystemPrompt)
+	}
+	// Other prompt fields stay zero — getConfigFromViper's overlay is what
+	// fills them back in from defaults at runtime.
+	if cfg.Agent.SystemPromptPlan != "" {
+		t.Errorf("Expected unset plan prompt to be empty, got %q", cfg.Agent.SystemPromptPlan)
+	}
+	if cfg.Git.CommitMessage.SystemPrompt != "" {
+		t.Errorf("Expected unset commit prompt to be empty, got %q", cfg.Git.CommitMessage.SystemPrompt)
+	}
+}
+
+func TestPromptsConfigService_Save_RoundTrip(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "prompts.yaml")
+	service := NewPromptsConfigService(configPath)
+
+	original := &config.PromptsConfig{
+		Agent: config.PromptsAgentConfig{
+			SystemPrompt: "round trip system prompt",
+			SystemReminders: config.PromptsAgentRemindersConfig{
+				ReminderText: "round trip reminder",
+			},
+		},
+		Git: config.PromptsGitConfig{
+			CommitMessage: config.PromptsGitCommitMessageConfig{
+				SystemPrompt: "round trip commit prompt",
+			},
+		},
+	}
+
+	if err := service.Save(original); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	loaded, err := service.Load()
+	if err != nil {
+		t.Fatalf("Load() after save failed: %v", err)
+	}
+	if loaded.Agent.SystemPrompt != original.Agent.SystemPrompt {
+		t.Errorf("agent.system_prompt not preserved, got %q", loaded.Agent.SystemPrompt)
+	}
+	if loaded.Agent.SystemReminders.ReminderText != original.Agent.SystemReminders.ReminderText {
+		t.Errorf("reminder_text not preserved, got %q", loaded.Agent.SystemReminders.ReminderText)
+	}
+	if loaded.Git.CommitMessage.SystemPrompt != original.Git.CommitMessage.SystemPrompt {
+		t.Errorf("git.commit_message.system_prompt not preserved, got %q", loaded.Git.CommitMessage.SystemPrompt)
+	}
+}
+
+func TestPromptsConfigService_Save_CreatesParentDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "nested", "deep", "prompts.yaml")
+	service := NewPromptsConfigService(configPath)
+
+	if err := service.Save(DefaultPromptsConfig()); err != nil {
+		t.Fatalf("Save() failed to create nested dirs: %v", err)
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("File not created at nested path: %v", err)
+	}
+}
+
+func TestPromptsConfigService_Save_StartsWithYAMLDocumentMarker(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "prompts.yaml")
+	service := NewPromptsConfigService(configPath)
+
+	if err := service.Save(DefaultPromptsConfig()); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if !strings.HasPrefix(string(data), "---\n") {
+		t.Errorf("Saved file should start with YAML document marker, got: %q", string(data[:min(20, len(data))]))
+	}
+}
+
+func TestDefaultPromptsConfig(t *testing.T) {
+	cfg := DefaultPromptsConfig()
+	if cfg == nil {
+		t.Fatal("DefaultPromptsConfig returned nil")
+	}
+	if cfg.Agent.SystemPrompt == "" {
+		t.Error("agent.system_prompt should be non-empty")
+	}
+	if cfg.Agent.SystemPromptPlan == "" {
+		t.Error("agent.system_prompt_plan should be non-empty")
+	}
+	if cfg.Agent.SystemPromptRemote == "" {
+		t.Error("agent.system_prompt_remote should be non-empty")
+	}
+	if cfg.Agent.SystemReminders.ReminderText == "" {
+		t.Error("agent.system_reminders.reminder_text should be non-empty")
+	}
+	if cfg.Git.CommitMessage.SystemPrompt == "" {
+		t.Error("git.commit_message.system_prompt should be non-empty")
+	}
+	if cfg.Conversation.TitleGeneration.SystemPrompt == "" {
+		t.Error("conversation.title_generation.system_prompt should be non-empty")
+	}
+	if cfg.Init.Prompt == "" {
+		t.Error("init.prompt should be non-empty")
+	}
+}


### PR DESCRIPTION
Moved all system prompts from config.yaml into a dedicated prompts.yaml file.
Added prompts config struct, service, and overlay logic to load prompts from
the new file with fallback to defaults. Updated init command to create
prompts.yaml. Removed prompt fields from main config struct.

Also cleanup unused configs.

Closes #439 