### PR TITLE
fix: Reasoning content preservation for thinking-mode providers

### DIFF
--- a/internal/agent/agent_streaming.go
+++ b/internal/agent/agent_streaming.go
@@ -244,6 +244,38 @@ func extractReasoningForEvent(delta sdk.ChatCompletionStreamResponseDelta) strin
 	return ""
 }
 
+// buildAssistantMessage constructs the assistant sdk.Message for a finalized
+// stream turn. Reasoning is preserved whether or not tool calls are present —
+// thinking-mode providers (e.g. Deepseek) reject follow-up requests with HTTP
+// 400 if a prior assistant turn that produced reasoning is replayed without
+// reasoning_content.
+func buildAssistantMessage(
+	content sdk.MessageContent,
+	reasoning string,
+	toolCalls []*sdk.ChatCompletionMessageToolCall,
+) sdk.Message {
+	msg := sdk.Message{
+		Role:    sdk.Assistant,
+		Content: content,
+	}
+
+	if reasoning != "" {
+		r := reasoning
+		msg.Reasoning = &r
+		msg.ReasoningContent = &r
+	}
+
+	if len(toolCalls) > 0 {
+		assistantToolCalls := make([]sdk.ChatCompletionMessageToolCall, 0, len(toolCalls))
+		for _, tc := range toolCalls {
+			assistantToolCalls = append(assistantToolCalls, *tc)
+		}
+		msg.ToolCalls = &assistantToolCalls
+	}
+
+	return msg
+}
+
 // finalizeStream processes the completed stream and transitions to next state
 func (a *EventDrivenAgent) finalizeStream(
 	message sdk.Message,
@@ -266,23 +298,7 @@ func (a *EventDrivenAgent) finalizeStream(
 		reasoning = *message.ReasoningContent
 	}
 
-	assistantMessage := sdk.Message{
-		Role:    sdk.Assistant,
-		Content: assistantContent,
-	}
-
-	if len(toolCalls) > 0 {
-		assistantToolCalls := make([]sdk.ChatCompletionMessageToolCall, 0, len(toolCalls))
-		for _, tc := range toolCalls {
-			assistantToolCalls = append(assistantToolCalls, *tc)
-		}
-		assistantMessage.ToolCalls = &assistantToolCalls
-
-		if reasoning != "" {
-			assistantMessage.Reasoning = &reasoning
-			assistantMessage.ReasoningContent = &reasoning
-		}
-	}
+	assistantMessage := buildAssistantMessage(assistantContent, reasoning, toolCalls)
 
 	*a.agentCtx.Conversation = append(*a.agentCtx.Conversation, assistantMessage)
 

--- a/internal/agent/agent_streaming_test.go
+++ b/internal/agent/agent_streaming_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	sdk "github.com/inference-gateway/sdk"
+)
+
+func TestBuildAssistantMessage(t *testing.T) {
+	toolCall := &sdk.ChatCompletionMessageToolCall{
+		Id:   "call_1",
+		Type: sdk.Function,
+		Function: sdk.ChatCompletionMessageToolCallFunction{
+			Name:      "Bash",
+			Arguments: `{"command":"ls"}`,
+		},
+	}
+
+	tests := []struct {
+		name             string
+		content          sdk.MessageContent
+		reasoning        string
+		toolCalls        []*sdk.ChatCompletionMessageToolCall
+		wantReasoning    bool
+		wantToolCalls    bool
+		wantToolCallsLen int
+	}{
+		{
+			name:          "reasoning without tool calls is preserved",
+			content:       sdk.NewMessageContent("Let me try a different approach."),
+			reasoning:     "the previous command failed because the path was wrong",
+			toolCalls:     nil,
+			wantReasoning: true,
+			wantToolCalls: false,
+		},
+		{
+			name:             "reasoning with tool calls is preserved",
+			content:          sdk.NewMessageContent(""),
+			reasoning:        "I need to list the directory first",
+			toolCalls:        []*sdk.ChatCompletionMessageToolCall{toolCall},
+			wantReasoning:    true,
+			wantToolCalls:    true,
+			wantToolCallsLen: 1,
+		},
+		{
+			name:          "empty reasoning yields nil pointers",
+			content:       sdk.NewMessageContent("hello"),
+			reasoning:     "",
+			toolCalls:     nil,
+			wantReasoning: false,
+			wantToolCalls: false,
+		},
+		{
+			name:             "tool calls without reasoning",
+			content:          sdk.NewMessageContent(""),
+			reasoning:        "",
+			toolCalls:        []*sdk.ChatCompletionMessageToolCall{toolCall},
+			wantReasoning:    false,
+			wantToolCalls:    true,
+			wantToolCallsLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := buildAssistantMessage(tt.content, tt.reasoning, tt.toolCalls)
+
+			assert.Equal(t, sdk.Assistant, msg.Role)
+
+			if tt.wantReasoning {
+				if assert.NotNil(t, msg.Reasoning, "Reasoning should be set") {
+					assert.Equal(t, tt.reasoning, *msg.Reasoning)
+				}
+				if assert.NotNil(t, msg.ReasoningContent, "ReasoningContent should be set") {
+					assert.Equal(t, tt.reasoning, *msg.ReasoningContent)
+				}
+			} else {
+				assert.Nil(t, msg.Reasoning, "Reasoning should be nil when reasoning is empty")
+				assert.Nil(t, msg.ReasoningContent, "ReasoningContent should be nil when reasoning is empty")
+			}
+
+			if tt.wantToolCalls {
+				if assert.NotNil(t, msg.ToolCalls) {
+					assert.Equal(t, tt.wantToolCallsLen, len(*msg.ToolCalls))
+				}
+			} else {
+				assert.Nil(t, msg.ToolCalls)
+			}
+		})
+	}
+}

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -179,21 +179,61 @@ func (h *ChatHandler) Handle(msg tea.Msg) tea.Cmd { // nolint:cyclop,gocyclo,fun
 }
 
 // buildAgentMessagesFromEntries converts conversation entries into the
