### PR TITLE
refactor: Move channels to separate channels.yaml config

### DIFF
--- a/.infer/channels.yaml
+++ b/.infer/channels.yaml
@@ -1,0 +1,17 @@
+---
+enabled: false
+max_workers: 5
+image_retention: 5
+require_approval: true
+telegram:
+  enabled: false
+  bot_token: ""
+  allowed_users: []
+  poll_timeout: 30
+whatsapp:
+  enabled: false
+  phone_number_id: ""
+  access_token: ""
+  verify_token: ""
+  webhook_port: 8443
+  allowed_users: []

--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -58,6 +58,7 @@ tools:
       - .infer/mcp.yaml
       - .infer/keybindings.yaml
       - .infer/prompts.yaml
+      - .infer/channels.yaml
       - .git/
       - '*.env'
   bash:
@@ -311,20 +312,3 @@ computer_use:
       enabled: true
     activate_app:
       enabled: true
-channels:
-  enabled: false
-  max_workers: 5
-  image_retention: 5
-  require_approval: true
-  telegram:
-    enabled: false
-    bot_token: ""
-    allowed_users: []
-    poll_timeout: 30
-  whatsapp:
-    enabled: false
-    phone_number_id: ""
-    access_token: ""
-    verify_token: ""
-    webhook_port: 8443
-    allowed_users: []

--- a/README.md
+++ b/README.md
@@ -914,18 +914,18 @@ https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates
 
 Find `"chat":{"id":123456789}` in the response.
 
-**3. Configure** in `.infer/config.yaml`:
+**3. Configure** in `.infer/channels.yaml` (seeded by `infer init`):
 
 ```yaml
-channels:
-  enabled: true
+---
+enabled: true
 
-  telegram:
-    enabled: true
-    bot_token: "${INFER_CHANNELS_TELEGRAM_BOT_TOKEN}"
-    allowed_users:
-      - "123456789"
-    poll_timeout: 30
+telegram:
+  enabled: true
+  bot_token: "${INFER_CHANNELS_TELEGRAM_BOT_TOKEN}"
+  allowed_users:
+    - "123456789"
+  poll_timeout: 30
 ```
 
 Or via environment variables:
@@ -955,11 +955,10 @@ before executing. The agent sends an approval prompt to the channel and waits
 for the user to reply "yes" or "no". Read-only tools (Read, Grep, Tree) execute
 without approval.
 
-This reuses the existing `tools.*.require_approval` configuration. To disable:
+This reuses the existing `tools.*.require_approval` configuration. To disable, set in `.infer/channels.yaml`:
 
 ```yaml
-channels:
-  require_approval: false  # default: true
+require_approval: false  # default: true
 ```
 
 Or: `INFER_CHANNELS_REQUIRE_APPROVAL=false`

--- a/cmd/channels.go
+++ b/cmd/channels.go
@@ -27,7 +27,9 @@ Each message spawns a new agent invocation with a deterministic session ID per s
 so conversations persist across messages. The agent runs autonomously, and the response
 is sent back through the originating channel.
 
-Configuration is done via .infer/config.yaml or environment variables.
+Configuration is done via .infer/channels.yaml (seeded by 'infer init') or
+INFER_CHANNELS_* environment variables. The legacy 'channels:' block in
+config.yaml is no longer read — re-run 'infer init' to migrate it.
 
 Examples:
   # Start listening for Telegram messages
