### PR TITLE
feat(logging): Add opt-in stdout output for logger

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -44,6 +44,7 @@ client:
 logging:
   debug: false
   dir: ""
+  stdout: false
 tools:
   enabled: true
   sandbox:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,6 +133,7 @@ func initConfig() {
 	verbose := v.GetBool("verbose")
 	debug := v.GetBool("logging.debug")
 	logDir := v.GetString("logging.dir")
+	stdout := v.GetBool("logging.stdout")
 
 	if logDir == "" {
 		configFile := v.ConfigFileUsed()
@@ -146,5 +147,6 @@ func initConfig() {
 		Verbose: verbose,
 		Debug:   debug,
 		LogDir:  logDir,
+		Stdout:  stdout,
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -94,8 +94,9 @@ type RetryConfig struct {
 
 // LoggingConfig contains logging settings
 type LoggingConfig struct {
-	Debug bool   `yaml:"debug" mapstructure:"debug"`
-	Dir   string `yaml:"dir" mapstructure:"dir"`
+	Debug  bool   `yaml:"debug" mapstructure:"debug"`
+	Dir    string `yaml:"dir" mapstructure:"dir"`
+	Stdout bool   `yaml:"stdout" mapstructure:"stdout"`
 }
 
 // ImageConfig contains image service settings
@@ -581,8 +582,9 @@ func DefaultConfig() *Config { //nolint:funlen
 			},
 		},
 		Logging: LoggingConfig{
-			Debug: false,
-			Dir:   "",
+			Debug:  false,
+			Dir:    "",
+			Stdout: false,
 		},
 		Tools: ToolsConfig{
 			Enabled: true,

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -99,6 +99,8 @@ client:
     retryable_status_codes: [400, 408, 429, 500, 502, 503, 504]
 logging:
   debug: false
+  dir: "" # Override log directory (defaults to <config-dir>/logs)
+  stdout: false # Also write logs to stdout/stderr in addition to the log file
 tools:
   enabled: true # Tools are enabled by default with safe read-only commands
   sandbox:
@@ -278,6 +280,8 @@ compact:
 ### Logging Settings
 
 - **logging.debug**: Enable debug logging for verbose output
+- **logging.dir**: Override the log directory (defaults to `<config-dir>/logs`)
+- **logging.stdout**: Also write logs to stdout/stderr in addition to the log file (default: `false`)
 
 ### Tool Settings
 
@@ -523,6 +527,7 @@ and replacing dots (`.`) with underscores (`_`), then prefixing with `INFER_`.
 
 - `INFER_LOGGING_DEBUG`: Enable debug logging (default: `false`)
 - `INFER_LOGGING_DIR`: Log directory path (default: `.infer/logs`)
+- `INFER_LOGGING_STDOUT`: Also write logs to stdout/stderr (default: `false`)
 
 ### Agent Configuration
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -21,6 +21,7 @@ type Config struct {
 	Verbose bool
 	Debug   bool
 	LogDir  string
+	Stdout  bool
 }
 
 // Init initializes the global logger (for migration period)
@@ -50,6 +51,11 @@ func NewLogger(cfg Config) (*zap.Logger, error) {
 	zapCfg := zap.NewProductionConfig()
 	zapCfg.OutputPaths = []string{logFile}
 	zapCfg.ErrorOutputPaths = []string{logFile}
+
+	if cfg.Stdout {
+		zapCfg.OutputPaths = append(zapCfg.OutputPaths, "stdout")
+		zapCfg.ErrorOutputPaths = append(zapCfg.ErrorOutputPaths, "stderr")
+	}
 
 	if cfg.Verbose || cfg.Debug {
 		zapCfg.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)


### PR DESCRIPTION
## Summary
- Add a new `logging.stdout` config flag (default `false`) that mirrors log output to stdout/stderr alongside the log file
- Plumb the flag through `LoggingConfig` → viper → `logger.Config` → `zap.Config.OutputPaths`/`ErrorOutputPaths`
- Useful for container/daemon environments where tailing the log file is impractical
