### PR TITLE
fix(services): Trigger auto-compact from gateway-reported tokens

### DIFF
--- a/config/model_context.go
+++ b/config/model_context.go
@@ -10,29 +10,39 @@ type ModelMatcher struct {
 const DefaultContextWindow = 8192
 
 // ContextMatchers defines all model patterns in priority order.
-// More specific patterns must come before less specific ones.
+// More specific patterns must come before less specific ones because matching
+// uses strings.Contains (e.g. "gemma-3-1b" must precede "gemma-3", and
+// "gemini-3" must precede "gemini-2"/"gemini").
+//
+// Coverage tracks the model IDs the gateway actually returns from /v1/models;
+// model families that aren't served are intentionally omitted to keep the list
+// small and the View output truthful.
 var ContextMatchers = []ModelMatcher{
-	{Patterns: []string{"deepseek-v4"}, ContextWindow: 1000000},
-	{Patterns: []string{"deepseek"}, ContextWindow: 128000},
-	{Patterns: []string{"o1", "o3"}, ContextWindow: 200000},
-	{Patterns: []string{"gpt-4o", "gpt-4-turbo"}, ContextWindow: 128000},
-	{Patterns: []string{"gpt-4-32k"}, ContextWindow: 32768},
-	{Patterns: []string{"gpt-4"}, ContextWindow: 8192},
-	{Patterns: []string{"gpt-3.5"}, ContextWindow: 16384},
 	{Patterns: []string{"claude-opus-4-7"}, ContextWindow: 1000000},
 	{Patterns: []string{"claude-opus-4", "claude-sonnet-4", "claude-haiku-4"}, ContextWindow: 200000},
 	{Patterns: []string{"claude"}, ContextWindow: 200000},
+	{Patterns: []string{"gemini-3"}, ContextWindow: 1048576},
 	{Patterns: []string{"gemini-2", "gemini-1.5"}, ContextWindow: 1000000},
+	{Patterns: []string{"gemini-pro", "gemini-flash"}, ContextWindow: 1000000},
 	{Patterns: []string{"gemini"}, ContextWindow: 32768},
-	{Patterns: []string{"mistral-large"}, ContextWindow: 128000},
-	{Patterns: []string{"mistral", "mixtral"}, ContextWindow: 32768},
-	{Patterns: []string{"llama-3.1", "llama-3.2", "llama-3.3"}, ContextWindow: 128000},
-	{Patterns: []string{"llama-3"}, ContextWindow: 8192},
-	{Patterns: []string{"llama"}, ContextWindow: 4096},
+	{Patterns: []string{"deep-research"}, ContextWindow: 1048576},
+	{Patterns: []string{"gemma-3-1b", "gemma3:1b", "gemma-3n", "gemma3n"}, ContextWindow: 32768},
+	{Patterns: []string{"gemma-3", "gemma3", "gemma-4", "gemma4"}, ContextWindow: 131072},
+	{Patterns: []string{"gpt-oss"}, ContextWindow: 131072},
+	{Patterns: []string{"deepseek-v4"}, ContextWindow: 1000000},
+	{Patterns: []string{"deepseek-v3"}, ContextWindow: 131072},
+	{Patterns: []string{"deepseek"}, ContextWindow: 131072},
 	{Patterns: []string{"qwen3", "qwen-3"}, ContextWindow: 262144},
 	{Patterns: []string{"qwen2.5", "qwen-2.5"}, ContextWindow: 131072},
 	{Patterns: []string{"qwen"}, ContextWindow: 128000},
-	{Patterns: []string{"command-r"}, ContextWindow: 128000},
+	{Patterns: []string{"ministral-3"}, ContextWindow: 256000},
+	{Patterns: []string{"ministral"}, ContextWindow: 131072},
+	{Patterns: []string{"mistral-large"}, ContextWindow: 131072},
+	{Patterns: []string{"devstral"}, ContextWindow: 131072},
+	{Patterns: []string{"mistral", "mixtral"}, ContextWindow: 32768},
+	{Patterns: []string{"minimax-m2"}, ContextWindow: 204800},
+	{Patterns: []string{"glm-4", "glm-5"}, ContextWindow: 200000},
+	{Patterns: []string{"nemotron-3"}, ContextWindow: 262144},
 	{Patterns: []string{"kimi-k2", "kimi-latest"}, ContextWindow: 262144},
 	{Patterns: []string{"moonshot-v1-128k"}, ContextWindow: 131072},
 	{Patterns: []string{"moonshot-v1-32k"}, ContextWindow: 32768},

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -267,6 +267,7 @@ func (c *ServiceContainer) initializeDomainServices() {
 			Client:            summaryClient,
 			Config:            c.config,
 			Tokenizer:         tokenizer,
+			Repo:              c.conversationRepo,
 		})
 
 		if persistentRepo, ok := c.conversationRepo.(*services.PersistentConversationRepository); ok {

--- a/internal/models/context.go
+++ b/internal/models/context.go
@@ -8,7 +8,17 @@ import (
 )
 
 // EstimateContextWindow returns an estimated context window size based on model name.
+// Falls back to config.DefaultContextWindow when no matcher pattern hits.
 func EstimateContextWindow(model string) int {
+	window, _ := LookupContextWindow(model)
+	return window
+}
+
+// LookupContextWindow returns the matched context window size and whether a
+// matcher pattern actually hit. Callers that need to distinguish a real match
+// from the default fallback (e.g. the model picker, which renders "?" for
+// unknown models) should use this instead of EstimateContextWindow.
+func LookupContextWindow(model string) (int, bool) {
 	model = strings.ToLower(model)
 
 	if idx := strings.Index(model, "/"); idx != -1 {
@@ -18,10 +28,10 @@ func EstimateContextWindow(model string) int {
 	for _, matcher := range config.ContextMatchers {
 		for _, pattern := range matcher.Patterns {
 			if strings.Contains(model, pattern) {
-				return matcher.ContextWindow
+				return matcher.ContextWindow, true
 			}
 		}
 	}
 
-	return config.DefaultContextWindow
+	return config.DefaultContextWindow, false
 }

--- a/internal/models/context_test.go
+++ b/internal/models/context_test.go
@@ -84,6 +84,12 @@ func TestMoonshotContextWindow(t *testing.T) {
 		{"moonshot/moonshot-v1-8k-vision-preview", 8192},
 		{"moonshot/moonshot-v1-32k-vision-preview", 32768},
 		{"moonshot/moonshot-v1-128k-vision-preview", 131072},
+		{"moonshot/kimi-k2.5", 262144},
+		{"moonshot/kimi-k2.6", 262144},
+		{"moonshot/kimi-k2-thinking-turbo", 262144},
+		{"moonshot/kimi-k2-turbo-preview", 262144},
+		{"ollama_cloud/kimi-k2.5", 262144},
+		{"ollama_cloud/kimi-k2.6", 262144},
 	}
 
 	for _, tc := range testModels {
@@ -91,6 +97,175 @@ func TestMoonshotContextWindow(t *testing.T) {
 		t.Logf("Model: %-45s -> Context Window: %d (expected: %d)", tc.model, result, tc.expected)
 		if result != tc.expected {
 			t.Errorf("Model %s: got %d, expected %d", tc.model, result, tc.expected)
+		}
+	}
+}
+
+// TestGeminiContextWindow covers the Gemini family served via the gateway,
+// including the 1M-token "*-latest" aliases that have to land on the
+// gemini-pro / gemini-flash matchers, not the 32K generic gemini fallback.
+func TestGeminiContextWindow(t *testing.T) {
+	testModels := []struct {
+		model    string
+		expected int
+	}{
+		{"google/models/gemini-3-pro-preview", 1048576},
+		{"google/models/gemini-3-flash-preview", 1048576},
+		{"google/models/gemini-3.1-pro-preview", 1048576},
+		{"google/models/gemini-3.1-flash-lite-preview", 1048576},
+		{"google/models/gemini-2.5-pro", 1000000},
+		{"google/models/gemini-2.5-flash", 1000000},
+		{"google/models/gemini-2.0-flash", 1000000},
+		{"google/models/gemini-2.0-flash-lite", 1000000},
+		{"google/models/gemini-pro-latest", 1000000},
+		{"google/models/gemini-flash-latest", 1000000},
+		{"google/models/gemini-flash-lite-latest", 1000000},
+	}
+
+	for _, tc := range testModels {
+		if got := EstimateContextWindow(tc.model); got != tc.expected {
+			t.Errorf("Model %s: got %d, expected %d", tc.model, got, tc.expected)
+		}
+	}
+}
+
+// TestDeepResearchContextWindow covers Google's Deep Research agents
+// (Gemini 3.1 Pro backed, 1M input window, agentic via Interactions API).
+func TestDeepResearchContextWindow(t *testing.T) {
+	testModels := []struct {
+		model    string
+		expected int
+	}{
+		{"google/models/deep-research-max-preview-04-2026", 1048576},
+		{"google/models/deep-research-preview-04-2026", 1048576},
+		{"google/models/deep-research-pro-preview-12-2025", 1048576},
+	}
+
+	for _, tc := range testModels {
+		if got := EstimateContextWindow(tc.model); got != tc.expected {
+			t.Errorf("Model %s: got %d, expected %d", tc.model, got, tc.expected)
+		}
+	}
+}
+
+// TestGemmaContextWindow covers Google's open-weight Gemma family. Gemma 3-1B
+// and the 3n (Nano) variants are 32K; 4B/12B/27B and Gemma 4 extend to 128K.
+func TestGemmaContextWindow(t *testing.T) {
+	testModels := []struct {
+		model    string
+		expected int
+	}{
+		{"google/models/gemma-3-1b-it", 32768},
+		{"google/models/gemma-3-4b-it", 131072},
+		{"google/models/gemma-3-12b-it", 131072},
+		{"google/models/gemma-3-27b-it", 131072},
+		{"google/models/gemma-3n-e4b-it", 32768},
+		{"google/models/gemma-3n-e2b-it", 32768},
+		{"google/models/gemma-4-26b-a4b-it", 131072},
+		{"google/models/gemma-4-31b-it", 131072},
+		{"ollama_cloud/gemma3:4b", 131072},
+		{"ollama_cloud/gemma3:12b", 131072},
+		{"ollama_cloud/gemma3:27b", 131072},
+		{"ollama_cloud/gemma4:31b", 131072},
+	}
+
+	for _, tc := range testModels {
+		if got := EstimateContextWindow(tc.model); got != tc.expected {
+			t.Errorf("Model %s: got %d, expected %d", tc.model, got, tc.expected)
+		}
+	}
+}
+
+// TestDeepSeekContextWindow covers V3 (and minor releases like V3.2) plus the
+// V4-pro/flash 1M-context tier.
+func TestDeepSeekContextWindow(t *testing.T) {
+	testModels := []struct {
+		model    string
+		expected int
+	}{
+		{"ollama_cloud/deepseek-v3.2", 131072},
+		{"ollama_cloud/deepseek-v4-pro", 1000000},
+		{"ollama_cloud/deepseek-v4-flash", 1000000},
+		{"deepseek/deepseek-v4-pro", 1000000},
+		{"deepseek/deepseek-v4-flash", 1000000},
+	}
+
+	for _, tc := range testModels {
+		if got := EstimateContextWindow(tc.model); got != tc.expected {
+			t.Errorf("Model %s: got %d, expected %d", tc.model, got, tc.expected)
+		}
+	}
+}
+
+// TestMistralFamilyContextWindow covers Mistral Large 3, Ministral 3, and
+// Devstral 2 variants served via ollama_cloud.
+func TestMistralFamilyContextWindow(t *testing.T) {
+	testModels := []struct {
+		model    string
+		expected int
+	}{
+		{"ollama_cloud/mistral-large-3:675b", 131072},
+		{"ollama_cloud/ministral-3:3b", 256000},
+		{"ollama_cloud/ministral-3:8b", 256000},
+		{"ollama_cloud/ministral-3:14b", 256000},
+		{"ollama_cloud/devstral-2:123b", 131072},
+		{"ollama_cloud/devstral-small-2:24b", 131072},
+	}
+
+	for _, tc := range testModels {
+		if got := EstimateContextWindow(tc.model); got != tc.expected {
+			t.Errorf("Model %s: got %d, expected %d", tc.model, got, tc.expected)
+		}
+	}
+}
+
+// TestMiscOpenWeightContextWindow covers GPT-OSS, MiniMax M2, GLM 4/5, and
+// Nemotron 3 — all served via ollama_cloud.
+func TestMiscOpenWeightContextWindow(t *testing.T) {
+	testModels := []struct {
+		model    string
+		expected int
+	}{
+		{"ollama_cloud/gpt-oss:20b", 131072},
+		{"ollama_cloud/gpt-oss:120b", 131072},
+		{"ollama_cloud/minimax-m2", 204800},
+		{"ollama_cloud/minimax-m2.1", 204800},
+		{"ollama_cloud/minimax-m2.5", 204800},
+		{"ollama_cloud/minimax-m2.7", 204800},
+		{"ollama_cloud/glm-4.6", 200000},
+		{"ollama_cloud/glm-4.7", 200000},
+		{"ollama_cloud/glm-5", 200000},
+		{"ollama_cloud/glm-5.1", 200000},
+		{"ollama_cloud/nemotron-3-super", 262144},
+		{"ollama_cloud/nemotron-3-nano:30b", 262144},
+	}
+
+	for _, tc := range testModels {
+		if got := EstimateContextWindow(tc.model); got != tc.expected {
+			t.Errorf("Model %s: got %d, expected %d", tc.model, got, tc.expected)
+		}
+	}
+}
+
+// TestQwenServedVariants covers the Qwen3 sub-families served via
+// ollama_cloud — VL, Coder, Next, and the qwen3.5 alias all match the
+// "qwen3" matcher (262K).
+func TestQwenServedVariants(t *testing.T) {
+	testModels := []struct {
+		model    string
+		expected int
+	}{
+		{"ollama_cloud/qwen3-vl:235b", 262144},
+		{"ollama_cloud/qwen3-vl:235b-instruct", 262144},
+		{"ollama_cloud/qwen3-coder:480b", 262144},
+		{"ollama_cloud/qwen3-coder-next", 262144},
+		{"ollama_cloud/qwen3-next:80b", 262144},
+		{"ollama_cloud/qwen3.5:397b", 262144},
+	}
+
+	for _, tc := range testModels {
+		if got := EstimateContextWindow(tc.model); got != tc.expected {
+			t.Errorf("Model %s: got %d, expected %d", tc.model, got, tc.expected)
 		}
 	}
 }

--- a/internal/services/conversation_optimizer.go
+++ b/internal/services/conversation_optimizer.go
@@ -23,6 +23,7 @@ type ConversationOptimizer struct {
 	client            domain.SDKClient
 	config            *config.Config
 	tokenizer         *TokenizerService
+	repo              domain.ConversationRepository
 }
 
 var _ domain.ConversationOptimizer = (*ConversationOptimizer)(nil)
@@ -36,6 +37,12 @@ type OptimizerConfig struct {
 	Client            domain.SDKClient
 	Config            *config.Config
 	Tokenizer         *TokenizerService
+	// Repo is optional. When provided, OptimizeMessages reads
+	// LastInputTokens from the repo's session stats and uses it as the
+	// trigger value (the gateway-reported count includes system prompt and
+	// tool definitions, matching what `/context` displays). When nil, the
+	// gate falls back to the entries-only estimate.
+	Repo domain.ConversationRepository
 }
 
 // NewConversationOptimizer creates a new conversation optimizer with configuration
@@ -64,7 +71,21 @@ func NewConversationOptimizer(config OptimizerConfig) domain.ConversationOptimiz
 		client:            config.Client,
 		config:            config.Config,
 		tokenizer:         tokenizer,
+		repo:              config.Repo,
 	}
+}
+
+// estimateTriggerTokens returns the value used to gate auto-compaction. It
+// prefers the gateway-reported LastInputTokens (which includes system prompt
+// and tool definitions) and falls back to the entries-only tokenizer estimate
+// before the first round-trip or when no repo is wired in.
+func (co *ConversationOptimizer) estimateTriggerTokens(messages []sdk.Message) int {
+	if co.repo != nil {
+		if stats := co.repo.GetSessionTokens(); stats.LastInputTokens > 0 {
+			return stats.LastInputTokens
+		}
+	}
+	return co.tokenizer.EstimateMessagesTokens(messages)
 }
 
 // OptimizeMessages reduces token usage by intelligently managing conversation history with LLM summarization
@@ -77,8 +98,6 @@ func (co *ConversationOptimizer) OptimizeMessages(messages []sdk.Message, model 
 		return messages
 	}
 
-	currentTokens := co.tokenizer.EstimateMessagesTokens(messages)
-
 	contextWindow := models.EstimateContextWindow(model)
 	if contextWindow == 0 {
 		contextWindow = 30000
@@ -86,8 +105,11 @@ func (co *ConversationOptimizer) OptimizeMessages(messages []sdk.Message, model 
 
 	threshold := (contextWindow * co.autoAt) / 100
 
-	if !force && currentTokens < threshold {
-		return messages
+	if !force {
+		currentTokens := co.estimateTriggerTokens(messages)
+		if currentTokens < threshold {
+			return messages
+		}
 	}
 
 	var systemMessages []sdk.Message

--- a/internal/services/conversation_optimizer_test.go
+++ b/internal/services/conversation_optimizer_test.go
@@ -377,6 +377,79 @@ func TestOptimizeMessages_EdgeCases(t *testing.T) {
 	}
 }
 
+// TestOptimizeMessages_LastInputTokensTrigger verifies that OptimizeMessages
+// uses the gateway-reported LastInputTokens from the wired-in repo, so
+// auto-compaction fires when the actual prompt size (including system prompt
+// and tool definitions) crosses the threshold — even though the entries-only
+// estimate is far below it.
+func TestOptimizeMessages_LastInputTokensTrigger(t *testing.T) {
+	model := "fake-provider/unknown-tiny-model"
+
+	t.Run("fires when LastInputTokens above threshold", func(t *testing.T) {
+		repo := services.NewInMemoryConversationRepository(nil, nil)
+		require.NoError(t, repo.AddTokenUsage(model, 7000, 100, 7100))
+
+		mockClient := createMockSDKClient(t, "Summary text")
+		optimizer := services.NewConversationOptimizer(services.OptimizerConfig{
+			Enabled:           true,
+			AutoAt:            80,
+			BufferSize:        2,
+			KeepFirstMessages: 2,
+			Client:            mockClient,
+			Config:            &config.Config{},
+			Tokenizer:         nil,
+			Repo:              repo,
+		})
+
+		messages := []sdk.Message{
+			{Role: "user", Content: sdk.NewMessageContent("hi")},
+			{Role: "assistant", Content: sdk.NewMessageContent("hello")},
+			{Role: "user", Content: sdk.NewMessageContent("again")},
+			{Role: "assistant", Content: sdk.NewMessageContent("ack")},
+			{Role: "user", Content: sdk.NewMessageContent("more")},
+		}
+
+		result := optimizer.OptimizeMessages(messages, model, false)
+
+		assert.Equal(t, 1, mockClient.GenerateContentCallCount(),
+			"summarizer should be invoked when LastInputTokens crosses threshold")
+		assert.Less(t, len(result), len(messages),
+			"compaction should reduce the message count")
+	})
+
+	t.Run("does not fire when LastInputTokens below threshold", func(t *testing.T) {
+		repo := services.NewInMemoryConversationRepository(nil, nil)
+		require.NoError(t, repo.AddTokenUsage(model, 1000, 100, 1100))
+
+		mockClient := createMockSDKClient(t, "Summary text")
+		optimizer := services.NewConversationOptimizer(services.OptimizerConfig{
+			Enabled:           true,
+			AutoAt:            80,
+			BufferSize:        2,
+			KeepFirstMessages: 2,
+			Client:            mockClient,
+			Config:            &config.Config{},
+			Tokenizer:         nil,
+			Repo:              repo,
+		})
+
+		messages := []sdk.Message{
+			{Role: "user", Content: sdk.NewMessageContent("hi")},
+			{Role: "assistant", Content: sdk.NewMessageContent("hello")},
+			{Role: "user", Content: sdk.NewMessageContent("again")},
+			{Role: "assistant", Content: sdk.NewMessageContent("ack")},
+			{Role: "user", Content: sdk.NewMessageContent("more")},
+		}
+
+		result := optimizer.OptimizeMessages(messages, model, false)
+
+		assert.Equal(t, 0, mockClient.GenerateContentCallCount(),
+			"summarizer must not be invoked when LastInputTokens is below threshold")
+		assert.Equal(t, len(messages), len(result),
+			"messages should be returned unchanged when gate does not fire")
+	})
+}
+
 // Helper functions
 
 func stringPtr(s string) *string {

--- a/internal/services/session_rollover_manager.go
+++ b/internal/services/session_rollover_manager.go
@@ -193,27 +193,34 @@ func (m *SessionRolloverManager) idleTriggerFires(entries []domain.ConversationE
 }
 
 // tokenTriggerFires reports whether the conversation's estimated token count
-// crosses compact.auto_at percent of the model's context window. Mirrors the
-// in-place check in conversation_optimizer.go:80-91.
+// crosses compact.auto_at percent of the model's context window.
+//
+// Prefers the gateway-reported LastInputTokens from session stats: that value
+// is the authoritative count of what was actually sent (including system
+// prompt and tool definitions) and is also what `/context` displays, so the
+// trigger and the UI stay in lock-step. Falls back to the entries-only
+// estimate before the first round-trip when LastInputTokens is still zero.
 func (m *SessionRolloverManager) tokenTriggerFires(entries []domain.ConversationEntry, model string) bool {
 	autoAt := m.cfg.Compact.AutoAt
 	if autoAt <= 0 || autoAt > 100 {
 		autoAt = 80
 	}
 
-	msgs := make([]sdk.Message, 0, len(entries))
-	for _, e := range entries {
-		msgs = append(msgs, e.Message)
-	}
-
-	currentTokens := m.tokenizer.EstimateMessagesTokens(msgs)
 	contextWindow := models.EstimateContextWindow(model)
 	if contextWindow == 0 {
 		contextWindow = 30000
 	}
-
 	threshold := (contextWindow * autoAt) / 100
-	return currentTokens >= threshold
+
+	if stats := m.repo.GetSessionTokens(); stats.LastInputTokens > 0 {
+		return stats.LastInputTokens >= threshold
+	}
+
+	msgs := make([]sdk.Message, 0, len(entries))
+	for _, e := range entries {
+		msgs = append(msgs, e.Message)
+	}
+	return m.tokenizer.EstimateMessagesTokens(msgs) >= threshold
 }
 
 // PerformRollover runs the optimizer with force=true to produce a summary,

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -234,6 +234,47 @@ func TestShouldRollover_TokenTriggerFires(t *testing.T) {
 	}
 }
 
+func TestShouldRollover_TokenTriggerFiresFromLastInputTokens(t *testing.T) {
+	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 0)
+	defer cleanup()
+
+	// One short message — entries-only estimate is far below the threshold.
+	addUserMessage(t, repo, "hi", time.Now())
+
+	// Simulate the gateway reporting a large prompt_tokens value (system
+	// prompt + tool defs + history). Threshold for unknown-tiny-model is
+	// 8192*80/100=6553 tokens.
+	if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+		t.Fatalf("AddTokenUsage: %v", err)
+	}
+
+	if !mgr.ShouldRollover("unknown-tiny-model") {
+		t.Error("LastInputTokens above threshold should trigger token rollover even when entries-only estimate is small")
+	}
+}
+
+func TestShouldRollover_TokenTriggerDoesNotFireWhenLastInputBelowThreshold(t *testing.T) {
+	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 0)
+	defer cleanup()
+
+	// Large entries that *would* trip the entries-only fallback…
+	bigContent := strings.Repeat("token ", 2000)
+	for i := 0; i < 10; i++ {
+		addUserMessage(t, repo, bigContent, time.Now())
+	}
+
+	// …but the gateway-reported count is well below the threshold. The
+	// gateway count must win — its number includes provider-specific
+	// reformatting and is what `/context` shows.
+	if err := repo.AddTokenUsage("unknown-tiny-model", 1000, 100, 1100); err != nil {
+		t.Fatalf("AddTokenUsage: %v", err)
+	}
+
+	if mgr.ShouldRollover("unknown-tiny-model") {
+		t.Error("LastInputTokens below threshold should not trigger rollover, even if entries-only estimate is large")
+	}
+}
+
 func TestShouldRollover_DisabledWhenCompactOff(t *testing.T) {
 	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()

--- a/internal/ui/components/model_selection_view.go
+++ b/internal/ui/components/model_selection_view.go
@@ -8,6 +8,7 @@ import (
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	models "github.com/inference-gateway/cli/internal/models"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
@@ -227,28 +228,18 @@ func (m *ModelSelectorImpl) View() string {
 
 	for i := start; i < start+maxVisible && i < len(m.filteredModels); i++ {
 		model := m.filteredModels[i]
-		var pricingSuffix string
-		if m.pricingService != nil {
-			if pricing := m.pricingService.FormatModelPricing(model); pricing != "" {
-				pricingSuffix = fmt.Sprintf("(%s)", pricing)
-			}
-		}
+		suffix := m.formatModelSuffix(model)
 
 		if i == m.selected {
 			b.WriteString(m.styleProvider.RenderWithColor("▶ "+model, accentColor))
-			if pricingSuffix != "" {
-				b.WriteString(" ")
-				b.WriteString(m.styleProvider.RenderDimText(pricingSuffix))
-			}
-			b.WriteString("\n")
 		} else {
 			fmt.Fprintf(&b, "  %s", model)
-			if pricingSuffix != "" {
-				b.WriteString(" ")
-				b.WriteString(m.styleProvider.RenderDimText(pricingSuffix))
-			}
-			b.WriteString("\n")
 		}
+		if suffix != "" {
+			b.WriteString(" ")
+			b.WriteString(m.styleProvider.RenderDimText(suffix))
+		}
+		b.WriteString("\n")
 	}
 
 	if len(m.filteredModels) > maxVisible {
@@ -269,6 +260,46 @@ func (m *ModelSelectorImpl) View() string {
 	}
 
 	return b.String()
+}
+
+// formatModelSuffix builds the parenthesised metadata shown next to each
+// model row, combining the context window (compact "128K"/"1M" form, or "?"
+// when no matcher pattern hits) with the pricing string when available.
+func (m *ModelSelectorImpl) formatModelSuffix(model string) string {
+	parts := make([]string, 0, 2)
+
+	window, ok := models.LookupContextWindow(model)
+	if ok {
+		parts = append(parts, formatContextWindow(window))
+	} else {
+		parts = append(parts, "?")
+	}
+
+	if m.pricingService != nil {
+		if pricing := m.pricingService.FormatModelPricing(model); pricing != "" {
+			parts = append(parts, pricing)
+		}
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(parts, ", "))
+}
+
+// formatContextWindow renders a token count as "1M" / "128K" / raw, picking
+// the most readable form. Boundaries are exact multiples to avoid awkward
+// numbers like "1.0M" when a matcher returns 1_000_000.
+func formatContextWindow(tokens int) string {
+	switch {
+	case tokens >= 1_000_000 && tokens%1_000_000 == 0:
+		return fmt.Sprintf("%dM", tokens/1_000_000)
+	case tokens >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(tokens)/1_000_000)
+	case tokens >= 1024 && tokens%1024 == 0:
+		return fmt.Sprintf("%dK", tokens/1024)
+	case tokens >= 1000:
+		return fmt.Sprintf("%dK", tokens/1000)
+	default:
+		return fmt.Sprintf("%d", tokens)
+	}
 }
 
 // applyFilters filters the models based on the current view and search query


### PR DESCRIPTION
## Summary

Closes #453. Auto-compact and session rollover never fired because the trigger gated on `tokenizer.EstimateMessagesTokens(entries)` — which counts only message content. The real prompt also includes the system prompt (~2K) and tool definitions (~3–5K for 15+ tools), so sessions blew past the 80% threshold without ever crossing the gate's underestimate.

- Trigger now prefers `repo.GetSessionTokens().LastInputTokens` (the gateway's authoritative count, already shown by `/context`). Falls back to the entries-only estimate before the first round-trip.
- Refreshed `ContextMatchers` to track the gateway's actual `/v1/models` output — added Gemini 3, Gemma 3/3n/4, GPT-OSS, Ministral 3, Devstral, MiniMax M2, GLM 4/5, Nemotron 3, and `deep-research` (1M); dropped patterns for families the gateway doesn't serve.
- Model picker (`/switch`) now shows the context window beside each row (`1M` / `128K` / `?` when unknown) alongside pricing.
