### PR TITLE
feat(plan-mode): Persist plans as markdown and fix approval UX

### DIFF
--- a/.infer/.gitignore
+++ b/.infer/.gitignore
@@ -6,3 +6,4 @@ conversations.db*
 conversations
 bin/
 tmp/
+plans/

--- a/.infer/prompts.yaml
+++ b/.infer/prompts.yaml
@@ -9,7 +9,7 @@ agent:
     CAPABILITIES IN PLAN MODE:
     - Read, Grep, and Tree tools for gathering information
     - TodoWrite for tracking planning progress
-    - RequestPlanApproval tool to submit your plan for user approval
+    - RequestPlanApproval tool to submit your plan for user approval (also persists the plan as a Markdown file under <configDir>/plans/)
     - Analyze code structure and dependencies
     - Break down complex tasks into concrete, executable steps
     - Identify exact files and code locations that need changes
@@ -23,28 +23,43 @@ agent:
     PLANNING WORKFLOW:
     1. Use Read/Grep/Tree to understand the codebase thoroughly
     2. Analyze the user's request and identify ALL requirements
-    3. If you need clarification or more information, ASK the user - do NOT call RequestPlanApproval yet
-    4. Break down into specific, numbered action steps
-    5. For EACH step, specify:
-       - Exact file paths to modify
-       - Specific changes to make
-       - Tool calls that will be needed
-    6. Include testing and validation steps
-    7. When your plan is complete and actionable, call RequestPlanApproval tool
+    3. If you need clarification or more information, ASK the user in a regular assistant turn - do NOT call RequestPlanApproval yet
+    4. Iterate with the user until the plan is complete and unambiguous
+    5. When the plan is final, call RequestPlanApproval with both a short title AND the Markdown plan body
 
     DECISION MAKING:
     - Need more info? ASK questions instead of requesting approval
     - Plan has gaps or uncertainties? ASK for clarification
     - Plan is complete and specific? Call RequestPlanApproval tool
 
-    OUTPUT FORMAT - ACTIONABLE STEPS:
-    Structure your plan with concrete actions:
-    - Overview: What will be done and why
-    - Steps: Numbered steps with SPECIFIC actions
-      Example: "Step 1: Edit /path/to/file.go - Add function X at line Y"
-      Example: "Step 2: Run 'task test' to verify changes"
-    - Files: Exact list of files to be modified
-    - Testing: Specific commands to run and expected outcomes
+    OUTPUT FORMAT - MARKDOWN PLAN:
+    The 'plan' argument MUST be a Markdown document using the following H2 sections, in this order. Omit any section that does not apply to the task; never invent extra top-level sections.
+
+    ## Context
+    Why this change is being made — the problem, the trigger, the intended outcome.
+
+    ## Files to Modify
+    Bullet list of exact file paths that will change, each with a one-line note on the kind of change.
+
+    ## Current Code
+    Short, relevant snippets of the existing code being changed (with file:line references). Skip when not applicable (e.g. brand-new files).
+
+    ## Changes
+    The concrete edits, grouped per file or per concern. Be specific: function names, signatures, what is added/removed/replaced.
+
+    ## Performance Impact
+    Expected runtime, memory, I/O, or token-usage impact. Write "Negligible." if there isn't any.
+
+    ## Critical Files
+    Files that other code depends on and that must remain backward-compatible (e.g. shared interfaces, public APIs). Skip when not applicable.
+
+    ## Edge Cases
+    Inputs and conditions that need explicit handling, plus how the plan handles them.
+
+    ## Verification
+    Concrete steps the user can run to confirm the change works end-to-end (commands, tests, manual checks).
+
+    The 'title' argument MUST be a short human-readable phrase (≤ 60 chars, no slashes). It becomes the H1 of the saved file and the basis of the on-disk filename.
 
     REMEMBER:
     - If accepted, YOU will execute this plan. Make it specific and actionable!
@@ -305,15 +320,19 @@ tools:
       When in doubt, use this tool. Being proactive with task management demonstrates attentiveness and ensures you complete all requirements successfully.
   RequestPlanApproval:
     description: |-
-      Submit your completed plan for user approval.
+      Submit your completed plan for user approval and persist it to disk.
 
       What happens:
-      - Your plan will be displayed to the user
-      - User can approve or reject
+      - The plan is written as a Markdown file to <configDir>/plans/<timestamp>-<slug>.md
+      - The plan is displayed to the user with Accept / Reject / Accept-and-Auto-Approve options
       - If approved, you'll switch to execution mode with full tool access
-      - If rejected, user will provide feedback
+      - If rejected, the file remains on disk as an audit trail and the user provides feedback
 
