### PR TITLE
fix(channels): Propagate agent errors to channel users

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -91,7 +91,18 @@ type AgentSession struct {
 	approvalCh       chan domain.ApprovalResponse
 }
 
-func RunAgentCommand(cfg *config.Config, modelFlag, taskDescription string, files []string, noSave bool, sessionID string, requireApproval bool) error {
+func RunAgentCommand(cfg *config.Config, modelFlag, taskDescription string, files []string, noSave bool, sessionID string, requireApproval bool) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			outputAgentError(fmt.Sprintf("agent panic: %v", r))
+			err = fmt.Errorf("agent panic: %v", r)
+			return
+		}
+		if err != nil {
+			outputAgentError(err.Error())
+		}
+	}()
+
 	svc := container.NewServiceContainer(cfg)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -796,6 +807,25 @@ func (s *AgentSession) isToolApprovalRequired(tc sdk.ChatCompletionMessageToolCa
 		}
 	}
 	return s.config.IsApprovalRequired(tc.Function.Name)
+}
+
+// outputAgentError emits an agent_error JSON line on stdout so the channels
+// manager can forward the failure to the user. Long messages are truncated to
+// stay within channel transport limits (Telegram caps messages at ~4096 chars).
+func outputAgentError(message string) {
+	const maxLen = 3500
+	if len(message) > maxLen {
+		message = message[:maxLen] + "…"
+	}
+	msg := domain.AgentErrorMessage{Type: "agent_error", Message: message}
+	out, err := json.Marshal(msg)
+	if err != nil {
+		logger.Error("Failed to marshal agent error", "error", err)
+		return
+	}
+	if _, werr := os.Stdout.Write(append(out, '\n')); werr != nil {
+		logger.Error("Failed to write agent error to stdout", "error", werr)
+	}
 }
 
 // outputApprovalRequest writes an approval request JSON line to stdout for the channel manager.

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -14,13 +17,80 @@ import (
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
+// captureStdout redirects os.Stdout for the duration of fn and returns what was written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+func TestOutputAgentError(t *testing.T) {
+	t.Run("emits valid agent_error JSON line", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			outputAgentError("context length exceeded")
+		})
+
+		line := strings.TrimRight(out, "\n")
+		if line == "" || strings.Contains(line, "\n") {
+			t.Fatalf("expected single JSON line, got %q", out)
+		}
+		var msg domain.AgentErrorMessage
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			t.Fatalf("unmarshal: %v (raw: %q)", err, line)
+		}
+		if msg.Type != "agent_error" {
+			t.Errorf("Type = %q, want %q", msg.Type, "agent_error")
+		}
+		if msg.Message != "context length exceeded" {
+			t.Errorf("Message = %q", msg.Message)
+		}
+	})
+
+	t.Run("truncates very long messages", func(t *testing.T) {
+		long := strings.Repeat("x", 5000)
+		out := captureStdout(t, func() {
+			outputAgentError(long)
+		})
+
+		var msg domain.AgentErrorMessage
+		if err := json.Unmarshal([]byte(strings.TrimRight(out, "\n")), &msg); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if !strings.HasSuffix(msg.Message, "…") {
+			t.Errorf("expected truncation suffix, got message ending with %q",
+				msg.Message[max(0, len(msg.Message)-10):])
+		}
+		runes := []rune(msg.Message)
+		if len(runes) > 3501 {
+			t.Errorf("expected at most 3501 runes, got %d", len(runes))
+		}
+	})
+}
+
 func TestFormatToolCallSummary(t *testing.T) {
 	cases := []struct {
 		name     string
 		tool     string
 		args     string
 		want     string
-		contains []string // alternative: substring assertions for long/truncated cases
+		contains []string
 	}{
 		{
 			name: "empty args returns bare name",

--- a/internal/domain/ipc.go
+++ b/internal/domain/ipc.go
@@ -15,3 +15,11 @@ type ApprovalResponse struct {
 	ToolCallID string `json:"tool_call_id"`
 	Approved   bool   `json:"approved"`
 }
+
+// AgentErrorMessage is emitted by the agent on stdout when a fatal error occurs
+// before exiting. The channel manager forwards this to the user-facing channel
+// so users aren't left waiting in silence when the agent process fails.
+type AgentErrorMessage struct {
+	Type    string `json:"type"` // "agent_error"
+	Message string `json:"message"`
+}

--- a/internal/services/channel_manager.go
+++ b/internal/services/channel_manager.go
@@ -30,7 +30,7 @@ type ChannelManagerService struct {
 	cfg      config.ChannelsConfig
 
 	// Per-sender mutex to serialize agent invocations for the same session
-	senderMutexes sync.Map // map[string]*sync.Mutex
+	senderMutexes sync.Map
 
 	// semaphore limits the number of concurrent agent subprocesses
 	semaphore chan struct{}
@@ -256,6 +256,7 @@ func (cm *ChannelManagerService) runAgent(ctx context.Context, senderKey, sessio
 
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	errorForwarded := false
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -271,15 +272,23 @@ func (cm *ChannelManagerService) runAgent(ctx context.Context, senderKey, sessio
 			}
 		}
 
+		isErr := parseAgentError(line)
 		content := formatAgentMessage(line)
 		if content != "" {
 			sendFn(content)
+			if isErr {
+				errorForwarded = true
+			}
 		}
 	}
 
 	if err := cmd.Wait(); err != nil {
+		stderrStr := stderrBuf.String()
 		if stderrBuf.Len() > 0 {
-			logger.Error("Agent stderr output", "stderr", stderrBuf.String())
+			logger.Error("Agent stderr output", "stderr", stderrStr)
+		}
+		if !errorForwarded {
+			sendFn("❌ Agent failed: " + tailStderr(stderrStr, 500))
 		}
 		return fmt.Errorf("agent process failed: %w", err)
 	}
@@ -343,6 +352,38 @@ func parseApprovalRequest(line []byte) (*domain.ApprovalRequest, bool) {
 	return &req, true
 }
 
+// parseAgentError reports whether the line is a structured agent_error IPC message.
+// Used to track whether a fatal error has already been forwarded to the user
+// so the channel manager doesn't double-send a generic safety-net message.
+func parseAgentError(line []byte) bool {
+	var m map[string]any
+	if err := json.Unmarshal(line, &m); err != nil {
+		return false
+	}
+	t, _ := m["type"].(string)
+	return t == "agent_error"
+}
+
+// tailStderr returns the last n bytes of stderr. If the cut lands mid-line,
+// it advances forward to the next newline so we don't start with a partial
+// line. Falls back to "unknown error" when input is empty.
+func tailStderr(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "unknown error"
+	}
+	if len(s) <= n {
+		return s
+	}
+	cut := len(s) - n
+	if cut > 0 && s[cut-1] != '\n' {
+		if i := strings.IndexByte(s[cut:], '\n'); i >= 0 {
+			cut += i + 1
+		}
+	}
+	return s[cut:]
+}
+
 // formatApprovalPrompt creates a human-readable approval prompt for the channel user.
 func formatApprovalPrompt(req *domain.ApprovalRequest) string {
 	var sb strings.Builder
@@ -380,7 +421,13 @@ func formatAgentMessage(line []byte) string {
 		return ""
 	}
 
-	// Skip status messages (type: "info", "warning", etc.)
+	if t, _ := msg["type"].(string); t == "agent_error" {
+		if errMsg, ok := msg["message"].(string); ok && errMsg != "" {
+			return "❌ Error: " + errMsg
+		}
+		return "❌ Error: agent failed"
+	}
+
 	if _, isStatus := msg["type"]; isStatus {
 		return ""
 	}

--- a/internal/services/channel_manager_test.go
+++ b/internal/services/channel_manager_test.go
@@ -330,12 +330,75 @@ func TestFormatAgentMessage(t *testing.T) {
 			line: `{"role":"assistant","content":""}`,
 			want: "",
 		},
+		{
+			name: "agent error with message",
+			line: `{"type":"agent_error","message":"context length exceeded"}`,
+			want: "❌ Error: context length exceeded",
+		},
+		{
+			name: "agent error with empty message falls back",
+			line: `{"type":"agent_error","message":""}`,
+			want: "❌ Error: agent failed",
+		},
+		{
+			name: "agent error with no message field falls back",
+			line: `{"type":"agent_error"}`,
+			want: "❌ Error: agent failed",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := formatAgentMessage([]byte(tt.line))
 			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAgentError(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"agent error", `{"type":"agent_error","message":"boom"}`, true},
+		{"agent error no message", `{"type":"agent_error"}`, true},
+		{"info message", `{"type":"info","message":"x"}`, false},
+		{"approval request", `{"type":"approval_request","tool_name":"Bash"}`, false},
+		{"assistant message", `{"role":"assistant","content":"hi"}`, false},
+		{"malformed json", `not json`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseAgentError([]byte(tt.line)); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTailStderr(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		n    int
+		want string
+	}{
+		{"empty falls back", "", 100, "unknown error"},
+		{"whitespace only falls back", "   \n\t  ", 100, "unknown error"},
+		{"short string returned as-is", "boom", 100, "boom"},
+		{"trims surrounding whitespace", "  hello world  \n", 100, "hello world"},
+		{"long string is tailed", strings.Repeat("a", 600), 500, strings.Repeat("a", 500)},
+		{"clean newline boundary keeps full slice", "first line\nsecond line\nthird line", 22, "second line\nthird line"},
+		{"mid-line cut advances to next newline", "first line\nsecond line\nthird line", 20, "third line"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tailStderr(tt.in, tt.n); got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
@@ -1079,5 +1142,129 @@ func TestChannelManagerService_ApprovalWithApprovalChannel(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatalf("timeout waiting for messages, got %d messages", len(messages))
+	}
+}
+
+// startAgentTestManager wires a ChannelManagerService with a fake channel and
+// a custom execCommandFunc, returning the channel that receives outbound
+// messages plus a cancel func. Used by error-propagation tests.
+func startAgentTestManager(t *testing.T, exec func(ctx context.Context, name string, args ...string) *exec.Cmd) (chan domain.OutboundMessage, context.CancelFunc) {
+	t.Helper()
+	cfg := config.ChannelsConfig{
+		Enabled: true,
+		Telegram: config.TelegramChannelConfig{
+			AllowedUsers: []string{"123"},
+		},
+	}
+	cm := NewChannelManagerService(cfg)
+	cm.execCommandFunc = exec
+
+	sent := make(chan domain.OutboundMessage, 8)
+	ch := &fakesdomain.FakeChannel{}
+	ch.NameReturns("telegram")
+	ch.StartStub = func(ctx context.Context, inbox chan<- domain.InboundMessage) error {
+		inbox <- domain.InboundMessage{
+			ChannelName: "telegram",
+			SenderID:    "123",
+			Content:     "trigger",
+			Timestamp:   time.Now(),
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	ch.SendStub = func(ctx context.Context, msg domain.OutboundMessage) error {
+		sent <- msg
+		return nil
+	}
+	cm.Register(ch)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := cm.Start(ctx); err != nil {
+		cancel()
+		t.Fatalf("unexpected start error: %v", err)
+	}
+	return sent, cancel
+}
+
+// collectMessages drains the sent channel until either deadline or noActivity passes.
+// Returns all messages observed.
+func collectMessages(sent chan domain.OutboundMessage, noActivity time.Duration, deadline time.Duration) []domain.OutboundMessage {
+	var msgs []domain.OutboundMessage
+	overall := time.After(deadline)
+	for {
+		select {
+		case m := <-sent:
+			msgs = append(msgs, m)
+		case <-time.After(noActivity):
+			return msgs
+		case <-overall:
+			return msgs
+		}
+	}
+}
+
+func TestRunAgent_ForwardsStructuredError(t *testing.T) {
+	sent, cancel := startAgentTestManager(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c",
+			`printf '%s\n' '{"type":"agent_error","message":"context length exceeded"}'; exit 1`)
+	})
+	defer cancel()
+
+	msgs := collectMessages(sent, 500*time.Millisecond, 5*time.Second)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 message, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Content != "❌ Error: context length exceeded" {
+		t.Errorf("got %q", msgs[0].Content)
+	}
+}
+
+func TestRunAgent_SafetyNetOnExitWithoutForward(t *testing.T) {
+	sent, cancel := startAgentTestManager(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c",
+			`printf 'fatal: something broke\n' >&2; exit 1`)
+	})
+	defer cancel()
+
+	msgs := collectMessages(sent, 500*time.Millisecond, 5*time.Second)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 safety-net message, got %d: %+v", len(msgs), msgs)
+	}
+	if !strings.HasPrefix(msgs[0].Content, "❌ Agent failed: ") {
+		t.Errorf("expected safety-net prefix, got %q", msgs[0].Content)
+	}
+	if !strings.Contains(msgs[0].Content, "fatal: something broke") {
+		t.Errorf("expected stderr tail in message, got %q", msgs[0].Content)
+	}
+}
+
+func TestRunAgent_SafetyNetOnExitWithEmptyStderr(t *testing.T) {
+	sent, cancel := startAgentTestManager(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c", "exit 1")
+	})
+	defer cancel()
+
+	msgs := collectMessages(sent, 500*time.Millisecond, 5*time.Second)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 message, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Content != "❌ Agent failed: unknown error" {
+		t.Errorf("got %q", msgs[0].Content)
+	}
+}
+
+func TestRunAgent_NoDoubleSendOnStructuredError(t *testing.T) {
+	sent, cancel := startAgentTestManager(t, func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c",
+			`printf '%s\n' '{"type":"agent_error","message":"boom"}'; printf 'noisy stderr\n' >&2; exit 1`)
+	})
+	defer cancel()
+
+	msgs := collectMessages(sent, 500*time.Millisecond, 5*time.Second)
+	if len(msgs) != 1 {
+		t.Fatalf("expected exactly 1 message (no safety-net duplicate), got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Content != "❌ Error: boom" {
+		t.Errorf("got %q", msgs[0].Content)
 	}
 }


### PR DESCRIPTION
## Summary

- Closes #478. When the `infer agent` subprocess (spawned by `infer channels-manager`) failed - LLM 400 context-full, gateway down, panics - the failure was logged on the daemon host but never delivered to the channel user, who just waited in silence.
- New `AgentErrorMessage` IPC type emitted on stdout via a named-return `defer` (with `recover`) in `RunAgentCommand`, so every error path is covered with no scattered changes.
- Channel manager forwards structured errors as `❌ Error: …` and adds a stderr-tail safety net (`❌ Agent failed: …`) for hard crashes that exit before emitting.
