### PR TITLE
refactor(channels): Slim remote-control prompt and disable system reminders

### DIFF
--- a/.infer/prompts.yaml
+++ b/.infer/prompts.yaml
@@ -66,37 +66,21 @@ agent:
     - Call RequestPlanApproval ONLY when your plan is complete and ready
     - If you need clarification, ASK - don't guess!
   system_prompt_remote: |-
-    Remote system administration agent. You are operating on a remote machine via SSH.
+    Remote-control assistant. You are responding through a messaging channel (e.g. Telegram).
 
-    FOCUS: System operations, service management, monitoring, diagnostics, and infrastructure tasks.
+    STYLE:
+    - Reply concisely. Match the user's tone and length.
+    - For casual messages ("hi", "thanks"), respond in one short line.
+    - Skip preamble, recaps, and tool-availability lists.
 
-    CONTEXT: This is a shared system environment, not a project workspace. Users may be managing servers, containers, services, or general infrastructure.
+    CAPABILITIES:
+    - You have full agent tools (Bash, Read, Write, Edit, etc.) plus any configured MCP/A2A tools.
+    - Use them only when the user asks for work that requires them.
+    - For greetings or open-ended questions, just chat - do not run tools.
 
-    COMPUTER USE TOOLS:
-    You have TWO ways to interact with the system:
-    1. Direct terminal tools (PRIMARY): Bash, Read, Write, Edit, Grep, etc.
-    2. GUI automation tools (FALLBACK): MouseMove, KeyboardType, MouseClick, GetLatestScreenshot
-
-    CRITICAL: ALWAYS prefer direct terminal tools over GUI automation when possible.
-
-    When to use DIRECT tools (preferred):
-    - Reading files: Use Read tool, NOT KeyboardType to open an editor
-    - Writing files: Use Write/Edit tools, NOT GUI text editor
-    - Running commands: Use Bash tool, NOT KeyboardType in a terminal window
-    - Searching code: Use Grep tool, NOT opening files via GUI
-    - System operations: Use Bash for systemctl, journalctl, docker, etc.
-
-    When to use GUI tools (only when necessary):
-    - Interacting with graphical applications that have no CLI equivalent
-    - Testing UI behavior or visual elements
-    - Remote desktop administration tasks that MUST be done through a GUI
-
-    Why prefer direct tools:
-    - 10-100x faster execution (no GUI rendering delays)
-    - More reliable (no window focus issues, no timing problems)
-    - Works over SSH without X11 forwarding
-    - Precise output (structured data, not visual interpretation)
-    - Lower resource usage (critical for remote systems)
+    CONSTRAINTS:
+    - Each message starts a fresh session; do not assume prior context unless it appears in the conversation history.
+    - Tool approval may be enforced by the channel manager - long approval chains are noisy in a chat UI, so prefer single, well-scoped tool calls.
   system_prompt_heartbeat: |-
     You are an autonomous agent that has just been woken up by a periodic heartbeat tick.
 
@@ -118,7 +102,7 @@ agent:
     - Each tick is a fresh session - you have no memory of previous ticks beyond what is persisted (todos, scheduled jobs, conversation history).
   custom_instructions: ""
   system_reminders:
-    enabled: true
+    enabled: false
     interval: 4
     reminder_text: |-
       <system-reminder>

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -53,7 +53,8 @@ Examples:
 		sessionID, _ := cmd.Flags().GetString("session-id")
 		requireApproval, _ := cmd.Flags().GetBool("require-approval")
 		heartbeat, _ := cmd.Flags().GetBool("heartbeat")
-		return RunAgentCommand(Cfg, model, args[0], files, noSave, sessionID, requireApproval, heartbeat)
+		remote, _ := cmd.Flags().GetBool("remote")
+		return RunAgentCommand(Cfg, model, args[0], files, noSave, sessionID, requireApproval, heartbeat, remote)
 	},
 }
 
@@ -92,7 +93,7 @@ type AgentSession struct {
 	approvalCh       chan domain.ApprovalResponse
 }
 
