### PR TITLE
feat(channels): Log CLI version on startup and dedupe scheduler log

### DIFF
--- a/cmd/channels.go
+++ b/cmd/channels.go
@@ -58,6 +58,11 @@ func RunChannelsCommand(cfg *config.Config) error {
 		return err
 	}
 
+	logger.Info("Starting channels-manager",
+		"version", version,
+		"commit", commit,
+		"build_date", date,
+	)
 	logger.Info("Starting channel listener...")
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -126,7 +131,6 @@ func startScheduler(ctx context.Context, cm *services.ChannelManagerService, cfg
 	if err := svc.Start(ctx); err != nil {
 		return nil, err
 	}
-	logger.Info("Scheduler started", "storage_dir", dir)
 	return svc, nil
 }
 


### PR DESCRIPTION
## Summary

- Adds a `Starting channels-manager` log line at the top of `infer channels-manager` that includes `version`, `commit`, and `build_date` (sourced from the existing `cmd.version`/`cmd.commit`/`cmd.date` vars populated via `-ldflags -X`), so operators can see which release is running in pod/container logs.
- Removes the duplicate `Scheduler started` log emitted from `cmd/channels.go` — the scheduler service already logs the same event from `internal/services/scheduler/scheduler.go` with richer `dir` + `jobs` fields.

Closes #470
