### PR TITLE
fix: Reconcile token displays and persist metadata-only saves

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -67,6 +67,11 @@ type ServiceContainer struct {
 	backgroundShellService *services.BackgroundShellService
 	storage                storage.ConversationStorage
 
+	// Token polyfill — used by /context, conversation optimizer, and the
+	// session rollover manager. Created unconditionally so any surface can
+	// fall back to it when the provider does not return usage metrics.
+	tokenizer *services.TokenizerService
+
 	// UI components
 	themeService domain.ThemeService
 
@@ -256,9 +261,12 @@ func (c *ServiceContainer) initializeDomainServices() {
 		c.toolService = services.NewNoOpToolService()
 	}
 
+	if c.tokenizer == nil {
+		c.tokenizer = services.NewTokenizerService(services.DefaultTokenizerConfig())
+	}
+
 	if c.config.Compact.Enabled {
 		summaryClient := c.createAgentSDKClient()
-		tokenizer := services.NewTokenizerService(services.DefaultTokenizerConfig())
 		c.conversationOptimizer = services.NewConversationOptimizer(services.OptimizerConfig{
 			Enabled:           c.config.Compact.Enabled,
 			AutoAt:            c.config.Compact.AutoAt,
@@ -266,7 +274,7 @@ func (c *ServiceContainer) initializeDomainServices() {
 			KeepFirstMessages: c.config.Compact.KeepFirstMessages,
 			Client:            summaryClient,
 			Config:            c.config,
-			Tokenizer:         tokenizer,
+			Tokenizer:         c.tokenizer,
 			Repo:              c.conversationRepo,
 		})
 
@@ -275,7 +283,7 @@ func (c *ServiceContainer) initializeDomainServices() {
 				c.config,
 				c.conversationOptimizer,
 				persistentRepo,
-				tokenizer,
+				c.tokenizer,
 			)
 		}
 	}
@@ -336,7 +344,7 @@ func (c *ServiceContainer) initializeExtensibility() {
 func (c *ServiceContainer) registerDefaultCommands() {
 	c.shortcutRegistry.Register(shortcuts.NewClearShortcut(c.conversationRepo, c.backgroundTaskRegistry))
 	c.shortcutRegistry.Register(shortcuts.NewCompactShortcut(c.conversationRepo))
-	c.shortcutRegistry.Register(shortcuts.NewContextShortcut(c.conversationRepo, c.modelService))
+	c.shortcutRegistry.Register(shortcuts.NewContextShortcut(c.conversationRepo, c.modelService, c.tokenizer))
 	c.shortcutRegistry.Register(shortcuts.NewCostShortcut(c.conversationRepo))
 	c.shortcutRegistry.Register(shortcuts.NewExitShortcut())
 	c.shortcutRegistry.Register(shortcuts.NewSwitchShortcut(c.modelService))

--- a/internal/infra/storage/jsonl.go
+++ b/internal/infra/storage/jsonl.go
@@ -70,9 +70,14 @@ func (s *JsonlStorage) conversationFilePath(conversationID string) string {
 	return filepath.Join(s.basePath, conversationID+".jsonl")
 }
 
-// saveConversationUnlocked saves a conversation without acquiring the lock
-// Caller must hold the lock before calling this method
-// Uses append-only optimization: only new entries are appended to existing v2 files
+// saveConversationUnlocked saves a conversation without acquiring the lock.
+// Caller must hold the lock before calling this method.
+//
+// Append strategy: any new entries since the last save get appended, then a
+// fresh metadata line is appended unconditionally. The reader uses the LAST
+// metadata line in the file, so each save publishes the latest token/cost
+// stats — even when no new entries were added (e.g. AddTokenUsage updated
+// stats after the assistant message was already persisted).
 func (s *JsonlStorage) saveConversationUnlocked(_ context.Context, conversationID string, entries []domain.ConversationEntry, metadata ConversationMetadata) error {
 	filePath := s.conversationFilePath(conversationID)
 
@@ -101,14 +106,11 @@ func (s *JsonlStorage) saveConversationUnlocked(_ context.Context, conversationI
 		return nil
 	}
 
-	if len(entries) > persistedCount {
-		newEntries := entries[persistedCount:]
-		if err := s.appendEntries(filePath, newEntries, persistedCount, metadata); err != nil {
-			return err
-		}
-		s.setPersistedCount(conversationID, len(entries))
+	newEntries := entries[persistedCount:]
+	if err := s.appendEntries(filePath, newEntries, persistedCount, metadata); err != nil {
+		return err
 	}
-
+	s.setPersistedCount(conversationID, len(entries))
 	return nil
 }
 

--- a/internal/infra/storage/jsonl_test.go
+++ b/internal/infra/storage/jsonl_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 	"time"
 
-	domain "github.com/inference-gateway/cli/internal/domain"
-	sdk "github.com/inference-gateway/sdk"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 func setupTestJsonlStorage(t *testing.T) (*JsonlStorage, string, func()) {
@@ -535,6 +537,66 @@ func TestJsonlStorage_AppendOnlyBehavior(t *testing.T) {
 
 	assert.Contains(t, lines[0], `"v":2`)
 	assert.Contains(t, lines[0], `"type":"entry"`)
+}
+
+// TestJsonlStorage_MetadataOnlyUpdatePersists is a regression test for the
+// bug where a save with no new entries (e.g. AddTokenUsage updating token
+// stats after the assistant message was already persisted) silently dropped
+// the metadata write, causing /conversations to lag by one save event.
+func TestJsonlStorage_MetadataOnlyUpdatePersists(t *testing.T) {
+	storage, _, cleanup := setupTestJsonlStorage(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	conversationID := "meta-only-update"
+
+	entries := []domain.ConversationEntry{
+		{
+			Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("Hi")},
+			Model:   "deepseek/deepseek-v4-flash",
+			Time:    time.Now(),
+		},
+		{
+			Message: sdk.Message{Role: sdk.Assistant, Content: sdk.NewMessageContent("Hello")},
+			Model:   "deepseek/deepseek-v4-flash",
+			Time:    time.Now(),
+		},
+	}
+
+	staleMetadata := ConversationMetadata{
+		ID:           conversationID,
+		Title:        "Hi",
+		MessageCount: 2,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+		TokenStats: domain.SessionTokenStats{
+			TotalInputTokens: 0,
+			RequestCount:     0,
+			LastInputTokens:  0,
+		},
+	}
+
+	require.NoError(t, storage.SaveConversation(ctx, conversationID, entries, staleMetadata))
+
+	freshMetadata := staleMetadata
+	freshMetadata.UpdatedAt = time.Now()
+	freshMetadata.TokenStats = domain.SessionTokenStats{
+		TotalInputTokens:  6510,
+		TotalOutputTokens: 125,
+		TotalTokens:       6635,
+		RequestCount:      1,
+		LastInputTokens:   6510,
+	}
+
+	require.NoError(t, storage.SaveConversation(ctx, conversationID, entries, freshMetadata))
+
+	summaries, err := storage.ListConversations(ctx, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, 6510, summaries[0].TokenStats.TotalInputTokens)
+	assert.Equal(t, 125, summaries[0].TokenStats.TotalOutputTokens)
+	assert.Equal(t, 1, summaries[0].TokenStats.RequestCount)
+	assert.Equal(t, 6510, summaries[0].TokenStats.LastInputTokens)
 }
 
 func TestJsonlStorage_V1FormatMigration(t *testing.T) {

--- a/internal/shortcuts/core.go
+++ b/internal/shortcuts/core.go
@@ -108,11 +108,11 @@ func (c *ContextShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 
 	contextWindowSize := c.estimateContextWindow(currentModel)
 
-	currentContextSize := stats.LastInputTokens
+	totalInputTokens := stats.TotalInputTokens
 	estimated := false
-	if currentContextSize == 0 {
-		currentContextSize = c.estimateCurrentContextSize()
-		estimated = currentContextSize > 0
+	if totalInputTokens == 0 {
+		totalInputTokens = c.estimateCurrentContextSize()
+		estimated = totalInputTokens > 0
 	}
 
 	var output strings.Builder
@@ -123,15 +123,15 @@ func (c *ContextShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 	}
 	fmt.Fprintf(&output, "**Messages:** %d\n", messageCount)
 	if estimated {
-		fmt.Fprintf(&output, "**Current Context Size:** ~%d tokens (estimated)\n", currentContextSize)
+		fmt.Fprintf(&output, "**Total Input Tokens:** ~%d tokens (estimated)\n", totalInputTokens)
 	} else {
-		fmt.Fprintf(&output, "**Current Context Size:** %d tokens\n", currentContextSize)
+		fmt.Fprintf(&output, "**Total Input Tokens:** %d tokens\n", totalInputTokens)
 	}
 	fmt.Fprintf(&output, "**API Requests:** %d\n", stats.RequestCount)
 	fmt.Fprintf(&output, "**Session Totals:** %d input, %d output\n", stats.TotalInputTokens, stats.TotalOutputTokens)
 
-	if contextWindowSize > 0 && currentContextSize > 0 {
-		output.WriteString(c.formatContextUsage(currentContextSize, contextWindowSize))
+	if contextWindowSize > 0 && totalInputTokens > 0 {
+		output.WriteString(c.formatContextUsage(totalInputTokens, contextWindowSize))
 	}
 
 	return ShortcutResult{
@@ -165,11 +165,11 @@ func (c *ContextShortcut) estimateContextWindow(model string) int {
 }
 
 // formatContextUsage formats the context window usage information
-func (c *ContextShortcut) formatContextUsage(lastInputTokens, contextWindowSize int) string {
+func (c *ContextShortcut) formatContextUsage(totalInputTokens, contextWindowSize int) string {
 	var output strings.Builder
 
-	usagePercent := float64(lastInputTokens) * 100 / float64(contextWindowSize)
-	remaining := contextWindowSize - lastInputTokens
+	usagePercent := float64(totalInputTokens) * 100 / float64(contextWindowSize)
+	remaining := contextWindowSize - totalInputTokens
 	if remaining < 0 {
 		remaining = 0
 	}

--- a/internal/shortcuts/core.go
+++ b/internal/shortcuts/core.go
@@ -8,6 +8,7 @@ import (
 
 	domain "github.com/inference-gateway/cli/internal/domain"
 	models "github.com/inference-gateway/cli/internal/models"
+	sdk "github.com/inference-gateway/sdk"
 )
 
 // ClearShortcut clears the conversation history
@@ -84,12 +85,14 @@ func (c *CompactShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 type ContextShortcut struct {
 	repo         domain.ConversationRepository
 	modelService domain.ModelService
+	tokenizer    domain.TokenEstimator
 }
 
-func NewContextShortcut(repo domain.ConversationRepository, modelService domain.ModelService) *ContextShortcut {
+func NewContextShortcut(repo domain.ConversationRepository, modelService domain.ModelService, tokenizer domain.TokenEstimator) *ContextShortcut {
 	return &ContextShortcut{
 		repo:         repo,
 		modelService: modelService,
+		tokenizer:    tokenizer,
 	}
 }
 
@@ -105,6 +108,13 @@ func (c *ContextShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 
 	contextWindowSize := c.estimateContextWindow(currentModel)
 
+	currentContextSize := stats.LastInputTokens
+	estimated := false
+	if currentContextSize == 0 {
+		currentContextSize = c.estimateCurrentContextSize()
+		estimated = currentContextSize > 0
+	}
+
 	var output strings.Builder
 	output.WriteString("## Context Window Usage\n\n")
 
@@ -112,18 +122,41 @@ func (c *ContextShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 		fmt.Fprintf(&output, "**Model:** %s\n", currentModel)
 	}
 	fmt.Fprintf(&output, "**Messages:** %d\n", messageCount)
-	fmt.Fprintf(&output, "**Current Context Size:** %d tokens\n", stats.LastInputTokens)
+	if estimated {
+		fmt.Fprintf(&output, "**Current Context Size:** ~%d tokens (estimated)\n", currentContextSize)
+	} else {
+		fmt.Fprintf(&output, "**Current Context Size:** %d tokens\n", currentContextSize)
+	}
 	fmt.Fprintf(&output, "**API Requests:** %d\n", stats.RequestCount)
 	fmt.Fprintf(&output, "**Session Totals:** %d input, %d output\n", stats.TotalInputTokens, stats.TotalOutputTokens)
 
-	if contextWindowSize > 0 && stats.LastInputTokens > 0 {
-		output.WriteString(c.formatContextUsage(stats.LastInputTokens, contextWindowSize))
+	if contextWindowSize > 0 && currentContextSize > 0 {
+		output.WriteString(c.formatContextUsage(currentContextSize, contextWindowSize))
 	}
 
 	return ShortcutResult{
 		Output:  output.String(),
 		Success: true,
 	}, nil
+}
+
+// estimateCurrentContextSize falls back to the tokenizer when the provider
+// did not return usage metrics so /context always reports a meaningful number.
+func (c *ContextShortcut) estimateCurrentContextSize() int {
+	if c.tokenizer == nil {
+		return 0
+	}
+
+	messages := c.repo.GetMessages()
+	if len(messages) == 0 {
+		return 0
+	}
+
+	sdkMessages := make([]sdk.Message, 0, len(messages))
+	for _, entry := range messages {
+		sdkMessages = append(sdkMessages, entry.Message)
+	}
+	return c.tokenizer.EstimateMessagesTokens(sdkMessages)
 }
 
 // estimateContextWindow returns an estimated context window size based on model name

--- a/internal/shortcuts/core_test.go
+++ b/internal/shortcuts/core_test.go
@@ -27,13 +27,13 @@ func (s *stubTokenEstimator) EstimateMessagesTokens([]sdk.Message) int {
 func TestContextShortcut_Execute_UsesProviderUsageWhenAvailable(t *testing.T) {
 	repo := &domainmocks.FakeConversationRepository{}
 	repo.GetSessionTokensReturns(domain.SessionTokenStats{
-		LastInputTokens:   144_670,
-		TotalInputTokens:  2_568_948,
-		TotalOutputTokens: 32_242,
-		TotalTokens:       2_601_190,
-		RequestCount:      37,
+		LastInputTokens:   7_250,
+		TotalInputTokens:  20_000,
+		TotalOutputTokens: 314,
+		TotalTokens:       20_314,
+		RequestCount:      3,
 	})
-	repo.GetMessageCountReturns(113)
+	repo.GetMessageCountReturns(8)
 
 	model := &mockModelService{currentModel: "deepseek/deepseek-v4-flash"}
 	tokenizer := &stubTokenEstimator{estimate: 999_999}
@@ -44,21 +44,21 @@ func TestContextShortcut_Execute_UsesProviderUsageWhenAvailable(t *testing.T) {
 		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	if !strings.Contains(res.Output, "**Current Context Size:** 144670 tokens") {
-		t.Errorf("expected raw provider count, got: %s", res.Output)
+	if !strings.Contains(res.Output, "**Total Input Tokens:** 20000 tokens") {
+		t.Errorf("expected cumulative provider count, got: %s", res.Output)
 	}
 	if strings.Contains(res.Output, "(estimated)") {
 		t.Errorf("did not expect (estimated) marker when provider returned usage, got: %s", res.Output)
 	}
-	if !strings.Contains(res.Output, "**Usage:** 14.5%") {
-		t.Errorf("expected 14.5%% usage, got: %s", res.Output)
+	if !strings.Contains(res.Output, "**Usage:** 2.0%") {
+		t.Errorf("expected 2.0%% usage (20000 input / 1M window), got: %s", res.Output)
 	}
 }
 
 func TestContextShortcut_Execute_FallsBackToTokenizerWhenProviderSilent(t *testing.T) {
 	repo := &domainmocks.FakeConversationRepository{}
 	repo.GetSessionTokensReturns(domain.SessionTokenStats{
-		LastInputTokens: 0,
+		TotalInputTokens: 0,
 	})
 	repo.GetMessageCountReturns(2)
 	repo.GetMessagesReturns([]domain.ConversationEntry{
@@ -75,7 +75,7 @@ func TestContextShortcut_Execute_FallsBackToTokenizerWhenProviderSilent(t *testi
 		t.Fatalf("Execute returned error: %v", err)
 	}
 
-	if !strings.Contains(res.Output, "**Current Context Size:** ~6643 tokens (estimated)") {
+	if !strings.Contains(res.Output, "**Total Input Tokens:** ~6643 tokens (estimated)") {
 		t.Errorf("expected estimated marker, got: %s", res.Output)
 	}
 	if !strings.Contains(res.Output, "**Usage:** 0.7%") {
@@ -85,7 +85,7 @@ func TestContextShortcut_Execute_FallsBackToTokenizerWhenProviderSilent(t *testi
 
 func TestContextShortcut_Execute_NoUsageNoEstimateOmitsPercent(t *testing.T) {
 	repo := &domainmocks.FakeConversationRepository{}
-	repo.GetSessionTokensReturns(domain.SessionTokenStats{LastInputTokens: 0})
+	repo.GetSessionTokensReturns(domain.SessionTokenStats{TotalInputTokens: 0})
 	repo.GetMessageCountReturns(0)
 	repo.GetMessagesReturns(nil)
 

--- a/internal/shortcuts/core_test.go
+++ b/internal/shortcuts/core_test.go
@@ -1,0 +1,104 @@
+package shortcuts
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+type stubTokenEstimator struct {
+	estimate int
+}
+
+func (s *stubTokenEstimator) GetToolStats(domain.ToolService, domain.AgentMode) (int, int) {
+	return 0, 0
+}
+
+func (s *stubTokenEstimator) EstimateMessagesTokens([]sdk.Message) int {
+	return s.estimate
+}
+
+func TestContextShortcut_Execute_UsesProviderUsageWhenAvailable(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.GetSessionTokensReturns(domain.SessionTokenStats{
+		LastInputTokens:   144_670,
+		TotalInputTokens:  2_568_948,
+		TotalOutputTokens: 32_242,
+		TotalTokens:       2_601_190,
+		RequestCount:      37,
+	})
+	repo.GetMessageCountReturns(113)
+
+	model := &mockModelService{currentModel: "deepseek/deepseek-v4-flash"}
+	tokenizer := &stubTokenEstimator{estimate: 999_999}
+
+	sc := NewContextShortcut(repo, model, tokenizer)
+	res, err := sc.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !strings.Contains(res.Output, "**Current Context Size:** 144670 tokens") {
+		t.Errorf("expected raw provider count, got: %s", res.Output)
+	}
+	if strings.Contains(res.Output, "(estimated)") {
+		t.Errorf("did not expect (estimated) marker when provider returned usage, got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, "**Usage:** 14.5%") {
+		t.Errorf("expected 14.5%% usage, got: %s", res.Output)
+	}
+}
+
+func TestContextShortcut_Execute_FallsBackToTokenizerWhenProviderSilent(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.GetSessionTokensReturns(domain.SessionTokenStats{
+		LastInputTokens: 0,
+	})
+	repo.GetMessageCountReturns(2)
+	repo.GetMessagesReturns([]domain.ConversationEntry{
+		{Message: sdk.Message{Role: sdk.User}},
+		{Message: sdk.Message{Role: sdk.Assistant}},
+	})
+
+	model := &mockModelService{currentModel: "deepseek/deepseek-v4-flash"}
+	tokenizer := &stubTokenEstimator{estimate: 6643}
+
+	sc := NewContextShortcut(repo, model, tokenizer)
+	res, err := sc.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !strings.Contains(res.Output, "**Current Context Size:** ~6643 tokens (estimated)") {
+		t.Errorf("expected estimated marker, got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, "**Usage:** 0.7%") {
+		t.Errorf("expected 0.7%% usage from estimator, got: %s", res.Output)
+	}
+}
+
+func TestContextShortcut_Execute_NoUsageNoEstimateOmitsPercent(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.GetSessionTokensReturns(domain.SessionTokenStats{LastInputTokens: 0})
+	repo.GetMessageCountReturns(0)
+	repo.GetMessagesReturns(nil)
+
+	model := &mockModelService{currentModel: "deepseek/deepseek-v4-flash"}
+	tokenizer := &stubTokenEstimator{estimate: 0}
+
+	sc := NewContextShortcut(repo, model, tokenizer)
+	res, err := sc.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if strings.Contains(res.Output, "**Usage:**") {
+		t.Errorf("expected no usage line when both provider and estimator are empty, got: %s", res.Output)
+	}
+}

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -448,9 +448,9 @@ func (isb *InputStatusBar) buildMCPIndicator() string {
 	return fmt.Sprintf("🔌 %d/%d", isb.mcpStatus.ConnectedServers, isb.mcpStatus.TotalServers)
 }
 
-// buildSessionTokensIndicator builds the current-context token indicator.
-// Shows the size of the most recent prompt sent to the model (LastInputTokens)
-// — the same value /context reports as "Current Context Size". When the
+// buildSessionTokensIndicator builds the cumulative input-tokens indicator.
+// Shows the total input tokens billed across the session — the same value
+// /context divides by the context window for its usage percentage. When the
 // provider did not return usage in its response, falls back to estimating
 // tokens from the message buffer via the tokenizer polyfill.
 func (isb *InputStatusBar) buildSessionTokensIndicator() string {
@@ -458,25 +458,26 @@ func (isb *InputStatusBar) buildSessionTokensIndicator() string {
 		return ""
 	}
 
-	currentTokens := isb.estimateCurrentContextTokens()
-	if currentTokens == 0 {
+	totalTokens := isb.totalInputTokensOrEstimate()
+	if totalTokens == 0 {
 		return ""
 	}
 
-	return fmt.Sprintf("T.%d", currentTokens)
+	return fmt.Sprintf("T.%d", totalTokens)
 }
 
-// estimateCurrentContextTokens returns LastInputTokens when reported by the
-// provider, or estimates from the message buffer otherwise. Used by both the
-// raw token indicator and the percentage indicator so they always agree.
-func (isb *InputStatusBar) estimateCurrentContextTokens() int {
+// totalInputTokensOrEstimate returns the cumulative TotalInputTokens reported
+// by the gateway, or — when the provider did not return usage — falls back
+// to estimating tokens from the current message buffer. Used by both the raw
+// indicator and the percentage indicator so they always agree.
+func (isb *InputStatusBar) totalInputTokensOrEstimate() int {
 	if isb.conversationRepo == nil {
 		return 0
 	}
 
 	stats := isb.conversationRepo.GetSessionTokens()
-	if stats.LastInputTokens > 0 {
-		return stats.LastInputTokens
+	if stats.TotalInputTokens > 0 {
+		return stats.TotalInputTokens
 	}
 
 	if isb.tokenEstimator == nil {
@@ -622,14 +623,14 @@ func (isb *InputStatusBar) getA2ATaskInfo() string {
 }
 
 // getContextUsageIndicator returns a context usage indicator string.
-// Uses the same calculation as the /context shortcut (current context tokens
-// divided by the model's context window) so both surfaces report the same
-// percentage. Renders whenever there is data, with HIGH/FULL warning labels
-// at high thresholds. Falls back to the tokenizer polyfill when the provider
-// did not return usage on the latest request.
+// Uses the same calculation as the /context shortcut (cumulative session
+// input tokens divided by the model's context window) so both surfaces
+// report the same percentage. Renders whenever there is data, with HIGH/FULL
+// warning labels at high thresholds. Falls back to the tokenizer polyfill
+// when the provider did not return usage on the latest request.
 func (isb *InputStatusBar) getContextUsageIndicator(model string) string {
-	currentContextSize := isb.estimateCurrentContextTokens()
-	if currentContextSize == 0 {
+	totalInputTokens := isb.totalInputTokensOrEstimate()
+	if totalInputTokens == 0 {
 		return ""
 	}
 
@@ -638,7 +639,7 @@ func (isb *InputStatusBar) getContextUsageIndicator(model string) string {
 		return ""
 	}
 
-	usagePercent := float64(currentContextSize) * 100 / float64(contextWindow)
+	usagePercent := float64(totalInputTokens) * 100 / float64(contextWindow)
 
 	displayPercent := usagePercent
 	if displayPercent > 100 {

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -448,31 +448,51 @@ func (isb *InputStatusBar) buildMCPIndicator() string {
 	return fmt.Sprintf("🔌 %d/%d", isb.mcpStatus.ConnectedServers, isb.mcpStatus.TotalServers)
 }
 
-// buildSessionTokensIndicator builds the session token usage indicator text
+// buildSessionTokensIndicator builds the current-context token indicator.
+// Shows the size of the most recent prompt sent to the model (LastInputTokens)
+// — the same value /context reports as "Current Context Size". When the
+// provider did not return usage in its response, falls back to estimating
+// tokens from the message buffer via the tokenizer polyfill.
 func (isb *InputStatusBar) buildSessionTokensIndicator() string {
 	if isb.conversationRepo == nil {
 		return ""
 	}
 
-	stats := isb.conversationRepo.GetSessionTokens()
-	totalTokens := stats.TotalTokens
-
-	if totalTokens == 0 && isb.tokenEstimator != nil {
-		messages := isb.conversationRepo.GetMessages()
-		if len(messages) > 0 {
-			sdkMessages := make([]sdk.Message, 0, len(messages))
-			for _, entry := range messages {
-				sdkMessages = append(sdkMessages, entry.Message)
-			}
-			totalTokens = isb.tokenEstimator.EstimateMessagesTokens(sdkMessages)
-		}
-	}
-
-	if totalTokens == 0 {
+	currentTokens := isb.estimateCurrentContextTokens()
+	if currentTokens == 0 {
 		return ""
 	}
 
-	return fmt.Sprintf("T.%d", totalTokens)
+	return fmt.Sprintf("T.%d", currentTokens)
+}
+
+// estimateCurrentContextTokens returns LastInputTokens when reported by the
+// provider, or estimates from the message buffer otherwise. Used by both the
+// raw token indicator and the percentage indicator so they always agree.
+func (isb *InputStatusBar) estimateCurrentContextTokens() int {
+	if isb.conversationRepo == nil {
+		return 0
+	}
+
+	stats := isb.conversationRepo.GetSessionTokens()
+	if stats.LastInputTokens > 0 {
+		return stats.LastInputTokens
+	}
+
+	if isb.tokenEstimator == nil {
+		return 0
+	}
+
+	messages := isb.conversationRepo.GetMessages()
+	if len(messages) == 0 {
+		return 0
+	}
+
+	sdkMessages := make([]sdk.Message, 0, len(messages))
+	for _, entry := range messages {
+		sdkMessages = append(sdkMessages, entry.Message)
+	}
+	return isb.tokenEstimator.EstimateMessagesTokens(sdkMessages)
 }
 
 // buildCostIndicator builds the cost indicator text
@@ -601,14 +621,14 @@ func (isb *InputStatusBar) getA2ATaskInfo() string {
 	return fmt.Sprintf("Tasks: (%d)", activeCount)
 }
 
-// getContextUsageIndicator returns a context usage indicator string
+// getContextUsageIndicator returns a context usage indicator string.
+// Uses the same calculation as the /context shortcut (current context tokens
+// divided by the model's context window) so both surfaces report the same
+// percentage. Renders whenever there is data, with HIGH/FULL warning labels
+// at high thresholds. Falls back to the tokenizer polyfill when the provider
+// did not return usage on the latest request.
 func (isb *InputStatusBar) getContextUsageIndicator(model string) string {
-	if isb.conversationRepo == nil {
-		return ""
-	}
-
-	stats := isb.conversationRepo.GetSessionTokens()
-	currentContextSize := stats.LastInputTokens
+	currentContextSize := isb.estimateCurrentContextTokens()
 	if currentContextSize == 0 {
 		return ""
 	}
@@ -625,15 +645,14 @@ func (isb *InputStatusBar) getContextUsageIndicator(model string) string {
 		displayPercent = 100
 	}
 
-	if usagePercent >= 90 {
+	switch {
+	case usagePercent >= 90:
 		return fmt.Sprintf("Context: %.0f%% FULL", displayPercent)
-	} else if usagePercent >= 75 {
+	case usagePercent >= 75:
 		return fmt.Sprintf("Context: %.0f%% HIGH", displayPercent)
-	} else if usagePercent >= 50 {
-		return fmt.Sprintf("Context: %.0f%%", displayPercent)
+	default:
+		return fmt.Sprintf("Context: %.1f%%", displayPercent)
 	}
-
-	return ""
 }
 
 // estimateContextWindow returns an estimated context window size based on model name

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -5,11 +5,25 @@ import (
 	"testing"
 	"time"
 
+	sdk "github.com/inference-gateway/sdk"
+
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
+
+type stubTokenEstimator struct {
+	estimate int
+}
+
+func (s *stubTokenEstimator) GetToolStats(domain.ToolService, domain.AgentMode) (int, int) {
+	return 0, 0
+}
+
+func (s *stubTokenEstimator) EstimateMessagesTokens([]sdk.Message) int {
+	return s.estimate
+}
 
 func TestInputStatusBar_MasterToggle(t *testing.T) {
 	tests := []struct {
@@ -335,21 +349,22 @@ func TestInputStatusBar_BuildSessionTokensIndicator(t *testing.T) {
 		nilRepo      bool
 	}{
 		{
-			name: "returns session tokens when present",
+			name: "renders last input tokens when present",
 			stats: domain.SessionTokenStats{
-				TotalInputTokens:  500,
-				TotalOutputTokens: 300,
-				TotalTokens:       800,
-				RequestCount:      5,
+				TotalInputTokens:  2_568_948,
+				TotalOutputTokens: 32_242,
+				TotalTokens:       2_601_190,
+				RequestCount:      37,
+				LastInputTokens:   144_670,
 			},
-			expectedText: "T.800",
+			expectedText: "T.144670",
 			expectEmpty:  false,
 			nilRepo:      false,
 		},
 		{
-			name: "returns empty when total tokens is zero",
+			name: "returns empty when last input tokens is zero",
 			stats: domain.SessionTokenStats{
-				TotalTokens: 0,
+				TotalTokens: 800,
 			},
 			expectedText: "",
 			expectEmpty:  true,
@@ -385,6 +400,119 @@ func TestInputStatusBar_BuildSessionTokensIndicator(t *testing.T) {
 				t.Errorf("Expected '%s' but got '%s'", tt.expectedText, result)
 			}
 		})
+	}
+}
+
+func TestInputStatusBar_GetContextUsageIndicator(t *testing.T) {
+	tests := []struct {
+		name         string
+		stats        domain.SessionTokenStats
+		model        string
+		expectedText string
+		expectEmpty  bool
+		nilRepo      bool
+	}{
+		{
+			name: "renders percentage at low usage",
+			stats: domain.SessionTokenStats{
+				LastInputTokens: 144_670,
+			},
+			model:        "deepseek/deepseek-v4-flash",
+			expectedText: "Context: 14.5%",
+			expectEmpty:  false,
+		},
+		{
+			name: "renders HIGH label between 75 and 90 percent",
+			stats: domain.SessionTokenStats{
+				LastInputTokens: 800_000,
+			},
+			model:        "deepseek/deepseek-v4-flash",
+			expectedText: "Context: 80% HIGH",
+			expectEmpty:  false,
+		},
+		{
+			name: "renders FULL label at or above 90 percent",
+			stats: domain.SessionTokenStats{
+				LastInputTokens: 950_000,
+			},
+			model:        "deepseek/deepseek-v4-flash",
+			expectedText: "Context: 95% FULL",
+			expectEmpty:  false,
+		},
+		{
+			name: "returns empty when last input tokens is zero",
+			stats: domain.SessionTokenStats{
+				LastInputTokens: 0,
+			},
+			model:        "deepseek/deepseek-v4-flash",
+			expectedText: "",
+			expectEmpty:  true,
+		},
+		{
+			name:         "returns empty when repo is nil",
+			model:        "deepseek/deepseek-v4-flash",
+			expectedText: "",
+			expectEmpty:  true,
+			nilRepo:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var conversationRepo domain.ConversationRepository
+			if !tt.nilRepo {
+				mockRepo := &domainmocks.FakeConversationRepository{}
+				mockRepo.GetSessionTokensReturns(tt.stats)
+				conversationRepo = mockRepo
+			}
+
+			statusBar := &InputStatusBar{
+				conversationRepo: conversationRepo,
+			}
+
+			result := statusBar.getContextUsageIndicator(tt.model)
+
+			if tt.expectEmpty && result != "" {
+				t.Errorf("Expected empty string but got: %s", result)
+			}
+			if !tt.expectEmpty && result != tt.expectedText {
+				t.Errorf("Expected '%s' but got '%s'", tt.expectedText, result)
+			}
+		})
+	}
+}
+
+func TestInputStatusBar_BuildSessionTokensIndicator_FallsBackToEstimator(t *testing.T) {
+	mockRepo := &domainmocks.FakeConversationRepository{}
+	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{LastInputTokens: 0})
+	mockRepo.GetMessagesReturns([]domain.ConversationEntry{
+		{Message: sdk.Message{Role: sdk.User}},
+	})
+
+	statusBar := &InputStatusBar{
+		conversationRepo: mockRepo,
+		tokenEstimator:   &stubTokenEstimator{estimate: 6643},
+	}
+
+	if got := statusBar.buildSessionTokensIndicator(); got != "T.6643" {
+		t.Errorf("expected fallback estimate T.6643, got: %s", got)
+	}
+}
+
+func TestInputStatusBar_GetContextUsageIndicator_FallsBackToEstimator(t *testing.T) {
+	mockRepo := &domainmocks.FakeConversationRepository{}
+	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{LastInputTokens: 0})
+	mockRepo.GetMessagesReturns([]domain.ConversationEntry{
+		{Message: sdk.Message{Role: sdk.User}},
+	})
+
+	statusBar := &InputStatusBar{
+		conversationRepo: mockRepo,
+		tokenEstimator:   &stubTokenEstimator{estimate: 6643},
+	}
+
+	if got := statusBar.getContextUsageIndicator("deepseek/deepseek-v4-flash"); got != "Context: 0.7%" {
+		t.Errorf("expected fallback estimator percentage, got: %s", got)
 	}
 }
 
@@ -431,7 +559,7 @@ func TestInputStatusBar_BuildModelDisplayText_WithSessionTokens(t *testing.T) {
 
 	mockRepo := &domainmocks.FakeConversationRepository{}
 	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{
-		TotalTokens: 1234,
+		LastInputTokens: 1234,
 	})
 
 	themeService := &domainmocks.FakeThemeService{}

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -349,20 +349,20 @@ func TestInputStatusBar_BuildSessionTokensIndicator(t *testing.T) {
 		nilRepo      bool
 	}{
 		{
-			name: "renders last input tokens when present",
+			name: "renders cumulative total input tokens when present",
 			stats: domain.SessionTokenStats{
-				TotalInputTokens:  2_568_948,
-				TotalOutputTokens: 32_242,
-				TotalTokens:       2_601_190,
-				RequestCount:      37,
-				LastInputTokens:   144_670,
+				TotalInputTokens:  20_000,
+				TotalOutputTokens: 314,
+				TotalTokens:       20_314,
+				RequestCount:      3,
+				LastInputTokens:   7_250,
 			},
-			expectedText: "T.144670",
+			expectedText: "T.20000",
 			expectEmpty:  false,
 			nilRepo:      false,
 		},
 		{
-			name: "returns empty when last input tokens is zero",
+			name: "returns empty when total input tokens is zero",
 			stats: domain.SessionTokenStats{
 				TotalTokens: 800,
 			},
@@ -415,16 +415,16 @@ func TestInputStatusBar_GetContextUsageIndicator(t *testing.T) {
 		{
 			name: "renders percentage at low usage",
 			stats: domain.SessionTokenStats{
-				LastInputTokens: 144_670,
+				TotalInputTokens: 20_000,
 			},
 			model:        "deepseek/deepseek-v4-flash",
-			expectedText: "Context: 14.5%",
+			expectedText: "Context: 2.0%",
 			expectEmpty:  false,
 		},
 		{
 			name: "renders HIGH label between 75 and 90 percent",
 			stats: domain.SessionTokenStats{
-				LastInputTokens: 800_000,
+				TotalInputTokens: 800_000,
 			},
 			model:        "deepseek/deepseek-v4-flash",
 			expectedText: "Context: 80% HIGH",
@@ -433,16 +433,16 @@ func TestInputStatusBar_GetContextUsageIndicator(t *testing.T) {
 		{
 			name: "renders FULL label at or above 90 percent",
 			stats: domain.SessionTokenStats{
-				LastInputTokens: 950_000,
+				TotalInputTokens: 950_000,
 			},
 			model:        "deepseek/deepseek-v4-flash",
 			expectedText: "Context: 95% FULL",
 			expectEmpty:  false,
 		},
 		{
-			name: "returns empty when last input tokens is zero",
+			name: "returns empty when total input tokens is zero",
 			stats: domain.SessionTokenStats{
-				LastInputTokens: 0,
+				TotalInputTokens: 0,
 			},
 			model:        "deepseek/deepseek-v4-flash",
 			expectedText: "",
@@ -484,7 +484,7 @@ func TestInputStatusBar_GetContextUsageIndicator(t *testing.T) {
 
 func TestInputStatusBar_BuildSessionTokensIndicator_FallsBackToEstimator(t *testing.T) {
 	mockRepo := &domainmocks.FakeConversationRepository{}
-	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{LastInputTokens: 0})
+	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{TotalInputTokens: 0})
 	mockRepo.GetMessagesReturns([]domain.ConversationEntry{
 		{Message: sdk.Message{Role: sdk.User}},
 	})
@@ -501,7 +501,7 @@ func TestInputStatusBar_BuildSessionTokensIndicator_FallsBackToEstimator(t *test
 
 func TestInputStatusBar_GetContextUsageIndicator_FallsBackToEstimator(t *testing.T) {
 	mockRepo := &domainmocks.FakeConversationRepository{}
-	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{LastInputTokens: 0})
+	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{TotalInputTokens: 0})
 	mockRepo.GetMessagesReturns([]domain.ConversationEntry{
 		{Message: sdk.Message{Role: sdk.User}},
 	})
@@ -559,7 +559,7 @@ func TestInputStatusBar_BuildModelDisplayText_WithSessionTokens(t *testing.T) {
 
 	mockRepo := &domainmocks.FakeConversationRepository{}
 	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{
-		LastInputTokens: 1234,
+		TotalInputTokens: 1234,
 	})
 
 	themeService := &domainmocks.FakeThemeService{}


### PR DESCRIPTION
## Summary

- **Token display reconciliation**: Status bar `T.<n>` and `Context: N%` now derive from `LastInputTokens`, matching `/context`'s `Current Context Size`. All three surfaces report the same metric — window fill, not cumulative billing.
- **Tokenizer fallback in `/context`**: When the provider does not return usage in its response, the shortcut falls back to the existing `TokenizerService` polyfill and marks the value as `~<n> (estimated)`. The container's tokenizer is now created unconditionally and reused by the shortcut, the optimizer, and the rollover manager.
- **JSONL metadata-only save bug**: `saveConversationUnlocked` previously skipped writing metadata when no new entries were added (`if len(entries) > persistedCount` gate). This dropped saves triggered by `AddTokenUsage` after the assistant message was already persisted, causing `/conversations` to lag by one save event. Now metadata is appended on every save; the reader already uses the last meta line.