@@ -47,7 +49,7 @@ Examples:
 // RunChannelsCommand starts the channel listener daemon
 func RunChannelsCommand(cfg *config.Config) error {
 	if !cfg.Channels.Enabled {
-		return fmt.Errorf("channels are not enabled. Set channels.enabled: true in config or INFER_CHANNELS_ENABLED=true")
+		return fmt.Errorf("channels are not enabled. Set enabled: true in .infer/channels.yaml or INFER_CHANNELS_ENABLED=true")
 	}
 
 	cm := services.NewChannelManagerService(cfg.Channels)

--- a/cmd/channels_overlay_test.go
+++ b/cmd/channels_overlay_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	require "github.com/stretchr/testify/require"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+// TestLoadConfigFromViper_ChannelsDefaultsWhenFileAbsent confirms that
+// runtime falls back to DefaultChannelsConfig when no channels.yaml exists,
+// so a fresh checkout doesn't crash the channels-manager daemon when it
+// tries to read cfg.Channels.
+func TestLoadConfigFromViper_ChannelsDefaultsWhenFileAbsent(t *testing.T) {
+	withHermeticEnv(t)
+	initConfig()
+
+	defaults := config.DefaultChannelsConfig()
+	require.Equal(t, defaults.Enabled, Cfg.Channels.Enabled)
+	require.Equal(t, defaults.MaxWorkers, Cfg.Channels.MaxWorkers)
+	require.Equal(t, defaults.RequireApproval, Cfg.Channels.RequireApproval)
+	require.Equal(t, defaults.Telegram.PollTimeout, Cfg.Channels.Telegram.PollTimeout)
+	require.Equal(t, defaults.WhatsApp.WebhookPort, Cfg.Channels.WhatsApp.WebhookPort)
+}
+
+// TestLoadConfigFromViper_ChannelsLoadsFromUserspace verifies the project
+// → userspace fallback by writing channels.yaml only to ~/.infer/ (the
+// hermetic HOME) and confirming initConfig picks it up.
+func TestLoadConfigFromViper_ChannelsLoadsFromUserspace(t *testing.T) {
+	withHermeticEnv(t)
+
+	homeDir := os.Getenv("HOME")
+	channelsPath := filepath.Join(homeDir, config.ConfigDirName, config.ChannelsFileName)
+	require.NoError(t, config.SaveChannels(channelsPath, &config.ChannelsConfig{
+		Enabled:    true,
+		MaxWorkers: 12,
+		Telegram: config.TelegramChannelConfig{
+			Enabled:  true,
+			BotToken: "from-userspace",
+		},
+	}))
+
+	initConfig()
+
+	require.True(t, Cfg.Channels.Enabled)
+	require.Equal(t, 12, Cfg.Channels.MaxWorkers)
+	require.True(t, Cfg.Channels.Telegram.Enabled)
+	require.Equal(t, "from-userspace", Cfg.Channels.Telegram.BotToken)
+}
+
+// TestLoadConfigFromViper_ChannelsEnvOverridesFile pins the precedence
+// order: env > file > in-code defaults. The docker-compose example in
+// examples/telegram-channel ships INFER_CHANNELS_TELEGRAM_BOT_TOKEN as an
+// env var rather than committing the secret to channels.yaml, so this
+// path must keep working.
+func TestLoadConfigFromViper_ChannelsEnvOverridesFile(t *testing.T) {
+	withHermeticEnv(t)
+
+	homeDir := os.Getenv("HOME")
+	channelsPath := filepath.Join(homeDir, config.ConfigDirName, config.ChannelsFileName)
+	require.NoError(t, config.SaveChannels(channelsPath, &config.ChannelsConfig{
+		Enabled:  false,
+		Telegram: config.TelegramChannelConfig{Enabled: false, BotToken: "from-file"},
+	}))
+
+	t.Setenv("INFER_CHANNELS_ENABLED", "true")
+	t.Setenv("INFER_CHANNELS_TELEGRAM_ENABLED", "true")
+	t.Setenv("INFER_CHANNELS_TELEGRAM_BOT_TOKEN", "from-env")
+	t.Setenv("INFER_CHANNELS_TELEGRAM_ALLOWED_USERS", "111, 222")
+	t.Setenv("INFER_CHANNELS_MAX_WORKERS", "9")
+	t.Setenv("INFER_CHANNELS_REQUIRE_APPROVAL", "false")
+
+	initConfig()
+
+	require.True(t, Cfg.Channels.Enabled, "INFER_CHANNELS_ENABLED should win")
+	require.True(t, Cfg.Channels.Telegram.Enabled)
+	require.Equal(t, "from-env", Cfg.Channels.Telegram.BotToken)
+	require.Equal(t, []string{"111", "222"}, Cfg.Channels.Telegram.AllowedUsers)
+	require.Equal(t, 9, Cfg.Channels.MaxWorkers)
+	require.False(t, Cfg.Channels.RequireApproval)
+}
+
+// TestLoadConfigFromViper_ChannelsBlockInConfigYAMLIsIgnored asserts the
+// hard contract from issue #441: a stale `channels:` block in config.yaml
+// must be ignored at runtime. Only channels.yaml feeds cfg.Channels.
+// `infer init` provides the migration path; the loader does not.
+func TestLoadConfigFromViper_ChannelsBlockInConfigYAMLIsIgnored(t *testing.T) {
+	withHermeticEnv(t)
+
+	homeDir := os.Getenv("HOME")
+	configDir := filepath.Join(homeDir, config.ConfigDirName)
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	configYAML := `---
+channels:
+  enabled: true
+  telegram:
+    enabled: true
+    bot_token: legacy-token
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, config.ConfigFileName), []byte(configYAML), 0644))
+
+	initConfig()
+
+	require.False(t, Cfg.Channels.Enabled, "legacy channels: block in config.yaml must not enable channels")
+	require.False(t, Cfg.Channels.Telegram.Enabled)
+	require.Empty(t, Cfg.Channels.Telegram.BotToken)
+}
+
+func TestGetEffectiveChannelsConfigPath_PrefersProject(t *testing.T) {
+	withHermeticEnv(t)
+
+	require.NoError(t, os.MkdirAll(config.ConfigDirName, 0755))
+	projectPath := config.DefaultChannelsPath
+	require.NoError(t, os.WriteFile(projectPath, []byte("---\nenabled: true\n"), 0644))
+
+	got := getEffectiveChannelsConfigPath()
+	require.Equal(t, projectPath, got)
+}
+
+func TestGetEffectiveChannelsConfigPath_FallsBackToUserspace(t *testing.T) {
+	withHermeticEnv(t)
+
+	projectDir := t.TempDir()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(projectDir))
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	homeDir := os.Getenv("HOME")
+	userPath := filepath.Join(homeDir, config.ConfigDirName, config.ChannelsFileName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(userPath), 0755))
+	require.NoError(t, os.WriteFile(userPath, []byte("---\nenabled: true\n"), 0644))
+
+	got := getEffectiveChannelsConfigPath()
+	require.Equal(t, userPath, got)
+}
+
+func TestGetEffectiveChannelsConfigPath_NeitherExists(t *testing.T) {
+	withHermeticEnv(t)
+
+	got := getEffectiveChannelsConfigPath()
+	require.Equal(t, config.DefaultChannelsPath, got)
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -588,6 +588,27 @@ func getEffectiveKeybindingsConfigPath() string {
 	return config.DefaultKeybindingsPath
 }
 
+// getEffectiveChannelsConfigPath returns the path to the channels config file
+// Searches in this order: 1) project .infer/channels.yaml, 2) user home ~/.infer/channels.yaml
+func getEffectiveChannelsConfigPath() string {
+	searchPaths := []string{
+		config.DefaultChannelsPath,
+	}
+
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		homePath := filepath.Join(homeDir, config.ConfigDirName, config.ChannelsFileName)
+		searchPaths = append(searchPaths, homePath)
+	}
+
+	for _, path := range searchPaths {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	return config.DefaultChannelsPath
+}
+
 // getEffectivePromptsConfigPath returns the path to the prompts config file
 // Searches in this order: 1) project .infer/prompts.yaml, 2) user home ~/.infer/prompts.yaml
 func getEffectivePromptsConfigPath() string {
@@ -660,6 +681,15 @@ func loadConfigFromViper() (*config.Config, error) {
 	}
 	applyPromptsOverlay(cfg, prompts)
 	applyPromptsEnvOverrides(cfg)
+
+	channelsPath := getEffectiveChannelsConfigPath()
+	channelsCfg, err := config.LoadChannels(channelsPath)
+	if err != nil {
+		logger.Warn("Failed to load channels config, using defaults", "error", err, "path", channelsPath)
+		channelsCfg = config.DefaultChannelsConfig()
+	}
+	cfg.Channels = *channelsCfg
+	applyChannelsEnvOverrides(cfg)
 
 	return cfg, nil
 }
@@ -773,6 +803,71 @@ func applyKeybindingEnvOverrides(cfg *config.Config) {
 			}
 		}
 	}
+}
+
+// applyChannelsEnvOverrides applies INFER_CHANNELS_* env vars onto the
+// in-memory channels config. Run AFTER LoadChannels so envs win over
+// channels.yaml. The channels config now lives in its own file
+// (yaml:"-" mapstructure:"-" on Config.Channels), so viper does not bind
+// these env vars itself — this function is the single source of env-var
+// support. Mirrors applyKeybindingEnvOverrides / applyPromptsEnvOverrides.
+func applyChannelsEnvOverrides(cfg *config.Config) {
+	setBool := func(env string, target *bool) {
+		val, ok := os.LookupEnv(env)
+		if !ok {
+			return
+		}
+		if b, err := strconv.ParseBool(strings.TrimSpace(val)); err == nil {
+			*target = b
+		}
+	}
+	setInt := func(env string, target *int) {
+		val, ok := os.LookupEnv(env)
+		if !ok {
+			return
+		}
+		if n, err := strconv.Atoi(strings.TrimSpace(val)); err == nil {
+			*target = n
+		}
+	}
+	setString := func(env string, target *string) {
+		if val, ok := os.LookupEnv(env); ok {
+			*target = val
+		}
+	}
+	setStringSlice := func(env string, target *[]string) {
+		val, ok := os.LookupEnv(env)
+		if !ok {
+			return
+		}
+		var out []string
+		for item := range strings.SplitSeq(val, ",") {
+			if trimmed := strings.TrimSpace(item); trimmed != "" {
+				out = append(out, trimmed)
+			}
+		}
+		if out == nil {
+			out = []string{}
+		}
+		*target = out
+	}
+
+	setBool("INFER_CHANNELS_ENABLED", &cfg.Channels.Enabled)
+	setBool("INFER_CHANNELS_REQUIRE_APPROVAL", &cfg.Channels.RequireApproval)
+	setInt("INFER_CHANNELS_MAX_WORKERS", &cfg.Channels.MaxWorkers)
+	setInt("INFER_CHANNELS_IMAGE_RETENTION", &cfg.Channels.ImageRetention)
+
+	setBool("INFER_CHANNELS_TELEGRAM_ENABLED", &cfg.Channels.Telegram.Enabled)
+	setString("INFER_CHANNELS_TELEGRAM_BOT_TOKEN", &cfg.Channels.Telegram.BotToken)
+	setStringSlice("INFER_CHANNELS_TELEGRAM_ALLOWED_USERS", &cfg.Channels.Telegram.AllowedUsers)
+	setInt("INFER_CHANNELS_TELEGRAM_POLL_TIMEOUT", &cfg.Channels.Telegram.PollTimeout)
+
+	setBool("INFER_CHANNELS_WHATSAPP_ENABLED", &cfg.Channels.WhatsApp.Enabled)
+	setString("INFER_CHANNELS_WHATSAPP_PHONE_NUMBER_ID", &cfg.Channels.WhatsApp.PhoneNumberID)
+	setString("INFER_CHANNELS_WHATSAPP_ACCESS_TOKEN", &cfg.Channels.WhatsApp.AccessToken)
+	setString("INFER_CHANNELS_WHATSAPP_VERIFY_TOKEN", &cfg.Channels.WhatsApp.VerifyToken)
+	setInt("INFER_CHANNELS_WHATSAPP_WEBHOOK_PORT", &cfg.Channels.WhatsApp.WebhookPort)
+	setStringSlice("INFER_CHANNELS_WHATSAPP_ALLOWED_USERS", &cfg.Channels.WhatsApp.AllowedUsers)
 }
 
 // GetUserspaceFlag checks for --userspace flag on the current command or parent commands

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -35,12 +35,12 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 }
 
-func initializeProject(cmd *cobra.Command) error {
+func initializeProject(cmd *cobra.Command) error { //nolint:funlen
 	overwrite, _ := cmd.Flags().GetBool("overwrite")
 	userspace, _ := cmd.Flags().GetBool("userspace")
 	skipMigrations, _ := cmd.Flags().GetBool("skip-migrations")
 
-	var configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, a2aShortcutsPath, mcpPath, keybindingsPath, promptsPath string
+	var configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, a2aShortcutsPath, mcpPath, keybindingsPath, promptsPath, channelsPath string
 
 	if userspace {
 		homeDir, err := os.UserHomeDir()
@@ -58,6 +58,7 @@ func initializeProject(cmd *cobra.Command) error {
 		mcpPath = filepath.Join(homeDir, config.ConfigDirName, config.MCPFileName)
 		keybindingsPath = filepath.Join(homeDir, config.ConfigDirName, config.KeybindingsFileName)
 		promptsPath = filepath.Join(homeDir, config.ConfigDirName, config.PromptsFileName)
+		channelsPath = filepath.Join(homeDir, config.ConfigDirName, config.ChannelsFileName)
 	} else {
 		configPath = config.DefaultConfigPath
 		gitignorePath = filepath.Join(config.ConfigDirName, config.GitignoreFileName)
@@ -70,10 +71,11 @@ func initializeProject(cmd *cobra.Command) error {
 		mcpPath = filepath.Join(config.ConfigDirName, config.MCPFileName)
 		keybindingsPath = config.DefaultKeybindingsPath
 		promptsPath = config.DefaultPromptsPath
+		channelsPath = config.DefaultChannelsPath
 	}
 
 	if !overwrite {
-		if err := validateFilesNotExist(configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, a2aShortcutsPath, mcpPath, keybindingsPath, promptsPath); err != nil {
+		if err := validateFilesNotExist(configPath, gitignorePath, scmShortcutsPath, gitShortcutsPath, mcpShortcutsPath, shellsShortcutsPath, exportShortcutsPath, a2aShortcutsPath, mcpPath, keybindingsPath, promptsPath, channelsPath); err != nil {
 			return err
 		}
 	}
@@ -132,6 +134,11 @@ tmp/
 		return fmt.Errorf("failed to create prompts config file: %w", err)
 	}
 
+	migrated, err := createChannelsConfigFile(channelsPath)
+	if err != nil {
+		return fmt.Errorf("failed to create channels config file: %w", err)
+	}
+
 	var scopeDesc string
 	if userspace {
 		scopeDesc = "userspace"
@@ -151,6 +158,11 @@ tmp/
 	fmt.Printf("   Created: %s\n", mcpPath)
 	fmt.Printf("   Created: %s\n", keybindingsPath)
 	fmt.Printf("   Created: %s\n", promptsPath)
+	fmt.Printf("   Created: %s\n", channelsPath)
+	if migrated {
+		fmt.Printf("\n%s Migrated legacy `channels:` block from config.yaml into %s.\n", icons.CheckMarkStyle.Render(icons.CheckMark), channelsPath)
+		fmt.Printf("   You can now remove the `channels:` block from %s.\n", configPath)
+	}
 	fmt.Println("")
 	if userspace {
 		fmt.Println("This userspace configuration will be used as a fallback for all projects.")
@@ -426,6 +438,32 @@ func createPromptsConfigFile(path string) error {
 	}
 
 	return config.SavePrompts(path, config.DefaultPromptsConfig())
+}
+
+// createChannelsConfigFile writes a fresh channels.yaml. Returns true when
+// the file was seeded from a legacy `channels:` block found in viper (i.e.
+// migrated from config.yaml) rather than from in-code defaults. Migration
+// only runs when no channels.yaml exists yet, so it is safe to re-run init.
+func createChannelsConfigFile(path string) (bool, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return false, fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	channelsCfg := config.DefaultChannelsConfig()
+	migrated := false
+
+	if _, err := os.Stat(path); os.IsNotExist(err) && V != nil && V.IsSet("channels") {
+		legacy := config.DefaultChannelsConfig()
+		if err := V.UnmarshalKey("channels", legacy); err == nil {
+			channelsCfg = legacy
+			migrated = true
+		}
+	}
+
+	if err := config.SaveChannels(path, channelsCfg); err != nil {
+		return false, err
+	}
+	return migrated, nil
 }
 
 // createMCPConfigFile creates the MCP configuration YAML file

--- a/config/channels.go
+++ b/config/channels.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+const (
+	ChannelsFileName    = "channels.yaml"
+	DefaultChannelsPath = ConfigDirName + "/" + ChannelsFileName
+)
+
+// DefaultChannelsConfig returns the in-code default channels configuration
+// used when no channels.yaml file exists. `infer init` seeds the file from
+// this and the runtime falls back to it when the file is absent.
+func DefaultChannelsConfig() *ChannelsConfig {
+	return &ChannelsConfig{
+		Enabled:         false,
+		MaxWorkers:      5,
+		ImageRetention:  5,
+		RequireApproval: true,
+		Telegram: TelegramChannelConfig{
+			Enabled:      false,
+			BotToken:     "",
+			AllowedUsers: []string{},
+			PollTimeout:  30,
+		},
+		WhatsApp: WhatsAppChannelConfig{
+			Enabled:       false,
+			PhoneNumberID: "",
+			AccessToken:   "",
+			VerifyToken:   "",
+			WebhookPort:   8443,
+			AllowedUsers:  []string{},
+		},
+	}
+}
+
+// LoadChannels reads channels.yaml from disk. When the file is missing it
+// returns the in-code defaults so callers can treat absence as "use
+// defaults" without special-casing. The file body is run through
+// os.ExpandEnv so `${BOT_TOKEN}`-style references resolve from the
+// environment.
+func LoadChannels(path string) (*ChannelsConfig, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return DefaultChannelsConfig(), nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read channels config: %w", err)
+	}
+
+	expandedData := os.ExpandEnv(string(data))
+
+	var cfg ChannelsConfig
+	if err := yaml.Unmarshal([]byte(expandedData), &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse channels config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// SaveChannels writes the channels configuration to disk, creating any
+// missing parent directories. The file holds bot tokens / access tokens,
+// so callers should ensure it is also listed in
+// tools.sandbox.protected_paths.
+func SaveChannels(path string, cfg *ChannelsConfig) error {
+	var buf bytes.Buffer
+	buf.WriteString("---\n")
+
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+
+	if err := encoder.Encode(cfg); err != nil {
+		return fmt.Errorf("failed to marshal channels config: %w", err)
+	}
+
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("failed to close encoder: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write channels config: %w", err)
+	}
+
+	return nil
+}

--- a/config/channels_test.go
+++ b/config/channels_test.go
@@ -1,0 +1,227 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+func TestChannelsConstants(t *testing.T) {
+	if config.ChannelsFileName != "channels.yaml" {
+		t.Errorf("Expected ChannelsFileName 'channels.yaml', got %q", config.ChannelsFileName)
+	}
+	expectedPath := config.ConfigDirName + "/" + config.ChannelsFileName
+	if config.DefaultChannelsPath != expectedPath {
+		t.Errorf("Expected DefaultChannelsPath %q, got %q", expectedPath, config.DefaultChannelsPath)
+	}
+}
+
+func TestDefaultChannelsConfig(t *testing.T) {
+	cfg := config.DefaultChannelsConfig()
+	if cfg == nil {
+		t.Fatal("DefaultChannelsConfig() returned nil")
+	}
+	if cfg.Enabled {
+		t.Error("Expected Enabled to be false by default")
+	}
+	if !cfg.RequireApproval {
+		t.Error("Expected RequireApproval to be true by default")
+	}
+	if cfg.MaxWorkers != 5 {
+		t.Errorf("Expected MaxWorkers=5, got %d", cfg.MaxWorkers)
+	}
+	if cfg.ImageRetention != 5 {
+		t.Errorf("Expected ImageRetention=5, got %d", cfg.ImageRetention)
+	}
+	if cfg.Telegram.PollTimeout != 30 {
+		t.Errorf("Expected Telegram.PollTimeout=30, got %d", cfg.Telegram.PollTimeout)
+	}
+	if cfg.Telegram.AllowedUsers == nil {
+		t.Error("Expected Telegram.AllowedUsers to be non-nil empty slice")
+	}
+	if cfg.WhatsApp.WebhookPort != 8443 {
+		t.Errorf("Expected WhatsApp.WebhookPort=8443, got %d", cfg.WhatsApp.WebhookPort)
+	}
+}
+
+func TestLoadChannels_NonExistentFile(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "non-existent.yaml")
+
+	cfg, err := config.LoadChannels(path)
+	if err != nil {
+		t.Fatalf("LoadChannels() should not error for missing file, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadChannels() returned nil")
+	}
+	defaults := config.DefaultChannelsConfig()
+	if cfg.Enabled != defaults.Enabled || cfg.MaxWorkers != defaults.MaxWorkers {
+		t.Errorf("Expected defaults, got %+v", cfg)
+	}
+}
+
+func TestLoadChannels_ValidYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "channels.yaml")
+
+	yamlContent := `---
+enabled: true
+max_workers: 8
+image_retention: 10
+require_approval: false
+telegram:
+  enabled: true
+  bot_token: "abc123"
+  allowed_users:
+    - "111"
+    - "222"
+  poll_timeout: 60
+whatsapp:
+  enabled: false
+  phone_number_id: ""
+  access_token: ""
+  verify_token: ""
+  webhook_port: 9000
+  allowed_users: []
+`
+	if err := os.WriteFile(path, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write yaml: %v", err)
+	}
+
+	cfg, err := config.LoadChannels(path)
+	if err != nil {
+		t.Fatalf("LoadChannels() failed: %v", err)
+	}
+	if !cfg.Enabled {
+		t.Error("Expected Enabled true")
+	}
+	if cfg.MaxWorkers != 8 {
+		t.Errorf("Expected MaxWorkers=8, got %d", cfg.MaxWorkers)
+	}
+	if cfg.RequireApproval {
+		t.Error("Expected RequireApproval false")
+	}
+	if !cfg.Telegram.Enabled {
+		t.Error("Expected Telegram.Enabled true")
+	}
+	if cfg.Telegram.BotToken != "abc123" {
+		t.Errorf("Expected bot_token 'abc123', got %q", cfg.Telegram.BotToken)
+	}
+	if len(cfg.Telegram.AllowedUsers) != 2 {
+		t.Errorf("Expected 2 allowed users, got %d", len(cfg.Telegram.AllowedUsers))
+	}
+	if cfg.Telegram.PollTimeout != 60 {
+		t.Errorf("Expected poll_timeout=60, got %d", cfg.Telegram.PollTimeout)
+	}
+	if cfg.WhatsApp.WebhookPort != 9000 {
+		t.Errorf("Expected webhook_port=9000, got %d", cfg.WhatsApp.WebhookPort)
+	}
+}
+
+func TestLoadChannels_EnvironmentVariableExpansion(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "channels.yaml")
+
+	t.Setenv("TEST_CHANNELS_BOT_TOKEN", "expanded-token")
+	t.Setenv("TEST_CHANNELS_ACCESS_TOKEN", "expanded-access")
+
+	yamlContent := `---
+enabled: true
+telegram:
+  enabled: true
+  bot_token: "${TEST_CHANNELS_BOT_TOKEN}"
+whatsapp:
+  access_token: "${TEST_CHANNELS_ACCESS_TOKEN}"
+`
+	if err := os.WriteFile(path, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("Failed to write yaml: %v", err)
+	}
+
+	cfg, err := config.LoadChannels(path)
+	if err != nil {
+		t.Fatalf("LoadChannels() failed: %v", err)
+	}
+	if cfg.Telegram.BotToken != "expanded-token" {
+		t.Errorf("Expected expanded bot_token 'expanded-token', got %q", cfg.Telegram.BotToken)
+	}
+	if cfg.WhatsApp.AccessToken != "expanded-access" {
+		t.Errorf("Expected expanded access_token 'expanded-access', got %q", cfg.WhatsApp.AccessToken)
+	}
+}
+
+func TestLoadChannels_InvalidYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "channels.yaml")
+	if err := os.WriteFile(path, []byte("not: valid: yaml: ["), 0644); err != nil {
+		t.Fatalf("Failed to write yaml: %v", err)
+	}
+
+	if _, err := config.LoadChannels(path); err == nil {
+		t.Fatal("Expected error from invalid YAML, got nil")
+	}
+}
+
+func TestSaveChannels_RoundTrip(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "subdir", "channels.yaml")
+
+	cfg := &config.ChannelsConfig{
+		Enabled:         true,
+		MaxWorkers:      3,
+		ImageRetention:  7,
+		RequireApproval: false,
+		Telegram: config.TelegramChannelConfig{
+			Enabled:      true,
+			BotToken:     "tok",
+			AllowedUsers: []string{"42"},
+			PollTimeout:  15,
+		},
+		WhatsApp: config.WhatsAppChannelConfig{
+			Enabled:       true,
+			PhoneNumberID: "pid",
+			AccessToken:   "tok2",
+			VerifyToken:   "verify",
+			WebhookPort:   9090,
+			AllowedUsers:  []string{"43"},
+		},
+	}
+
+	if err := config.SaveChannels(path, cfg); err != nil {
+		t.Fatalf("SaveChannels() failed: %v", err)
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatal("File was not created")
+	}
+
+	loaded, err := config.LoadChannels(path)
+	if err != nil {
+		t.Fatalf("LoadChannels() failed: %v", err)
+	}
+	if loaded.Enabled != cfg.Enabled || loaded.MaxWorkers != cfg.MaxWorkers ||
+		loaded.RequireApproval != cfg.RequireApproval || loaded.ImageRetention != cfg.ImageRetention {
+		t.Errorf("Top-level fields mismatch: got %+v", loaded)
+	}
+	if loaded.Telegram.BotToken != cfg.Telegram.BotToken ||
+		loaded.Telegram.PollTimeout != cfg.Telegram.PollTimeout ||
+		len(loaded.Telegram.AllowedUsers) != 1 {
+		t.Errorf("Telegram mismatch: got %+v", loaded.Telegram)
+	}
+	if loaded.WhatsApp.PhoneNumberID != cfg.WhatsApp.PhoneNumberID ||
+		loaded.WhatsApp.WebhookPort != cfg.WhatsApp.WebhookPort {
+		t.Errorf("WhatsApp mismatch: got %+v", loaded.WhatsApp)
+	}
+}
+
+func TestSaveChannels_CreatesParentDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "deeply", "nested", "channels.yaml")
+	if err := config.SaveChannels(path, config.DefaultChannelsConfig()); err != nil {
+		t.Fatalf("SaveChannels() failed: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("File not created at nested path: %v", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	Compact          CompactConfig          `yaml:"compact" mapstructure:"compact"`
 	Web              WebConfig              `yaml:"web" mapstructure:"web"`
 	ComputerUse      ComputerUseConfig      `yaml:"computer_use" mapstructure:"computer_use"`
-	Channels         ChannelsConfig         `yaml:"channels" mapstructure:"channels"`
+	Channels         ChannelsConfig         `yaml:"-" mapstructure:"-"`
 	configDir        string
 }
 
@@ -742,6 +742,7 @@ func DefaultConfig() *Config { //nolint:funlen
 					ConfigDirName + "/mcp.yaml",
 					ConfigDirName + "/keybindings.yaml",
 					ConfigDirName + "/prompts.yaml",
+					ConfigDirName + "/channels.yaml",
 					".git/",
 					"*.env",
 				},
@@ -1022,26 +1023,6 @@ func DefaultConfig() *Config { //nolint:funlen
 				ActivateApp: ActivateAppToolConfig{
 					Enabled: true,
 				},
-			},
-		},
-		Channels: ChannelsConfig{
-			Enabled:         false,
-			MaxWorkers:      5,
-			ImageRetention:  5,
-			RequireApproval: true,
-			Telegram: TelegramChannelConfig{
-				Enabled:      false,
-				BotToken:     "",
-				AllowedUsers: []string{},
-				PollTimeout:  30,
-			},
-			WhatsApp: WhatsAppChannelConfig{
-				Enabled:       false,
-				PhoneNumberID: "",
-				AccessToken:   "",
-				VerifyToken:   "",
-				WebhookPort:   8443,
-				AllowedUsers:  []string{},
 			},
 		},
 	}

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -78,19 +78,27 @@ Key features:
 
 ### 3. Configure the CLI
 
-Add to your `.infer/config.yaml`:
+Channel settings live in their own file at `.infer/channels.yaml` (separate
+from the main `config.yaml` so bot tokens stay out of the agent's reach —
+the file is in `tools.sandbox.protected_paths` by default). `infer init`
+seeds it from the in-code defaults; edit it like so:
 
 ```yaml
-channels:
+# .infer/channels.yaml
+---
+enabled: true
+
+telegram:
   enabled: true
+  bot_token: "${INFER_CHANNELS_TELEGRAM_BOT_TOKEN}"
+  allowed_users:
+    - "123456789"  # your chat ID
+  poll_timeout: 30
+```
 
-  telegram:
-    enabled: true
-    bot_token: "${INFER_CHANNELS_TELEGRAM_BOT_TOKEN}"
-    allowed_users:
-      - "123456789"  # your chat ID
-    poll_timeout: 30
+Agent-side settings still live in `.infer/config.yaml`:
 
+```yaml
 agent:
   model: "openai/gpt-4"
   system_prompt: "You are a helpful assistant"
@@ -124,36 +132,61 @@ Open Telegram, message your bot, and the agent will respond.
 
 ## Configuration
 
+### File Layout
+
+Channel settings live in their own file:
+
+- **`.infer/channels.yaml`** — all channel settings (Telegram, WhatsApp,
+  max workers, approval flag). Holds bot tokens, so it's listed in
+  `tools.sandbox.protected_paths` and the agent cannot read or rewrite it.
+- **`.infer/config.yaml`** — agent settings (model, system prompt, etc.).
+  Any legacy `channels:` block here is **ignored** at runtime; only
+  `channels.yaml` is read. Run `infer init` to migrate an existing block:
+  it seeds `channels.yaml` from the loaded values when no
+  `channels.yaml` exists yet.
+
+The lookup order for `channels.yaml` is project (`./.infer/channels.yaml`)
+first, then userspace (`~/.infer/channels.yaml`).
+
 ### Full Configuration Reference
 
 ```yaml
-channels:
-  # Master switch for all channels
+# .infer/channels.yaml
+---
+# Master switch for all channels
+enabled: false
+
+# Worker pool size for processing inbound messages
+max_workers: 5
+
+# Image retention (number of recent images cached per session)
+image_retention: 5
+
+# Require user approval for sensitive tools (default: true)
+# When true, tools like Write, Edit, Delete, and Bash will prompt the user
+# for approval before executing. Read-only tools (Read, Grep, Tree) are
+# not affected. Reuses existing tools.*.require_approval configuration.
+require_approval: true
+
+# Telegram Bot API channel
+telegram:
   enabled: false
+  bot_token: ""              # Bot token from @BotFather
+  allowed_users: []          # List of allowed chat IDs (strings)
+  poll_timeout: 30           # Long-polling timeout in seconds
 
-  # Require user approval for sensitive tools (default: true)
-  # When true, tools like Write, Edit, Delete, and Bash will prompt the user
-  # for approval before executing. Read-only tools (Read, Grep, Tree) are
-  # not affected. Reuses existing tools.*.require_approval configuration.
-  require_approval: true
+# WhatsApp Business API channel (Phase 2 - not yet implemented)
+whatsapp:
+  enabled: false
+  phone_number_id: ""        # Meta Business phone number ID
+  access_token: ""           # Meta API access token
+  verify_token: ""           # Webhook verification token
+  webhook_port: 8443         # Local port for webhook receiver
+  allowed_users: []          # List of allowed phone numbers
+```
 
-  # Telegram Bot API channel
-  telegram:
-    enabled: false
-    bot_token: ""              # Bot token from @BotFather
-    allowed_users: []          # List of allowed chat IDs (strings)
-    poll_timeout: 30           # Long-polling timeout in seconds
-
-  # WhatsApp Business API channel (Phase 2 - not yet implemented)
-  whatsapp:
-    enabled: false
-    phone_number_id: ""        # Meta Business phone number ID
-    access_token: ""           # Meta API access token
-    verify_token: ""           # Webhook verification token
-    webhook_port: 8443         # Local port for webhook receiver
-    allowed_users: []          # List of allowed phone numbers
-
-# Recommended agent settings for channel use
+```yaml
+# .infer/config.yaml — recommended agent settings for channel use
 agent:
   model: "deepseek/deepseek-v4-pro"              # Model to use
   system_prompt: "You are a helpful assistant"  # Base identity

--- a/examples/telegram-channel/README.md
+++ b/examples/telegram-channel/README.md
@@ -161,14 +161,14 @@ Add multiple chat IDs to allow more users:
 INFER_CHANNELS_TELEGRAM_ALLOWED_USERS="123456789,987654321"
 ```
 
-Or in `config.yaml`:
+Or in `.infer/channels.yaml`:
 
 ```yaml
-channels:
-  telegram:
-    allowed_users:
-      - "123456789"
-      - "987654321"
+---
+telegram:
+  allowed_users:
+    - "123456789"
+    - "987654321"
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Splits the `channels:` block (Telegram, WhatsApp, max workers, image retention, approval flag) out of `.infer/config.yaml` into a dedicated `.infer/channels.yaml`, mirroring the `mcp.yaml` / `keybindings.yaml` / `prompts.yaml` pattern.
- Adds `.infer/channels.yaml` to `tools.sandbox.protected_paths` defaults so the agent cannot read or rewrite bot tokens.
- `infer init` seeds the new file from in-code defaults and, when a legacy `channels:` block is present in `config.yaml` and no `channels.yaml` exists yet, migrates the values across and prints a one-line follow-up note pointing the user at the now-redundant block.
- Preserves `INFER_CHANNELS_*` env-var support via an explicit `applyChannelsEnvOverrides` (mirroring `applyKeybindingEnvOverrides` / `applyPromptsEnvOverrides`) so the docker-compose example in `examples/telegram-channel` keeps working unchanged.

Closes #441
