### PR TITLE
fix(storage): Persist session groups via configured storage backend

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -213,39 +213,7 @@ func (c *ServiceContainer) initializeDomainServices() {
 
 	storageConfig := storage.NewStorageFromConfig(c.config)
 	storageBackend, err := storage.NewStorage(storageConfig)
-	if err != nil {
-		isExplicitStorage := c.config.Storage.Enabled && storageConfig.Type != "memory"
-
-		if isExplicitStorage {
-			logger.Error("Storage backend initialization failed",
-				"error", err,
-				"type", storageConfig.Type,
-				"enabled", c.config.Storage.Enabled)
-			logger.Error("Storage backend '%s' is not available. "+
-				"Either fix the configuration or disable storage by setting 'storage.enabled: false'",
-				storageConfig.Type)
-			panic(fmt.Sprintf("Failed to initialize storage backend '%s': %v\n\n"+
-				"To use in-memory storage instead, set:\n"+
-				"  storage.enabled: false\n\n"+
-				"Or use an alternative storage backend:\n"+
-				"  storage.type: postgres  # or redis", storageConfig.Type, err))
-		}
-
-		logger.Warn("Using in-memory conversation storage (conversations will not be persisted)")
-		c.conversationRepo = services.NewInMemoryConversationRepository(toolFormatterService, c.PricingService())
-	} else {
-		c.storage = storageBackend
-		persistentRepo := services.NewPersistentConversationRepository(toolFormatterService, c.PricingService(), storageBackend)
-		c.conversationRepo = persistentRepo
-		logger.Info("Initialized conversation storage", "type", storageConfig.Type)
-
-		titleClient := c.createRawSDKClient()
-		c.titleGenerator = services.NewConversationTitleGenerator(titleClient, storageBackend, c.config)
-		c.backgroundJobManager = services.NewBackgroundJobManager(c.titleGenerator, c.config)
-
-		persistentRepo.SetTitleGenerator(c.titleGenerator)
-		persistentRepo.SetA2ATaskTracker(c.backgroundTaskRegistry)
-	}
+	groupStore := c.initializeStorageBackend(storageBackend, storageConfig, toolFormatterService, err)
 
 	if c.config.IsClaudeCodeMode() {
 		logger.Info("Using static Claude model list (Claude Code mode)")
@@ -284,6 +252,7 @@ func (c *ServiceContainer) initializeDomainServices() {
 				c.conversationOptimizer,
 				persistentRepo,
 				c.tokenizer,
+				groupStore,
 			)
 		}
 	}
@@ -303,6 +272,70 @@ func (c *ServiceContainer) initializeDomainServices() {
 		c.conversationOptimizer,
 		c.backgroundTaskRegistry,
 	)
+}
+
+// initializeStorageBackend wires the conversation repository for the configured
+// storage backend and returns the matching SessionGroupStorage. When the
+// backend fails to initialize, falls back to in-memory conversation storage
+// (or panics on an explicit, non-default backend so the user gets a clear
+// signal that the configuration is broken).
+func (c *ServiceContainer) initializeStorageBackend(
+	storageBackend storage.ConversationStorage,
+	storageConfig storage.StorageConfig,
+	toolFormatterService *services.ToolFormatterService,
+	err error,
+) storage.SessionGroupStorage {
+	if err != nil {
+		c.handleStorageInitFailure(storageConfig, toolFormatterService, err)
+		return storage.NewMemorySessionGroupStorage()
+	}
+
+	c.storage = storageBackend
+	persistentRepo := services.NewPersistentConversationRepository(toolFormatterService, c.PricingService(), storageBackend)
+	c.conversationRepo = persistentRepo
+	logger.Info("Initialized conversation storage", "type", storageConfig.Type)
+
+	titleClient := c.createRawSDKClient()
+	c.titleGenerator = services.NewConversationTitleGenerator(titleClient, storageBackend, c.config)
+	c.backgroundJobManager = services.NewBackgroundJobManager(c.titleGenerator, c.config)
+
+	persistentRepo.SetTitleGenerator(c.titleGenerator)
+	persistentRepo.SetA2ATaskTracker(c.backgroundTaskRegistry)
+
+	if gs, ok := storageBackend.(storage.SessionGroupStorage); ok {
+		return gs
+	}
+
+	logger.Warn("storage backend does not implement SessionGroupStorage, falling back to in-memory group store",
+		"type", storageConfig.Type)
+	return storage.NewMemorySessionGroupStorage()
+}
+
+// handleStorageInitFailure panics on explicit-backend failure (so the user
+// sees a clear configuration error) and falls back to in-memory conversation
+// storage on the implicit default path.
+func (c *ServiceContainer) handleStorageInitFailure(
+	storageConfig storage.StorageConfig,
+	toolFormatterService *services.ToolFormatterService,
+	err error,
+) {
+	if c.config.Storage.Enabled && storageConfig.Type != "memory" {
+		logger.Error("Storage backend initialization failed",
+			"error", err,
+			"type", storageConfig.Type,
+			"enabled", c.config.Storage.Enabled)
+		logger.Error("Storage backend '%s' is not available. "+
+			"Either fix the configuration or disable storage by setting 'storage.enabled: false'",
+			storageConfig.Type)
+		panic(fmt.Sprintf("Failed to initialize storage backend '%s': %v\n\n"+
+			"To use in-memory storage instead, set:\n"+
+			"  storage.enabled: false\n\n"+
+			"Or use an alternative storage backend:\n"+
+			"  storage.type: postgres  # or redis", storageConfig.Type, err))
+	}
+
+	logger.Warn("Using in-memory conversation storage (conversations will not be persisted)")
+	c.conversationRepo = services.NewInMemoryConversationRepository(toolFormatterService, c.PricingService())
 }
 
 // initializeStateManager creates the state manager before domain services need it