-// flat slice of SDK messages sent to the model. Plan-mode entries are
-// skipped: they are synthesized assistant messages used for UI rendering
-// only, and their content duplicates the args of the preceding
-// RequestPlanApproval tool call. Including them produces an assistant
-// turn with no `reasoning_content`, which DeepSeek (and similar
-// thinking-mode providers) reject with HTTP 400.
+// flat slice of SDK messages sent to the model.
+//
+// Two classes of entries are filtered:
+//
+//  1. Plan-mode entries (entry.IsPlan): synthesized assistant messages used
+//     for UI rendering only; their content duplicates the args of the
+//     preceding RequestPlanApproval tool call.
+//  2. User-initiated bash entries: synthetic assistant + tool pairs created
+//     when the user types `!command` directly in chat. Their assistant
+//     side has tool_calls but no reasoning_content (the user, not the
+//     model, generated them).
+//
+// Sending either to a thinking-mode provider (DeepSeek, etc.) produces an
+// assistant turn lacking `reasoning_content`, which is rejected with HTTP
+// 400 ("The reasoning_content in the thinking mode must be passed back to
+// the API.").
 func buildAgentMessagesFromEntries(entries []domain.ConversationEntry) []sdk.Message {
 	messages := make([]sdk.Message, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsPlan {
 			continue
 		}
-		messages = append(messages, entry.Message)
+		if isUserInitiatedBashEntry(entry) {
+			continue
+		}
+		msg := entry.Message
+		if entry.ReasoningContent != "" && msg.Reasoning == nil && msg.ReasoningContent == nil {
+			rc := entry.ReasoningContent
+			msg.Reasoning = &rc
+			msg.ReasoningContent = &rc
+		}
+		messages = append(messages, msg)
 	}
 	return messages
+}
+
+// isUserInitiatedBashEntry reports whether the entry was synthesized for a
+// user-typed `!command` shortcut. Tool-call IDs created by that path are
+// prefixed with `user-bash-` (see executeBashCommandImmediate in this file).
+func isUserInitiatedBashEntry(entry domain.ConversationEntry) bool {
+	const userBashPrefix = "user-bash-"
+
+	if entry.Message.ToolCallId != nil && strings.HasPrefix(*entry.Message.ToolCallId, userBashPrefix) {
+		return true
+	}
+
+	if entry.Message.ToolCalls != nil {
+		for _, tc := range *entry.Message.ToolCalls {
+			if strings.HasPrefix(tc.Id, userBashPrefix) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (h *ChatHandler) startChatCompletion() tea.Cmd {

--- a/internal/handlers/chat_handler_test.go
+++ b/internal/handlers/chat_handler_test.go
@@ -111,6 +111,123 @@ func TestBuildAgentMessagesFromEntries_PreservesNonPlanEntries(t *testing.T) {
 	}
 }
 
+// Regression for issue #474: when finalizeStream stored an assistant entry
+// without populating Message.Reasoning (the pre-fix behavior for non-tool-call
+// assistant turns), the rebuilt request would lack reasoning_content and
+// thinking-mode providers (e.g. Deepseek) would 400. The helper now backfills
+// Message.Reasoning/ReasoningContent from the entry's top-level
+// ReasoningContent so legacy entries and any future writers stay safe.
+func TestBuildAgentMessagesFromEntries_BackfillsReasoningFromEntry(t *testing.T) {
+	reasoning := "I should retry with a different path."
+
+	entries := []domain.ConversationEntry{
+		{
+			Message: sdk.Message{
+				Role:    sdk.Assistant,
+				Content: sdk.NewMessageContent("Let me try a different path."),
+			},
+			ReasoningContent: reasoning,
+		},
+	}
+
+	out := buildAgentMessagesFromEntries(entries)
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(out))
+	}
+	if out[0].Reasoning == nil || *out[0].Reasoning != reasoning {
+		t.Errorf("expected Reasoning backfilled to %q, got %v", reasoning, out[0].Reasoning)
+	}
+	if out[0].ReasoningContent == nil || *out[0].ReasoningContent != reasoning {
+		t.Errorf("expected ReasoningContent backfilled to %q, got %v", reasoning, out[0].ReasoningContent)
+	}
+}
+
+// Regression for the second flavor of issue #474: user-typed `!command`
+// shortcuts synthesize an assistant entry (with tool_calls but no
+// reasoning_content) followed by a tool result. Tool-call IDs are prefixed
+// with `user-bash-`. Previously these were sent verbatim to the model and
+// rejected by thinking-mode providers (DeepSeek 400) on the next turn. Both
+// the assistant and the matching tool entry must be filtered.
+func TestBuildAgentMessagesFromEntries_FiltersUserBashEntries(t *testing.T) {
+	userBashID := "user-bash-1234567890"
+
+	entries := []domain.ConversationEntry{
+		{Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("!task lint")}},
+		{
+			Message: sdk.Message{
+				Role:    sdk.Assistant,
+				Content: sdk.NewMessageContent(""),
+				ToolCalls: &[]sdk.ChatCompletionMessageToolCall{
+					{
+						Id:   userBashID,
+						Type: sdk.Function,
+						Function: sdk.ChatCompletionMessageToolCallFunction{
+							Name:      "Bash",
+							Arguments: `{"command":"task lint"}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Message: sdk.Message{
+				Role:       sdk.Tool,
+				Content:    sdk.NewMessageContent("0 issues."),
+				ToolCallId: &userBashID,
+			},
+		},
+		{Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("anything else?")}},
+	}
+
+	out := buildAgentMessagesFromEntries(entries)
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages after filtering user-bash pair, got %d", len(out))
+	}
+	for i, msg := range out {
+		if msg.ToolCalls != nil {
+			for _, tc := range *msg.ToolCalls {
+				if strings.HasPrefix(tc.Id, "user-bash-") {
+					t.Errorf("user-bash tool call leaked into request at message %d", i)
+				}
+			}
+		}
+		if msg.ToolCallId != nil && strings.HasPrefix(*msg.ToolCallId, "user-bash-") {
+			t.Errorf("user-bash tool result leaked into request at message %d", i)
+		}
+	}
+}
+
+func TestBuildAgentMessagesFromEntries_DoesNotOverwriteExistingReasoning(t *testing.T) {
+	existing := "from message"
+	other := "from entry"
+
+	entries := []domain.ConversationEntry{
+		{
+			Message: sdk.Message{
+				Role:             sdk.Assistant,
+				Content:          sdk.NewMessageContent("hello"),
+				Reasoning:        &existing,
+				ReasoningContent: &existing,
+			},
+			ReasoningContent: other,
+		},
+	}
+
+	out := buildAgentMessagesFromEntries(entries)
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(out))
+	}
+	if out[0].Reasoning == nil || *out[0].Reasoning != existing {
+		t.Errorf("expected Reasoning preserved as %q, got %v", existing, out[0].Reasoning)
+	}
+	if out[0].ReasoningContent == nil || *out[0].ReasoningContent != existing {
+		t.Errorf("expected ReasoningContent preserved as %q, got %v", existing, out[0].ReasoningContent)
+	}
+}
+
 func TestChatHandler_extractMarkdownSummary_BasicCases(t *testing.T) {
 	handler := &ChatHandler{}
 


### PR DESCRIPTION
The streaming agent now preserves `reasoning_content` even when no tool calls are present, preventing HTTP 400 errors from thinking-mode providers (e.g. Deepseek).  
The conversation message builder also backfills missing reasoning from the entry's top-level field, fixing a regression where legacy assistant turns would lose their reasoning.

Closes #474 