### PR TITLE
fix(services): Prevent compact summary truncation at 200-token cap

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -258,6 +258,7 @@ compact:
   auto_at: 80
   keep_first_messages: 2
   rollover_on_idle_minutes: 30
+  summary_max_tokens: 1024
 web:
   enabled: false
   port: 3000

--- a/config/config.go
+++ b/config/config.go
@@ -289,6 +289,7 @@ type CompactConfig struct {
 	AutoAt                int  `yaml:"auto_at" mapstructure:"auto_at"`
 	KeepFirstMessages     int  `yaml:"keep_first_messages" mapstructure:"keep_first_messages"`
 	RolloverOnIdleMinutes int  `yaml:"rollover_on_idle_minutes" mapstructure:"rollover_on_idle_minutes"`
+	SummaryMaxTokens      int  `yaml:"summary_max_tokens" mapstructure:"summary_max_tokens"`
 }
 
 // WebConfig contains web terminal settings
@@ -807,6 +808,7 @@ func DefaultConfig() *Config { //nolint:funlen
 			AutoAt:                80,
 			KeepFirstMessages:     2,
 			RolloverOnIdleMinutes: 30,
+			SummaryMaxTokens:      1024,
 		},
 		Web: WebConfig{
 			Enabled:               false,

--- a/internal/services/conversation_optimizer.go
+++ b/internal/services/conversation_optimizer.go
@@ -326,7 +326,10 @@ Keep the summary brief but informative (2-3 sentences max).`),
 	provider := model[:slashIndex]
 	modelName := model[slashIndex+1:]
 
-	maxTokens := 200
+	maxTokens := 1024
+	if co.config != nil && co.config.Compact.SummaryMaxTokens > 0 {
+		maxTokens = co.config.Compact.SummaryMaxTokens
+	}
 	options := &sdk.CreateChatCompletionRequest{
 		MaxTokens: &maxTokens,
 	}
@@ -350,5 +353,12 @@ Keep the summary brief but informative (2-3 sentences max).`),
 	if err != nil {
 		return "", fmt.Errorf("failed to extract summary content: %w", err)
 	}
+
+	if response.Choices[0].FinishReason == sdk.Length {
+		logger.Warn("Summary truncated by max_tokens cap; consider raising compact.summary_max_tokens",
+			"max_tokens", maxTokens,
+			"summary_length", len(contentStr))
+	}
+
 	return strings.TrimSpace(contentStr), nil
 }


### PR DESCRIPTION
## Summary

- `GenerateLLMSummary` hardcoded `maxTokens := 200` and ignored `FinishReason`, so when the model hit the cap the truncated mid-sentence text was rendered as a complete `--- Context Summary ---` block. Raise the default to **1024** and expose it as `compact.summary_max_tokens` for tuning.
- Warn-log when `response.Choices[0].FinishReason == sdk.Length` so future truncations are visible in logs instead of failing silently.
- Bug surfaced after #454 (`fix(services): Trigger auto-compact from gateway-reported tokens`) made auto-compact actually fire on the gateway-reported token count — the 200-cap was always too tight, but compaction rarely triggered before, so the truncation was rarely visible.