### PR TITLE
fix(ui): Restore typing while agent is busy

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -519,7 +519,7 @@ func (app *ChatApplication) handleViewSpecificMessages(msg tea.Msg) []tea.Cmd {
 			inHistoryMode = cv.IsInMessageHistoryMode()
 		}
 
-		if app.stateManager.GetApprovalUIState() != nil || app.stateManager.GetPlanApprovalUIState() != nil || inHistoryMode || app.stateManager.IsAgentBusy() {
+		if app.stateManager.GetApprovalUIState() != nil || app.stateManager.GetPlanApprovalUIState() != nil || inHistoryMode {
 			inputView.SetDisabled(true)
 		} else {
 			inputView.SetDisabled(false)


### PR DESCRIPTION
## Summary
- Drops the `IsAgentBusy()` clause from the input-disable predicate in `internal/app/chat.go` so the user can keep typing while the agent is processing.
- Restores the prior UX where messages submitted mid-turn are enqueued via `MessageQueue` and drained by `CheckingQueueState` at end-of-turn — the queue plumbing was already intact, only the input view was blocking it.
- Approval flows (tool/plan approval) and message-history mode remain disabled, since typing in those contexts has a different meaning.

The `IsAgentBusy()` clause was introduced in #410 (Telegram channels feature). Removing it is the minimal fix.