--- a/internal/infra/storage/interfaces.go
+++ b/internal/infra/storage/interfaces.go
@@ -7,6 +7,32 @@ import (
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
+// SessionGroupEntry tracks the active session for a given group key plus a
+// rollover history so old conversations can still be looked up via
+// `infer conversations list`.
+type SessionGroupEntry struct {
+	CurrentSessionID string    `json:"current_session_id"`
+	History          []string  `json:"history,omitempty"`
+	LastRollover     time.Time `json:"last_rollover,omitempty"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+// SessionGroupStorage defines the interface for persisting the session-group
+// index that maps a stable channel/sender key (e.g. "channel-telegram-12345")
+// to the current conversation session UUID for that key.
+type SessionGroupStorage interface {
+	// GetSessionGroup returns the entry for groupKey. The bool is false when
+	// no entry exists; the error is non-nil only on storage failure.
+	GetSessionGroup(ctx context.Context, groupKey string) (SessionGroupEntry, bool, error)
+
+	// PutSessionGroup creates or replaces the entry for groupKey atomically.
+	PutSessionGroup(ctx context.Context, groupKey string, entry SessionGroupEntry) error
+
+	// ListSessionGroups returns all entries keyed by their group key. Used by
+	// administrative tooling and tests.
+	ListSessionGroups(ctx context.Context) (map[string]SessionGroupEntry, error)
+}
+
 // ConversationStorage defines the interface for persistent conversation storage
 type ConversationStorage interface {
 	// SaveConversation saves a conversation with a unique ID

--- a/internal/infra/storage/jsonl.go
+++ b/internal/infra/storage/jsonl.go
@@ -20,6 +20,18 @@ type JsonlStorage struct {
 	mu              sync.RWMutex
 	persistedCounts map[string]int
 	persistedMutex  sync.RWMutex
+	groupIndexMu    sync.Mutex
+}
+
+// sessionGroupsFileName is the on-disk index that maps a "group key" to the
+// current session UUID for that group. The file is kept one level above the
+// JSONL conversations directory so that legacy installs (where it previously
+// lived at <ConfigDirName>/session_groups.json) keep working without
+// migration.
+const sessionGroupsFileName = "session_groups.json"
+
+type sessionGroupIndexFile struct {
+	Groups map[string]SessionGroupEntry `json:"groups"`
 }
 
 // V2 format version constant
@@ -774,4 +786,106 @@ func (s *JsonlStorage) loadV2Format(file *os.File) ([]domain.ConversationEntry, 
 	}
 
 	return entries, metadata, nil
+}
+
+// sessionGroupsPath is the path of the on-disk session-groups index. It lives
+// one directory level above basePath so existing installs (where the file
+// previously lived at <ConfigDirName>/session_groups.json next to the
+// conversations dir) keep working without migration.
+func (s *JsonlStorage) sessionGroupsPath() string {
+	return filepath.Join(filepath.Dir(s.basePath), sessionGroupsFileName)
+}
+
+func (s *JsonlStorage) loadSessionGroupsLocked() (map[string]SessionGroupEntry, error) {
+	data, err := os.ReadFile(s.sessionGroupsPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]SessionGroupEntry), nil
+		}
+		return nil, fmt.Errorf("read session groups index: %w", err)
+	}
+	if len(data) == 0 {
+		return make(map[string]SessionGroupEntry), nil
+	}
+	var idx sessionGroupIndexFile
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("parse session groups index: %w", err)
+	}
+	if idx.Groups == nil {
+		idx.Groups = make(map[string]SessionGroupEntry)
+	}
+	return idx.Groups, nil
+}
+
+func (s *JsonlStorage) saveSessionGroupsLocked(groups map[string]SessionGroupEntry) error {
+	indexPath := s.sessionGroupsPath()
+	if err := os.MkdirAll(filepath.Dir(indexPath), 0o755); err != nil {
+		return fmt.Errorf("create session groups dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(sessionGroupIndexFile{Groups: groups}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal session groups index: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(indexPath), sessionGroupsFileName+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp index file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write temp index file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close temp index file: %w", err)
+	}
+	if err := os.Rename(tmpName, indexPath); err != nil {
+		cleanup()
+		return fmt.Errorf("replace session groups index: %w", err)
+	}
+	return nil
+}
+
+// GetSessionGroup returns the entry for groupKey, or (_, false, nil) if missing.
+func (s *JsonlStorage) GetSessionGroup(_ context.Context, groupKey string) (SessionGroupEntry, bool, error) {
+	s.groupIndexMu.Lock()
+	defer s.groupIndexMu.Unlock()
+
+	groups, err := s.loadSessionGroupsLocked()
+	if err != nil {
+		return SessionGroupEntry{}, false, err
+	}
+	entry, ok := groups[groupKey]
+	if !ok {
+		return SessionGroupEntry{}, false, nil
+	}
+	return entry, true, nil
+}
+
+// PutSessionGroup creates or replaces the entry for groupKey using an atomic
+// temp-file + rename so concurrent agent subprocesses don't see a partially
+// written file.
+func (s *JsonlStorage) PutSessionGroup(_ context.Context, groupKey string, entry SessionGroupEntry) error {
+	s.groupIndexMu.Lock()
+	defer s.groupIndexMu.Unlock()
+
+	groups, err := s.loadSessionGroupsLocked()
+	if err != nil {
+		return err
+	}
+	groups[groupKey] = entry
+	return s.saveSessionGroupsLocked(groups)
+}
+
+// ListSessionGroups returns all entries from the on-disk index.
+func (s *JsonlStorage) ListSessionGroups(_ context.Context) (map[string]SessionGroupEntry, error) {
+	s.groupIndexMu.Lock()
+	defer s.groupIndexMu.Unlock()
+
+	return s.loadSessionGroupsLocked()
 }

--- a/internal/infra/storage/jsonl_test.go
+++ b/internal/infra/storage/jsonl_test.go
@@ -808,3 +808,50 @@ func TestJsonlStorage_ListV2Conversations(t *testing.T) {
 		assert.Equal(t, 2, summary.MessageCount)
 	}
 }
+
+func TestJsonlStorage_SessionGroups_AtomicWrite(t *testing.T) {
+	s, basePath, cleanup := setupTestJsonlStorage(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	_, ok, err := s.GetSessionGroup(ctx, "missing")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, s.PutSessionGroup(ctx, "channel-test", SessionGroupEntry{
+		CurrentSessionID: "id-1",
+		History:          []string{"prev"},
+		LastRollover:     now,
+		UpdatedAt:        now,
+	}))
+	require.NoError(t, s.PutSessionGroup(ctx, "second", SessionGroupEntry{
+		CurrentSessionID: "id-2",
+		UpdatedAt:        now,
+	}))
+
+	indexPath := filepath.Join(filepath.Dir(basePath), "session_groups.json")
+	stat, err := os.Stat(indexPath)
+	require.NoError(t, err)
+	assert.Greater(t, stat.Size(), int64(0))
+
+	dir := filepath.Dir(indexPath)
+	dirEntries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range dirEntries {
+		if strings.HasPrefix(e.Name(), filepath.Base(indexPath)+".tmp-") {
+			t.Errorf("temp file leaked: %s", e.Name())
+		}
+	}
+
+	got, ok, err := s.GetSessionGroup(ctx, "channel-test")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "id-1", got.CurrentSessionID)
+	assert.Equal(t, []string{"prev"}, got.History)
+
+	all, err := s.ListSessionGroups(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+}

--- a/internal/infra/storage/memory.go
+++ b/internal/infra/storage/memory.go
@@ -7,13 +7,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/inference-gateway/cli/internal/domain"
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 // MemoryStorage implements ConversationStorage using in-memory storage
 // This allows conversation history features to work without persistent storage
 type MemoryStorage struct {
 	conversations map[string]conversationData
+	sessionGroups map[string]SessionGroupEntry
 	mutex         sync.RWMutex
 }
 
@@ -26,7 +27,15 @@ type conversationData struct {
 func NewMemoryStorage() *MemoryStorage {
 	return &MemoryStorage{
 		conversations: make(map[string]conversationData),
+		sessionGroups: make(map[string]SessionGroupEntry),
 	}
+}
+
+// NewMemorySessionGroupStorage returns an in-memory SessionGroupStorage. Used
+// as a fallback when conversation storage is disabled but the rollover manager
+// still needs somewhere to keep group state for the lifetime of the process.
+func NewMemorySessionGroupStorage() SessionGroupStorage {
+	return NewMemoryStorage()
 }
 
 // SaveConversation saves a conversation with a unique ID
@@ -146,7 +155,51 @@ func (m *MemoryStorage) Close() error {
 	defer m.mutex.Unlock()
 
 	m.conversations = make(map[string]conversationData)
+	m.sessionGroups = make(map[string]SessionGroupEntry)
 	return nil
+}
+
+// GetSessionGroup returns the entry for groupKey or (_, false, nil) if missing.
+func (m *MemoryStorage) GetSessionGroup(_ context.Context, groupKey string) (SessionGroupEntry, bool, error) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	entry, ok := m.sessionGroups[groupKey]
+	if !ok {
+		return SessionGroupEntry{}, false, nil
+	}
+	return cloneSessionGroupEntry(entry), true, nil
+}
+
+// PutSessionGroup creates or replaces the entry for groupKey.
+func (m *MemoryStorage) PutSessionGroup(_ context.Context, groupKey string, entry SessionGroupEntry) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.sessionGroups[groupKey] = cloneSessionGroupEntry(entry)
+	return nil
+}
+
+// ListSessionGroups returns a copy of all session-group entries.
+func (m *MemoryStorage) ListSessionGroups(_ context.Context) (map[string]SessionGroupEntry, error) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	out := make(map[string]SessionGroupEntry, len(m.sessionGroups))
+	for k, v := range m.sessionGroups {
+		out[k] = cloneSessionGroupEntry(v)
+	}
+	return out, nil
+}
+
+func cloneSessionGroupEntry(entry SessionGroupEntry) SessionGroupEntry {
+	if len(entry.History) == 0 {
+		return entry
+	}
+	historyCopy := make([]string, len(entry.History))
+	copy(historyCopy, entry.History)
+	entry.History = historyCopy
+	return entry
 }
 
 // Health checks if the storage is healthy and reachable

--- a/internal/infra/storage/memory_test.go
+++ b/internal/infra/storage/memory_test.go
@@ -251,3 +251,75 @@ func TestMemoryStorage_Close(t *testing.T) {
 		t.Error("Expected error when loading conversation after Close, but got nil")
 	}
 }
+
+func TestMemoryStorage_SessionGroups(t *testing.T) {
+	s := NewMemoryStorage()
+	ctx := context.Background()
+
+	if _, ok, err := s.GetSessionGroup(ctx, "missing"); err != nil || ok {
+		t.Fatalf("missing group should be (_, false, nil); got ok=%v err=%v", ok, err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	entry := SessionGroupEntry{
+		CurrentSessionID: "id-1",
+		History:          []string{"prev-1", "prev-2"},
+		LastRollover:     now,
+		UpdatedAt:        now,
+	}
+	if err := s.PutSessionGroup(ctx, "channel-test", entry); err != nil {
+		t.Fatalf("PutSessionGroup: %v", err)
+	}
+
+	got, ok, err := s.GetSessionGroup(ctx, "channel-test")
+	if err != nil || !ok {
+		t.Fatalf("expected entry; ok=%v err=%v", ok, err)
+	}
+	if got.CurrentSessionID != "id-1" {
+		t.Errorf("CurrentSessionID: got %q want id-1", got.CurrentSessionID)
+	}
+	if len(got.History) != 2 || got.History[0] != "prev-1" || got.History[1] != "prev-2" {
+		t.Errorf("History: got %v", got.History)
+	}
+
+	got.History[0] = "tampered"
+	again, _, _ := s.GetSessionGroup(ctx, "channel-test")
+	if again.History[0] != "prev-1" {
+		t.Errorf("entry must be cloned on read: got %q", again.History[0])
+	}
+
+	if err := s.PutSessionGroup(ctx, "channel-test", SessionGroupEntry{
+		CurrentSessionID: "id-2", UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("overwrite Put: %v", err)
+	}
+	got, _, _ = s.GetSessionGroup(ctx, "channel-test")
+	if got.CurrentSessionID != "id-2" {
+		t.Errorf("overwrite failed: got %q", got.CurrentSessionID)
+	}
+
+	if err := s.PutSessionGroup(ctx, "second", SessionGroupEntry{
+		CurrentSessionID: "id-3", UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("Put second: %v", err)
+	}
+	all, err := s.ListSessionGroups(ctx)
+	if err != nil {
+		t.Fatalf("ListSessionGroups: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("List should return 2, got %d", len(all))
+	}
+}
+
+func TestNewMemorySessionGroupStorage_StandaloneFallback(t *testing.T) {
+	s := NewMemorySessionGroupStorage()
+	ctx := context.Background()
+
+	if err := s.PutSessionGroup(ctx, "g", SessionGroupEntry{CurrentSessionID: "x", UpdatedAt: time.Now()}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if entry, ok, err := s.GetSessionGroup(ctx, "g"); err != nil || !ok || entry.CurrentSessionID != "x" {
+		t.Errorf("standalone constructor must return a working store; ok=%v err=%v entry=%+v", ok, err, entry)
+	}
+}

--- a/internal/infra/storage/migrations/postgres_migrations.go
+++ b/internal/infra/storage/migrations/postgres_migrations.go
@@ -49,5 +49,21 @@ func GetPostgresMigrations() []Migration {
 				DROP TABLE IF EXISTS conversations;
 			`,
 		},
+		{
+			Version:     "002",
+			Description: "Session groups index for channel-keyed rollover",
+			UpSQL: `
+				CREATE TABLE IF NOT EXISTS session_groups (
+					group_key          TEXT PRIMARY KEY,
+					current_session_id TEXT NOT NULL,
+					history            JSONB NOT NULL DEFAULT '[]'::jsonb,
+					last_rollover      TIMESTAMP WITH TIME ZONE,
+					updated_at         TIMESTAMP WITH TIME ZONE NOT NULL
+				);
+			`,
+			DownSQL: `
+				DROP TABLE IF EXISTS session_groups;
+			`,
+		},
 	}
 }