-      Include your complete plan in the 'plan' parameter.
+      Required parameters:
+      - title: A short human-readable phrase (≤ 60 chars, no slashes). Becomes the H1 heading and the filename slug.
+      - plan: The full plan as Markdown using H2 sections in this order — ## Context, ## Files to Modify, ## Current Code, ## Changes, ## Performance Impact, ## Critical Files, ## Edge Cases, ## Verification. Omit any section that is not applicable.
+
+      Only call this tool when the plan is final. If you need clarification, ask the user in a normal assistant turn first.
   WebFetch:
     description: Fetch content from whitelisted URLs. Set download=true to save the file to disk automatically. Useful for downloading A2A task artifacts or other files.
   WebSearch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,6 +595,33 @@ images that don't ship `/usr/share/zoneinfo`.
   ...)` calls in `cmd/root.go` — without those, viper unmarshals an empty
   config and the defaults function's values are ignored.
 
+## Plan Mode
+
+Plan mode (`AgentModePlan` in `internal/domain/state.go`) is a read-only
+operating mode the user enters via Shift+Tab in the chat TUI. The model
+gets `Read`/`Grep`/`Tree`/`TodoWrite` plus the `RequestPlanApproval` tool
+and is otherwise blocked from any mutating tools (enforced in
+`internal/services/tools.go::FilterToolsForMode`).
+
+When the model calls `RequestPlanApproval`, the tool persists the plan as
+a Markdown file under `<configDir>/plans/<YYYY-MM-DD-HHMMSS>-<slug>.md`
+(atomic write: `.tmp` → `os.Rename`). The plan body must follow a fixed
+8-section H2 template (Context, Files to Modify, Current Code, Changes,
+Performance Impact, Critical Files, Edge Cases, Verification) — see
+`config/prompts.go::DefaultPromptsConfig` for the prompt that pins this
+contract.
+
+- Tool: `internal/agent/tools/request_plan_approval.go`
+- System prompt: `config/prompts.go` (`agent.system_prompt_plan`)
+- Approval event flow: `internal/agent/agent.go` →
+  `PlanApprovalRequestedEvent` → `internal/handlers/chat_handler.go`
+  `HandlePlanApprovalRequestedEvent` / `HandlePlanApprovalResponseEvent`
+- UI state: `domain.PlanApprovalUIState`, `ViewStatePlanApproval`
+
+Rejected plans stay on disk as an audit trail — by design.
+
+See `docs/plan-mode.md` for the full user-facing guide.
+
 ## Model Thinking Visualization
 
 When models use extended thinking (reasoning), their internal thought process is displayed as collapsible blocks above responses.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -95,6 +95,7 @@ conversations.db*
 conversations
 bin/
 tmp/
+plans/
 `
 
 	if err := os.WriteFile(gitignorePath, []byte(gitignoreContent), 0644); err != nil {

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -191,7 +191,7 @@ type PromptsToolsConfig struct {
 // DefaultPromptsConfig returns the in-code default prompts. This is the
 // single source of truth — `infer init` seeds prompts.yaml from this and
 // the runtime overlay falls back to it when fields are missing.
-func DefaultPromptsConfig() *PromptsConfig {
+func DefaultPromptsConfig() *PromptsConfig { //nolint:funlen
 	return &PromptsConfig{
 		Agent: PromptsAgentConfig{
 			SystemPrompt: `Autonomous software engineering agent. Execute tasks iteratively until completion.`,
@@ -202,7 +202,7 @@ CRITICAL: Your plan MUST be actionable - if the user accepts it, you will be ask
 CAPABILITIES IN PLAN MODE:
 - Read, Grep, and Tree tools for gathering information
 - TodoWrite for tracking planning progress
-- RequestPlanApproval tool to submit your plan for user approval
+- RequestPlanApproval tool to submit your plan for user approval (also persists the plan as a Markdown file under <configDir>/plans/)
 - Analyze code structure and dependencies
 - Break down complex tasks into concrete, executable steps
 - Identify exact files and code locations that need changes
@@ -216,28 +216,43 @@ RESTRICTIONS IN PLAN MODE:
 PLANNING WORKFLOW:
 1. Use Read/Grep/Tree to understand the codebase thoroughly
 2. Analyze the user's request and identify ALL requirements
-3. If you need clarification or more information, ASK the user - do NOT call RequestPlanApproval yet
-4. Break down into specific, numbered action steps
-5. For EACH step, specify:
-   - Exact file paths to modify
-   - Specific changes to make
-   - Tool calls that will be needed
-6. Include testing and validation steps
-7. When your plan is complete and actionable, call RequestPlanApproval tool
+3. If you need clarification or more information, ASK the user in a regular assistant turn - do NOT call RequestPlanApproval yet
+4. Iterate with the user until the plan is complete and unambiguous
+5. When the plan is final, call RequestPlanApproval with both a short title AND the Markdown plan body
 
 DECISION MAKING:
 - Need more info? ASK questions instead of requesting approval
 - Plan has gaps or uncertainties? ASK for clarification
 - Plan is complete and specific? Call RequestPlanApproval tool
 
-OUTPUT FORMAT - ACTIONABLE STEPS:
-Structure your plan with concrete actions:
-- Overview: What will be done and why
-- Steps: Numbered steps with SPECIFIC actions
-  Example: "Step 1: Edit /path/to/file.go - Add function X at line Y"
-  Example: "Step 2: Run 'task test' to verify changes"
-- Files: Exact list of files to be modified
-- Testing: Specific commands to run and expected outcomes
+OUTPUT FORMAT - MARKDOWN PLAN:
+The 'plan' argument MUST be a Markdown document using the following H2 sections, in this order. Omit any section that does not apply to the task; never invent extra top-level sections.
+
+## Context
+Why this change is being made — the problem, the trigger, the intended outcome.
+
+## Files to Modify
+Bullet list of exact file paths that will change, each with a one-line note on the kind of change.
+
+## Current Code
+Short, relevant snippets of the existing code being changed (with file:line references). Skip when not applicable (e.g. brand-new files).
+
+## Changes
+The concrete edits, grouped per file or per concern. Be specific: function names, signatures, what is added/removed/replaced.
+
+## Performance Impact
+Expected runtime, memory, I/O, or token-usage impact. Write "Negligible." if there isn't any.
+
+## Critical Files
+Files that other code depends on and that must remain backward-compatible (e.g. shared interfaces, public APIs). Skip when not applicable.
+
+## Edge Cases
+Inputs and conditions that need explicit handling, plus how the plan handles them.
+
+## Verification
+Concrete steps the user can run to confirm the change works end-to-end (commands, tests, manual checks).
+
+The 'title' argument MUST be a short human-readable phrase (≤ 60 chars, no slashes). It becomes the H1 of the saved file and the basis of the on-disk filename.
 
 REMEMBER:
 - If accepted, YOU will execute this plan. Make it specific and actionable!
@@ -505,15 +520,19 @@ NOTE that you should not use this tool if there is only one trivial task to do. 
 When in doubt, use this tool. Being proactive with task management demonstrates attentiveness and ensures you complete all requirements successfully.`,
 		},
 		RequestPlanApproval: PromptsToolDescription{
-			Description: `Submit your completed plan for user approval.
+			Description: `Submit your completed plan for user approval and persist it to disk.
 
 What happens:
-- Your plan will be displayed to the user
-- User can approve or reject
+- The plan is written as a Markdown file to <configDir>/plans/<timestamp>-<slug>.md
+- The plan is displayed to the user with Accept / Reject / Accept-and-Auto-Approve options
 - If approved, you'll switch to execution mode with full tool access
-- If rejected, user will provide feedback
+- If rejected, the file remains on disk as an audit trail and the user provides feedback
 
-Include your complete plan in the 'plan' parameter.`,
+Required parameters:
+- title: A short human-readable phrase (≤ 60 chars, no slashes). Becomes the H1 heading and the filename slug.
+- plan: The full plan as Markdown using H2 sections in this order — ## Context, ## Files to Modify, ## Current Code, ## Changes, ## Performance Impact, ## Critical Files, ## Edge Cases, ## Verification. Omit any section that is not applicable.
+
+Only call this tool when the plan is final. If you need clarification, ask the user in a normal assistant turn first.`,
 		},
 		WebFetch: PromptsToolDescription{
 			Description: `Fetch content from whitelisted URLs. Set download=true to save the file to disk automatically. Useful for downloading A2A task artifacts or other files.`,

--- a/config/prompts_test.go
+++ b/config/prompts_test.go
@@ -59,6 +59,42 @@ func TestDefaultPromptsConfig_AllPromptsPopulated(t *testing.T) {
 	}
 }
 
+// The plan-mode prompt advertises a fixed Markdown section template to
+// the model. This guards the template against accidental edits and makes
+// the contract with docs/plan-mode.md explicit.
+func TestDefaultPromptsConfig_PlanPromptStructure(t *testing.T) {
+	cfg := config.DefaultPromptsConfig()
+	plan := cfg.Agent.SystemPromptPlan
+
+	wantSections := []string{
+		"## Context",
+		"## Files to Modify",
+		"## Current Code",
+		"## Changes",
+		"## Performance Impact",
+		"## Critical Files",
+		"## Edge Cases",
+		"## Verification",
+	}
+	for _, section := range wantSections {
+		if !strings.Contains(plan, section) {
+			t.Errorf("plan-mode system prompt missing section heading %q", section)
+		}
+	}
+
+	if !strings.Contains(plan, "title") {
+		t.Errorf("plan-mode system prompt should mention the 'title' parameter")
+	}
+
+	desc := cfg.Tools.RequestPlanApproval.Description
+	if !strings.Contains(desc, "title") || !strings.Contains(desc, "plan") {
+		t.Errorf("RequestPlanApproval description should mention both 'title' and 'plan' parameters, got %q", desc)
+	}
+	if !strings.Contains(desc, "<configDir>/plans/") {
+		t.Errorf("RequestPlanApproval description should mention the on-disk path, got %q", desc)
+	}
+}
+
 // custom_instructions is intentionally empty - it's a user-supplied
 // opt-in. This guards it in the opposite direction so a future "fill in
 // a default" change is intentional.

--- a/docs/plan-mode.md
+++ b/docs/plan-mode.md
@@ -1,0 +1,178 @@
+# Plan Mode
+
+[← Back to README](../README.md)
+
+Plan Mode is a read-only operating mode for the agent. The model can use
+`Read`, `Grep`, `Tree`, and `TodoWrite` to investigate the codebase, but it
+cannot write, edit, delete, or run shell commands. Instead, it produces a
+**plan** for the proposed change, persists that plan as a Markdown file
+under `<configDir>/plans/`, and surfaces it to you for approval before any
+real work happens.
+
+## Why use it
+
+Plan mode exists for tasks where you want a human gate between
+"understand the change" and "make the change":
+
+- Risky or far-reaching refactors.
+- Migrations and schema changes.
+- Multi-file features where you want a written record before execution.
+- Pair-programming flows: review the plan, push back, iterate.
+
+Every plan — accepted **or** rejected — is left on disk in
+`<configDir>/plans/` as an audit trail. You can grep, share, or revisit
+them later.
+
+## How to enter plan mode
+
+In the interactive chat TUI, press **Shift+Tab** to cycle the agent mode.
+The status line shows the current mode; cycle until it reads
+**Plan Mode**. Press Shift+Tab again to leave.
+
+The cycle is:
+
+```text
+Standard → Plan Mode → Auto-Accept → Standard → …
+```
+
+When a plan is **accepted**, the mode automatically flips back to Standard
+(or to Auto-Accept if you chose "Accept & Auto-Approve") and the agent
+begins executing.
+
+## What the model is told to do
+
+The default plan-mode system prompt (defined in
+`config/prompts.go::DefaultPromptsConfig`, key `agent.system_prompt_plan`)
+instructs the model to:
+
+1. Use `Read`, `Grep`, `Tree` to investigate.
+2. Ask clarifying questions in regular assistant turns first — **not**
+   call `RequestPlanApproval` while gaps remain.
+3. Only call `RequestPlanApproval` when the plan is complete.
+4. Pass two arguments to that tool:
+   - `title`: a short phrase (≤ 60 chars, no slashes or `..`).
+   - `plan`: the plan body as Markdown using the standard sections below.
+
+## Plan structure
+
+The plan body is a Markdown document using these H2 sections, in this
+order. Sections that don't apply to the task are omitted; no extra
+top-level sections are introduced.
+
+- `## Context` — why this change is being made: problem, trigger,
+  intended outcome.
+- `## Files to Modify` — bullet list of paths plus a one-line note per
+  file.
+- `## Current Code` — short snippets of the existing code being changed
+  (skip for new files).
+- `## Changes` — concrete edits: function names, signatures, what's
+  added / removed / replaced.
+- `## Performance Impact` — expected runtime / memory / I/O impact.
+  "Negligible." is a valid answer.
+- `## Critical Files` — files other code depends on and that must remain
+  backward-compatible.
+- `## Edge Cases` — inputs and conditions needing explicit handling,
+  plus the handling.
+- `## Verification` — concrete steps you can run to confirm the change
+  works end-to-end.
+
+The H1 of the saved file is derived from the `title` argument, e.g.:
+
+```markdown
+# Add Login Flow
+
+## Context
+…
+```
+
+## Where plans are saved
+
+```text
+<configDir>/plans/<YYYY-MM-DD-HHMMSS>-<slug>.md
+```
+
+`<configDir>` is whatever
+`config.Config.GetConfigDir()` resolves to — usually `./.infer/` in a
+project, or `~/.infer/` for the userspace config. The `plans/`
+subdirectory is created on first use.
+
+`<slug>` is the title lowercased, with non-alphanumerics collapsed to
+`-`, capped at 60 characters. If two plans land in the same second with
+the same title, the second filename gets a numeric suffix (`-1`, `-2`, …)
+so writes never clobber each other.
+
+Writes are atomic: the tool writes to `<path>.tmp` and then `os.Rename`s,
+so you'll never see a half-written plan file.
+
+Example listing:
+
+```bash
+$ ls ~/.infer/plans/
+2026-04-25-091230-rip-out-old-auth-middleware.md
+2026-04-26-143015-add-login-flow.md
+2026-04-27-103015-rename-config-loader.md
+```
+
+## Accept / Reject UX
+
+When the model calls `RequestPlanApproval`, the chat TUI:
+
+1. Renders the saved plan in a dedicated panel.
+2. Shows a status line: `Plan ready — use arrow keys to select and Enter
+   to confirm`.
+3. Offers three options:
+
+   - **Accept** — agent flips to Standard mode and executes the plan.
+   - **Accept & Auto-Approve** — agent flips to Auto-Accept (no per-tool
+     approval prompts) and executes the plan.
+   - **Reject** — chat session ends; you can write a follow-up message
+     with feedback and the agent re-iterates the plan.
+
+In all three cases the plan file remains on disk. Rejecting a plan does
+**not** delete it.
+
+## Iterating on a plan
+
+Plan mode encourages a back-and-forth before the tool call lands. Typical
+flow:
+
+1. You: *"Plan a refactor that splits `chat_handler.go` into smaller
+   files."*
+2. Model: *"Before I draft this, three questions: …"* (regular assistant
+   turn, no tool call yet).
+3. You answer.
+4. Model: *(maybe more questions)* — repeat until aligned.
+5. Model calls `RequestPlanApproval` with the final plan.
+6. You **Reject** with a comment ("the split is too granular — keep
+   shortcut handling in the same file").
+7. Model adjusts and re-submits a new plan (a new file lands in
+   `plans/`).
+8. You **Accept** — the agent executes.
+
+## Configuration
+
+Plan mode itself has no separate config — it ships with the CLI. You can
+customise the system prompt and the tool description in
+`.infer/prompts.yaml`:
+
+```yaml
+agent:
+  system_prompt_plan: |-
+    # your custom plan-mode prompt
+tools:
+  RequestPlanApproval:
+    description: |-
+      # your custom tool description
+```
+
+Empty fields fall back to the in-code defaults (see
+`config/prompts.go::DefaultPromptsConfig`). Environment-variable
+overrides:
+
+- `INFER_PROMPTS_AGENT_SYSTEM_PROMPT_PLAN`
+- `INFER_PROMPTS_TOOLS_REQUEST_PLAN_APPROVAL_DESCRIPTION`
+
+## Related
+
+- [Tools Reference — RequestPlanApproval](tools-reference.md#requestplanapproval-tool)
+- [Configuration Reference](configuration-reference.md)

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -24,6 +24,7 @@ is enabled in the Inference Gateway CLI.
   - [Github Tool](#github-tool)
 - [Workflow Tools](#workflow-tools)
   - [TodoWrite Tool](#todowrite-tool)
+  - [RequestPlanApproval Tool](#requestplanapproval-tool)
   - [Schedule Tool](#schedule-tool)
 - [Agent-to-Agent Communication](#agent-to-agent-communication)
   - [A2A_SubmitTask Tool](#a2a_submittask-tool)
@@ -562,6 +563,46 @@ tools:
     enabled: true
     require_approval: false
 ```
+
+### RequestPlanApproval Tool
+
+Submits a finalized plan for user approval and persists it as a
+Markdown file under `<configDir>/plans/`. Available only when the agent
+is in **Plan Mode** (toggle via Shift+Tab in the chat TUI).
+
+> **📖 For the full plan-mode workflow, see [Plan Mode Guide](plan-mode.md).**
+
+**How it works:**
+
+- The plan is written atomically to `<configDir>/plans/<YYYY-MM-DD-HHMMSS>-<slug>.md` (e.g. `~/.infer/plans/2026-04-27-103015-add-login-flow.md`).
+- The chat TUI shows the rendered plan with **Accept**, **Reject**, and **Accept & Auto-Approve** options.
+- On accept, the agent switches out of plan mode and executes the plan.
+- On reject, the file remains on disk as an audit trail; the user can reply with feedback and the agent re-iterates.
+- The LLM is instructed to ask clarifying questions in normal assistant turns first, and only call this tool when the plan is complete.
+
+**Parameters:**
+
+- `title` (required): A short human-readable phrase (≤ 60 chars, no
+  slashes or `..`). Becomes the H1 heading of the saved file and the
+  basis of the filename slug.
+- `plan` (required): The full plan as Markdown. Use H2 sections in this
+  order — `## Context`, `## Files to Modify`, `## Current Code`,
+  `## Changes`, `## Performance Impact`, `## Critical Files`,
+  `## Edge Cases`, `## Verification`. Omit any section that is not
+  applicable.
+
+**Example:**
+
+```json
+{
+  "title": "Add login flow",
+  "plan": "## Context\n\nUsers can't sign in...\n\n## Files to Modify\n\n- internal/auth/login.go — add handler\n\n## Verification\n\nRun `task test`."
+}
+```
+
+**Configuration:**
+
+The tool is auto-registered and always enabled in plan mode. No config knobs.
 
 ### Schedule Tool
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -915,10 +915,7 @@ func (s *AgentServiceImpl) executeToolInternal(
 	}
 
 	if result.ToolName == "RequestPlanApproval" && result.Success {
-		planContent := extractPlanContent(result)
-		if planContent != "" {
-			eventPublisher.publishPlanApprovalRequest(planContent)
-		} else {
+		if extractPlanContent(result) == "" {
 			logger.Warn("RequestPlanApproval succeeded but plan content is empty")
 		}
 	}
@@ -1019,6 +1016,8 @@ func (s *AgentServiceImpl) createPlanMessage(
 	if err := s.conversationRepo.AddMessage(planEntry); err != nil {
 		logger.Error("failed to store plan message", "error", err)
 	}
+
+	eventPublisher.publishPlanApprovalRequest(planContent)
 
 	logger.Info("Plan approval requested - stopping agent loop")
 	eventPublisher.publishChatComplete("", []sdk.ChatCompletionMessageToolCall{}, s.GetMetrics(req.RequestID))

--- a/internal/agent/tools/request_plan_approval.go
+++ b/internal/agent/tools/request_plan_approval.go
@@ -3,26 +3,48 @@ package tools
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
+
+	sdk "github.com/inference-gateway/sdk"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
-	sdk "github.com/inference-gateway/sdk"
 )
 
-// RequestPlanApprovalTool handles requesting plan approval from the user
+// plansSubdir is the directory (relative to the resolved config dir) where
+// approved plan markdown files are persisted.
+const plansSubdir = "plans"
+
+// maxSlugLength caps the title-derived slug used in plan filenames so that
+// long titles cannot produce unwieldy paths.
+const maxSlugLength = 60
+
+// titleSlugRegex matches sequences of characters that must be replaced with
+// "-" to form a filesystem-safe slug.
+var titleSlugRegex = regexp.MustCompile(`[^a-z0-9]+`)
+
+// RequestPlanApprovalTool handles requesting plan approval from the user.
+// On execute it persists the plan as a markdown file under
+// "<configDir>/plans/" so users have an auditable record of every plan the
+// agent produced — even when they reject it.
 type RequestPlanApprovalTool struct {
 	config    *config.Config
 	enabled   bool
 	formatter domain.BaseFormatter
+	now       func() time.Time
 }
 
 // NewRequestPlanApprovalTool creates a new RequestPlanApproval tool
 func NewRequestPlanApprovalTool(cfg *config.Config) *RequestPlanApprovalTool {
 	return &RequestPlanApprovalTool{
 		config:    cfg,
-		enabled:   true, // Always enabled when in plan mode
+		enabled:   true,
 		formatter: domain.NewBaseFormatter("RequestPlanApproval"),
+		now:       time.Now,
 	}
 }
 
@@ -39,11 +61,15 @@ func (t *RequestPlanApprovalTool) Definition() sdk.ChatCompletionTool {
 				"$schema":              "http://json-schema.org/draft-07/schema#",
 				"additionalProperties": false,
 				"type":                 "object",
-				"required":             []string{"plan"},
+				"required":             []string{"title", "plan"},
 				"properties": map[string]any{
+					"title": map[string]any{
+						"type":        "string",
+						"description": "A short human-readable title for the plan. Used as the H1 heading and to derive the on-disk filename.",
+					},
 					"plan": map[string]any{
 						"type":        "string",
-						"description": "The complete, detailed plan to be executed",
+						"description": "The complete plan as Markdown. Use H2 sections (## Context, ## Files to Modify, ## Current Code, ## Changes, ## Performance Impact, ## Critical Files, ## Edge Cases, ## Verification) — include only sections that apply.",
 					},
 				},
 			},
@@ -51,47 +77,65 @@ func (t *RequestPlanApprovalTool) Definition() sdk.ChatCompletionTool {
 	}
 }
 
-// Execute runs the RequestPlanApproval tool with given arguments
+// Execute runs the RequestPlanApproval tool with given arguments. It writes
+// the plan markdown to disk and returns the plan content plus the saved
+// path so downstream consumers can surface both to the user and the LLM.
 func (t *RequestPlanApprovalTool) Execute(ctx context.Context, args map[string]any) (*domain.ToolExecutionResult, error) {
-	start := time.Now()
+	start := t.now()
 
-	plan, ok := args["plan"].(string)
-	if !ok || plan == "" {
+	title, plan, err := extractPlanArgs(args)
+	if err != nil {
 		return &domain.ToolExecutionResult{
 			ToolName:  "RequestPlanApproval",
 			Arguments: args,
 			Success:   false,
 			Duration:  time.Since(start),
-			Error:     "plan parameter is required and must be a non-empty string",
+			Error:     err.Error(),
 		}, nil
 	}
 
-	result := &domain.ToolExecutionResult{
+	path, err := t.writePlanFile(title, plan, start)
+	if err != nil {
+		return &domain.ToolExecutionResult{
+			ToolName:  "RequestPlanApproval",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(start),
+			Error:     err.Error(),
+		}, nil
+	}
+
+	canonical, err := os.ReadFile(path)
+	if err != nil {
+		return &domain.ToolExecutionResult{
+			ToolName:  "RequestPlanApproval",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(start),
+			Error:     fmt.Errorf("failed to read back plan file %s: %w", path, err).Error(),
+		}, nil
+	}
+
+	return &domain.ToolExecutionResult{
 		ToolName:  "RequestPlanApproval",
 		Arguments: args,
 		Success:   true,
 		Duration:  time.Since(start),
 		Data: map[string]any{
-			"plan":    plan,
+			"title":   title,
+			"plan":    string(canonical),
+			"path":    path,
 			"message": "Plan approval requested - waiting for user decision",
 		},
-	}
-
-	return result, nil
+	}, nil
 }
 
-// Validate checks if the RequestPlanApproval tool arguments are valid
+// Validate checks if the RequestPlanApproval tool arguments are valid. The
+// title is rejected up front when it contains path separators or ".." so we
+// never even attempt to slug a malicious title.
 func (t *RequestPlanApprovalTool) Validate(args map[string]any) error {
-	plan, ok := args["plan"].(string)
-	if !ok {
-		return fmt.Errorf("plan parameter is required and must be a string")
-	}
-
-	if plan == "" {
-		return fmt.Errorf("plan cannot be empty")
-	}
-
-	return nil
+	_, _, err := extractPlanArgs(args)
+	return err
 }
 
 // IsEnabled returns whether the RequestPlanApproval tool is enabled
@@ -120,6 +164,9 @@ func (t *RequestPlanApprovalTool) FormatPreview(result *domain.ToolExecutionResu
 	}
 
 	if result.Success {
+		if path := planPath(result); path != "" {
+			return fmt.Sprintf("Plan saved to %s", path)
+		}
 		return "Plan approval requested"
 	}
 
@@ -133,6 +180,9 @@ func (t *RequestPlanApprovalTool) FormatForUI(result *domain.ToolExecutionResult
 	}
 
 	statusIcon := t.formatter.FormatStatusIcon(result.Success)
+	if path := planPath(result); path != "" {
+		return fmt.Sprintf("RequestPlanApproval(...)\n└─ %s Plan saved to %s", statusIcon, path)
+	}
 	return fmt.Sprintf("RequestPlanApproval(...)\n└─ %s Plan submitted for approval", statusIcon)
 }
 
@@ -143,6 +193,9 @@ func (t *RequestPlanApprovalTool) FormatForLLM(result *domain.ToolExecutionResul
 	}
 
 	if result.Success {
+		if path := planPath(result); path != "" {
+			return fmt.Sprintf("Plan approval requested. Plan saved to %s. The user will review your plan and decide whether to accept, reject, or enable auto-approve mode.", path)
+		}
 		return "Plan approval requested. The user will review your plan and decide whether to accept, reject, or enable auto-approve mode."
 	}
 
@@ -157,4 +210,135 @@ func (t *RequestPlanApprovalTool) ShouldCollapseArg(key string) bool {
 // ShouldAlwaysExpand determines if tool results should always be expanded in UI
 func (t *RequestPlanApprovalTool) ShouldAlwaysExpand() bool {
 	return false
+}
+
+// extractPlanArgs pulls and validates `title` and `plan` from the raw
+// argument map. It is shared between Validate and Execute so both apply
+// the same rules.
+func extractPlanArgs(args map[string]any) (title, plan string, err error) {
+	rawTitle, ok := args["title"].(string)
+	if !ok {
+		return "", "", fmt.Errorf("title parameter is required and must be a string")
+	}
+	title = strings.TrimSpace(rawTitle)
+	if title == "" {
+		return "", "", fmt.Errorf("title cannot be empty")
+	}
+	if strings.ContainsAny(title, `/\`) || strings.Contains(title, "..") {
+		return "", "", fmt.Errorf("title must not contain path separators or '..'")
+	}
+
+	rawPlan, ok := args["plan"].(string)
+	if !ok {
+		return "", "", fmt.Errorf("plan parameter is required and must be a string")
+	}
+	plan = strings.TrimSpace(rawPlan)
+	if plan == "" {
+		return "", "", fmt.Errorf("plan cannot be empty")
+	}
+	return title, plan, nil
+}
+
+// writePlanFile materialises the plan as a markdown file in the configured
+// plans directory. Writes go through a `.tmp` sibling and an os.Rename so
+// the final file is never observed half-written.
+func (t *RequestPlanApprovalTool) writePlanFile(title, plan string, ts time.Time) (string, error) {
+	dir := filepath.Join(t.config.GetConfigDir(), plansSubdir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create plans directory %s: %w", dir, err)
+	}
+
+	final, err := uniquePlanPath(dir, title, ts)
+	if err != nil {
+		return "", err
+	}
+
+	body := buildPlanMarkdown(title, plan)
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write plan file %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("failed to finalise plan file %s: %w", final, err)
+	}
+
+	if abs, err := filepath.Abs(final); err == nil {
+		return abs, nil
+	}
+	return final, nil
+}
+
+// uniquePlanPath builds a non-colliding path for a plan file in `dir`.
+// Same-second titles get a `-1`, `-2`, … suffix so concurrent or rapid
+// Schedule writes do not clobber each other.
+func uniquePlanPath(dir, title string, ts time.Time) (string, error) {
+	slug := slugifyTitle(title)
+	stamp := ts.Format("2006-01-02-150405")
+	base := fmt.Sprintf("%s-%s", stamp, slug)
+
+	candidate := filepath.Join(dir, base+".md")
+	if _, err := os.Stat(candidate); os.IsNotExist(err) {
+		return candidate, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to stat plan path %s: %w", candidate, err)
+	}
+
+	for i := 1; i < 1000; i++ {
+		candidate = filepath.Join(dir, fmt.Sprintf("%s-%d.md", base, i))
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate, nil
+		} else if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("failed to stat plan path %s: %w", candidate, err)
+		}
+	}
+	return "", fmt.Errorf("could not find unique plan filename in %s", dir)
+}
+
+// slugifyTitle converts a free-form title into a lower-case, hyphen-separated
+// slug bounded by maxSlugLength. Falls back to "plan" if the title contains
+// no slug-friendly characters.
+func slugifyTitle(title string) string {
+	lower := strings.ToLower(title)
+	slug := titleSlugRegex.ReplaceAllString(lower, "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		return "plan"
+	}
+	if len(slug) > maxSlugLength {
+		slug = strings.TrimRight(slug[:maxSlugLength], "-")
+		if slug == "" {
+			return "plan"
+		}
+	}
+	return slug
+}
+
+// buildPlanMarkdown wraps the LLM-supplied plan body with an H1 derived from
+// the title. The plan body is preserved verbatim so the model retains full
+// control over the section structure.
+func buildPlanMarkdown(title, plan string) string {
+	var b strings.Builder
+	b.WriteString("# ")
+	b.WriteString(title)
+	b.WriteString("\n\n")
+	b.WriteString(plan)
+	if !strings.HasSuffix(plan, "\n") {
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// planPath safely extracts the persisted-file path from a tool result.
+// Returns "" when the result has no path (e.g. legacy callers).
+func planPath(result *domain.ToolExecutionResult) string {
+	if result == nil || result.Data == nil {
+		return ""
+	}
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		return ""
+	}
+	path, _ := data["path"].(string)
+	return path
 }

--- a/internal/agent/tools/request_plan_approval_test.go
+++ b/internal/agent/tools/request_plan_approval_test.go
@@ -1,0 +1,346 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/inference-gateway/cli/config"
+)
+
+func newPlanToolForTest(t *testing.T) (*RequestPlanApprovalTool, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Prompts: *config.DefaultPromptsConfig(),
+	}
+	cfg.SetConfigDir(tmpDir)
+	tool := NewRequestPlanApprovalTool(cfg)
+	tool.now = func() time.Time {
+		return time.Date(2026, 4, 27, 10, 30, 15, 0, time.UTC)
+	}
+	return tool, tmpDir
+}
+
+func TestRequestPlanApprovalTool_Definition(t *testing.T) {
+	tool, _ := newPlanToolForTest(t)
+	def := tool.Definition()
+
+	if def.Function.Name != "RequestPlanApproval" {
+		t.Errorf("expected name 'RequestPlanApproval', got %s", def.Function.Name)
+	}
+	if def.Function.Description == nil || *def.Function.Description == "" {
+		t.Fatal("expected non-empty description")
+	}
+
+	params := def.Function.Parameters
+	if params == nil {
+		t.Fatal("expected non-nil parameters")
+	}
+
+	required, ok := (*params)["required"].([]string)
+	if !ok {
+		t.Fatalf("expected required to be []string, got %T", (*params)["required"])
+	}
+	wantRequired := map[string]bool{"title": false, "plan": false}
+	for _, name := range required {
+		if _, exists := wantRequired[name]; exists {
+			wantRequired[name] = true
+		}
+	}
+	for name, found := range wantRequired {
+		if !found {
+			t.Errorf("expected %q in required params, got %v", name, required)
+		}
+	}
+
+	props, ok := (*params)["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected properties to be map[string]any, got %T", (*params)["properties"])
+	}
+	for _, name := range []string{"title", "plan"} {
+		if _, exists := props[name]; !exists {
+			t.Errorf("expected property %q in schema", name)
+		}
+	}
+}
+
+func TestRequestPlanApprovalTool_IsEnabled(t *testing.T) {
+	tool, _ := newPlanToolForTest(t)
+	if !tool.IsEnabled() {
+		t.Error("expected RequestPlanApproval to be enabled by default")
+	}
+}
+
+func TestRequestPlanApprovalTool_Validate(t *testing.T) {
+	tool, _ := newPlanToolForTest(t)
+
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr bool
+		errSub  string
+	}{
+		{
+			name:    "valid args",
+			args:    map[string]any{"title": "My Plan", "plan": "## Context\n..."},
+			wantErr: false,
+		},
+		{
+			name:    "missing title",
+			args:    map[string]any{"plan": "body"},
+			wantErr: true,
+			errSub:  "title",
+		},
+		{
+			name:    "non-string title",
+			args:    map[string]any{"title": 42, "plan": "body"},
+			wantErr: true,
+			errSub:  "title",
+		},
+		{
+			name:    "empty title",
+			args:    map[string]any{"title": "   ", "plan": "body"},
+			wantErr: true,
+			errSub:  "title",
+		},
+		{
+			name:    "title with slash",
+			args:    map[string]any{"title": "../etc/passwd", "plan": "body"},
+			wantErr: true,
+			errSub:  "path separators",
+		},
+		{
+			name:    "title with backslash",
+			args:    map[string]any{"title": `bad\title`, "plan": "body"},
+			wantErr: true,
+			errSub:  "path separators",
+		},
+		{
+			name:    "title with parent traversal",
+			args:    map[string]any{"title": "..", "plan": "body"},
+			wantErr: true,
+			errSub:  "path separators",
+		},
+		{
+			name:    "missing plan",
+			args:    map[string]any{"title": "Plan"},
+			wantErr: true,
+			errSub:  "plan",
+		},
+		{
+			name:    "empty plan",
+			args:    map[string]any{"title": "Plan", "plan": "   "},
+			wantErr: true,
+			errSub:  "plan",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tool.Validate(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errSub)
+				}
+				if !strings.Contains(err.Error(), tt.errSub) {
+					t.Errorf("expected error to contain %q, got %v", tt.errSub, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRequestPlanApprovalTool_Execute_WritesFile(t *testing.T) {
+	tool, configDir := newPlanToolForTest(t)
+
+	planBody := "## Context\n\nDo X.\n\n## Verification\n\nRun tests.\n"
+	args := map[string]any{
+		"title": "Add Feature X!",
+		"plan":  planBody,
+	}
+
+	result, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got error: %s", result.Error)
+	}
+
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected Data to be map[string]any, got %T", result.Data)
+	}
+	gotPlan, _ := data["plan"].(string)
+	if !strings.HasPrefix(gotPlan, "# Add Feature X!\n\n") {
+		t.Errorf("expected plan in Data to be the file contents (H1 + body), got %q", gotPlan)
+	}
+	if !strings.Contains(gotPlan, strings.TrimSpace(planBody)) {
+		t.Errorf("expected plan in Data to contain the input plan body, got %q", gotPlan)
+	}
+	if got, _ := data["title"].(string); got != "Add Feature X!" {
+		t.Errorf("title in result Data does not match input, got %q", got)
+	}
+	path, _ := data["path"].(string)
+	if path == "" {
+		t.Fatal("expected non-empty path in result Data")
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected plan file to exist at %s, got %v", path, err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read plan file: %v", err)
+	}
+	got := string(content)
+	if !strings.HasPrefix(got, "# Add Feature X!\n\n") {
+		t.Errorf("expected file to start with H1 from title, got %q", got)
+	}
+	if !strings.Contains(got, "## Context") || !strings.Contains(got, "## Verification") {
+		t.Errorf("expected file to contain plan section headings, got %q", got)
+	}
+	if got != gotPlan {
+		t.Errorf("plan in Data should match file contents byte-for-byte:\nfile=%q\ndata=%q", got, gotPlan)
+	}
+
+	rel, err := filepath.Rel(configDir, path)
+	if err != nil {
+		t.Fatalf("failed to compute relative path: %v", err)
+	}
+	relParts := strings.Split(rel, string(filepath.Separator))
+	if len(relParts) < 2 || relParts[0] != "plans" {
+		t.Errorf("expected plan to be saved under 'plans/', got %s", rel)
+	}
+
+	filename := filepath.Base(path)
+	pattern := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}-\d{6}-[a-z0-9-]+\.md$`)
+	if !pattern.MatchString(filename) {
+		t.Errorf("filename %q does not match expected pattern", filename)
+	}
+}
+
+func TestRequestPlanApprovalTool_Execute_NoTempLeft(t *testing.T) {
+	tool, configDir := newPlanToolForTest(t)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"title": "Atomic Write",
+		"plan":  "body",
+	})
+	if err != nil || !result.Success {
+		t.Fatalf("execute failed: err=%v success=%v error=%s", err, result.Success, result.Error)
+	}
+
+	plansDir := filepath.Join(configDir, "plans")
+	entries, err := os.ReadDir(plansDir)
+	if err != nil {
+		t.Fatalf("failed to read plans dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("found leftover .tmp file: %s", e.Name())
+		}
+	}
+}
+
+func TestRequestPlanApprovalTool_Execute_CreatesPlansDir(t *testing.T) {
+	tool, configDir := newPlanToolForTest(t)
+
+	plansDir := filepath.Join(configDir, "plans")
+	if _, err := os.Stat(plansDir); !os.IsNotExist(err) {
+		t.Fatalf("plans dir unexpectedly exists before Execute: %v", err)
+	}
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"title": "Create Dir",
+		"plan":  "body",
+	})
+	if err != nil || !result.Success {
+		t.Fatalf("execute failed: err=%v error=%s", err, result.Error)
+	}
+
+	info, err := os.Stat(plansDir)
+	if err != nil {
+		t.Fatalf("expected plans dir to be created, got %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected plans dir to be a directory")
+	}
+}
+
+func TestRequestPlanApprovalTool_Execute_HandlesSlugCollision(t *testing.T) {
+	tool, configDir := newPlanToolForTest(t)
+
+	args := map[string]any{
+		"title": "Same Title",
+		"plan":  "body",
+	}
+
+	for i := range 3 {
+		result, err := tool.Execute(context.Background(), args)
+		if err != nil || !result.Success {
+			t.Fatalf("iteration %d failed: err=%v error=%s", i, err, result.Error)
+		}
+	}
+
+	entries, err := os.ReadDir(filepath.Join(configDir, "plans"))
+	if err != nil {
+		t.Fatalf("failed to read plans dir: %v", err)
+	}
+	mdFiles := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") {
+			mdFiles++
+		}
+	}
+	if mdFiles != 3 {
+		t.Errorf("expected 3 distinct plan files after collision handling, got %d", mdFiles)
+	}
+}
+
+func TestSlugifyTitle(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"My Plan", "my-plan"},
+		{"  Add Feature X!  ", "add-feature-x"},
+		{"Already-slugged", "already-slugged"},
+		{"!!!", "plan"},
+		{strings.Repeat("a", 200), strings.Repeat("a", maxSlugLength)},
+		{"unicode 文档 plan", "unicode-plan"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := slugifyTitle(tt.in)
+			if got != tt.want {
+				t.Errorf("slugifyTitle(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPlanMarkdown_AlwaysEndsWithNewline(t *testing.T) {
+	got := buildPlanMarkdown("Title", "body without newline")
+	if !strings.HasSuffix(got, "\n") {
+		t.Error("expected output to end with newline")
+	}
+	if !strings.HasPrefix(got, "# Title\n\n") {
+		t.Errorf("expected H1 prefix, got %q", got)
+	}
+
+	got2 := buildPlanMarkdown("Title", "body with newline\n")
+	if strings.HasSuffix(got2, "\n\n") {
+		t.Error("expected single trailing newline, not double")
+	}
+}

--- a/internal/domain/ui_events.go
+++ b/internal/domain/ui_events.go
@@ -283,3 +283,10 @@ type TriggerGithubActionSetupEvent struct{}
 type ApprovalSelectionChangedEvent struct {
 	NewIndex int
 }
+
+// PlanApprovalSelectionChangedEvent signals that the plan-approval button
+// selection has moved and the conversation viewport needs to re-render so
+// the highlighted button reflects the new index.
+type PlanApprovalSelectionChangedEvent struct {
+	NewIndex int
+}

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -178,6 +178,24 @@ func (h *ChatHandler) Handle(msg tea.Msg) tea.Cmd { // nolint:cyclop,gocyclo,fun
 	return nil
 }
 
+// buildAgentMessagesFromEntries converts conversation entries into the
+// flat slice of SDK messages sent to the model. Plan-mode entries are
+// skipped: they are synthesized assistant messages used for UI rendering
+// only, and their content duplicates the args of the preceding
+// RequestPlanApproval tool call. Including them produces an assistant
+// turn with no `reasoning_content`, which DeepSeek (and similar
+// thinking-mode providers) reject with HTTP 400.
+func buildAgentMessagesFromEntries(entries []domain.ConversationEntry) []sdk.Message {
+	messages := make([]sdk.Message, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsPlan {
+			continue
+		}
+		messages = append(messages, entry.Message)
+	}
+	return messages
+}
+
 func (h *ChatHandler) startChatCompletion() tea.Cmd {
 	return func() tea.Msg {
 		ctx := context.Background()
@@ -192,11 +210,7 @@ func (h *ChatHandler) startChatCompletion() tea.Cmd {
 		}
 
 		entries := h.conversationRepo.GetMessages()
-		originalCount := len(entries)
-		messages := make([]sdk.Message, originalCount)
-		for i, entry := range entries {
-			messages[i] = entry.Message
-		}
+		messages := buildAgentMessagesFromEntries(entries)
 
 		requestID := generateRequestID()
 
@@ -667,17 +681,6 @@ func (h *ChatHandler) HandlePlanApprovalRequestedEvent(
 	msg domain.PlanApprovalRequestedEvent,
 ) tea.Cmd {
 	logger.Info("HandlePlanApprovalRequestedEvent called")
-
-	h.executeOnConversationRepo(
-		func(repo *services.InMemoryConversationRepository) {
-			logger.Info("Marking last message as plan (InMemory)")
-			repo.MarkLastMessageAsPlan()
-		},
-		func(repo *services.PersistentConversationRepository) {
-			logger.Info("Marking last message as plan (Persistent)")
-			repo.MarkLastMessageAsPlan()
-		},
-	)
 
 	h.stateManager.SetupPlanApprovalUIState(msg.PlanContent, msg.ResponseChan)
 

--- a/internal/handlers/chat_handler_test.go
+++ b/internal/handlers/chat_handler_test.go
@@ -8,13 +8,108 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	assert "github.com/stretchr/testify/assert"
 
+	sdk "github.com/inference-gateway/sdk"
+
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	services "github.com/inference-gateway/cli/internal/services"
 	shortcuts "github.com/inference-gateway/cli/internal/shortcuts"
 	mocks "github.com/inference-gateway/cli/tests/mocks/domain"
-	sdk "github.com/inference-gateway/sdk"
 )
+
+// The synthesized plan-mode assistant entry duplicates the args of the
+// preceding RequestPlanApproval tool call and lacks reasoning_content.
+// Sending it on the next turn breaks DeepSeek's thinking-mode contract
+// ("The reasoning_content in the thinking mode must be passed back to
+// the API.") with HTTP 400. The helper below filters those entries out.
+func TestBuildAgentMessagesFromEntries_FiltersPlanEntries(t *testing.T) {
+	planContent := "## Context\nDo X."
+	reasoning := "thought process"
+	planTitle := "Add Feature X"
+
+	entries := []domain.ConversationEntry{
+		{
+			Message: sdk.Message{
+				Role:    sdk.User,
+				Content: sdk.NewMessageContent("Please plan it"),
+			},
+		},
+		{
+			Message: sdk.Message{
+				Role:    sdk.Assistant,
+				Content: sdk.NewMessageContent("Submitting plan"),
+				ToolCalls: &[]sdk.ChatCompletionMessageToolCall{
+					{
+						Id:   "call_1",
+						Type: sdk.Function,
+						Function: sdk.ChatCompletionMessageToolCallFunction{
+							Name:      "RequestPlanApproval",
+							Arguments: `{"title":"` + planTitle + `","plan":"` + planContent + `"}`,
+						},
+					},
+				},
+				Reasoning:        &reasoning,
+				ReasoningContent: &reasoning,
+			},
+			ReasoningContent: reasoning,
+		},
+		{
+			Message: sdk.Message{
+				Role:       sdk.Tool,
+				Content:    sdk.NewMessageContent("Plan approval requested. Plan saved to ..."),
+				ToolCallId: new("call_1"),
+			},
+		},
+		{
+			Message: sdk.Message{
+				Role:    sdk.Assistant,
+				Content: sdk.NewMessageContent(planContent),
+			},
+			IsPlan:             true,
+			PlanApprovalStatus: domain.PlanApprovalAccepted,
+		},
+		{
+			Message: sdk.Message{
+				Role:    sdk.User,
+				Content: sdk.NewMessageContent("The plan has been approved."),
+			},
+			Hidden: true,
+		},
+	}
+
+	out := buildAgentMessagesFromEntries(entries)
+
+	if len(out) != 4 {
+		t.Fatalf("expected 4 messages after filtering plan entry, got %d", len(out))
+	}
+
+	if out[1].Role != sdk.Assistant {
+		t.Errorf("expected message[1] to be the assistant tool-call turn, got role %s", out[1].Role)
+	}
+	if out[1].ReasoningContent == nil || *out[1].ReasoningContent != reasoning {
+		t.Errorf("expected reasoning_content preserved on assistant tool-call turn, got %v", out[1].ReasoningContent)
+	}
+
+	for i, msg := range out {
+		if msg.Role == sdk.Assistant && msg.ToolCalls == nil {
+			content, _ := msg.Content.AsMessageContent0()
+			if strings.Contains(content, "## Context") {
+				t.Errorf("plan-mode synthesized assistant message leaked into request at index %d", i)
+			}
+		}
+	}
+}
+
+func TestBuildAgentMessagesFromEntries_PreservesNonPlanEntries(t *testing.T) {
+	entries := []domain.ConversationEntry{
+		{Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hi")}},
+		{Message: sdk.Message{Role: sdk.Assistant, Content: sdk.NewMessageContent("hello")}},
+	}
+	out := buildAgentMessagesFromEntries(entries)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(out))
+	}
+}
 
 func TestChatHandler_extractMarkdownSummary_BasicCases(t *testing.T) {
 	handler := &ChatHandler{}

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -976,6 +976,8 @@ func (cv *ConversationView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case domain.ApprovalSelectionChangedEvent:
 		return cv.handleApprovalSelectionChanged(msg, cmd)
+	case domain.PlanApprovalSelectionChangedEvent:
+		return cv.handlePlanApprovalSelectionChanged(msg, cmd)
 	case domain.UpdateHistoryEvent:
 		return cv.handleUpdateHistoryEvent(msg, cmd)
 	case domain.ToolCallPreviewEvent, domain.ToolCallUpdateEvent, domain.ToolCallReadyEvent,
@@ -1020,6 +1022,15 @@ func (cv *ConversationView) handleWindowSizeEvents(msg tea.Msg) tea.Cmd {
 
 // handleApprovalSelectionChanged processes approval selection change events
 func (cv *ConversationView) handleApprovalSelectionChanged(msg domain.ApprovalSelectionChangedEvent, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if cv.navigationMode != NavigationModeMessageHistory {
+		cv.updateViewportContent()
+	}
+	return cv, cmd
+}
+
+// handlePlanApprovalSelectionChanged refreshes the conversation viewport so
+// the highlighted plan-approval button reflects the new selection index.
+func (cv *ConversationView) handlePlanApprovalSelectionChanged(_ domain.PlanApprovalSelectionChangedEvent, cmd tea.Cmd) (tea.Model, tea.Cmd) {
 	if cv.navigationMode != NavigationModeMessageHistory {
 		cv.updateViewportContent()
 	}
@@ -1165,54 +1176,62 @@ func (cv *ConversationView) renderToolCommandEntry(_ domain.ConversationEntry, c
 	return message + "\n"
 }
 
-// renderPlanEntry renders a plan entry with inline approval buttons
+// renderPlanEntry renders the plan body as a regular markdown-rendered
+// assistant message under a status-aware header, followed by inline
+// approval buttons while approval is pending.
 func (cv *ConversationView) renderPlanEntry(entry domain.ConversationEntry, index int) string {
 	var result strings.Builder
 
-	var color string
-	var role string
-	switch entry.PlanApprovalStatus {
-	case domain.PlanApprovalPending:
-		color = cv.styleProvider.GetThemeColor("accent")
-		role = "Plan (Pending Approval)"
-	case domain.PlanApprovalAccepted:
-		color = cv.styleProvider.GetThemeColor("success")
-		role = "Plan (Accepted)"
-	case domain.PlanApprovalRejected:
-		color = cv.styleProvider.GetThemeColor("dim")
-		role = "Plan (Rejected)"
-	default:
-		color = cv.getAssistantColor()
-		role = "Plan"
-	}
-
+	color, role := cv.planRoleAndColor(entry)
 	roleStyled := cv.styleProvider.RenderWithColor(role+":", color)
 
-	// Render the plan content
 	contentStr, err := entry.Message.Content.AsMessageContent0()
 	if err != nil {
 		contentStr = formatting.ExtractTextFromContent(entry.Message.Content, entry.Images)
 	}
 
-	var formattedContent string
+	wrapWidth := max(cv.width-2, 40)
 
-	if entry.PlanApprovalStatus == domain.PlanApprovalRejected {
-		plainContent := formatting.FormatResponsiveMessage(contentStr, cv.width)
-		formattedContent = cv.styleProvider.RenderWithColor(plainContent, color)
-	} else if cv.markdownRenderer != nil && !cv.rawFormat {
-		formattedContent = cv.markdownRenderer.Render(contentStr)
-	} else {
-		formattedContent = formatting.FormatResponsiveMessage(contentStr, cv.width)
+	var formattedContent string
+	switch entry.PlanApprovalStatus {
+	case domain.PlanApprovalRejected:
+		plain := formatting.FormatResponsiveMessage(contentStr, wrapWidth)
+		formattedContent = cv.styleProvider.RenderWithColor(plain, color)
+	default:
+		formattedContent = cv.applyMarkdownIfEnabled(contentStr, wrapWidth)
 	}
 
-	result.WriteString(roleStyled + " " + formattedContent + "\n")
+	result.WriteString(roleStyled + "\n\n")
+	for line := range strings.SplitSeq(formattedContent, "\n") {
+		if line == "" {
+			result.WriteString("\n")
+			continue
+		}
+		result.WriteString("  " + line + "\n")
+	}
 
 	if entry.PlanApprovalStatus == domain.PlanApprovalPending {
 		result.WriteString("\n")
 		result.WriteString(cv.renderInlineApprovalButtons(index))
+		result.WriteString("\n")
 	}
 
 	return result.String() + "\n"
+}
+
+// planRoleAndColor returns the role label + theme color for a plan entry
+// based on its approval status.
+func (cv *ConversationView) planRoleAndColor(entry domain.ConversationEntry) (string, string) {
+	switch entry.PlanApprovalStatus {
+	case domain.PlanApprovalPending:
+		return cv.styleProvider.GetThemeColor("accent"), "Plan (Pending Approval)"
+	case domain.PlanApprovalAccepted:
+		return cv.styleProvider.GetThemeColor("success"), "Plan (Accepted)"
+	case domain.PlanApprovalRejected:
+		return cv.styleProvider.GetThemeColor("dim"), "Plan (Rejected)"
+	default:
+		return cv.getAssistantColor(), "Plan"
+	}
 }
 
 // renderInlineApprovalButtons renders inline approval buttons for a plan

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -356,6 +356,15 @@ func (r *Registry) createTextEditingActions() []*KeyAction {
 
 // createHistoryActions creates history navigation key actions
 func (r *Registry) createHistoryActions() []*KeyAction {
+	noApprovalPending := ContextCondition{
+		Name: "no_approval_pending",
+		Check: func(app KeyHandlerContext) bool {
+			stateManager := app.GetStateManager()
+			return stateManager.GetPlanApprovalUIState() == nil &&
+				stateManager.GetApprovalUIState() == nil
+		},
+	}
+
 	return []*KeyAction{
 		{
 			Namespace:   config.NamespaceTextEditing,
@@ -367,7 +376,8 @@ func (r *Registry) createHistoryActions() []*KeyAction {
 			Priority:    200,
 			Enabled:     true,
 			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
+				Views:      []domain.ViewState{domain.ViewStateChat},
+				Conditions: []ContextCondition{noApprovalPending},
 			},
 		},
 		{
@@ -380,7 +390,8 @@ func (r *Registry) createHistoryActions() []*KeyAction {
 			Priority:    200,
 			Enabled:     true,
 			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
+				Views:      []domain.ViewState{domain.ViewStateChat},
+				Conditions: []ContextCondition{noApprovalPending},
 			},
 		},
 	}
@@ -973,7 +984,9 @@ func handleCursorLeftOrPlanNav(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd
 			newIndex = int(domain.PlanApprovalAcceptAndAutoApprove)
 		}
 		stateManager.SetPlanApprovalSelectedIndex(newIndex)
-		return nil
+		return func() tea.Msg {
+			return domain.PlanApprovalSelectionChangedEvent{NewIndex: newIndex}
+		}
 	}
 
 	inputView := app.GetInputView()
@@ -1009,7 +1022,9 @@ func handleCursorRightOrPlanNav(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cm
 			newIndex = 0
 		}
 		stateManager.SetPlanApprovalSelectedIndex(newIndex)
-		return nil
+		return func() tea.Msg {
+			return domain.PlanApprovalSelectionChangedEvent{NewIndex: newIndex}
+		}
 	}
 
 	inputView := app.GetInputView()
@@ -1597,7 +1612,9 @@ func handlePlanApprovalLeft(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 	}
 	stateManager.SetPlanApprovalSelectedIndex(newIndex)
 
-	return func() tea.Msg { return nil }
+	return func() tea.Msg {
+		return domain.PlanApprovalSelectionChangedEvent{NewIndex: newIndex}
+	}
 }
 
 func handlePlanApprovalRight(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
@@ -1613,7 +1630,9 @@ func handlePlanApprovalRight(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 	}
 	stateManager.SetPlanApprovalSelectedIndex(newIndex)
 
-	return func() tea.Msg { return nil }
+	return func() tea.Msg {
+		return domain.PlanApprovalSelectionChangedEvent{NewIndex: newIndex}
+	}
 }
 
 func handlePlanApprovalAccept(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {


### PR DESCRIPTION
## Summary

- Closes #434 — `RequestPlanApproval` now writes the plan to `<configDir>/plans/<timestamp>-<slug>.md` (atomic write) and reads it back as canonical content; the default plan-mode prompt mandates an 8-section H2 template (Context, Files to Modify, Current Code, Changes, Performance Impact, Critical Files, Edge Cases, Verification).
- Fixes several pre-existing plan-mode bugs surfaced during end-to-end testing: dropped `reasoning_content` on the post-approval turn (DeepSeek 400); race that marked the wrong assistant message as `IsPlan`; approval-button navigation didn't refresh the viewport; up/down arrow triggered history navigation while approval was pending; the plan body was rendered with an empty visible region above the buttons.
- Adds `docs/plan-mode.md`, a `RequestPlanApproval` entry in `docs/tools-reference.md`, and a `CLAUDE.md` pointer; adds `plans/` to `.infer/.gitignore` (project + `cmd/init.go` embedded copy).
