### PR TITLE
refactor(config): Centralize sub-config definitions and consolidate prompts

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -164,9 +164,6 @@ export:
 agent:
   model: ""
   system_prompt_with_defaults: true
-  system_reminders:
-    enabled: true
-    interval: 4
   context:
     git_context_enabled: true
     working_dir_enabled: true

--- a/.infer/prompts.yaml
+++ b/.infer/prompts.yaml
@@ -84,6 +84,8 @@ agent:
     - Lower resource usage (critical for remote systems)
   custom_instructions: ""
   system_reminders:
+    enabled: true
+    interval: 4
     reminder_text: |-
       <system-reminder>
       This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -697,7 +697,7 @@ func loadConfigFromViper() (*config.Config, error) {
 		logger.Warn("Failed to load prompts config, using defaults", "error", err, "path", promptsPath)
 		prompts = config.DefaultPromptsConfig()
 	}
-	applyPromptsOverlay(cfg, prompts)
+	cfg.Prompts = *prompts
 	applyPromptsEnvOverrides(cfg)
 
 	channelsPath := getEffectiveChannelsConfigPath()
@@ -721,44 +721,19 @@ func loadConfigFromViper() (*config.Config, error) {
 	return cfg, nil
 }
 
-// applyPromptsOverlay copies every prompt loaded from prompts.yaml into the
-// in-memory Config. Empty fields fall back to DefaultPromptsConfig() so a
-// user who blanks one entry doesn't lose every other prompt.
-func applyPromptsOverlay(cfg *config.Config, p *config.PromptsConfig) {
-	defaults := config.DefaultPromptsConfig()
-
-	pickString := func(loaded, fallback string) string {
-		if loaded != "" {
-			return loaded
-		}
-		return fallback
-	}
-
-	cfg.Agent.SystemPrompt = pickString(p.Agent.SystemPrompt, defaults.Agent.SystemPrompt)
-	cfg.Agent.SystemPromptPlan = pickString(p.Agent.SystemPromptPlan, defaults.Agent.SystemPromptPlan)
-	cfg.Agent.SystemPromptRemote = pickString(p.Agent.SystemPromptRemote, defaults.Agent.SystemPromptRemote)
-	cfg.Agent.CustomInstructions = p.Agent.CustomInstructions
-	cfg.Agent.SystemReminders.ReminderText = pickString(p.Agent.SystemReminders.ReminderText, defaults.Agent.SystemReminders.ReminderText)
-
-	cfg.Git.CommitMessage.SystemPrompt = pickString(p.Git.CommitMessage.SystemPrompt, defaults.Git.CommitMessage.SystemPrompt)
-	cfg.Conversation.TitleGeneration.SystemPrompt = pickString(p.Conversation.TitleGeneration.SystemPrompt, defaults.Conversation.TitleGeneration.SystemPrompt)
-	cfg.Init.Prompt = pickString(p.Init.Prompt, defaults.Init.Prompt)
-}
-
-// applyPromptsEnvOverrides lets users force a prompt from the environment.
-// Run AFTER applyPromptsOverlay so envs win over the YAML file. Only the
-// prompt fields exposed in PromptsConfig are checked, so an unrelated
-// INFER_PROMPTS_* var is silently ignored.
+// applyPromptsEnvOverrides lets users force a prompt from the
+// environment. Run AFTER cfg.Prompts has been populated from
+// prompts.yaml so envs win over the file.
 func applyPromptsEnvOverrides(cfg *config.Config) {
 	envOverrides := map[string]*string{
-		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT":                         &cfg.Agent.SystemPrompt,
-		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT_PLAN":                    &cfg.Agent.SystemPromptPlan,
-		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT_REMOTE":                  &cfg.Agent.SystemPromptRemote,
-		"INFER_PROMPTS_AGENT_CUSTOM_INSTRUCTIONS":                   &cfg.Agent.CustomInstructions,
-		"INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_REMINDER_TEXT":        &cfg.Agent.SystemReminders.ReminderText,
-		"INFER_PROMPTS_GIT_COMMIT_MESSAGE_SYSTEM_PROMPT":            &cfg.Git.CommitMessage.SystemPrompt,
-		"INFER_PROMPTS_CONVERSATION_TITLE_GENERATION_SYSTEM_PROMPT": &cfg.Conversation.TitleGeneration.SystemPrompt,
-		"INFER_PROMPTS_INIT_PROMPT":                                 &cfg.Init.Prompt,
+		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT":                         &cfg.Prompts.Agent.SystemPrompt,
+		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT_PLAN":                    &cfg.Prompts.Agent.SystemPromptPlan,
+		"INFER_PROMPTS_AGENT_SYSTEM_PROMPT_REMOTE":                  &cfg.Prompts.Agent.SystemPromptRemote,
+		"INFER_PROMPTS_AGENT_CUSTOM_INSTRUCTIONS":                   &cfg.Prompts.Agent.CustomInstructions,
+		"INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_REMINDER_TEXT":        &cfg.Prompts.Agent.SystemReminders.ReminderText,
+		"INFER_PROMPTS_GIT_COMMIT_MESSAGE_SYSTEM_PROMPT":            &cfg.Prompts.Git.CommitMessage.SystemPrompt,
+		"INFER_PROMPTS_CONVERSATION_TITLE_GENERATION_SYSTEM_PROMPT": &cfg.Prompts.Conversation.TitleGeneration.SystemPrompt,
+		"INFER_PROMPTS_INIT_PROMPT":                                 &cfg.Prompts.Init.Prompt,
 	}
 
 	for envKey, target := range envOverrides {

--- a/cmd/prompts_load_test.go
+++ b/cmd/prompts_load_test.go
@@ -10,9 +10,9 @@ import (
 	config "github.com/inference-gateway/cli/config"
 )
 
-// TestLoadConfigFromViper_PromptsDefaultsWhenFileAbsent confirms the
-// overlay falls back to in-code defaults when no prompts.yaml exists,
-// so freshly-cloned repos still get a working agent prompt.
+// TestLoadConfigFromViper_PromptsDefaultsWhenFileAbsent confirms cfg.Prompts
+// falls back to in-code defaults when no prompts.yaml exists, so
+// freshly-cloned repos still get a working agent prompt.
 func TestLoadConfigFromViper_PromptsDefaultsWhenFileAbsent(t *testing.T) {
 	withHermeticEnv(t)
 	initConfig()
@@ -20,18 +20,18 @@ func TestLoadConfigFromViper_PromptsDefaultsWhenFileAbsent(t *testing.T) {
 	cfg := Cfg
 
 	defaults := config.DefaultPromptsConfig()
-	require.Equal(t, defaults.Agent.SystemPrompt, cfg.Agent.SystemPrompt)
-	require.Equal(t, defaults.Agent.SystemPromptPlan, cfg.Agent.SystemPromptPlan)
-	require.Equal(t, defaults.Agent.SystemPromptRemote, cfg.Agent.SystemPromptRemote)
-	require.Equal(t, defaults.Agent.SystemReminders.ReminderText, cfg.Agent.SystemReminders.ReminderText)
-	require.Equal(t, defaults.Git.CommitMessage.SystemPrompt, cfg.Git.CommitMessage.SystemPrompt)
-	require.Equal(t, defaults.Conversation.TitleGeneration.SystemPrompt, cfg.Conversation.TitleGeneration.SystemPrompt)
-	require.Equal(t, defaults.Init.Prompt, cfg.Init.Prompt)
+	require.Equal(t, defaults.Agent.SystemPrompt, cfg.Prompts.Agent.SystemPrompt)
+	require.Equal(t, defaults.Agent.SystemPromptPlan, cfg.Prompts.Agent.SystemPromptPlan)
+	require.Equal(t, defaults.Agent.SystemPromptRemote, cfg.Prompts.Agent.SystemPromptRemote)
+	require.Equal(t, defaults.Agent.SystemReminders.ReminderText, cfg.Prompts.Agent.SystemReminders.ReminderText)
+	require.Equal(t, defaults.Git.CommitMessage.SystemPrompt, cfg.Prompts.Git.CommitMessage.SystemPrompt)
+	require.Equal(t, defaults.Conversation.TitleGeneration.SystemPrompt, cfg.Prompts.Conversation.TitleGeneration.SystemPrompt)
+	require.Equal(t, defaults.Init.Prompt, cfg.Prompts.Init.Prompt)
 }
 
 // TestLoadConfigFromViper_PromptsPartialFileFallsBackForUnsetFields
-// guards the partial-overlay rule: if a user blanks out (or never sets)
-// a single prompt key, the others must still resolve to defaults instead
+// guards the partial-load rule: if a user blanks out (or never sets) a
+// single prompt key, the others must still resolve to defaults instead
 // of becoming empty strings. Empty prompts at runtime would cause the
 // LLM to receive no system instructions.
 func TestLoadConfigFromViper_PromptsPartialFileFallsBackForUnsetFields(t *testing.T) {
@@ -50,10 +50,10 @@ func TestLoadConfigFromViper_PromptsPartialFileFallsBackForUnsetFields(t *testin
 	cfg := Cfg
 
 	defaults := config.DefaultPromptsConfig()
-	require.Equal(t, "USER OVERRIDE: only this is set", cfg.Agent.SystemPrompt)
-	require.Equal(t, defaults.Agent.SystemPromptPlan, cfg.Agent.SystemPromptPlan, "unset plan prompt should fall back to default")
-	require.Equal(t, defaults.Git.CommitMessage.SystemPrompt, cfg.Git.CommitMessage.SystemPrompt, "unset git prompt should fall back to default")
-	require.Equal(t, defaults.Init.Prompt, cfg.Init.Prompt, "unset init prompt should fall back to default")
+	require.Equal(t, "USER OVERRIDE: only this is set", cfg.Prompts.Agent.SystemPrompt)
+	require.Equal(t, defaults.Agent.SystemPromptPlan, cfg.Prompts.Agent.SystemPromptPlan, "unset plan prompt should fall back to default")
+	require.Equal(t, defaults.Git.CommitMessage.SystemPrompt, cfg.Prompts.Git.CommitMessage.SystemPrompt, "unset git prompt should fall back to default")
+	require.Equal(t, defaults.Init.Prompt, cfg.Prompts.Init.Prompt, "unset init prompt should fall back to default")
 }
 
 // TestLoadConfigFromViper_PromptsEnvOverridesFile pins the precedence
@@ -73,5 +73,5 @@ func TestLoadConfigFromViper_PromptsEnvOverridesFile(t *testing.T) {
 	initConfig()
 	cfg := Cfg
 
-	require.Equal(t, "from-env", cfg.Agent.SystemPrompt)
+	require.Equal(t, "from-env", cfg.Prompts.Agent.SystemPrompt)
 }

--- a/config/channels.go
+++ b/config/channels.go
@@ -9,6 +9,34 @@ const (
 	DefaultChannelsPath = ConfigDirName + "/" + ChannelsFileName
 )
 
+// ChannelsConfig contains configuration for external messaging channels
+type ChannelsConfig struct {
+	Enabled         bool                  `yaml:"enabled" mapstructure:"enabled"`
+	MaxWorkers      int                   `yaml:"max_workers" mapstructure:"max_workers"`
+	ImageRetention  int                   `yaml:"image_retention" mapstructure:"image_retention"`
+	RequireApproval bool                  `yaml:"require_approval" mapstructure:"require_approval"`
+	Telegram        TelegramChannelConfig `yaml:"telegram" mapstructure:"telegram"`
+	WhatsApp        WhatsAppChannelConfig `yaml:"whatsapp" mapstructure:"whatsapp"`
+}
+
+// TelegramChannelConfig contains Telegram bot settings
+type TelegramChannelConfig struct {
+	Enabled      bool     `yaml:"enabled" mapstructure:"enabled"`
+	BotToken     string   `yaml:"bot_token" mapstructure:"bot_token"`
+	AllowedUsers []string `yaml:"allowed_users" mapstructure:"allowed_users"`
+	PollTimeout  int      `yaml:"poll_timeout" mapstructure:"poll_timeout"`
+}
+
+// WhatsAppChannelConfig contains WhatsApp Business API settings
+type WhatsAppChannelConfig struct {
+	Enabled       bool     `yaml:"enabled" mapstructure:"enabled"`
+	PhoneNumberID string   `yaml:"phone_number_id" mapstructure:"phone_number_id"`
+	AccessToken   string   `yaml:"access_token" mapstructure:"access_token"`
+	VerifyToken   string   `yaml:"verify_token" mapstructure:"verify_token"`
+	WebhookPort   int      `yaml:"webhook_port" mapstructure:"webhook_port"`
+	AllowedUsers  []string `yaml:"allowed_users" mapstructure:"allowed_users"`
+}
+
 // DefaultChannelsConfig returns the in-code default channels configuration
 // used when no channels.yaml file exists. `infer init` seeds the file from
 // this and the runtime falls back to it when the file is absent.

--- a/config/computer_use.go
+++ b/config/computer_use.go
@@ -9,6 +9,89 @@ const (
 	DefaultComputerUsePath = ConfigDirName + "/" + ComputerUseFileName
 )
 
+// ComputerUseConfig contains computer use tool settings
+type ComputerUseConfig struct {
+	Enabled        bool                   `yaml:"enabled" mapstructure:"enabled"`
+	FloatingWindow FloatingWindowConfig   `yaml:"floating_window" mapstructure:"floating_window"`
+	Screenshot     ScreenshotToolConfig   `yaml:"screenshot" mapstructure:"screenshot"`
+	RateLimit      RateLimitConfig        `yaml:"rate_limit" mapstructure:"rate_limit"`
+	Tools          ComputerUseToolsConfig `yaml:"tools" mapstructure:"tools"`
+}
+
+// ComputerUseToolsConfig contains individual computer use tool settings
+type ComputerUseToolsConfig struct {
+	MouseMove     MouseMoveToolConfig     `yaml:"mouse_move" mapstructure:"mouse_move"`
+	MouseClick    MouseClickToolConfig    `yaml:"mouse_click" mapstructure:"mouse_click"`
+	MouseScroll   MouseScrollToolConfig   `yaml:"mouse_scroll" mapstructure:"mouse_scroll"`
+	KeyboardType  KeyboardTypeToolConfig  `yaml:"keyboard_type" mapstructure:"keyboard_type"`
+	GetFocusedApp GetFocusedAppToolConfig `yaml:"get_focused_app" mapstructure:"get_focused_app"`
+	ActivateApp   ActivateAppToolConfig   `yaml:"activate_app" mapstructure:"activate_app"`
+}
+
+// ScreenshotToolConfig contains screenshot-specific tool settings
+type ScreenshotToolConfig struct {
+	Enabled          bool   `yaml:"enabled" mapstructure:"enabled"`
+	MaxWidth         int    `yaml:"max_width" mapstructure:"max_width"`
+	MaxHeight        int    `yaml:"max_height" mapstructure:"max_height"`
+	TargetWidth      int    `yaml:"target_width" mapstructure:"target_width"`
+	TargetHeight     int    `yaml:"target_height" mapstructure:"target_height"`
+	Format           string `yaml:"format" mapstructure:"format"`
+	Quality          int    `yaml:"quality" mapstructure:"quality"`
+	StreamingEnabled bool   `yaml:"streaming_enabled" mapstructure:"streaming_enabled"`
+	CaptureInterval  int    `yaml:"capture_interval" mapstructure:"capture_interval"`
+	BufferSize       int    `yaml:"buffer_size" mapstructure:"buffer_size"`
+	TempDir          string `yaml:"temp_dir" mapstructure:"temp_dir"`
+	LogCaptures      bool   `yaml:"log_captures" mapstructure:"log_captures"`
+	ShowOverlay      bool   `yaml:"show_overlay" mapstructure:"show_overlay"`
+}
+
+// FloatingWindowConfig contains floating progress window settings
+type FloatingWindowConfig struct {
+	Enabled        bool   `yaml:"enabled" mapstructure:"enabled"`
+	RespawnOnClose bool   `yaml:"respawn_on_close" mapstructure:"respawn_on_close"`
+	Position       string `yaml:"position" mapstructure:"position"`
+	AlwaysOnTop    bool   `yaml:"always_on_top" mapstructure:"always_on_top"`
+}
+
+// MouseMoveToolConfig contains mouse move-specific tool settings
+type MouseMoveToolConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
+}
+
+// MouseClickToolConfig contains mouse click-specific tool settings
+type MouseClickToolConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
+}
+
+// MouseScrollToolConfig contains mouse scroll-specific tool settings
+type MouseScrollToolConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
+}
+
+// KeyboardTypeToolConfig contains keyboard type-specific tool settings
+type KeyboardTypeToolConfig struct {
+	Enabled       bool `yaml:"enabled" mapstructure:"enabled"`
+	MaxTextLength int  `yaml:"max_text_length" mapstructure:"max_text_length"`
+	TypingDelayMs int  `yaml:"typing_delay_ms" mapstructure:"typing_delay_ms"`
+}
+
+// GetFocusedAppToolConfig contains get focused app-specific tool settings
+type GetFocusedAppToolConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
+}
+
+// ActivateAppToolConfig contains activate app-specific tool settings
+type ActivateAppToolConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
+}
+
+// RateLimitConfig contains rate limiting settings
+type RateLimitConfig struct {
+	Enabled             bool `yaml:"enabled" mapstructure:"enabled"`
+	MaxActionsPerMinute int  `yaml:"max_actions_per_minute" mapstructure:"max_actions_per_minute"`
+	WindowSeconds       int  `yaml:"window_seconds" mapstructure:"window_seconds"`
+}
+
 // DefaultComputerUseConfig returns the in-code default computer_use
 // configuration used when no computer_use.yaml file exists. `infer init`
 // seeds the file from this and the runtime falls back to it when the file

