### PR TITLE
fix: Reset status when setting input via shortcut

### DIFF
--- a/internal/handlers/chat_shortcut_handler.go
+++ b/internal/handlers/chat_shortcut_handler.go
@@ -399,9 +399,18 @@ func (s *ChatShortcutHandler) handleSetInputSideEffect(data any) tea.Msg {
 		}
 	}
 
-	return domain.SetInputEvent{
-		Text: text,
-	}
+	return tea.Batch(
+		func() tea.Msg {
+			return domain.SetStatusEvent{
+				Message:    "",
+				Spinner:    false,
+				StatusType: domain.StatusDefault,
+			}
+		},
+		func() tea.Msg {
+			return domain.SetInputEvent{Text: text}
+		},
+	)()
 }
 
 func (s *ChatShortcutHandler) handleGenerateSnippetSideEffect(data any) tea.Msg {


### PR DESCRIPTION
Updated `handleSetInputSideEffect` to clear the status and stop the spinner before setting the input text.
This prevents stale status messages from lingering when a shortcut updates the input.

Closes #494