-func RunAgentCommand(cfg *config.Config, modelFlag, taskDescription string, files []string, noSave bool, sessionID string, requireApproval, heartbeat bool) (err error) {
+func RunAgentCommand(cfg *config.Config, modelFlag, taskDescription string, files []string, noSave bool, sessionID string, requireApproval, heartbeat, remote bool) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			outputAgentError(fmt.Sprintf("agent panic: %v", r))
@@ -106,6 +107,10 @@ func RunAgentCommand(cfg *config.Config, modelFlag, taskDescription string, file
 
 	if heartbeat && cfg.Prompts.Agent.SystemPromptHeartbeat != "" {
 		cfg.Prompts.Agent.SystemPrompt = cfg.Prompts.Agent.SystemPromptHeartbeat
+	}
+
+	if remote && cfg.Prompts.Agent.SystemPromptRemote != "" {
+		cfg.Prompts.Agent.SystemPrompt = cfg.Prompts.Agent.SystemPromptRemote
 	}
 
 	svc := container.NewServiceContainer(cfg)
@@ -1122,5 +1127,6 @@ func init() {
 	agentCmd.Flags().String("session-id", "", "Resume an existing agent session by conversation ID")
 	agentCmd.Flags().Bool("require-approval", false, "Enable IPC-based tool approval via stdin/stdout (used by channel manager)")
 	agentCmd.Flags().Bool("heartbeat", false, "Run with the heartbeat system prompt (used by the heartbeat service)")
+	agentCmd.Flags().Bool("remote", false, "Run with the remote-control system prompt (used by the channels-manager daemon)")
 	rootCmd.AddCommand(agentCmd)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -800,6 +800,17 @@ func applyPromptsEnvOverrides(cfg *config.Config) {
 			*target = val
 		}
 	}
+
+	if v := os.Getenv("INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_ENABLED"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.Prompts.Agent.SystemReminders.Enabled = b
+		}
+	}
+	if v := os.Getenv("INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_INTERVAL"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Prompts.Agent.SystemReminders.Interval = n
+		}
+	}
 }
 
 // applyKeybindingEnvOverrides walks INFER_CHAT_KEYBINDINGS_BINDINGS_*

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -44,6 +44,9 @@ func mergePromptDefaults(loaded, defaults *PromptsConfig) {
 	if loaded.Agent.SystemReminders.ReminderText == "" {
 		loaded.Agent.SystemReminders.ReminderText = defaults.Agent.SystemReminders.ReminderText
 	}
+	if loaded.Agent.SystemReminders.Interval == 0 {
+		loaded.Agent.SystemReminders.Interval = defaults.Agent.SystemReminders.Interval
+	}
 	if loaded.Git.CommitMessage.SystemPrompt == "" {
 		loaded.Git.CommitMessage.SystemPrompt = defaults.Git.CommitMessage.SystemPrompt
 	}
@@ -262,37 +265,21 @@ REMEMBER:
 - If accepted, YOU will execute this plan. Make it specific and actionable!
 - Call RequestPlanApproval ONLY when your plan is complete and ready
 - If you need clarification, ASK - don't guess!`,
-			SystemPromptRemote: `Remote system administration agent. You are operating on a remote machine via SSH.
+			SystemPromptRemote: `Remote-control assistant. You are responding through a messaging channel (e.g. Telegram).
 
-FOCUS: System operations, service management, monitoring, diagnostics, and infrastructure tasks.
+STYLE:
+- Reply concisely. Match the user's tone and length.
+- For casual messages ("hi", "thanks"), respond in one short line.
+- Skip preamble, recaps, and tool-availability lists.
 
-CONTEXT: This is a shared system environment, not a project workspace. Users may be managing servers, containers, services, or general infrastructure.
+CAPABILITIES:
+- You have full agent tools (Bash, Read, Write, Edit, etc.) plus any configured MCP/A2A tools.
+- Use them only when the user asks for work that requires them.
+- For greetings or open-ended questions, just chat - do not run tools.
 
-COMPUTER USE TOOLS:
-You have TWO ways to interact with the system:
-1. Direct terminal tools (PRIMARY): Bash, Read, Write, Edit, Grep, etc.
-2. GUI automation tools (FALLBACK): MouseMove, KeyboardType, MouseClick, GetLatestScreenshot
-
-CRITICAL: ALWAYS prefer direct terminal tools over GUI automation when possible.
-
-When to use DIRECT tools (preferred):
-- Reading files: Use Read tool, NOT KeyboardType to open an editor
-- Writing files: Use Write/Edit tools, NOT GUI text editor
-- Running commands: Use Bash tool, NOT KeyboardType in a terminal window
-- Searching code: Use Grep tool, NOT opening files via GUI
-- System operations: Use Bash for systemctl, journalctl, docker, etc.
-
-When to use GUI tools (only when necessary):
-- Interacting with graphical applications that have no CLI equivalent
-- Testing UI behavior or visual elements
-- Remote desktop administration tasks that MUST be done through a GUI
-
-Why prefer direct tools:
-- 10-100x faster execution (no GUI rendering delays)
-- More reliable (no window focus issues, no timing problems)
-- Works over SSH without X11 forwarding
-- Precise output (structured data, not visual interpretation)
-- Lower resource usage (critical for remote systems)`,
+CONSTRAINTS:
+- Each message starts a fresh session; do not assume prior context unless it appears in the conversation history.
+- Tool approval may be enforced by the channel manager - long approval chains are noisy in a chat UI, so prefer single, well-scoped tool calls.`,
 			SystemPromptHeartbeat: `You are an autonomous agent that has just been woken up by a periodic heartbeat tick.
 
 PURPOSE: Self-driven progress checks. The user did not just send a message - you were woken up on a schedule to inspect persistent state and take any action that has become possible or overdue since the last tick.
@@ -313,7 +300,7 @@ CONSTRAINTS:
 - Each tick is a fresh session - you have no memory of previous ticks beyond what is persisted (todos, scheduled jobs, conversation history).`,
 			CustomInstructions: ``,
 			SystemReminders: PromptsAgentRemindersConfig{
-				Enabled:  true,
+				Enabled:  false,
 				Interval: 4,
 				ReminderText: `<system-reminder>
 This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.

--- a/config/prompts_test.go
+++ b/config/prompts_test.go
@@ -107,6 +107,22 @@ func TestDefaultPromptsConfig_OptionalPromptsBlank(t *testing.T) {
 	}
 }
 
+// System reminders ship disabled by default (issue #525) - the
+// `<system-reminder>` nudge is no longer useful with modern LLMs and was
+// burning tokens in channel-driven sessions. Interval must still default
+// to a positive number so a user who flips Enabled=true gets sensible
+// cadence without also having to set Interval.
+func TestDefaultPromptsConfig_SystemRemindersDisabled(t *testing.T) {
+	cfg := config.DefaultPromptsConfig()
+
+	if cfg.Agent.SystemReminders.Enabled {
+		t.Error("agent.system_reminders.enabled should default to false")
+	}
+	if cfg.Agent.SystemReminders.Interval <= 0 {
+		t.Errorf("agent.system_reminders.interval should default to a positive value, got %d", cfg.Agent.SystemReminders.Interval)
+	}
+}
+
 func TestLoadPrompts_NonExistentFile(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "non-existent.yaml")

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -10,6 +10,7 @@ remote-control the agent from external platforms like Telegram or WhatsApp.
 - [Quick Start (Telegram)](#quick-start-telegram)
 - [Configuration](#configuration)
 - [Security](#security)
+- [Remote-Control Prompt and System Reminders](#remote-control-prompt-and-system-reminders)
 - [Adding a Custom Channel](#adding-a-custom-channel)
 - [Supported Channels](#supported-channels)
 - [Troubleshooting](#troubleshooting)
@@ -302,6 +303,50 @@ conversations, which means:
   SQLite, PostgreSQL), conversations survive restarts.
 - **No extra configuration needed**: Conversation memory works out of the box
   using the same settings as regular agent sessions.
+
+## Remote-Control Prompt and System Reminders
+
+Messages routed through the channels-manager invoke `infer agent --remote`,
+which swaps the default agent system prompt for
+`prompts.agent.system_prompt_remote`. That prompt is tuned for short,
+chat-style replies so that a casual "Hi" does not trigger a paragraph-long
+response or unnecessary tool calls.
+
+Customise it in `~/.infer/prompts.yaml`:
+
+```yaml
+agent:
+  system_prompt_remote: |-
+    Remote-control assistant. You are responding through a messaging channel.
+    Reply concisely and only use tools when the user asks for work.
+```
+
+Or override via environment:
+
+```bash
+export INFER_PROMPTS_AGENT_SYSTEM_PROMPT_REMOTE="Pirate-themed assistant."
+```
+
+### System Reminders
+
+The CLI can periodically inject a `<system-reminder>` user message into the
+conversation to nudge the agent about empty todo lists. Modern LLMs no longer
+need this nudge, so it ships **disabled by default**. Re-enable it via
+`prompts.yaml`:
+
+```yaml
+agent:
+  system_reminders:
+    enabled: true
+    interval: 4  # inject every N turns
+```
+
+Or via environment:
+
+```bash
+export INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_ENABLED=true
+export INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_INTERVAL=4
+```
 
 ## Adding a Custom Channel
 

--- a/internal/services/channel_manager.go
+++ b/internal/services/channel_manager.go
@@ -209,7 +209,7 @@ func (cm *ChannelManagerService) handleMessage(ctx context.Context, msg domain.I
 // If images are present, they are written to session-scoped files and passed via --files flags.
 // When require_approval is enabled, it also creates a stdin pipe for approval IPC.
 func (cm *ChannelManagerService) runAgent(ctx context.Context, senderKey, sessionID, message string, images []domain.ImageAttachment, sendFn func(string), ch domain.Channel) error {
-	args := []string{"agent", "--session-id", sessionID}
+	args := []string{"agent", "--session-id", sessionID, "--remote"}
 
 	if cm.cfg.RequireApproval {
 		args = append(args, "--require-approval")

--- a/internal/services/channel_manager_test.go
+++ b/internal/services/channel_manager_test.go
@@ -463,6 +463,17 @@ func TestChannelManagerService_SessionID(t *testing.T) {
 	if !found {
 		t.Errorf("expected session ID %q in args, got %v", expectedSessionID, capturedArgs)
 	}
+
+	remoteFound := false
+	for _, arg := range capturedArgs {
+		if arg == "--remote" {
+			remoteFound = true
+			break
+		}
+	}
+	if !remoteFound {
+		t.Errorf("expected --remote flag in args (channel sessions must use the remote-control system prompt), got %v", capturedArgs)
+	}
 }
 
 func TestWriteSessionImage(t *testing.T) {


### PR DESCRIPTION
## Summary

- Wire the existing `SystemPromptRemote` (previously dead code) into channel-driven agent sessions via a new `infer agent --remote` flag, mirroring the `--heartbeat` pattern. The channels-manager now spawns the subprocess with `--remote`.
- Rewrite `SystemPromptRemote` for short, chat-style replies suited to messaging channels (Telegram, etc.). The old SSH/computer-use body was unused and unrelated.
- Flip `SystemReminders.Enabled` default to `false` (the `<system-reminder>` nudge burned tokens on every 4th turn). Users can opt back in via `prompts.yaml` or new env vars: `INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_ENABLED`, `INFER_PROMPTS_AGENT_SYSTEM_REMINDERS_INTERVAL`.
- Extend `mergePromptDefaults` to backfill `SystemReminders.Interval` when zero, so users who only flip `enabled: true` get sensible cadence.
- Sync `.infer/prompts.yaml` with the new defaults; add a "Remote-Control Prompt and System Reminders" subsection to `docs/channels.md`.

Closes #525.