--- a/config/config.go
+++ b/config/config.go
@@ -39,11 +39,11 @@ type Config struct {
 	A2A              A2AConfig              `yaml:"a2a" mapstructure:"a2a"`
 	MCP              MCPConfig              `yaml:"mcp" mapstructure:"mcp"`
 	Pricing          PricingConfig          `yaml:"pricing" mapstructure:"pricing"`
-	Init             InitConfig             `yaml:"-" mapstructure:"-"`
 	Compact          CompactConfig          `yaml:"compact" mapstructure:"compact"`
 	Web              WebConfig              `yaml:"web" mapstructure:"web"`
 	ComputerUse      ComputerUseConfig      `yaml:"-" mapstructure:"-"`
 	Channels         ChannelsConfig         `yaml:"-" mapstructure:"-"`
+	Prompts          PromptsConfig          `yaml:"-" mapstructure:"-"`
 	configDir        string
 }
 
@@ -272,89 +272,6 @@ type SandboxConfig struct {
 	ProtectedPaths []string `yaml:"protected_paths" mapstructure:"protected_paths"`
 }
 
-// ComputerUseConfig contains computer use tool settings
-type ComputerUseConfig struct {
-	Enabled        bool                   `yaml:"enabled" mapstructure:"enabled"`
-	FloatingWindow FloatingWindowConfig   `yaml:"floating_window" mapstructure:"floating_window"`
-	Screenshot     ScreenshotToolConfig   `yaml:"screenshot" mapstructure:"screenshot"`
-	RateLimit      RateLimitConfig        `yaml:"rate_limit" mapstructure:"rate_limit"`
-	Tools          ComputerUseToolsConfig `yaml:"tools" mapstructure:"tools"`
-}
-
-// ComputerUseToolsConfig contains individual computer use tool settings
-type ComputerUseToolsConfig struct {
-	MouseMove     MouseMoveToolConfig     `yaml:"mouse_move" mapstructure:"mouse_move"`
-	MouseClick    MouseClickToolConfig    `yaml:"mouse_click" mapstructure:"mouse_click"`
-	MouseScroll   MouseScrollToolConfig   `yaml:"mouse_scroll" mapstructure:"mouse_scroll"`
-	KeyboardType  KeyboardTypeToolConfig  `yaml:"keyboard_type" mapstructure:"keyboard_type"`
-	GetFocusedApp GetFocusedAppToolConfig `yaml:"get_focused_app" mapstructure:"get_focused_app"`
-	ActivateApp   ActivateAppToolConfig   `yaml:"activate_app" mapstructure:"activate_app"`
-}
-
-// ScreenshotToolConfig contains screenshot-specific tool settings
-type ScreenshotToolConfig struct {
-	Enabled          bool   `yaml:"enabled" mapstructure:"enabled"`
-	MaxWidth         int    `yaml:"max_width" mapstructure:"max_width"`
-	MaxHeight        int    `yaml:"max_height" mapstructure:"max_height"`
-	TargetWidth      int    `yaml:"target_width" mapstructure:"target_width"`
-	TargetHeight     int    `yaml:"target_height" mapstructure:"target_height"`
-	Format           string `yaml:"format" mapstructure:"format"`
-	Quality          int    `yaml:"quality" mapstructure:"quality"`
-	StreamingEnabled bool   `yaml:"streaming_enabled" mapstructure:"streaming_enabled"`
-	CaptureInterval  int    `yaml:"capture_interval" mapstructure:"capture_interval"`
-	BufferSize       int    `yaml:"buffer_size" mapstructure:"buffer_size"`
-	TempDir          string `yaml:"temp_dir" mapstructure:"temp_dir"`
-	LogCaptures      bool   `yaml:"log_captures" mapstructure:"log_captures"`
-	ShowOverlay      bool   `yaml:"show_overlay" mapstructure:"show_overlay"`
-}
-
-// FloatingWindowConfig contains floating progress window settings
-type FloatingWindowConfig struct {
-	Enabled        bool   `yaml:"enabled" mapstructure:"enabled"`
-	RespawnOnClose bool   `yaml:"respawn_on_close" mapstructure:"respawn_on_close"`
-	Position       string `yaml:"position" mapstructure:"position"`
-	AlwaysOnTop    bool   `yaml:"always_on_top" mapstructure:"always_on_top"`
-}
-
-// MouseMoveToolConfig contains mouse move-specific tool settings
-type MouseMoveToolConfig struct {
-	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
-}
-
-// MouseClickToolConfig contains mouse click-specific tool settings
-type MouseClickToolConfig struct {
-	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
-}
-
-// MouseScrollToolConfig contains mouse scroll-specific tool settings
-type MouseScrollToolConfig struct {
-	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
-}
-
-// KeyboardTypeToolConfig contains keyboard type-specific tool settings
-type KeyboardTypeToolConfig struct {
-	Enabled       bool `yaml:"enabled" mapstructure:"enabled"`
-	MaxTextLength int  `yaml:"max_text_length" mapstructure:"max_text_length"`
-	TypingDelayMs int  `yaml:"typing_delay_ms" mapstructure:"typing_delay_ms"`
-}
-
-// GetFocusedAppToolConfig contains get focused app-specific tool settings
-type GetFocusedAppToolConfig struct {
-	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
-}
-
-// ActivateAppToolConfig contains activate app-specific tool settings
-type ActivateAppToolConfig struct {
-	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
-}
-
-// RateLimitConfig contains rate limiting settings
-type RateLimitConfig struct {
-	Enabled             bool `yaml:"enabled" mapstructure:"enabled"`
-	MaxActionsPerMinute int  `yaml:"max_actions_per_minute" mapstructure:"max_actions_per_minute"`
-	WindowSeconds       int  `yaml:"window_seconds" mapstructure:"window_seconds"`
-}
-
 // SafetyConfig contains safety approval settings
 type SafetyConfig struct {
 	RequireApproval bool `yaml:"require_approval" mapstructure:"require_approval"`
@@ -409,15 +326,6 @@ type SSHServerConfig struct {
 	Tags        []string `yaml:"tags" mapstructure:"tags"`
 }
 
-// SystemRemindersConfig contains settings for dynamic system reminders.
-// ReminderText is sourced from prompts.yaml at runtime — it carries no
-// yaml/mapstructure tags so it never appears in config.yaml.
-type SystemRemindersConfig struct {
-	Enabled      bool   `yaml:"enabled" mapstructure:"enabled"`
-	Interval     int    `yaml:"interval" mapstructure:"interval"`
-	ReminderText string `yaml:"-" mapstructure:"-"`
-}
-
 // AgentContextConfig contains settings for agent context enrichment
 type AgentContextConfig struct {
 	GitContextEnabled      bool `yaml:"git_context_enabled" mapstructure:"git_context_enabled"`
@@ -426,22 +334,16 @@ type AgentContextConfig struct {
 }
 
 // AgentConfig contains agent command-specific settings.
-// The SystemPrompt*, CustomInstructions, and SystemReminders fields are
-// sourced from prompts.yaml at runtime — they carry no yaml/mapstructure
-// tags so they never appear in config.yaml.
+// All system prompts, custom instructions, and system reminder settings
+// live in prompts.yaml and are read from cfg.Prompts.Agent.* at runtime.
 type AgentConfig struct {
-	Model                    string                `yaml:"model" mapstructure:"model"`
-	SystemPrompt             string                `yaml:"-" mapstructure:"-"`
-	SystemPromptWithDefaults bool                  `yaml:"system_prompt_with_defaults" mapstructure:"system_prompt_with_defaults"`
-	CustomInstructions       string                `yaml:"-" mapstructure:"-"`
-	SystemPromptPlan         string                `yaml:"-" mapstructure:"-"`
-	SystemPromptRemote       string                `yaml:"-" mapstructure:"-"`
-	SystemReminders          SystemRemindersConfig `yaml:"system_reminders" mapstructure:"system_reminders"`
-	Context                  AgentContextConfig    `yaml:"context" mapstructure:"context"`
-	VerboseTools             bool                  `yaml:"verbose_tools" mapstructure:"verbose_tools"`
-	MaxTurns                 int                   `yaml:"max_turns" mapstructure:"max_turns"`
-	MaxTokens                int                   `yaml:"max_tokens" mapstructure:"max_tokens"`
-	MaxConcurrentTools       int                   `yaml:"max_concurrent_tools" mapstructure:"max_concurrent_tools"`
+	Model                    string             `yaml:"model" mapstructure:"model"`
+	SystemPromptWithDefaults bool               `yaml:"system_prompt_with_defaults" mapstructure:"system_prompt_with_defaults"`
+	Context                  AgentContextConfig `yaml:"context" mapstructure:"context"`
+	VerboseTools             bool               `yaml:"verbose_tools" mapstructure:"verbose_tools"`
+	MaxTurns                 int                `yaml:"max_turns" mapstructure:"max_turns"`
+	MaxTokens                int                `yaml:"max_tokens" mapstructure:"max_tokens"`
+	MaxConcurrentTools       int                `yaml:"max_concurrent_tools" mapstructure:"max_concurrent_tools"`
 }
 
 // GitConfig contains git shortcut-specific settings
@@ -471,21 +373,20 @@ type ConversationConfig struct {
 }
 
 // GitCommitMessageConfig contains settings for AI-generated commit
-// messages. SystemPrompt is sourced from prompts.yaml at runtime — it
-// carries no yaml/mapstructure tags so it never appears in config.yaml.
+// messages. The system prompt lives in prompts.yaml under
+// git.commit_message.system_prompt.
 type GitCommitMessageConfig struct {
-	Model        string `yaml:"model" mapstructure:"model"`
-	SystemPrompt string `yaml:"-" mapstructure:"-"`
+	Model string `yaml:"model" mapstructure:"model"`
 }
 
 // ConversationTitleConfig contains settings for AI-generated conversation
-// titles. SystemPrompt is sourced from prompts.yaml at runtime.
+// titles. The system prompt lives in prompts.yaml under
+// conversation.title_generation.system_prompt.
 type ConversationTitleConfig struct {
-	Enabled      bool   `yaml:"enabled" mapstructure:"enabled"`
-	Model        string `yaml:"model" mapstructure:"model"`
-	SystemPrompt string `yaml:"-" mapstructure:"-"`
-	BatchSize    int    `yaml:"batch_size" mapstructure:"batch_size"`
-	Interval     int    `yaml:"interval" mapstructure:"interval"`
+	Enabled   bool   `yaml:"enabled" mapstructure:"enabled"`
+	Model     string `yaml:"model" mapstructure:"model"`
+	BatchSize int    `yaml:"batch_size" mapstructure:"batch_size"`
+	Interval  int    `yaml:"interval" mapstructure:"interval"`
 }
 
 // ChatConfig contains chat interface settings
@@ -493,20 +394,6 @@ type ChatConfig struct {
 	Theme       string            `yaml:"theme" mapstructure:"theme"`
 	Keybindings KeybindingsConfig `yaml:"-" mapstructure:"-"`
 	StatusBar   StatusBarConfig   `yaml:"status_bar" mapstructure:"status_bar"`
-}
-
-// KeybindingsConfig contains settings for customizing keybindings
-type KeybindingsConfig struct {
-	Enabled  bool                       `yaml:"enabled" mapstructure:"enabled"`
-	Bindings map[string]KeyBindingEntry `yaml:"bindings,omitempty" mapstructure:"bindings,omitempty"`
-}
-
-// KeyBindingEntry defines a complete keybinding with its properties
-type KeyBindingEntry struct {
-	Keys        []string `yaml:"keys" mapstructure:"keys"`
-	Description string   `yaml:"description,omitempty" mapstructure:"description,omitempty"`
-	Category    string   `yaml:"category,omitempty" mapstructure:"category,omitempty"`
-	Enabled     *bool    `yaml:"enabled,omitempty" mapstructure:"enabled,omitempty"`
 }
 
 // StatusBarConfig contains settings for the chat status bar
@@ -531,12 +418,6 @@ type StatusBarIndicators struct {
 	SessionTokens    bool `yaml:"session_tokens" mapstructure:"session_tokens"`
 	Cost             bool `yaml:"cost" mapstructure:"cost"`
 	GitBranch        bool `yaml:"git_branch" mapstructure:"git_branch"`
-}
-
-// InitConfig contains settings for the /init shortcut. Prompt is sourced
-// from prompts.yaml at runtime.
-type InitConfig struct {
-	Prompt string `yaml:"-" mapstructure:"-"`
 }
 
 // FetchSafetyConfig contains safety settings for fetch operations
@@ -600,34 +481,6 @@ type RedisStorageConfig struct {
 // JsonlStorageConfig contains JSONL-specific configuration
 type JsonlStorageConfig struct {
 	Path string `yaml:"path" mapstructure:"path"`
-}
-
-// ChannelsConfig contains configuration for external messaging channels
-type ChannelsConfig struct {
-	Enabled         bool                  `yaml:"enabled" mapstructure:"enabled"`
-	MaxWorkers      int                   `yaml:"max_workers" mapstructure:"max_workers"`
-	ImageRetention  int                   `yaml:"image_retention" mapstructure:"image_retention"`
-	RequireApproval bool                  `yaml:"require_approval" mapstructure:"require_approval"`
-	Telegram        TelegramChannelConfig `yaml:"telegram" mapstructure:"telegram"`
-	WhatsApp        WhatsAppChannelConfig `yaml:"whatsapp" mapstructure:"whatsapp"`
-}
-
-// TelegramChannelConfig contains Telegram bot settings
-type TelegramChannelConfig struct {
-	Enabled      bool     `yaml:"enabled" mapstructure:"enabled"`
-	BotToken     string   `yaml:"bot_token" mapstructure:"bot_token"`
-	AllowedUsers []string `yaml:"allowed_users" mapstructure:"allowed_users"`
-	PollTimeout  int      `yaml:"poll_timeout" mapstructure:"poll_timeout"`
-}
-
-// WhatsAppChannelConfig contains WhatsApp Business API settings
-type WhatsAppChannelConfig struct {
-	Enabled       bool     `yaml:"enabled" mapstructure:"enabled"`
-	PhoneNumberID string   `yaml:"phone_number_id" mapstructure:"phone_number_id"`
-	AccessToken   string   `yaml:"access_token" mapstructure:"access_token"`
-	VerifyToken   string   `yaml:"verify_token" mapstructure:"verify_token"`
-	WebhookPort   int      `yaml:"webhook_port" mapstructure:"webhook_port"`
-	AllowedUsers  []string `yaml:"allowed_users" mapstructure:"allowed_users"`
 }
 
 // A2AAgentInfo contains information about an A2A agent connection
@@ -867,14 +720,10 @@ func DefaultConfig() *Config { //nolint:funlen
 				GitContextRefreshTurns: 10,
 			},
 			SystemPromptWithDefaults: true,
-			SystemReminders: SystemRemindersConfig{
-				Enabled:  true,
-				Interval: 4,
-			},
-			VerboseTools:       false,
-			MaxTurns:           50,
-			MaxTokens:          8192,
-			MaxConcurrentTools: 5,
+			VerboseTools:             false,
+			MaxTurns:                 50,
+			MaxTokens:                8192,
+			MaxConcurrentTools:       5,
 		},
 		Git: GitConfig{
 			CommitMessage: GitCommitMessageConfig{
@@ -953,7 +802,6 @@ func DefaultConfig() *Config { //nolint:funlen
 		},
 		MCP:     *DefaultMCPConfig(),
 		Pricing: GetDefaultPricingConfig(),
-		Init:    InitConfig{},
 		Compact: CompactConfig{
 			Enabled:               true,
 			AutoAt:                80,
@@ -1084,13 +932,6 @@ func (c *Config) GetAPIKey() string {
 
 func (c *Config) GetTimeout() int {
 	return c.Gateway.Timeout
-}
-
-func (c *Config) GetSystemPrompt() string {
-	if os.Getenv("INFER_REMOTE_MANAGED") == "true" && c.Agent.SystemPromptRemote != "" {
-		return c.Agent.SystemPromptRemote
-	}
-	return c.Agent.SystemPrompt
 }
 
 func (c *Config) GetDefaultModel() string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,14 +105,11 @@ func testChatDefaults(t *testing.T, cfg *Config) {
 	if cfg.Agent.Model != "" {
 		t.Errorf("Expected default model to be empty, got %q", cfg.Agent.Model)
 	}
-	// Prompt defaults moved to prompts.yaml as of issue #439 — DefaultConfig
-	// leaves these fields empty so the runtime overlay (or env vars) fills
-	// them. See config/prompts.go for the live defaults.
-	if cfg.Agent.SystemPrompt != "" {
-		t.Errorf("Expected system prompt to be empty in main config (now sourced from prompts.yaml), got %q", cfg.Agent.SystemPrompt)
+	if cfg.Prompts.Agent.SystemPrompt != "" {
+		t.Errorf("Expected DefaultConfig to leave cfg.Prompts empty, got %q", cfg.Prompts.Agent.SystemPrompt)
 	}
-	if cfg.Agent.CustomInstructions != "" {
-		t.Errorf("Expected custom instructions to be empty by default, got %q", cfg.Agent.CustomInstructions)
+	if cfg.Prompts.Agent.CustomInstructions != "" {
+		t.Errorf("Expected DefaultConfig to leave cfg.Prompts empty, got %q", cfg.Prompts.Agent.CustomInstructions)
 	}
 }
 
@@ -329,19 +326,15 @@ func TestSaveConfig(t *testing.T) {
 			name: "save chat config",
 			setupFunc: func(cfg *Config) {
 				cfg.Agent.Model = "anthropic/claude-4"
-				cfg.Agent.SystemPrompt = "Be helpful"
+				cfg.Prompts.Agent.SystemPrompt = "Be helpful"
 				cfg.Gateway.APIKey = "secret-key"
 			},
 			validator: func(t *testing.T, cfg *Config) {
 				if cfg.Agent.Model != "anthropic/claude-4" {
 					t.Errorf("Expected default model to be 'anthropic/claude-4', got %q", cfg.Agent.Model)
 				}
-				// SystemPrompt is now sourced from prompts.yaml (issue #439)
-				// and tagged yaml:"-" — it intentionally does NOT round-trip
-				// through config.yaml. Asserting it is empty after save+load
-				// guards against accidentally re-tagging the field.
-				if cfg.Agent.SystemPrompt != "" {
-					t.Errorf("Expected system prompt to be empty after round-trip (it lives in prompts.yaml), got %q", cfg.Agent.SystemPrompt)
+				if cfg.Prompts.Agent.SystemPrompt != "" {
+					t.Errorf("Expected system prompt to be empty after round-trip (it lives in prompts.yaml), got %q", cfg.Prompts.Agent.SystemPrompt)
 				}
 				if cfg.Gateway.APIKey != "secret-key" {
 					t.Errorf("Expected API key to be 'secret-key', got %q", cfg.Gateway.APIKey)
@@ -369,11 +362,9 @@ func runSaveConfigTest(t *testing.T, setupFunc func(*Config), validator func(t *
 	cfg := DefaultConfig()
 	setupFunc(cfg)
 
-	// Create a new Viper instance for this test
 	v := viper.New()
 	v.SetConfigFile(configPath)
 
-	// Set all config values in Viper
 	v.Set("gateway.url", cfg.Gateway.URL)
 	v.Set("gateway.api_key", cfg.Gateway.APIKey)
 	v.Set("gateway.timeout", cfg.Gateway.Timeout)
@@ -386,13 +377,11 @@ func runSaveConfigTest(t *testing.T, setupFunc func(*Config), validator func(t *
 	v.Set("tools.web_search.timeout", cfg.Tools.WebSearch.Timeout)
 	v.Set("tools.web_search.engines", cfg.Tools.WebSearch.Engines)
 	v.Set("agent.model", cfg.Agent.Model)
-	v.Set("agent.system_prompt", cfg.Agent.SystemPrompt)
 
 	if err := writeViperConfigForTest(v, 2); err != nil {
 		t.Fatalf("Failed to save config: %v", err)
 	}
 
-	// Load the saved config back
 	loadV := viper.New()
 	loadV.SetConfigFile(configPath)
 	if err := loadV.ReadInConfig(); err != nil {
@@ -809,15 +798,10 @@ func TestParseGithubOwnerFromURL(t *testing.T) {
 }
 
 func TestDetectGithubOwner(t *testing.T) {
-	// Note: This test will only pass if the test is run in the actual git repository
-	// For CI/CD environments, this should detect the owner correctly
 	owner := DetectGithubOwner()
 
-	// We can't assert a specific value since the test might run in different contexts
-	// But we can verify it returns a string (empty or not)
 	if owner != "" {
 		t.Logf("Detected GitHub owner: %s", owner)
-		// Basic validation: owner should not contain slashes or special characters
 		if strings.Contains(owner, "/") {
 			t.Errorf("GitHub owner should not contain slashes: %s", owner)
 		}

--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -9,6 +9,20 @@ const (
 	DefaultKeybindingsPath = ConfigDirName + "/" + KeybindingsFileName
 )
 
+// KeybindingsConfig contains settings for customizing keybindings
+type KeybindingsConfig struct {
+	Enabled  bool                       `yaml:"enabled" mapstructure:"enabled"`
+	Bindings map[string]KeyBindingEntry `yaml:"bindings,omitempty" mapstructure:"bindings,omitempty"`
+}
+
+// KeyBindingEntry defines a complete keybinding with its properties
+type KeyBindingEntry struct {
+	Keys        []string `yaml:"keys" mapstructure:"keys"`
+	Description string   `yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Category    string   `yaml:"category,omitempty" mapstructure:"category,omitempty"`
+	Enabled     *bool    `yaml:"enabled,omitempty" mapstructure:"enabled,omitempty"`
+}
+
 // DefaultKeybindingsConfig returns the default keybindings config used when
 // no file exists. Callers (init, reset) use it to seed a fresh file.
 func DefaultKeybindingsConfig() *KeybindingsConfig {

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -14,8 +14,42 @@ const (
 // defaults" without special-casing. The file body is run through
 // os.ExpandEnv — any literal `${…}` token in a customised prompt must be
 // escaped as `$$…`.
+//
+// Any field left empty in a partial prompts.yaml is backfilled from
+// DefaultPromptsConfig() so callers always get a fully populated config.
+// CustomInstructions is intentionally excluded from backfill — empty is
+// a meaningful user choice there.
 func LoadPrompts(path string) (*PromptsConfig, error) {
-	return utils.LoadYAML(path, "prompts", DefaultPromptsConfig)
+	cfg, err := utils.LoadYAML(path, "prompts", DefaultPromptsConfig)
+	if err != nil {
+		return nil, err
+	}
+	mergePromptDefaults(cfg, DefaultPromptsConfig())
+	return cfg, nil
+}
+
+func mergePromptDefaults(loaded, defaults *PromptsConfig) {
+	if loaded.Agent.SystemPrompt == "" {
+		loaded.Agent.SystemPrompt = defaults.Agent.SystemPrompt
+	}
+	if loaded.Agent.SystemPromptPlan == "" {
+		loaded.Agent.SystemPromptPlan = defaults.Agent.SystemPromptPlan
+	}
+	if loaded.Agent.SystemPromptRemote == "" {
+		loaded.Agent.SystemPromptRemote = defaults.Agent.SystemPromptRemote
+	}
+	if loaded.Agent.SystemReminders.ReminderText == "" {
+		loaded.Agent.SystemReminders.ReminderText = defaults.Agent.SystemReminders.ReminderText
+	}
+	if loaded.Git.CommitMessage.SystemPrompt == "" {
+		loaded.Git.CommitMessage.SystemPrompt = defaults.Git.CommitMessage.SystemPrompt
+	}
+	if loaded.Conversation.TitleGeneration.SystemPrompt == "" {
+		loaded.Conversation.TitleGeneration.SystemPrompt = defaults.Conversation.TitleGeneration.SystemPrompt
+	}
+	if loaded.Init.Prompt == "" {
+		loaded.Init.Prompt = defaults.Init.Prompt
+	}
 }
 
 // SavePrompts writes the prompts configuration to disk, creating any
@@ -43,6 +77,8 @@ type PromptsAgentConfig struct {
 }
 
 type PromptsAgentRemindersConfig struct {
+	Enabled      bool   `yaml:"enabled" mapstructure:"enabled"`
+	Interval     int    `yaml:"interval" mapstructure:"interval"`
 	ReminderText string `yaml:"reminder_text" mapstructure:"reminder_text"`
 }
 
@@ -154,6 +190,8 @@ Why prefer direct tools:
 - Lower resource usage (critical for remote systems)`,
 			CustomInstructions: ``,
 			SystemReminders: PromptsAgentRemindersConfig{
+				Enabled:  true,
+				Interval: 4,
 				ReminderText: `<system-reminder>
 This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.
 </system-reminder>`,

--- a/config/prompts_test.go
+++ b/config/prompts_test.go
@@ -120,15 +120,17 @@ agent:
 		t.Fatalf("LoadPrompts() failed: %v", err)
 	}
 	if cfg.Agent.SystemPrompt != "only this field is set" {
-		t.Errorf("Expected partial value, got %q", cfg.Agent.SystemPrompt)
+		t.Errorf("Expected user override to be preserved, got %q", cfg.Agent.SystemPrompt)
 	}
-	// Other prompt fields stay zero — the runtime overlay (cmd applies it
-	// on top of LoadPrompts) is what fills them back in from defaults.
-	if cfg.Agent.SystemPromptPlan != "" {
-		t.Errorf("Expected unset plan prompt to be empty, got %q", cfg.Agent.SystemPromptPlan)
+	// Unset fields are backfilled from DefaultPromptsConfig() inside
+	// LoadPrompts so callers always get a fully populated config without
+	// running their own overlay.
+	defaults := config.DefaultPromptsConfig()
+	if cfg.Agent.SystemPromptPlan != defaults.Agent.SystemPromptPlan {
+		t.Errorf("Expected unset plan prompt to be backfilled with default, got %q", cfg.Agent.SystemPromptPlan)
 	}
-	if cfg.Git.CommitMessage.SystemPrompt != "" {
-		t.Errorf("Expected unset commit prompt to be empty, got %q", cfg.Git.CommitMessage.SystemPrompt)
+	if cfg.Git.CommitMessage.SystemPrompt != defaults.Git.CommitMessage.SystemPrompt {
+		t.Errorf("Expected unset commit prompt to be backfilled with default, got %q", cfg.Git.CommitMessage.SystemPrompt)
 	}
 }
 

--- a/internal/agent/agent_helpers_test.go
+++ b/internal/agent/agent_helpers_test.go
@@ -90,10 +90,12 @@ func TestShouldInjectSystemReminder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
-				Agent: config.AgentConfig{
-					SystemReminders: config.SystemRemindersConfig{
-						Enabled:  tt.enabled,
-						Interval: tt.interval,
+				Prompts: config.PromptsConfig{
+					Agent: config.PromptsAgentConfig{
+						SystemReminders: config.PromptsAgentRemindersConfig{
+							Enabled:  tt.enabled,
+							Interval: tt.interval,
+						},
 					},
 				},
 			}
@@ -123,9 +125,11 @@ func TestGetSystemPromptForMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
-				Agent: config.AgentConfig{
-					SystemPrompt:     tt.systemPrompt,
-					SystemPromptPlan: tt.planPrompt,
+				Prompts: config.PromptsConfig{
+					Agent: config.PromptsAgentConfig{
+						SystemPrompt:     tt.systemPrompt,
+						SystemPromptPlan: tt.planPrompt,
+					},
 				},
 			}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -350,13 +350,13 @@ func TestAgentServiceImpl_ShouldInjectSystemReminder(t *testing.T) {
 	tests := []struct {
 		name            string
 		turns           int
-		remindersConfig config.SystemRemindersConfig
+		remindersConfig config.PromptsAgentRemindersConfig
 		expectedResult  bool
 	}{
 		{
 			name:  "reminders_disabled",
 			turns: 4,
-			remindersConfig: config.SystemRemindersConfig{
+			remindersConfig: config.PromptsAgentRemindersConfig{
 				Enabled:  false,
 				Interval: 4,
 			},
@@ -365,7 +365,7 @@ func TestAgentServiceImpl_ShouldInjectSystemReminder(t *testing.T) {
 		{
 			name:  "turn_matches_interval",
 			turns: 4,
-			remindersConfig: config.SystemRemindersConfig{
+			remindersConfig: config.PromptsAgentRemindersConfig{
 				Enabled:  true,
 				Interval: 4,
 			},
@@ -374,7 +374,7 @@ func TestAgentServiceImpl_ShouldInjectSystemReminder(t *testing.T) {
 		{
 			name:  "turn_does_not_match_interval",
 			turns: 3,
-			remindersConfig: config.SystemRemindersConfig{
+			remindersConfig: config.PromptsAgentRemindersConfig{
 				Enabled:  true,
 				Interval: 4,
 			},
@@ -383,7 +383,7 @@ func TestAgentServiceImpl_ShouldInjectSystemReminder(t *testing.T) {
 		{
 			name:  "turn_zero",
 			turns: 0,
-			remindersConfig: config.SystemRemindersConfig{
+			remindersConfig: config.PromptsAgentRemindersConfig{
 				Enabled:  true,
 				Interval: 4,
 			},
@@ -392,7 +392,7 @@ func TestAgentServiceImpl_ShouldInjectSystemReminder(t *testing.T) {
 		{
 			name:  "turn_multiple_of_interval",
 			turns: 8,
-			remindersConfig: config.SystemRemindersConfig{
+			remindersConfig: config.PromptsAgentRemindersConfig{
 				Enabled:  true,
 				Interval: 4,
 			},
@@ -401,7 +401,7 @@ func TestAgentServiceImpl_ShouldInjectSystemReminder(t *testing.T) {
 		{
 			name:  "default_interval_when_zero",
 			turns: 4,
-			remindersConfig: config.SystemRemindersConfig{
+			remindersConfig: config.PromptsAgentRemindersConfig{
 				Enabled:  true,
 				Interval: 0,
 			},
@@ -410,7 +410,7 @@ func TestAgentServiceImpl_ShouldInjectSystemReminder(t *testing.T) {
 		{
 			name:  "negative_interval_defaults_to_4",
 			turns: 4,
-			remindersConfig: config.SystemRemindersConfig{
+			remindersConfig: config.PromptsAgentRemindersConfig{
 				Enabled:  true,
 				Interval: -1,
 			},
@@ -421,8 +421,10 @@ func TestAgentServiceImpl_ShouldInjectSystemReminder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
-				Agent: config.AgentConfig{
-					SystemReminders: tt.remindersConfig,
+				Prompts: config.PromptsConfig{
+					Agent: config.PromptsAgentConfig{
+						SystemReminders: tt.remindersConfig,
+					},
 				},
 			}
 
@@ -461,9 +463,11 @@ func TestAgentServiceImpl_GetSystemReminderMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
-				Agent: config.AgentConfig{
-					SystemReminders: config.SystemRemindersConfig{
-						ReminderText: tt.reminderText,
+				Prompts: config.PromptsConfig{
+					Agent: config.PromptsAgentConfig{
+						SystemReminders: config.PromptsAgentRemindersConfig{
+							ReminderText: tt.reminderText,
+						},
 					},
 				},
 			}
@@ -1178,9 +1182,11 @@ func TestAgentServiceImpl_GetSystemPromptForMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
-				Agent: config.AgentConfig{
-					SystemPrompt:     tt.systemPrompt,
-					SystemPromptPlan: tt.planPrompt,
+				Prompts: config.PromptsConfig{
+					Agent: config.PromptsAgentConfig{
+						SystemPrompt:     tt.systemPrompt,
+						SystemPromptPlan: tt.planPrompt,
+					},
 				},
 			}
 
@@ -1204,8 +1210,12 @@ func TestAgentServiceImpl_GetSystemPromptForMode(t *testing.T) {
 func TestAgentServiceImpl_AddSystemPrompt(t *testing.T) {
 	cfg := &config.Config{
 		Agent: config.AgentConfig{
-			SystemPrompt:             "You are a helpful assistant.",
 			SystemPromptWithDefaults: true,
+		},
+		Prompts: config.PromptsConfig{
+			Agent: config.PromptsAgentConfig{
+				SystemPrompt: "You are a helpful assistant.",
+			},
 		},
 		Tools: config.ToolsConfig{
 			Sandbox: config.SandboxConfig{
@@ -1240,8 +1250,10 @@ func TestAgentServiceImpl_AddSystemPrompt(t *testing.T) {
 
 func TestAgentServiceImpl_AddSystemPrompt_EmptyPrompt(t *testing.T) {
 	cfg := &config.Config{
-		Agent: config.AgentConfig{
-			SystemPrompt: "",
+		Prompts: config.PromptsConfig{
+			Agent: config.PromptsAgentConfig{
+				SystemPrompt: "",
+			},
 		},
 	}
 

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -105,8 +105,8 @@ func (s *AgentServiceImpl) addSystemPrompt(messages []sdk.Message) []sdk.Message
 	agentConfig := s.config.GetAgentConfig()
 	parts := []string{baseSystemPrompt}
 
-	if agentConfig.CustomInstructions != "" {
-		parts = append(parts, agentConfig.CustomInstructions)
+	if s.config.Prompts.Agent.CustomInstructions != "" {
+		parts = append(parts, s.config.Prompts.Agent.CustomInstructions)
 	}
 
 	if agentConfig.SystemPromptWithDefaults {
@@ -138,28 +138,28 @@ func (s *AgentServiceImpl) buildContextInfo(currentTurn int) string {
 
 // getSystemPromptForMode returns the appropriate system prompt based on current agent mode
 func (s *AgentServiceImpl) getSystemPromptForMode() string {
-	agentConfig := s.config.GetAgentConfig()
+	prompts := s.config.Prompts.Agent
 
 	if s.stateManager == nil {
-		return agentConfig.SystemPrompt
+		return prompts.SystemPrompt
 	}
 
 	mode := s.stateManager.GetAgentMode()
 	switch mode {
 	case domain.AgentModePlan:
-		if agentConfig.SystemPromptPlan != "" {
-			return agentConfig.SystemPromptPlan
+		if prompts.SystemPromptPlan != "" {
+			return prompts.SystemPromptPlan
 		}
-		return agentConfig.SystemPrompt
+		return prompts.SystemPrompt
 
 	case domain.AgentModeAutoAccept:
-		return agentConfig.SystemPrompt
+		return prompts.SystemPrompt
 
 	case domain.AgentModeStandard:
-		return agentConfig.SystemPrompt
+		return prompts.SystemPrompt
 
 	default:
-		return agentConfig.SystemPrompt
+		return prompts.SystemPrompt
 	}
 }
 
@@ -418,13 +418,13 @@ func (s *AgentServiceImpl) parseProvider(model string) (string, string, error) {
 
 // shouldInjectSystemReminder checks if a system reminder should be injected
 func (s *AgentServiceImpl) shouldInjectSystemReminder(turns int) bool {
-	cfg := s.config.GetAgentConfig()
+	reminders := s.config.Prompts.Agent.SystemReminders
 
-	if !cfg.SystemReminders.Enabled {
+	if !reminders.Enabled {
 		return false
 	}
 
-	interval := cfg.SystemReminders.Interval
+	interval := reminders.Interval
 	if interval <= 0 {
 		interval = 4
 	}
@@ -434,9 +434,7 @@ func (s *AgentServiceImpl) shouldInjectSystemReminder(turns int) bool {
 
 // getSystemReminderMessage returns the system reminder message to inject
 func (s *AgentServiceImpl) getSystemReminderMessage() sdk.Message {
-	cfg := s.config.GetAgentConfig()
-
-	reminderText := cfg.SystemReminders.ReminderText
+	reminderText := s.config.Prompts.Agent.SystemReminders.ReminderText
 	if reminderText == "" {
 		reminderText = `<system-reminder>
 This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.

--- a/internal/services/conversation_title_generator.go
+++ b/internal/services/conversation_title_generator.go
@@ -176,7 +176,7 @@ func (g *ConversationTitleGenerator) generateTitle(ctx context.Context, entries 
 		return "", fmt.Errorf("no model configured for conversation titles")
 	}
 
-	systemPrompt := g.config.Conversation.TitleGeneration.SystemPrompt
+	systemPrompt := g.config.Prompts.Conversation.TitleGeneration.SystemPrompt
 
 	conversationText := g.formatConversationForTitleGeneration(entries)
 	if conversationText == "" {

--- a/internal/shortcuts/init.go
+++ b/internal/shortcuts/init.go
@@ -28,7 +28,7 @@ func (c *InitShortcut) CanExecute(args []string) bool {
 }
 
 func (c *InitShortcut) Execute(ctx context.Context, args []string) (ShortcutResult, error) {
-	prompt := c.config.Init.Prompt
+	prompt := c.config.Prompts.Init.Prompt
 	if prompt == "" {
 		prompt = defaultInitPrompt()
 	}


### PR DESCRIPTION
## Summary

Two related cleanups that finish the sub-config restructuring started in recent refactors (45e4fb6, aa43e0e, aab481c, a762c64).

### Part 1 — Sub-config struct relocation

Move struct definitions out of `config/config.go` and into their already-existing companion files, matching the pattern of `agents.go`, `mcp.go`, `prompts.go`, `pricing.go`:

- `ComputerUseConfig` + 10 supporting structs → `config/computer_use.go`
- `ChannelsConfig`, `TelegramChannelConfig`, `WhatsAppChannelConfig` → `config/channels.go`
- `KeybindingsConfig`, `KeyBindingEntry` → `config/keybindings.go`

Pure relocation: same field names, tags, types, ordering. No semantic change.

### Part 2 — Prompt field consolidation

Eliminate the duplication where every prompt lived in two places: as `yaml:"-"` string fields scattered across `AgentConfig`, `SystemRemindersConfig`, `GitCommitMessageConfig`, `ConversationTitleConfig`, `InitConfig`, **and** mirrored in `PromptsConfig`. The two sides were bridged at load time by `applyPromptsOverlay`.

After this PR, every prompt is read from `cfg.Prompts.*` (a new top-level sub-config alongside `cfg.Channels`, `cfg.ComputerUse`).

**Removed:**
- `AgentConfig.{SystemPrompt,SystemPromptPlan,SystemPromptRemote,CustomInstructions}`
- `AgentConfig.SystemReminders` and the `SystemRemindersConfig` type entirely (folded into `PromptsAgentRemindersConfig`)
- `GitCommitMessageConfig.SystemPrompt`
- `ConversationTitleConfig.SystemPrompt`
- `InitConfig` (became empty) and its `Config.Init` field
- `(c *Config) GetSystemPrompt()` (was unused)
- `applyPromptsOverlay` in `cmd/config.go`; replaced with `cfg.Prompts = *prompts`

**LoadPrompts** now backfills empty fields from `DefaultPromptsConfig()` so callers always get a fully populated config without an external overlay step.

**Env overrides** — `INFER_PROMPTS_*` names are unchanged; only their internal targets move to `cfg.Prompts.*`.

## Breaking changes

- Existing users with `agent.system_reminders.enabled` or `interval` in `config.yaml` will need to move those keys to `prompts.yaml` under `agent.system_reminders.*`. Other reminder behavior (defaults to enabled, interval 4) is unchanged.