--- a/internal/infra/storage/migrations/sqlite_migrations.go
+++ b/internal/infra/storage/migrations/sqlite_migrations.go
@@ -32,5 +32,21 @@ func GetSQLiteMigrations() []Migration {
 				DROP TABLE IF EXISTS conversations;
 			`,
 		},
+		{
+			Version:     "002",
+			Description: "Session groups index for channel-keyed rollover",
+			UpSQL: `
+				CREATE TABLE IF NOT EXISTS session_groups (
+					group_key          TEXT PRIMARY KEY,
+					current_session_id TEXT NOT NULL,
+					history            TEXT NOT NULL DEFAULT '[]',
+					last_rollover      DATETIME,
+					updated_at         DATETIME NOT NULL
+				);
+			`,
+			DownSQL: `
+				DROP TABLE IF EXISTS session_groups;
+			`,
+		},
 	}
 }

--- a/internal/infra/storage/postgres.go
+++ b/internal/infra/storage/postgres.go
@@ -416,3 +416,124 @@ func (s *PostgresStorage) Health(ctx context.Context) error {
 
 	return nil
 }
+
+// GetSessionGroup returns the entry for groupKey or (_, false, nil) if missing.
+func (s *PostgresStorage) GetSessionGroup(ctx context.Context, groupKey string) (SessionGroupEntry, bool, error) {
+	const query = `
+		SELECT current_session_id, history, last_rollover, updated_at
+		FROM session_groups
+		WHERE group_key = $1
+	`
+
+	var (
+		currentSessionID string
+		historyJSON      []byte
+		lastRollover     sql.NullTime
+		updatedAt        time.Time
+	)
+
+	err := s.db.QueryRowContext(ctx, query, groupKey).Scan(&currentSessionID, &historyJSON, &lastRollover, &updatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return SessionGroupEntry{}, false, nil
+		}
+		return SessionGroupEntry{}, false, fmt.Errorf("query session group %s: %w", groupKey, err)
+	}
+
+	var history []string
+	if len(historyJSON) > 0 {
+		if err := json.Unmarshal(historyJSON, &history); err != nil {
+			return SessionGroupEntry{}, false, fmt.Errorf("decode history for %s: %w", groupKey, err)
+		}
+	}
+
+	entry := SessionGroupEntry{
+		CurrentSessionID: currentSessionID,
+		History:          history,
+		UpdatedAt:        updatedAt,
+	}
+	if lastRollover.Valid {
+		entry.LastRollover = lastRollover.Time
+	}
+	return entry, true, nil
+}
+
+// PutSessionGroup creates or replaces the entry for groupKey via UPSERT.
+func (s *PostgresStorage) PutSessionGroup(ctx context.Context, groupKey string, entry SessionGroupEntry) error {
+	historyJSON, err := json.Marshal(entry.History)
+	if err != nil {
+		return fmt.Errorf("encode history for %s: %w", groupKey, err)
+	}
+	if len(historyJSON) == 0 || string(historyJSON) == "null" {
+		historyJSON = []byte("[]")
+	}
+
+	var lastRollover any
+	if !entry.LastRollover.IsZero() {
+		lastRollover = entry.LastRollover
+	}
+
+	const query = `
+		INSERT INTO session_groups(group_key, current_session_id, history, last_rollover, updated_at)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (group_key) DO UPDATE SET
+			current_session_id = EXCLUDED.current_session_id,
+			history            = EXCLUDED.history,
+			last_rollover      = EXCLUDED.last_rollover,
+			updated_at         = EXCLUDED.updated_at
+	`
+
+	if _, err := s.db.ExecContext(ctx, query, groupKey, entry.CurrentSessionID, historyJSON, lastRollover, entry.UpdatedAt); err != nil {
+		return fmt.Errorf("upsert session group %s: %w", groupKey, err)
+	}
+	return nil
+}
+
+// ListSessionGroups returns all session-group entries.
+func (s *PostgresStorage) ListSessionGroups(ctx context.Context) (map[string]SessionGroupEntry, error) {
+	const query = `
+		SELECT group_key, current_session_id, history, last_rollover, updated_at
+		FROM session_groups
+	`
+
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list session groups: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]SessionGroupEntry)
+	for rows.Next() {
+		var (
+			groupKey         string
+			currentSessionID string
+			historyJSON      []byte
+			lastRollover     sql.NullTime
+			updatedAt        time.Time
+		)
+		if err := rows.Scan(&groupKey, &currentSessionID, &historyJSON, &lastRollover, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan session group row: %w", err)
+		}
+
+		var history []string
+		if len(historyJSON) > 0 {
+			if err := json.Unmarshal(historyJSON, &history); err != nil {
+				return nil, fmt.Errorf("decode history for %s: %w", groupKey, err)
+			}
+		}
+
+		entry := SessionGroupEntry{
+			CurrentSessionID: currentSessionID,
+			History:          history,
+			UpdatedAt:        updatedAt,
+		}
+		if lastRollover.Valid {
+			entry.LastRollover = lastRollover.Time
+		}
+		out[groupKey] = entry
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate session groups: %w", err)
+	}
+	return out, nil
+}

--- a/internal/infra/storage/redis.go
+++ b/internal/infra/storage/redis.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	redis "github.com/go-redis/redis/v8"
+
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
@@ -416,4 +417,64 @@ func (s *RedisStorage) Health(ctx context.Context) error {
 	s.client.Del(ctx, testKey)
 
 	return nil
+}
+
+// sessionGroupsKey is the Redis hash where session-group entries live, keyed
+// by group key with the JSON-serialized SessionGroupEntry as the value.
+const sessionGroupsKey = "session_groups"
+
+// GetSessionGroup returns the entry for groupKey or (_, false, nil) if missing.
+func (s *RedisStorage) GetSessionGroup(ctx context.Context, groupKey string) (SessionGroupEntry, bool, error) {
+	raw, err := s.client.HGet(ctx, sessionGroupsKey, groupKey).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return SessionGroupEntry{}, false, nil
+		}
+		return SessionGroupEntry{}, false, fmt.Errorf("redis HGET %s/%s: %w", sessionGroupsKey, groupKey, err)
+	}
+
+	var entry SessionGroupEntry
+	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		return SessionGroupEntry{}, false, fmt.Errorf("decode session group %s: %w", groupKey, err)
+	}
+	return entry, true, nil
+}
+
+// PutSessionGroup creates or replaces the entry for groupKey via an atomic
+// HSET. If a TTL is configured for this Redis backend, the TTL is refreshed on
+// the parent hash so the index doesn't outlive the conversation data.
+func (s *RedisStorage) PutSessionGroup(ctx context.Context, groupKey string, entry SessionGroupEntry) error {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encode session group %s: %w", groupKey, err)
+	}
+
+	if err := s.client.HSet(ctx, sessionGroupsKey, groupKey, data).Err(); err != nil {
+		return fmt.Errorf("redis HSET %s/%s: %w", sessionGroupsKey, groupKey, err)
+	}
+
+	if s.ttl > 0 {
+		if err := s.client.Expire(ctx, sessionGroupsKey, s.ttl).Err(); err != nil {
+			return fmt.Errorf("redis EXPIRE %s: %w", sessionGroupsKey, err)
+		}
+	}
+	return nil
+}
+
+// ListSessionGroups returns all entries from the session-groups hash.
+func (s *RedisStorage) ListSessionGroups(ctx context.Context) (map[string]SessionGroupEntry, error) {
+	raw, err := s.client.HGetAll(ctx, sessionGroupsKey).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis HGETALL %s: %w", sessionGroupsKey, err)
+	}
+
+	out := make(map[string]SessionGroupEntry, len(raw))
+	for k, v := range raw {
+		var entry SessionGroupEntry
+		if err := json.Unmarshal([]byte(v), &entry); err != nil {
+			return nil, fmt.Errorf("decode session group %s: %w", k, err)
+		}
+		out[k] = entry
+	}
+	return out, nil
 }

--- a/internal/infra/storage/sqlite.go
+++ b/internal/infra/storage/sqlite.go
@@ -427,3 +427,124 @@ func (s *SQLiteStorage) Health(ctx context.Context) error {
 
 	return nil
 }
+
+// GetSessionGroup returns the entry for groupKey or (_, false, nil) if missing.
+func (s *SQLiteStorage) GetSessionGroup(ctx context.Context, groupKey string) (SessionGroupEntry, bool, error) {
+	const query = `
+		SELECT current_session_id, history, last_rollover, updated_at
+		FROM session_groups
+		WHERE group_key = ?
+	`
+
+	var (
+		currentSessionID string
+		historyJSON      string
+		lastRollover     sql.NullTime
+		updatedAt        time.Time
+	)
+
+	err := s.db.QueryRowContext(ctx, query, groupKey).Scan(&currentSessionID, &historyJSON, &lastRollover, &updatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return SessionGroupEntry{}, false, nil
+		}
+		return SessionGroupEntry{}, false, fmt.Errorf("query session group %s: %w", groupKey, err)
+	}
+
+	var history []string
+	if historyJSON != "" {
+		if err := json.Unmarshal([]byte(historyJSON), &history); err != nil {
+			return SessionGroupEntry{}, false, fmt.Errorf("decode history for %s: %w", groupKey, err)
+		}
+	}
+
+	entry := SessionGroupEntry{
+		CurrentSessionID: currentSessionID,
+		History:          history,
+		UpdatedAt:        updatedAt,
+	}
+	if lastRollover.Valid {
+		entry.LastRollover = lastRollover.Time
+	}
+	return entry, true, nil
+}
+
+// PutSessionGroup creates or replaces the entry for groupKey via UPSERT.
+func (s *SQLiteStorage) PutSessionGroup(ctx context.Context, groupKey string, entry SessionGroupEntry) error {
+	historyJSON, err := json.Marshal(entry.History)
+	if err != nil {
+		return fmt.Errorf("encode history for %s: %w", groupKey, err)
+	}
+	if len(historyJSON) == 0 || string(historyJSON) == "null" {
+		historyJSON = []byte("[]")
+	}
+
+	var lastRollover any
+	if !entry.LastRollover.IsZero() {
+		lastRollover = entry.LastRollover
+	}
+
+	const query = `
+		INSERT INTO session_groups(group_key, current_session_id, history, last_rollover, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(group_key) DO UPDATE SET
+			current_session_id = excluded.current_session_id,
+			history            = excluded.history,
+			last_rollover      = excluded.last_rollover,
+			updated_at         = excluded.updated_at
+	`
+
+	if _, err := s.db.ExecContext(ctx, query, groupKey, entry.CurrentSessionID, string(historyJSON), lastRollover, entry.UpdatedAt); err != nil {
+		return fmt.Errorf("upsert session group %s: %w", groupKey, err)
+	}
+	return nil
+}
+
+// ListSessionGroups returns all session-group entries.
+func (s *SQLiteStorage) ListSessionGroups(ctx context.Context) (map[string]SessionGroupEntry, error) {
+	const query = `
+		SELECT group_key, current_session_id, history, last_rollover, updated_at
+		FROM session_groups
+	`
+
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list session groups: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]SessionGroupEntry)
+	for rows.Next() {
+		var (
+			groupKey         string
+			currentSessionID string
+			historyJSON      string
+			lastRollover     sql.NullTime
+			updatedAt        time.Time
+		)
+		if err := rows.Scan(&groupKey, &currentSessionID, &historyJSON, &lastRollover, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan session group row: %w", err)
+		}
+
+		var history []string
+		if historyJSON != "" {
+			if err := json.Unmarshal([]byte(historyJSON), &history); err != nil {
+				return nil, fmt.Errorf("decode history for %s: %w", groupKey, err)
+			}
+		}
+
+		entry := SessionGroupEntry{
+			CurrentSessionID: currentSessionID,
+			History:          history,
+			UpdatedAt:        updatedAt,
+		}
+		if lastRollover.Valid {
+			entry.LastRollover = lastRollover.Time
+		}
+		out[groupKey] = entry
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate session groups: %w", err)
+	}
+	return out, nil
+}

--- a/internal/infra/storage/sqlite_test.go
+++ b/internal/infra/storage/sqlite_test.go
@@ -252,3 +252,55 @@ func createTestMetadata(id string) ConversationMetadata {
 		Tags:  []string{"test", "demo"},
 	}
 }
+
+func TestSQLiteStorage_SessionGroups(t *testing.T) {
+	s, cleanup := setupTestStorage(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	_, ok, err := s.GetSessionGroup(ctx, "missing")
+	require.NoError(t, err)
+	assert.False(t, ok, "missing key must report not-found")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	entry := SessionGroupEntry{
+		CurrentSessionID: "uuid-1",
+		History:          []string{"prev-a", "prev-b"},
+		LastRollover:     now,
+		UpdatedAt:        now,
+	}
+	require.NoError(t, s.PutSessionGroup(ctx, "channel-telegram-42", entry))
+
+	got, ok, err := s.GetSessionGroup(ctx, "channel-telegram-42")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "uuid-1", got.CurrentSessionID)
+	assert.Equal(t, []string{"prev-a", "prev-b"}, got.History)
+	assert.WithinDuration(t, now, got.UpdatedAt, time.Second)
+	assert.WithinDuration(t, now, got.LastRollover, time.Second)
+
+	require.NoError(t, s.PutSessionGroup(ctx, "channel-telegram-42", SessionGroupEntry{
+		CurrentSessionID: "uuid-2",
+		History:          []string{"prev-a", "prev-b", "uuid-1"},
+		UpdatedAt:        now,
+	}))
+
+	got, ok, err = s.GetSessionGroup(ctx, "channel-telegram-42")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "uuid-2", got.CurrentSessionID)
+	assert.Equal(t, []string{"prev-a", "prev-b", "uuid-1"}, got.History)
+	assert.True(t, got.LastRollover.IsZero(), "LastRollover must be cleared when UPSERT supplies zero value")
+
+	require.NoError(t, s.PutSessionGroup(ctx, "second", SessionGroupEntry{
+		CurrentSessionID: "uuid-3",
+		UpdatedAt:        now,
+	}))
+	all, err := s.ListSessionGroups(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+	assert.Equal(t, "uuid-2", all["channel-telegram-42"].CurrentSessionID)
+	assert.Equal(t, "uuid-3", all["second"].CurrentSessionID)
+	assert.True(t, all["second"].LastRollover.IsZero())
+}

--- a/internal/services/session_rollover_manager.go
+++ b/internal/services/session_rollover_manager.go
@@ -2,11 +2,8 @@ package services
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -15,80 +12,51 @@ import (
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	storage "github.com/inference-gateway/cli/internal/infra/storage"
 	logger "github.com/inference-gateway/cli/internal/logger"
 	models "github.com/inference-gateway/cli/internal/models"
 )
-
-// sessionGroupsFileName is the on-disk index that maps a "group key" (any
-// non-UUID identifier such as "channel-telegram-6312551834") to the current
-// session UUID for that group. The file lives next to the conversations
-// directory at <project>/.infer/session_groups.json.
-const sessionGroupsFileName = "session_groups.json"
-
-// SessionGroupEntry tracks the active session for a given group key plus a
-// rollover history so old conversations can still be looked up via
-// `infer conversations list`.
-type SessionGroupEntry struct {
-	CurrentSessionID string    `json:"current_session_id"`
-	History          []string  `json:"history,omitempty"`
-	LastRollover     time.Time `json:"last_rollover,omitempty"`
-	UpdatedAt        time.Time `json:"updated_at"`
-}
-
-// sessionGroupIndex is the on-disk schema for session_groups.json.
-type sessionGroupIndex struct {
-	Groups map[string]SessionGroupEntry `json:"groups"`
-}
 
 // SessionRolloverManager decides when to roll over a long-running conversation
 // into a new file (matching the chat-mode `/compact` behavior) and exposes the
 // machinery to perform that rollover. It also resolves "group key" inputs from
 // the channel manager (e.g. `channel-telegram-XYZ`) to the current session UUID
-// via a small JSON index, so callers like the channel manager can keep using a
-// stable, deterministic identifier without worrying about which physical
-// session it points at right now.
+// via the configured SessionGroupStorage backend, so callers like the channel
+// manager can keep using a stable, deterministic identifier without worrying
+// about which physical session it points at right now.
 type SessionRolloverManager struct {
 	cfg        *config.Config
 	optimizer  domain.ConversationOptimizer
 	repo       *PersistentConversationRepository
 	tokenizer  *TokenizerService
-	indexPath  string
+	groupStore storage.SessionGroupStorage
 	indexMutex sync.Mutex
 }
 
 // NewSessionRolloverManager constructs a manager. The optimizer is required for
 // PerformRollover to work; if it's nil, ShouldRollover always returns false and
 // PerformRollover returns an error. This mirrors how the chat-mode /compact
-// shortcut behaves when the optimizer is disabled.
+// shortcut behaves when the optimizer is disabled. groupStore is required for
+// non-UUID session-id resolution; if it is nil, group-keyed lookups will fall
+// back to passing the raw id through.
 func NewSessionRolloverManager(
 	cfg *config.Config,
 	optimizer domain.ConversationOptimizer,
 	repo *PersistentConversationRepository,
 	tokenizer *TokenizerService,
+	groupStore storage.SessionGroupStorage,
 ) *SessionRolloverManager {
-	indexPath := filepath.Join(config.ConfigDirName, sessionGroupsFileName)
-	if abs, err := filepath.Abs(indexPath); err == nil {
-		indexPath = abs
-	}
-
 	if tokenizer == nil {
 		tokenizer = NewTokenizerService(DefaultTokenizerConfig())
 	}
 
 	return &SessionRolloverManager{
-		cfg:       cfg,
-		optimizer: optimizer,
-		repo:      repo,
-		tokenizer: tokenizer,
-		indexPath: indexPath,
+		cfg:        cfg,
+		optimizer:  optimizer,
+		repo:       repo,
+		tokenizer:  tokenizer,
+		groupStore: groupStore,
 	}
-}
-
-// SetIndexPath overrides the index file location. Used by tests.
-func (m *SessionRolloverManager) SetIndexPath(path string) {
-	m.indexMutex.Lock()
-	defer m.indexMutex.Unlock()
-	m.indexPath = path
 }
 
 // ResolveSessionID maps a raw --session-id value to the conversation ID that
@@ -96,14 +64,14 @@ func (m *SessionRolloverManager) SetIndexPath(path string) {
 //
 //   - If rawID parses as a UUID, it is treated as a literal session ID and
 //     returned unchanged with an empty groupKey.
-//   - Otherwise it is treated as a group key. The index file is consulted: if
-//     the group exists, its current_session_id is returned; if it does not,
-//     the group is registered with rawID as its initial current_session_id
-//     (this is the migration path for existing channel JSONL files named
-//     after the deterministic group key).
+//   - Otherwise it is treated as a group key. The configured SessionGroupStorage
+//     is consulted: if the group exists, its current_session_id is returned; if
+//     it does not, the group is registered with rawID as its initial
+//     current_session_id (this is the migration path for existing channel JSONL
+//     files named after the deterministic group key).
 //
 // Returns (sessionID, groupKey, error). On any error reading/writing the
-// index, the function logs a warning and falls back to passing rawID through
+// store, the function logs a warning and falls back to passing rawID through
 // unchanged so the agent can still run.
 func (m *SessionRolloverManager) ResolveSessionID(rawID string) (string, string, error) {
 	if rawID == "" {
@@ -112,27 +80,32 @@ func (m *SessionRolloverManager) ResolveSessionID(rawID string) (string, string,
 	if _, err := uuid.Parse(rawID); err == nil {
 		return rawID, "", nil
 	}
+	if m.groupStore == nil {
+		logger.Warn("session group storage is not configured, using raw id", "raw_id", rawID)
+		return rawID, rawID, nil
+	}
 
 	groupKey := rawID
+	ctx := context.Background()
 
 	m.indexMutex.Lock()
 	defer m.indexMutex.Unlock()
 
-	idx, err := m.loadIndexLocked()
+	entry, found, err := m.groupStore.GetSessionGroup(ctx, groupKey)
 	if err != nil {
-		logger.Warn("failed to load session groups index, using raw id", "error", err, "raw_id", rawID)
+		logger.Warn("failed to load session group, using raw id", "error", err, "raw_id", rawID)
 		return rawID, groupKey, nil
 	}
 
-	if entry, ok := idx.Groups[groupKey]; ok && entry.CurrentSessionID != "" {
+	if found && entry.CurrentSessionID != "" {
 		return entry.CurrentSessionID, groupKey, nil
 	}
 
-	idx.Groups[groupKey] = SessionGroupEntry{
+	newEntry := storage.SessionGroupEntry{
 		CurrentSessionID: rawID,
 		UpdatedAt:        time.Now(),
 	}
-	if err := m.saveIndexAtomicLocked(idx); err != nil {
+	if err := m.groupStore.PutSessionGroup(ctx, groupKey, newEntry); err != nil {
 		logger.Warn("failed to register session group, using raw id", "error", err, "group", groupKey)
 	}
 
@@ -225,8 +198,8 @@ func (m *SessionRolloverManager) tokenTriggerFires(entries []domain.Conversation
 
 // PerformRollover runs the optimizer with force=true to produce a summary,
 // calls StartNewConversation on the repo to begin a fresh conversation file,
-// re-adds the summarized messages, and (if groupKey != "") updates the index
-// to point the group at the new session ID.
+// re-adds the summarized messages, and (if groupKey != "") updates the
+// configured SessionGroupStorage to point the group at the new session ID.
 //
 // This mirrors performCompactAsync in chat_shortcut_handler.go:510-615 — same
 // optimizer call, same StartNewConversation call, same AddMessage loop.
@@ -293,7 +266,7 @@ func (m *SessionRolloverManager) PerformRollover(ctx context.Context, model, gro
 	}
 
 	if groupKey != "" {
-		if err := m.updateGroupIndex(groupKey, newID, originalID); err != nil {
+		if err := m.updateGroupIndex(ctx, groupKey, newID, originalID); err != nil {
 			logger.Warn("failed to update session groups index", "error", err, "group", groupKey)
 		}
 	}
@@ -307,85 +280,26 @@ func (m *SessionRolloverManager) PerformRollover(ctx context.Context, model, gro
 }
 
 // updateGroupIndex sets the group's current_session_id to newID and appends
-// the previous ID to the history. Acquires the index mutex.
-func (m *SessionRolloverManager) updateGroupIndex(groupKey, newID, previousID string) error {
+// the previous ID to the history.
+func (m *SessionRolloverManager) updateGroupIndex(ctx context.Context, groupKey, newID, previousID string) error {
+	if m.groupStore == nil {
+		return errors.New("session group storage is not configured")
+	}
+
 	m.indexMutex.Lock()
 	defer m.indexMutex.Unlock()
 
-	idx, err := m.loadIndexLocked()
+	entry, _, err := m.groupStore.GetSessionGroup(ctx, groupKey)
 	if err != nil {
 		return err
 	}
 
-	entry := idx.Groups[groupKey]
 	if previousID != "" && previousID != newID {
 		entry.History = append(entry.History, previousID)
 	}
 	entry.CurrentSessionID = newID
 	entry.LastRollover = time.Now()
 	entry.UpdatedAt = time.Now()
-	idx.Groups[groupKey] = entry
 
-	return m.saveIndexAtomicLocked(idx)
-}
-
-// loadIndexLocked reads and parses the index file. Returns an empty index if
-// the file does not exist. Caller must hold indexMutex.
-func (m *SessionRolloverManager) loadIndexLocked() (*sessionGroupIndex, error) {
-	data, err := os.ReadFile(m.indexPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return &sessionGroupIndex{Groups: make(map[string]SessionGroupEntry)}, nil
-		}
-		return nil, fmt.Errorf("read session groups index: %w", err)
-	}
-
-	var idx sessionGroupIndex
-	if len(data) == 0 {
-		return &sessionGroupIndex{Groups: make(map[string]SessionGroupEntry)}, nil
-	}
-	if err := json.Unmarshal(data, &idx); err != nil {
-		return nil, fmt.Errorf("parse session groups index: %w", err)
-	}
-	if idx.Groups == nil {
-		idx.Groups = make(map[string]SessionGroupEntry)
-	}
-	return &idx, nil
-}
-
-// saveIndexAtomicLocked writes the index to a temp file in the same directory
-// then renames it over the target. This avoids corrupting the index if two
-// agent subprocesses race on the same file. Caller must hold indexMutex.
-func (m *SessionRolloverManager) saveIndexAtomicLocked(idx *sessionGroupIndex) error {
-	if err := os.MkdirAll(filepath.Dir(m.indexPath), 0o755); err != nil {
-		return fmt.Errorf("create session groups dir: %w", err)
-	}
-
-	data, err := json.MarshalIndent(idx, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal session groups index: %w", err)
-	}
-
-	tmp, err := os.CreateTemp(filepath.Dir(m.indexPath), sessionGroupsFileName+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("create temp index file: %w", err)
-	}
-	tmpName := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpName) }
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return fmt.Errorf("write temp index file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return fmt.Errorf("close temp index file: %w", err)
-	}
-
-	if err := os.Rename(tmpName, m.indexPath); err != nil {
-		cleanup()
-		return fmt.Errorf("replace session groups index: %w", err)
-	}
-	return nil
+	return m.groupStore.PutSessionGroup(ctx, groupKey, entry)
 }

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -2,9 +2,6 @@ package services
 
 import (
 	"context"
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -47,7 +44,7 @@ func (f *fakeOptimizer) OptimizeMessages(messages []sdk.Message, model string, f
 	return out
 }
 
-func newRolloverManagerForTest(t *testing.T, autoAt int, idleMin int) (*SessionRolloverManager, *PersistentConversationRepository, *fakeOptimizer, func()) {
+func newRolloverManagerForTest(t *testing.T, autoAt int, idleMin int) (*SessionRolloverManager, *PersistentConversationRepository, *fakeOptimizer, storage.SessionGroupStorage, func()) {
 	t.Helper()
 
 	storageBackend, err := storage.NewSQLiteStorage(storage.SQLiteConfig{Path: ":memory:"})
@@ -64,15 +61,14 @@ func newRolloverManagerForTest(t *testing.T, autoAt int, idleMin int) (*SessionR
 
 	opt := &fakeOptimizer{returnCount: 2}
 
-	tmpDir := t.TempDir()
-	mgr := NewSessionRolloverManager(cfg, opt, repo, NewTokenizerService(DefaultTokenizerConfig()))
-	mgr.SetIndexPath(filepath.Join(tmpDir, "session_groups.json"))
+	groupStore := storage.NewMemorySessionGroupStorage()
+	mgr := NewSessionRolloverManager(cfg, opt, repo, NewTokenizerService(DefaultTokenizerConfig()), groupStore)
 
 	cleanup := func() {
 		_ = repo.Close()
 		_ = storageBackend.Close()
 	}
-	return mgr, repo, opt, cleanup
+	return mgr, repo, opt, groupStore, cleanup
 }
 
 func addUserMessage(t *testing.T, repo *PersistentConversationRepository, content string, when time.Time) {
@@ -90,7 +86,7 @@ func addUserMessage(t *testing.T, repo *PersistentConversationRepository, conten
 }
 
 func TestResolveSessionID_UUIDPassthrough(t *testing.T) {
-	mgr, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, _, _, groupStore, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	literal := uuid.New().String()
@@ -105,13 +101,17 @@ func TestResolveSessionID_UUIDPassthrough(t *testing.T) {
 		t.Errorf("UUID input should produce empty group key, got %q", group)
 	}
 
-	if _, err := os.Stat(mgr.indexPath); err == nil {
-		t.Errorf("UUID passthrough must not create index file")
+	all, err := groupStore.ListSessionGroups(context.Background())
+	if err != nil {
+		t.Fatalf("ListSessionGroups: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("UUID passthrough must not register any group entries; got %d", len(all))
 	}
 }
 
 func TestResolveSessionID_GroupKeyMigration(t *testing.T) {
-	mgr, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, _, _, groupStore, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	got, group, err := mgr.ResolveSessionID("channel-telegram-12345")
@@ -125,15 +125,10 @@ func TestResolveSessionID_GroupKeyMigration(t *testing.T) {
 		t.Errorf("group key should be set, got %q", group)
 	}
 
-	data, err := os.ReadFile(mgr.indexPath)
+	entry, ok, err := groupStore.GetSessionGroup(context.Background(), "channel-telegram-12345")
 	if err != nil {
-		t.Fatalf("expected index file to be created: %v", err)
+		t.Fatalf("GetSessionGroup: %v", err)
 	}
-	var idx sessionGroupIndex
-	if err := json.Unmarshal(data, &idx); err != nil {
-		t.Fatalf("parse index: %v", err)
-	}
-	entry, ok := idx.Groups["channel-telegram-12345"]
 	if !ok {
 		t.Fatalf("group should be registered after first lookup")
 	}
@@ -143,25 +138,19 @@ func TestResolveSessionID_GroupKeyMigration(t *testing.T) {
 }
 
 func TestResolveSessionID_GroupKeyAfterRollover(t *testing.T) {
-	mgr, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, _, _, groupStore, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	// Pre-populate the index as if a rollover has already happened.
 	rolledOverID := uuid.New().String()
-	mgr.indexMutex.Lock()
-	idx := &sessionGroupIndex{Groups: map[string]SessionGroupEntry{
-		"channel-telegram-12345": {
-			CurrentSessionID: rolledOverID,
-			History:          []string{"channel-telegram-12345"},
-			LastRollover:     time.Now(),
-			UpdatedAt:        time.Now(),
-		},
-	}}
-	if err := mgr.saveIndexAtomicLocked(idx); err != nil {
-		mgr.indexMutex.Unlock()
+	if err := groupStore.PutSessionGroup(context.Background(), "channel-telegram-12345", storage.SessionGroupEntry{
+		CurrentSessionID: rolledOverID,
+		History:          []string{"channel-telegram-12345"},
+		LastRollover:     time.Now(),
+		UpdatedAt:        time.Now(),
+	}); err != nil {
 		t.Fatalf("seed index: %v", err)
 	}
-	mgr.indexMutex.Unlock()
 
 	got, group, err := mgr.ResolveSessionID("channel-telegram-12345")
 	if err != nil {
@@ -176,7 +165,7 @@ func TestResolveSessionID_GroupKeyAfterRollover(t *testing.T) {
 }
 
 func TestShouldRollover_EmptyConversation(t *testing.T) {
-	mgr, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, _, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	if mgr.ShouldRollover("openai/gpt-4") {
@@ -185,7 +174,7 @@ func TestShouldRollover_EmptyConversation(t *testing.T) {
 }
 
 func TestShouldRollover_IdleTriggerFires(t *testing.T) {
-	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	addUserMessage(t, repo, "old message", time.Now().Add(-31*time.Minute))
@@ -196,7 +185,7 @@ func TestShouldRollover_IdleTriggerFires(t *testing.T) {
 }
 
 func TestShouldRollover_IdleTriggerDoesNotFireUnderThreshold(t *testing.T) {
-	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	addUserMessage(t, repo, "recent", time.Now().Add(-5*time.Minute))
@@ -207,7 +196,7 @@ func TestShouldRollover_IdleTriggerDoesNotFireUnderThreshold(t *testing.T) {
 }
 
 func TestShouldRollover_IdleDisabledByZero(t *testing.T) {
-	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 0)
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
 	defer cleanup()
 
 	addUserMessage(t, repo, "old", time.Now().Add(-24*time.Hour))
@@ -218,7 +207,7 @@ func TestShouldRollover_IdleDisabledByZero(t *testing.T) {
 }
 
 func TestShouldRollover_TokenTriggerFires(t *testing.T) {
-	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 0)
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
 	defer cleanup()
 
 	// Use a model with a tiny context window so we can blow past 80% with a
@@ -235,7 +224,7 @@ func TestShouldRollover_TokenTriggerFires(t *testing.T) {
 }
 
 func TestShouldRollover_TokenTriggerFiresFromLastInputTokens(t *testing.T) {
-	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 0)
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
 	defer cleanup()
 
 	// One short message — entries-only estimate is far below the threshold.
@@ -254,7 +243,7 @@ func TestShouldRollover_TokenTriggerFiresFromLastInputTokens(t *testing.T) {
 }
 
 func TestShouldRollover_TokenTriggerDoesNotFireWhenLastInputBelowThreshold(t *testing.T) {
-	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 0)
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
 	defer cleanup()
 
 	// Large entries that *would* trip the entries-only fallback…
@@ -276,7 +265,7 @@ func TestShouldRollover_TokenTriggerDoesNotFireWhenLastInputBelowThreshold(t *te
 }
 
 func TestShouldRollover_DisabledWhenCompactOff(t *testing.T) {
-	mgr, repo, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 	mgr.cfg.Compact.Enabled = false
 
@@ -288,7 +277,7 @@ func TestShouldRollover_DisabledWhenCompactOff(t *testing.T) {
 }
 
 func TestPerformRollover_CreatesNewSessionAndUpdatesIndex(t *testing.T) {
-	mgr, repo, opt, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, repo, opt, groupStore, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	// Seed the group index so PerformRollover has a known initial state.
@@ -320,13 +309,13 @@ func TestPerformRollover_CreatesNewSessionAndUpdatesIndex(t *testing.T) {
 	}
 
 	// Index should now reflect the rollover.
-	mgr.indexMutex.Lock()
-	idx, err := mgr.loadIndexLocked()
-	mgr.indexMutex.Unlock()
+	entry, ok, err := groupStore.GetSessionGroup(context.Background(), "channel-telegram-12345")
 	if err != nil {
-		t.Fatalf("load index: %v", err)
+		t.Fatalf("GetSessionGroup: %v", err)
 	}
-	entry := idx.Groups["channel-telegram-12345"]
+	if !ok {
+		t.Fatalf("group should still be registered after rollover")
+	}
 	if entry.CurrentSessionID != newID {
 		t.Errorf("group current_session_id should be %q, got %q", newID, entry.CurrentSessionID)
 	}
@@ -339,7 +328,7 @@ func TestPerformRollover_CreatesNewSessionAndUpdatesIndex(t *testing.T) {
 }
 
 func TestPerformRollover_ErrorWhenNoMessages(t *testing.T) {
-	mgr, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, _, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	if _, err := mgr.PerformRollover(context.Background(), "openai/gpt-4", ""); err == nil {
@@ -347,57 +336,41 @@ func TestPerformRollover_ErrorWhenNoMessages(t *testing.T) {
 	}
 }
 
-func TestSaveIndexAtomicLocked_OverwriteIsAtomic(t *testing.T) {
-	mgr, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+func TestPutSessionGroup_OverwriteReplacesPriorEntry(t *testing.T) {
+	_, _, _, groupStore, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
-	mgr.indexMutex.Lock()
-	idx1 := &sessionGroupIndex{Groups: map[string]SessionGroupEntry{
-		"a": {CurrentSessionID: "id-1", UpdatedAt: time.Now()},
-	}}
-	if err := mgr.saveIndexAtomicLocked(idx1); err != nil {
-		mgr.indexMutex.Unlock()
-		t.Fatalf("first save: %v", err)
+	ctx := context.Background()
+	if err := groupStore.PutSessionGroup(ctx, "a", storage.SessionGroupEntry{
+		CurrentSessionID: "id-1", UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("first put: %v", err)
+	}
+	if err := groupStore.PutSessionGroup(ctx, "a", storage.SessionGroupEntry{
+		CurrentSessionID: "id-2", UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("second put: %v", err)
+	}
+	if err := groupStore.PutSessionGroup(ctx, "b", storage.SessionGroupEntry{
+		CurrentSessionID: "id-3", UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("third put: %v", err)
 	}
 
-	idx2 := &sessionGroupIndex{Groups: map[string]SessionGroupEntry{
-		"a": {CurrentSessionID: "id-2", UpdatedAt: time.Now()},
-		"b": {CurrentSessionID: "id-3", UpdatedAt: time.Now()},
-	}}
-	if err := mgr.saveIndexAtomicLocked(idx2); err != nil {
-		mgr.indexMutex.Unlock()
-		t.Fatalf("second save: %v", err)
+	got, ok, err := groupStore.GetSessionGroup(ctx, "a")
+	if err != nil || !ok {
+		t.Fatalf("get a: %v ok=%v", err, ok)
 	}
-	mgr.indexMutex.Unlock()
-
-	mgr.indexMutex.Lock()
-	loaded, err := mgr.loadIndexLocked()
-	mgr.indexMutex.Unlock()
-	if err != nil {
-		t.Fatalf("load: %v", err)
+	if got.CurrentSessionID != "id-2" {
+		t.Errorf("second put should overwrite first: got %q", got.CurrentSessionID)
 	}
-	if loaded.Groups["a"].CurrentSessionID != "id-2" {
-		t.Errorf("second save should overwrite first: got %q", loaded.Groups["a"].CurrentSessionID)
-	}
-	if _, ok := loaded.Groups["b"]; !ok {
-		t.Errorf("second save should add b")
-	}
-
-	// No leftover .tmp files in the index dir.
-	dir := filepath.Dir(mgr.indexPath)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read dir: %v", err)
-	}
-	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), filepath.Base(mgr.indexPath)+".tmp-") {
-			t.Errorf("temp file leaked: %s", e.Name())
-		}
+	if _, ok, _ := groupStore.GetSessionGroup(ctx, "b"); !ok {
+		t.Errorf("expected b to be present")
 	}
 }
 
 func TestConcurrentRolloversForDifferentGroups(t *testing.T) {
-	mgr, _, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	mgr, _, _, groupStore, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
 	const groupCount = 8
@@ -414,13 +387,11 @@ func TestConcurrentRolloversForDifferentGroups(t *testing.T) {
 	}
 	wg.Wait()
 
-	mgr.indexMutex.Lock()
-	idx, err := mgr.loadIndexLocked()
-	mgr.indexMutex.Unlock()
+	all, err := groupStore.ListSessionGroups(context.Background())
 	if err != nil {
-		t.Fatalf("load: %v", err)
+		t.Fatalf("list: %v", err)
 	}
-	if len(idx.Groups) != groupCount {
-		t.Errorf("expected %d groups after concurrent registration, got %d", groupCount, len(idx.Groups))
+	if len(all) != groupCount {
+		t.Errorf("expected %d groups after concurrent registration, got %d", groupCount, len(all))
 	}
 }


### PR DESCRIPTION
Closes #473.

## Summary

- Session-group state was always written to `~/.infer/session_groups.json` on local disk, even when `storage.type: redis` (or postgres/sqlite). In Kubernetes deployments the file is ephemeral so pod restarts dropped state, defeating the point of choosing a remote backend.
- Introduce a `SessionGroupStorage` interface implemented by every backend; refactor `SessionRolloverManager` to consume it instead of doing direct filesystem I/O.
- JSONL keeps the file at the same path (`<configDir>/session_groups.json`) for backward compatibility; SQLite/Postgres get migration `002` (a `session_groups` table with UPSERT); Redis stores entries in a `session_groups` hash.
