### PR TITLE
fix(google): Preserve thought_signature on tool calls and bump response-header timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/inference-gateway/adk v0.17.1
-	github.com/inference-gateway/sdk v1.15.0
+	github.com/inference-gateway/sdk v1.16.0
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/lib/pq v1.12.3
 	github.com/metoro-io/mcp-golang v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inference-gateway/adk v0.17.1 h1:KQ56sObxhOMNiVJ186HUWC2NqdggY0ymqtSFj7o4sjY=
 github.com/inference-gateway/adk v0.17.1/go.mod h1:UbWW5qTu/VzF3mnGTSOJgbyAy6Rz08GH+zI6zhDQUEs=
-github.com/inference-gateway/sdk v1.15.0 h1:1z4vE41sRI/YCwG2fEMvnLU4/hJdbvL9pORkHFvG5wQ=
-github.com/inference-gateway/sdk v1.15.0/go.mod h1:2r2k+E38WtScmJk6e0GYCaUAbm48pH0oXcmIrVu/xhs=
+github.com/inference-gateway/sdk v1.16.0 h1:yzUn42aSyg9EQz3ttRW/eWwTAyiZyl8Qp68jBubBPIg=
+github.com/inference-gateway/sdk v1.16.0/go.mod h1:2r2k+E38WtScmJk6e0GYCaUAbm48pH0oXcmIrVu/xhs=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jezek/xgb v1.3.0 h1:Wa1pn4GVtcmNVAVB6/pnQVJ7xPFZVZ/W1Tc27msDhgI=

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -802,6 +802,28 @@ func TestAgentServiceImpl_AccumulateToolCalls(t *testing.T) {
 				assert.Equal(t, `{"file_path": "/test.txt"}`, result["0"].Function.Arguments)
 			},
 		},
+		{
+			name: "preserves_google_thought_signature_across_chunks",
+			deltas: func() []sdk.ChatCompletionMessageToolCallChunk {
+				sig := "sig-abc-123"
+				first := makeToolCallChunk(0, "call-1", "A2A_QueryAgent", `{"agent_url":`)
+				second := makeToolCallChunk(0, "", "", `"http://localhost:8081"}`)
+				second.ExtraContent = &sdk.ToolCallExtraContent{
+					Google: &sdk.ToolCallExtraContent_Google{ThoughtSignature: &sig},
+				}
+				return []sdk.ChatCompletionMessageToolCallChunk{first, second}
+			}(),
+			expectedCalls: 1,
+			validateResult: func(t *testing.T, result map[string]*sdk.ChatCompletionMessageToolCall) {
+				tc := result["0"]
+				assert.Equal(t, "call-1", tc.Id)
+				assert.Equal(t, `{"agent_url":"http://localhost:8081"}`, tc.Function.Arguments)
+				if assert.NotNil(t, tc.ExtraContent) && assert.NotNil(t, tc.ExtraContent.Google) {
+					assert.NotNil(t, tc.ExtraContent.Google.ThoughtSignature)
+					assert.Equal(t, "sig-abc-123", *tc.ExtraContent.Google.ThoughtSignature)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -43,6 +43,9 @@ func (s *AgentServiceImpl) accumulateToolCalls(deltas []sdk.ChatCompletionMessag
 		if delta.Function.Name != "" && toolCall.Function.Name == "" {
 			toolCall.Function.Name = delta.Function.Name
 		}
+		if delta.ExtraContent != nil {
+			mergeToolCallExtraContent(toolCall, delta.ExtraContent)
+		}
 		if delta.Function.Arguments != "" {
 			if toolCall.Function.Arguments == "" {
 				toolCall.Function.Arguments = delta.Function.Arguments
@@ -54,6 +57,30 @@ func (s *AgentServiceImpl) accumulateToolCalls(deltas []sdk.ChatCompletionMessag
 			}
 
 			toolCall.Function.Arguments += delta.Function.Arguments
+		}
+	}
+}
+
+// mergeToolCallExtraContent copies provider-specific extras (e.g. Google
+// Gemini's thought_signature) from a streaming chunk onto the accumulated
+// tool call. The signature must be echoed back verbatim on the next request,
+// or Google rejects it with HTTP 400 "missing thought_signature".
+func mergeToolCallExtraContent(toolCall *sdk.ChatCompletionMessageToolCall, src *sdk.ToolCallExtraContent) {
+	if toolCall.ExtraContent == nil {
+		toolCall.ExtraContent = &sdk.ToolCallExtraContent{}
+	}
+	if src.Google != nil {
+		if toolCall.ExtraContent.Google == nil {
+			toolCall.ExtraContent.Google = &sdk.ToolCallExtraContent_Google{}
+		}
+		if src.Google.ThoughtSignature != nil && *src.Google.ThoughtSignature != "" {
+			toolCall.ExtraContent.Google.ThoughtSignature = src.Google.ThoughtSignature
+		}
+		for k, v := range src.Google.AdditionalProperties {
+			if toolCall.ExtraContent.Google.AdditionalProperties == nil {
+				toolCall.ExtraContent.Google.AdditionalProperties = map[string]any{}
+			}
+			toolCall.ExtraContent.Google.AdditionalProperties[k] = v
 		}
 	}
 }

--- a/internal/services/gateway_manager.go
+++ b/internal/services/gateway_manager.go
@@ -319,6 +319,7 @@ func (gm *GatewayManager) runContainer(ctx context.Context) error {
 		args = append(args, "-e", fmt.Sprintf("SERVER_WRITE_TIMEOUT=%ds", timeout))
 		args = append(args, "-e", fmt.Sprintf("SERVER_IDLE_TIMEOUT=%ds", timeout))
 		args = append(args, "-e", fmt.Sprintf("CLIENT_TIMEOUT=%ds", timeout))
+		args = append(args, "-e", fmt.Sprintf("CLIENT_RESPONSE_HEADER_TIMEOUT=%ds", timeout))
 	}
 
 	if gm.config.Gateway.VisionEnabled {
@@ -492,6 +493,7 @@ func (gm *GatewayManager) runBinary(binaryPath string) error {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("SERVER_WRITE_TIMEOUT=%ds", timeout))
 		cmd.Env = append(cmd.Env, fmt.Sprintf("SERVER_IDLE_TIMEOUT=%ds", timeout))
 		cmd.Env = append(cmd.Env, fmt.Sprintf("CLIENT_TIMEOUT=%ds", timeout))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("CLIENT_RESPONSE_HEADER_TIMEOUT=%ds", timeout))
 	}
 
 	if gm.config.Gateway.VisionEnabled {


### PR DESCRIPTION
## Summary

- Pull in SDK v1.16.0 and merge `extra_content.google.thought_signature` into accumulated tool calls so it round-trips back to the gateway, fixing Google Gemini extended-thinking models rejecting follow-up turns with `HTTP 400: Function call is missing a thought_signature in functionCall parts`.
- Propagate `CLIENT_RESPONSE_HEADER_TIMEOUT` from `gateway.timeout` in both Docker and local-binary spawn paths - the gateway's HTTP client otherwise defaults to 10s and cuts slow upstream responses off before `CLIENT_TIMEOUT` would fire.
- Add a regression test case (`preserves_google_thought_signature_across_chunks`) for the streaming-chunk merge.

## Background

Gemini-3-Pro and other extended-thinking Gemini models return a per-tool-call `thought_signature` on each function-call part (Google docs: https://ai.google.dev/gemini-api/docs/thought-signatures). Google requires this opaque value to be echoed back on every subsequent request — otherwise it returns `400 INVALID_ARGUMENT`.

The signature lives at `tool_calls[].extra_content.google.thought_signature` in Google's OpenAI-compatible API. The schema/SDK update (released as `inference-gateway/sdk@v1.16.0`) introduces `ChatCompletionMessageToolCall.ExtraContent` so the typed unmarshal preserves the field. This PR is the CLI side: capture it from streaming chunks in `accumulateToolCalls` and let it ride through `ConversationEntry.Message.ToolCalls` on the next outbound request.

The timeout change is independent but discovered during testing - image-generation flows sat 10s+ on the upstream call and the gateway's per-client `ResponseHeaderTimeout` (default 10s) was killing them well before `CLIENT_TIMEOUT` (already configured) had any chance to apply.
