### PR TITLE
Fix orphan tool calls and improve cancellation reliability

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -505,7 +505,12 @@ func (s *AgentSession) buildSDKMessages() []sdk.Message {
 		messages = append(messages, sdkMsg)
 	}
 
-	return messages
+	repaired, synthetics := services.EnsureToolCallsClosed(messages)
+	if len(synthetics) > 0 {
+		logger.Warn("resumed conversation had orphan tool_calls; patched in-memory",
+			"count", len(synthetics))
+	}
+	return repaired
 }
 
 func (s *AgentSession) buildMessageContent(msg ConversationMessage) sdk.MessageContent {

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -832,12 +832,13 @@ func TestReasoningContentRoundTripSyncPath(t *testing.T) {
 						},
 					}},
 				},
+				{Role: "tool", Content: "hi", ToolCallID: "call_1"},
 			},
 		}
 
 		msgs := session.buildSDKMessages()
-		if len(msgs) != 2 {
-			t.Fatalf("expected 2 sdk messages, got %d", len(msgs))
+		if len(msgs) != 3 {
+			t.Fatalf("expected 3 sdk messages, got %d", len(msgs))
 		}
 
 		out := msgs[1]

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -33,13 +33,17 @@ type AgentServiceImpl struct {
 	approvalPolicy   domain.ApprovalPolicy
 	bgRegistry       domain.BackgroundTaskRegistry
 
-	// Request tracking
+	// Request tracking: per-iteration streaming timeout contexts.
+	// Lifetime is one LLM turn (created in startStreaming, deleted via defer).
 	activeRequests map[string]context.CancelFunc
 	requestsMux    sync.RWMutex
 
-	// Cancel channels for graceful stopping of agent event loops
-	cancelChannels map[string]chan struct{}
-	cancelMux      sync.RWMutex
+	// Session tracking: covers the full lifetime of a RunWithStream call.
+	// Cancelling a session aborts streaming, tool execution, approval waits,
+	// background pollers, and the main event loop in one shot. Idempotent
+	// via sync.Once so multiple Esc presses are safe.
+	activeSessions map[string]*sessionCancel
+	sessionMux     sync.RWMutex
 
 	// Metrics tracking
 	metrics    map[string]*domain.ChatMetrics
@@ -53,6 +57,26 @@ type AgentServiceImpl struct {
 	gitContextCache string
 	gitContextTurn  int
 	contextCacheMux sync.RWMutex
+}
+
+// sessionCancel bundles the two cancellation primitives for a single
+// RunWithStream session: a context.CancelFunc that aborts in-flight
+// streaming/tool/approval work, and a broadcast channel that wakes the
+// agent's main event loop and any polling goroutines. sync.Once makes
+// Cancel safe to call repeatedly so the UI can fire it on every Esc
+// press without panicking on double-close.
+type sessionCancel struct {
+	cancelCtx  context.CancelFunc
+	cancelChan chan struct{}
+	once       sync.Once
+}
+
+// Cancel triggers both primitives exactly once.
+func (sc *sessionCancel) Cancel() {
+	sc.once.Do(func() {
+		sc.cancelCtx()
+		close(sc.cancelChan)
+	})
 }
 
 // eventPublisher provides a utility for publishing chat events
@@ -77,7 +101,8 @@ func (p *eventPublisher) publishChatStart() {
 	}
 }
 
-// publishChatComplete publishes a ChatCompleteEvent
+// publishChatComplete publishes a ChatCompleteEvent for a normally-finished
+// chat turn.
 func (p *eventPublisher) publishChatComplete(reasoning string, toolCalls []sdk.ChatCompletionMessageToolCall, metrics *domain.ChatMetrics) {
 	p.chatEvents <- domain.ChatCompleteEvent{
 		RequestID:        p.requestID,
@@ -85,6 +110,19 @@ func (p *eventPublisher) publishChatComplete(reasoning string, toolCalls []sdk.C
 		ReasoningContent: reasoning,
 		ToolCalls:        toolCalls,
 		Metrics:          metrics,
+	}
+}
+
+// publishChatCancelled publishes a ChatCompleteEvent flagged as cancelled so
+// the UI shows "User interrupted" instead of "Response complete". The event
+// reuses ChatCompleteEvent (rather than a new type) so existing listeners
+// keep handling lifecycle bookkeeping uniformly.
+func (p *eventPublisher) publishChatCancelled(metrics *domain.ChatMetrics) {
+	p.chatEvents <- domain.ChatCompleteEvent{
+		RequestID: p.requestID,
+		Timestamp: time.Now(),
+		Metrics:   metrics,
+		Cancelled: true,
 	}
 }
 
@@ -267,7 +305,7 @@ func NewAgent(
 		approvalPolicy:   approvalPolicy,
 		bgRegistry:       bgRegistry,
 		activeRequests:   make(map[string]context.CancelFunc),
-		cancelChannels:   make(map[string]chan struct{}),
+		activeSessions:   make(map[string]*sessionCancel),
 		metrics:          make(map[string]*domain.ChatMetrics),
 		toolCallsMap:     make(map[string]*sdk.ChatCompletionMessageToolCall),
 	}
@@ -372,6 +410,69 @@ func extractFirstChoice(response *sdk.CreateChatCompletionResponse) (string, str
 	return content, reasoning, toolCalls
 }
 
+// ensureConversationIntegrity enforces the OpenAI tool_call/response
+// invariant by inserting a synthetic Tool-role message for every
+// orphan tool_call_id in the current conversation. Returns the number
+// of synthetics inserted.
+//
+// persistSynthetics:
+//   - true at the drain-time chokepoint (real corruption point — JSONL
+//     append order matches logical order, so repo state stays valid).
+//   - false at defensive call sites (e.g. before sending to the
+//     gateway) where the orphan may have come from a pre-existing
+//     disk state we cannot retroactively repair without rewriting the
+//     JSONL.
+//
+// Idempotent: re-running on an already-repaired conversation is a
+// no-op (returns 0).
+func (s *AgentServiceImpl) ensureConversationIntegrity(
+	conversation *[]sdk.Message,
+	publisher *eventPublisher,
+	requestID string,
+	persistSynthetics bool,
+) int {
+	if conversation == nil || len(*conversation) == 0 {
+		return 0
+	}
+
+	repaired, synthetics := services.EnsureToolCallsClosed(*conversation)
+	if len(synthetics) == 0 {
+		return 0
+	}
+
+	*conversation = repaired
+
+	logger.Info("synthesized cancelled tool responses for orphan tool_calls",
+		"count", len(synthetics),
+		"persisted", persistSynthetics)
+
+	if !persistSynthetics {
+		return len(synthetics)
+	}
+
+	for _, syn := range synthetics {
+		entry := domain.ConversationEntry{
+			Message: syn.Message,
+			Time:    time.Now(),
+		}
+		if s.conversationRepo != nil {
+			if err := s.conversationRepo.AddMessage(entry); err != nil {
+				logger.Error("failed to persist synthetic cancelled tool response",
+					"tool_call_id", syn.ToolCallID, "error", err)
+			}
+		}
+		if publisher != nil {
+			publisher.chatEvents <- domain.ToolCancelledEvent{
+				RequestID:  requestID,
+				Timestamp:  time.Now(),
+				ToolCallID: syn.ToolCallID,
+				ToolName:   syn.ToolName,
+			}
+		}
+	}
+	return len(synthetics)
+}
+
 // batchDrainQueue drains all queued messages and adds them to conversation
 // Returns the number of messages drained
 func (s *AgentServiceImpl) batchDrainQueue(
@@ -394,6 +495,8 @@ func (s *AgentServiceImpl) batchDrainQueue(
 	if len(messages) == 0 {
 		return 0
 	}
+
+	s.ensureConversationIntegrity(conversation, eventPublisher, messages[0].RequestID, true)
 
 	logger.Info("Batching queued messages into conversation",
 		"count", len(messages),
@@ -435,21 +538,23 @@ func (s *AgentServiceImpl) RunWithStream(ctx context.Context, req *domain.AgentR
 	chatEvents := make(chan domain.ChatEvent, 1000)
 	eventPublisher := newEventPublisher(req.RequestID, chatEvents)
 
-	cancelChan := make(chan struct{}, 1)
-	s.cancelMux.Lock()
-	s.cancelChannels[req.RequestID] = cancelChan
-	s.cancelMux.Unlock()
-
-	defer func() {
-		s.cancelMux.Lock()
-		delete(s.cancelChannels, req.RequestID)
-		s.cancelMux.Unlock()
-	}()
+	sessionCtx, cancelCtx := context.WithCancel(ctx)
+	sc := &sessionCancel{
+		cancelCtx:  cancelCtx,
+		cancelChan: make(chan struct{}),
+	}
+	s.sessionMux.Lock()
+	s.activeSessions[req.RequestID] = sc
+	s.sessionMux.Unlock()
 
 	conversation := s.addSystemPrompt(req.Messages)
 
 	provider, model, err := s.parseProvider(req.Model)
 	if err != nil {
+		sc.Cancel()
+		s.sessionMux.Lock()
+		delete(s.activeSessions, req.RequestID)
+		s.sessionMux.Unlock()
 		return nil, fmt.Errorf("failed to parse provider from model '%s': %w", model, err)
 	}
 
@@ -458,7 +563,7 @@ func (s *AgentServiceImpl) RunWithStream(ctx context.Context, req *domain.AgentR
 
 	if taskTracker != nil {
 		poller = services.NewA2ATaskPoller(taskTracker, chatEvents, s.messageQueue, req.RequestID, s.conversationRepo)
-		go poller.Start(ctx)
+		go poller.Start(sessionCtx)
 	}
 
 	go func() {
@@ -467,17 +572,21 @@ func (s *AgentServiceImpl) RunWithStream(ctx context.Context, req *domain.AgentR
 				poller.Stop()
 			}
 			close(chatEvents)
+			s.sessionMux.Lock()
+			delete(s.activeSessions, req.RequestID)
+			s.sessionMux.Unlock()
+			sc.Cancel()
 		}()
 
-		conversation = s.optimizeConversation(ctx, req, conversation, eventPublisher)
+		conversation = s.optimizeConversation(sessionCtx, req, conversation, eventPublisher)
 
 		agent := NewEventDrivenAgent(
 			s,
-			ctx,
+			sessionCtx,
 			req,
 			&conversation,
 			eventPublisher,
-			cancelChan,
+			sc.cancelChan,
 			provider,
 			model,
 			s.bgRegistry,
@@ -494,44 +603,20 @@ func (s *AgentServiceImpl) RunWithStream(ctx context.Context, req *domain.AgentR
 	return chatEvents, nil
 }
 
-// CancelRequest cancels an active request
+// CancelRequest cancels an active request. Safe to call multiple times for
+// the same requestID — subsequent calls are no-ops via sync.Once on the
+// underlying sessionCancel. Returns nil even when the request is unknown,
+// so the UI can fire it on every Esc press without surfacing spurious
+// errors after the session has already torn down. The agent loop publishes
+// ChatCompleteEvent{Cancelled:true} as the single cancel-completion signal;
+// no separate CancelledEvent broadcast is needed.
 func (s *AgentServiceImpl) CancelRequest(requestID string) error {
-	s.requestsMux.Lock()
-	cancel, contextExists := s.activeRequests[requestID]
-	if contextExists {
-		delete(s.activeRequests, requestID)
-	}
-	s.requestsMux.Unlock()
+	s.sessionMux.RLock()
+	sc, sessionExists := s.activeSessions[requestID]
+	s.sessionMux.RUnlock()
 
-	s.cancelMux.Lock()
-	cancelChan, chanExists := s.cancelChannels[requestID]
-	if chanExists {
-		delete(s.cancelChannels, requestID)
-	}
-	s.cancelMux.Unlock()
-
-	if !contextExists && !chanExists {
-		return fmt.Errorf("request %s not found or already completed", requestID)
-	}
-
-	if contextExists {
-		cancel()
-	}
-
-	if chanExists {
-		select {
-		case cancelChan <- struct{}{}:
-		default:
-		}
-	}
-
-	if s.stateManager != nil {
-		cancelEvent := domain.CancelledEvent{
-			RequestID: requestID,
-			Timestamp: time.Now(),
-			Reason:    "user cancelled",
-		}
-		s.stateManager.BroadcastEvent(cancelEvent)
+	if sessionExists {
+		sc.Cancel()
 	}
 
 	return nil

--- a/internal/agent/agent_event_driven.go
+++ b/internal/agent/agent_event_driven.go
@@ -152,6 +152,9 @@ func (a *EventDrivenAgent) registerStateHandlers() {
 		PublishChatComplete: func(reasoning string, toolCalls []sdk.ChatCompletionMessageToolCall, metrics *domain.ChatMetrics) {
 			a.eventPublisher.publishChatComplete(reasoning, toolCalls, metrics)
 		},
+		PublishChatCancelled: func(metrics *domain.ChatMetrics) {
+			a.eventPublisher.publishChatCancelled(metrics)
+		},
 	}
 
 	a.registerHandler(states.NewIdleState(ctx))
@@ -196,15 +199,30 @@ func (a *EventDrivenAgent) Wait() {
 	close(a.events)
 }
 
-// processEvents is the main event processing loop
+// processEvents is the main event processing loop. The double-select pattern
+// (non-blocking probe before the real select) gives cancellation strict
+// priority over pending events. Without the probe, Go's select chooses
+// randomly when both channels are ready, so a flurry of in-flight events
+// could mask the cancel signal and force the user to press Esc again.
 func (a *EventDrivenAgent) processEvents() {
 	defer a.wg.Done()
+
+	cancelAndExit := func() {
+		_ = a.stateMachine.Transition(a.agentCtx, domain.StateCancelled)
+		a.eventPublisher.publishChatCancelled(a.service.GetMetrics(a.req.RequestID))
+	}
 
 	for {
 		select {
 		case <-a.cancelChan:
-			_ = a.stateMachine.Transition(a.agentCtx, domain.StateCancelled)
-			a.eventPublisher.publishChatComplete("", []sdk.ChatCompletionMessageToolCall{}, a.service.GetMetrics(a.req.RequestID))
+			cancelAndExit()
+			return
+		default:
+		}
+
+		select {
+		case <-a.cancelChan:
+			cancelAndExit()
 			return
 
 		case event, ok := <-a.events:

--- a/internal/agent/agent_event_driven_test.go
+++ b/internal/agent/agent_event_driven_test.go
@@ -531,6 +531,152 @@ func TestHandlePostToolExecutionState(t *testing.T) {
 	})
 }
 
+// TestHandlePostToolExecutionState_DrainsThenStopsWhenCancelled verifies the
+// "drain then stop" semantics for Esc cancellation: when the session ctx is
+// cancelled and the message queue still has entries, the post-tool-execution
+// handler must drain the queue (so queued user input lands in history) and
+// then transition to Completing rather than starting another LLM turn.
+func TestHandlePostToolExecutionState_DrainsThenStopsWhenCancelled(t *testing.T) {
+	mocks := setupTestMocks()
+	ctx := createTestContext(mocks)
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx.Ctx = cancelledCtx
+	agent := createTestAgent(mocks, ctx)
+
+	ctx.Turns = 1
+	ctx.MaxTurns = 10
+
+	// Calls 1+2 (the entry-log and the outer `if !IsEmpty()`) report
+	// queue-not-empty; calls 3+ (inside batchDrainQueue's drain loop)
+	// report empty so the loop exits.
+	callCount := 0
+	mocks.queue.IsEmptyCalls(func() bool {
+		callCount++
+		return callCount > 2
+	})
+	mocks.stateMachine.TransitionReturns(nil)
+
+	_ = agent.stateHandlers[domain.StatePostToolExecution].Handle(domain.MessageReceivedEvent{})
+
+	assert.GreaterOrEqual(t, mocks.stateMachine.TransitionCallCount(), 1)
+	_, toState := mocks.stateMachine.TransitionArgsForCall(0)
+	assert.Equal(t, domain.StateCompleting, toState,
+		"cancelled session must short-circuit to Completing after drain, not loop back to CheckingQueue")
+}
+
+// TestHandleCheckingQueueState_StopsAfterDrainWhenCancelled verifies that
+// CheckingQueue also honours the drain-then-stop contract.
+func TestHandleCheckingQueueState_StopsAfterDrainWhenCancelled(t *testing.T) {
+	mocks := setupTestMocks()
+	ctx := createTestContext(mocks)
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ctx.Ctx = cancelledCtx
+	agent := createTestAgent(mocks, ctx)
+
+	ctx.Turns = 1
+	ctx.HasToolResults = false
+
+	mocks.queue.IsEmptyReturns(true)
+	mocks.stateMachine.TransitionReturns(nil)
+
+	_ = agent.stateHandlers[domain.StateCheckingQueue].Handle(domain.MessageReceivedEvent{})
+
+	assert.GreaterOrEqual(t, mocks.stateMachine.TransitionCallCount(), 1)
+	_, toState := mocks.stateMachine.TransitionArgsForCall(0)
+	assert.Equal(t, domain.StateCompleting, toState,
+		"cancelled session in CheckingQueue must transition to Completing, not StreamingLLM")
+}
+
+// TestProcessEvents_PriorityProbeFavoursCancellation verifies the double-select
+// pattern: even when the events channel has pending work, a closed cancelChan
+// takes priority and exits the loop without draining events. This is the core
+// fix for the "Esc requires multiple presses" bug — a single Esc closes the
+// channel, and the next loop iteration always sees it first.
+func TestProcessEvents_PriorityProbeFavoursCancellation(t *testing.T) {
+	mocks := setupTestMocks()
+	agentCtx := createTestContext(mocks)
+	agent := createTestAgent(mocks, agentCtx)
+	agent.req = &domain.AgentRequest{RequestID: "test-123", Model: "test-model"}
+
+	cancelChan := make(chan struct{})
+	agent.cancelChan = cancelChan
+
+	for range 50 {
+		agent.events <- domain.MessageReceivedEvent{}
+	}
+
+	close(cancelChan)
+
+	mocks.stateMachine.TransitionReturns(nil)
+
+	agent.wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		agent.processEvents()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processEvents did not exit within 2s — cancelChan priority probe broken")
+	}
+
+	assert.GreaterOrEqual(t, mocks.stateMachine.TransitionCallCount(), 1)
+	foundCancelled := false
+	for i := range mocks.stateMachine.TransitionCallCount() {
+		_, toState := mocks.stateMachine.TransitionArgsForCall(i)
+		if toState == domain.StateCancelled {
+			foundCancelled = true
+			break
+		}
+	}
+	assert.True(t, foundCancelled, "expected a transition to StateCancelled")
+}
+
+// TestProcessEvents_PublishesCancelledFlag verifies that the ChatCompleteEvent
+// emitted on the cancel path carries Cancelled=true so the chat UI can
+// distinguish "User interrupted" from "Response complete".
+func TestProcessEvents_PublishesCancelledFlag(t *testing.T) {
+	mocks := setupTestMocks()
+	agentCtx := createTestContext(mocks)
+	agent := createTestAgent(mocks, agentCtx)
+	agent.req = &domain.AgentRequest{RequestID: "test-123", Model: "test-model"}
+
+	chatEvents := make(chan domain.ChatEvent, 10)
+	agent.eventPublisher = &eventPublisher{chatEvents: chatEvents}
+
+	cancelChan := make(chan struct{})
+	agent.cancelChan = cancelChan
+	close(cancelChan)
+
+	mocks.stateMachine.TransitionReturns(nil)
+
+	agent.wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		agent.processEvents()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processEvents did not exit within 2s")
+	}
+
+	select {
+	case ev := <-chatEvents:
+		complete, ok := ev.(domain.ChatCompleteEvent)
+		assert.True(t, ok, "expected a ChatCompleteEvent on the cancel path")
+		assert.True(t, complete.Cancelled, "ChatCompleteEvent.Cancelled must be true on user cancellation")
+	default:
+		t.Fatal("expected a ChatCompleteEvent on the events channel")
+	}
+}
+
 func TestHandleCompletingState(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -651,5 +797,44 @@ func TestHandleApprovingToolsState(t *testing.T) {
 		assert.Equal(t, 1, mocks.stateMachine.TransitionCallCount())
 		_, toState := mocks.stateMachine.TransitionArgsForCall(0)
 		assert.Equal(t, domain.StateError, toState)
+	})
+
+	t.Run("cancelled_ctx_short_circuits_to_all_tools_processed", func(t *testing.T) {
+		mocks := setupTestMocks()
+		ctx := createTestContext(mocks)
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		ctx.Ctx = cancelledCtx
+		agent := createTestAgent(mocks, ctx)
+		agent.req = &domain.AgentRequest{RequestID: "test-123", Model: "test-model"}
+
+		agent.currentToolCalls = []*sdk.ChatCompletionMessageToolCall{
+			{
+				ID:   "call-1",
+				Type: sdk.Function,
+				Function: sdk.ChatCompletionMessageToolCallFunction{
+					Name:      "test_tool",
+					Arguments: "{}",
+				},
+			},
+			{
+				ID:   "call-2",
+				Type: sdk.Function,
+				Function: sdk.ChatCompletionMessageToolCallFunction{
+					Name:      "test_tool",
+					Arguments: "{}",
+				},
+			},
+		}
+
+		_ = agent.stateHandlers[domain.StateApprovingTools].Handle(domain.MessageReceivedEvent{})
+
+		select {
+		case event := <-agent.events:
+			_, ok := event.(domain.AllToolsProcessedEvent)
+			assert.True(t, ok, "cancelled ctx must emit AllToolsProcessedEvent without running approval prompts")
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("processNextTool did not fast-exit on cancelled ctx")
+		}
 	})
 }

--- a/internal/agent/agent_streaming.go
+++ b/internal/agent/agent_streaming.go
@@ -81,6 +81,8 @@ func (a *EventDrivenAgent) startStreaming() {
 		client = client.WithTools(&a.availableTools)
 	}
 
+	a.service.ensureConversationIntegrity(a.agentCtx.Conversation, a.eventPublisher, a.req.RequestID, false)
+
 	events, err := client.GenerateContentStream(requestCtx, sdk.Provider(a.provider), a.model, *a.agentCtx.Conversation)
 	if err != nil {
 		logger.Error("Failed to create stream",
@@ -113,7 +115,7 @@ func (a *EventDrivenAgent) processStreamEvents(
 	for {
 		select {
 		case <-requestCtx.Done():
-			a.handleContextTimeout(requestCtx)
+			a.handleStreamInterrupted(requestCtx, message)
 			return
 
 		case event, ok := <-events:
@@ -129,8 +131,14 @@ func (a *EventDrivenAgent) processStreamEvents(
 	}
 }
 
-// handleContextTimeout handles context cancellation and timeout errors
-func (a *EventDrivenAgent) handleContextTimeout(requestCtx context.Context) {
+// handleStreamInterrupted handles a stream that ended via ctx cancellation —
+// either a real timeout (DeadlineExceeded) or user cancellation (Canceled).
+// Timeout: publish an error and transition to StateError.
+// Cancellation: persist any partial assistant content so the user doesn't
+// lose mid-flight output (e.g. a half-written poem when Esc is pressed),
+// then return silently — the main event loop owns the StateCancelled
+// transition via cancelChan.
+func (a *EventDrivenAgent) handleStreamInterrupted(requestCtx context.Context, partial sdk.Message) {
 	if requestCtx.Err() == context.DeadlineExceeded {
 		logger.Error("stream timeout", "error", requestCtx.Err())
 		a.eventPublisher.chatEvents <- domain.ChatErrorEvent{
@@ -138,8 +146,50 @@ func (a *EventDrivenAgent) handleContextTimeout(requestCtx context.Context) {
 			Timestamp: time.Now(),
 			Error:     fmt.Errorf("stream timed out after %d seconds", a.service.timeoutSeconds),
 		}
+		_ = a.stateMachine.Transition(a.agentCtx, domain.StateError)
+		return
 	}
-	_ = a.stateMachine.Transition(a.agentCtx, domain.StateError)
+
+	logger.Debug("stream cancelled", "request_id", a.req.RequestID, "err", requestCtx.Err())
+	a.persistPartialAssistantMessage(partial)
+}
+
+// persistPartialAssistantMessage saves the partial assistant text + reasoning
+// produced before cancellation. Partial tool calls are intentionally dropped:
+// a half-streamed tool call can't be executed safely, so attempting to
+// preserve it risks malformed arguments. Text content alone is appended to
+// both the in-memory conversation and the repo so the next session sees the
+// interruption point in history.
+func (a *EventDrivenAgent) persistPartialAssistantMessage(partial sdk.Message) {
+	content, err := partial.Content.AsMessageContent0()
+	if err != nil {
+		content = ""
+	}
+
+	reasoning := ""
+	switch {
+	case partial.Reasoning != nil && *partial.Reasoning != "":
+		reasoning = *partial.Reasoning
+	case partial.ReasoningContent != nil && *partial.ReasoningContent != "":
+		reasoning = *partial.ReasoningContent
+	}
+
+	if content == "" && reasoning == "" {
+		return
+	}
+
+	assistantMessage := buildAssistantMessage(sdk.NewMessageContent(content), reasoning, nil)
+	*a.agentCtx.Conversation = append(*a.agentCtx.Conversation, assistantMessage)
+
+	entry := domain.ConversationEntry{
+		Message:          assistantMessage,
+		ReasoningContent: reasoning,
+		Model:            a.req.Model,
+		Time:             time.Now(),
+	}
+	if err := a.service.conversationRepo.AddMessage(entry); err != nil {
+		logger.Error("failed to persist partial assistant message after cancel", "error", err)
+	}
 }
 
 // processStreamEvent processes a single SSE event from the stream

--- a/internal/agent/agent_streaming_test.go
+++ b/internal/agent/agent_streaming_test.go
@@ -1,11 +1,16 @@
 package agent
 
 import (
+	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/assert"
 
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+
 	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 func TestBuildAssistantMessage(t *testing.T) {
@@ -90,4 +95,54 @@ func TestBuildAssistantMessage(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPersistPartialAssistantMessage_KeepsContent verifies that a half-streamed
+// LLM response (text + reasoning) is appended to the conversation and the
+// repo when the user cancels mid-generation — so a partially-written poem
+// isn't lost the moment Esc is pressed.
+func TestPersistPartialAssistantMessage_KeepsContent(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.AddMessageReturns(nil)
+
+	conversation := []sdk.Message{
+		{Role: sdk.User, Content: sdk.NewMessageContent("Write a long poem")},
+	}
+
+	agent := &EventDrivenAgent{
+		service:  &AgentServiceImpl{conversationRepo: repo},
+		agentCtx: &domain.AgentContext{Conversation: &conversation, Ctx: context.Background()},
+		req:      &domain.AgentRequest{RequestID: "r1", Model: "deepseek/deepseek-v4-flash"},
+	}
+
+	partial := sdk.Message{
+		Role:    sdk.Assistant,
+		Content: sdk.NewMessageContent("Roses are red,\nViolets are blue,\nGo concurrency..."),
+	}
+
+	agent.persistPartialAssistantMessage(partial)
+
+	assert.Len(t, conversation, 2, "partial assistant message should be appended")
+	assert.Equal(t, sdk.Assistant, conversation[1].Role)
+	got, _ := conversation[1].Content.AsMessageContent0()
+	assert.Contains(t, got, "Roses are red")
+	assert.Equal(t, 1, repo.AddMessageCallCount(), "partial assistant message should be saved to repo")
+}
+
+// TestPersistPartialAssistantMessage_SkipsEmpty verifies that a cancel before
+// the model emits anything does NOT add an empty assistant message to history.
+func TestPersistPartialAssistantMessage_SkipsEmpty(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	conversation := []sdk.Message{}
+
+	agent := &EventDrivenAgent{
+		service:  &AgentServiceImpl{conversationRepo: repo},
+		agentCtx: &domain.AgentContext{Conversation: &conversation, Ctx: context.Background()},
+		req:      &domain.AgentRequest{RequestID: "r1"},
+	}
+
+	agent.persistPartialAssistantMessage(sdk.Message{Role: sdk.Assistant, Content: sdk.NewMessageContent("")})
+
+	assert.Empty(t, conversation, "empty partial should not be appended")
+	assert.Equal(t, 0, repo.AddMessageCallCount())
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -69,43 +69,39 @@ func TestAgentServiceImpl_GetMetrics(t *testing.T) {
 
 func TestAgentServiceImpl_CancelRequest(t *testing.T) {
 	tests := []struct {
-		name          string
-		requestID     string
-		setupRequest  bool
-		expectedError bool
+		name         string
+		requestID    string
+		setupSession bool
 	}{
 		{
-			name:          "cancel_existing_request",
-			requestID:     "cancel-123",
-			setupRequest:  true,
-			expectedError: false,
+			name:         "cancel_existing_request",
+			requestID:    "cancel-123",
+			setupSession: true,
 		},
 		{
-			name:          "cancel_nonexistent_request",
-			requestID:     "nonexistent",
-			setupRequest:  false,
-			expectedError: true,
+			name:         "cancel_nonexistent_request",
+			requestID:    "nonexistent",
+			setupSession: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			agentService := &AgentServiceImpl{
-				activeRequests: make(map[string]context.CancelFunc),
+				activeSessions: make(map[string]*sessionCancel),
 			}
 
-			if tt.setupRequest {
+			if tt.setupSession {
 				_, cancel := context.WithCancel(context.Background())
-				agentService.activeRequests[tt.requestID] = cancel
+				agentService.activeSessions[tt.requestID] = &sessionCancel{
+					cancelCtx:  cancel,
+					cancelChan: make(chan struct{}),
+				}
 			}
 
 			err := agentService.CancelRequest(tt.requestID)
 
-			if tt.expectedError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -277,7 +273,7 @@ func TestNewAgentService(t *testing.T) {
 	assert.Equal(t, 120, agentService.timeoutSeconds)
 	assert.Equal(t, 4096, agentService.maxTokens)
 	assert.NotNil(t, agentService.activeRequests)
-	assert.NotNil(t, agentService.cancelChannels)
+	assert.NotNil(t, agentService.activeSessions)
 	assert.NotNil(t, agentService.metrics)
 	assert.NotNil(t, agentService.toolCallsMap)
 }
@@ -874,7 +870,7 @@ func TestAgentServiceImpl_ClearToolCallsMap(t *testing.T) {
 	agentService.clearToolCallsMap()
 
 	assert.Empty(t, agentService.toolCallsMap)
-	assert.NotNil(t, agentService.toolCallsMap) // Should be a new empty map, not nil
+	assert.NotNil(t, agentService.toolCallsMap)
 }
 
 func TestAgentServiceImpl_StoreIterationMetrics(t *testing.T) {
@@ -1078,7 +1074,6 @@ func TestEventPublisher_PublishToolsQueued(t *testing.T) {
 
 	publisher.publishToolsQueued(toolCalls)
 
-	// Should publish individual events for each tool
 	for i, tc := range toolCalls {
 		select {
 		case event := <-chatEvents:
@@ -1116,11 +1111,15 @@ func TestEventPublisher_PublishToolStatusChange(t *testing.T) {
 func TestAgentServiceImpl_CancelRequest_WithCancelChannel(t *testing.T) {
 	agentService := &AgentServiceImpl{
 		activeRequests: make(map[string]context.CancelFunc),
-		cancelChannels: make(map[string]chan struct{}),
+		activeSessions: make(map[string]*sessionCancel),
 	}
 
-	cancelChan := make(chan struct{}, 1)
-	agentService.cancelChannels["request-123"] = cancelChan
+	_, cancel := context.WithCancel(context.Background())
+	cancelChan := make(chan struct{})
+	agentService.activeSessions["request-123"] = &sessionCancel{
+		cancelCtx:  cancel,
+		cancelChan: cancelChan,
+	}
 
 	err := agentService.CancelRequest("request-123")
 
@@ -1136,14 +1135,15 @@ func TestAgentServiceImpl_CancelRequest_WithCancelChannel(t *testing.T) {
 func TestAgentServiceImpl_CancelRequest_WithBothContextAndChannel(t *testing.T) {
 	agentService := &AgentServiceImpl{
 		activeRequests: make(map[string]context.CancelFunc),
-		cancelChannels: make(map[string]chan struct{}),
+		activeSessions: make(map[string]*sessionCancel),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	agentService.activeRequests["request-123"] = cancel
-
-	cancelChan := make(chan struct{}, 1)
-	agentService.cancelChannels["request-123"] = cancelChan
+	cancelChan := make(chan struct{})
+	agentService.activeSessions["request-123"] = &sessionCancel{
+		cancelCtx:  cancel,
+		cancelChan: cancelChan,
+	}
 
 	err := agentService.CancelRequest("request-123")
 
@@ -1155,6 +1155,90 @@ func TestAgentServiceImpl_CancelRequest_WithBothContextAndChannel(t *testing.T) 
 	case <-cancelChan:
 	default:
 		t.Fatal("expected cancel signal")
+	}
+}
+
+// TestAgentServiceImpl_CancelRequest_IsIdempotent verifies that multiple
+// Esc presses (or any repeated CancelRequest calls) are safe — no panic on
+// double-close of the cancel channel, and every call returns nil.
+func TestAgentServiceImpl_CancelRequest_IsIdempotent(t *testing.T) {
+	agentService := &AgentServiceImpl{
+		activeRequests: make(map[string]context.CancelFunc),
+		activeSessions: make(map[string]*sessionCancel),
+	}
+
+	_, cancel := context.WithCancel(context.Background())
+	cancelChan := make(chan struct{})
+	agentService.activeSessions["request-123"] = &sessionCancel{
+		cancelCtx:  cancel,
+		cancelChan: cancelChan,
+	}
+
+	for range 5 {
+		assert.NoError(t, agentService.CancelRequest("request-123"))
+	}
+
+	select {
+	case <-cancelChan:
+	default:
+		t.Fatal("expected cancel signal after repeated CancelRequest calls")
+	}
+}
+
+// TestAgentServiceImpl_CancelRequest_CancelsSessionContext verifies that
+// cancellation propagates through the session-level context so downstream
+// tool execution and approval waits observe ctx.Done().
+func TestAgentServiceImpl_CancelRequest_CancelsSessionContext(t *testing.T) {
+	agentService := &AgentServiceImpl{
+		activeRequests: make(map[string]context.CancelFunc),
+		activeSessions: make(map[string]*sessionCancel),
+	}
+
+	sessionCtx, cancel := context.WithCancel(context.Background())
+	agentService.activeSessions["request-123"] = &sessionCancel{
+		cancelCtx:  cancel,
+		cancelChan: make(chan struct{}),
+	}
+
+	require.NoError(t, agentService.CancelRequest("request-123"))
+
+	assert.Equal(t, context.Canceled, sessionCtx.Err())
+}
+
+// TestSessionCancel_OnlyClosesOnce verifies the sync.Once contract: the
+// cancel channel is closed at most once, and the cancelCtx func is called
+// at most once, even when Cancel is invoked many times concurrently.
+func TestSessionCancel_OnlyClosesOnce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelCallCount := 0
+	wrappedCancel := func() {
+		cancelCallCount++
+		cancel()
+	}
+
+	sc := &sessionCancel{
+		cancelCtx:  wrappedCancel,
+		cancelChan: make(chan struct{}),
+	}
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sc.Cancel()
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, cancelCallCount, "cancelCtx should be invoked exactly once")
+	assert.Equal(t, context.Canceled, ctx.Err())
+
+	select {
+	case _, ok := <-sc.cancelChan:
+		assert.False(t, ok, "cancelChan should be closed")
+	default:
+		t.Fatal("expected cancelChan to be closed")
 	}
 }
 
@@ -1335,7 +1419,6 @@ func TestAgentServiceImpl_ConcurrentToolCallsAccess(t *testing.T) {
 	var wg sync.WaitGroup
 	numGoroutines := 50
 
-	// Concurrent accumulations
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
 		go func(id int) {
@@ -1358,7 +1441,6 @@ func TestAgentServiceImpl_ConcurrentToolCallsAccess(t *testing.T) {
 }
 
 func TestAgentServiceImpl_BuildA2AAgentInfo(t *testing.T) {
-	// Helper to create configured fake A2A agent service
 	createFakeA2AAgentService := func(agents []string) *domainmocks.FakeA2AAgentService {
 		fake := &domainmocks.FakeA2AAgentService{}
 		fake.GetConfiguredAgentsReturns(agents)
@@ -1421,4 +1503,119 @@ func TestAgentServiceImpl_BuildA2AAgentInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAgentServiceImpl_BatchDrainQueue_ClosesOrphanToolCalls is the
+// regression test for the bug where a user message queued during tool
+// execution + Esc would land in the conversation immediately after an
+// assistant message with orphan tool_calls, producing a payload the
+// gateway rejected with HTTP 400 ("insufficient tool messages
+// following tool_calls message").
+func TestAgentServiceImpl_BatchDrainQueue_ClosesOrphanToolCalls(t *testing.T) {
+	toolCalls := []sdk.ChatCompletionMessageToolCall{
+		{ID: "tc-a", Type: sdk.Function, Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Read"}},
+		{ID: "tc-b", Type: sdk.Function, Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Read"}},
+		{ID: "tc-c", Type: sdk.Function, Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Tree"}},
+	}
+	conversation := []sdk.Message{
+		{Role: sdk.User, Content: sdk.NewMessageContent("read 3 files")},
+		{Role: sdk.Assistant, Content: sdk.NewMessageContent("reading"), ToolCalls: &toolCalls},
+	}
+
+	queue := services.NewMessageQueueService()
+	queue.Enqueue(sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("Hi")}, "req-1")
+
+	repo := &domainmocks.FakeConversationRepository{}
+
+	svc := &AgentServiceImpl{
+		messageQueue:     queue,
+		conversationRepo: repo,
+	}
+
+	eventCh := make(chan domain.ChatEvent, 16)
+	publisher := newEventPublisher("req-1", eventCh)
+
+	drained := svc.batchDrainQueue(&conversation, publisher)
+
+	assert.Equal(t, 1, drained, "exactly one queued message should be drained")
+	require.Len(t, conversation, 6, "conversation must be user, assistant, tool×3, user")
+
+	assert.Equal(t, sdk.User, conversation[0].Role)
+	assert.Equal(t, sdk.Assistant, conversation[1].Role)
+	assert.Equal(t, sdk.Tool, conversation[2].Role)
+	assert.Equal(t, sdk.Tool, conversation[3].Role)
+	assert.Equal(t, sdk.Tool, conversation[4].Role)
+	assert.Equal(t, sdk.User, conversation[5].Role, "queued user message must land AFTER synthetic tool responses")
+
+	require.NotNil(t, conversation[2].ToolCallID)
+	require.NotNil(t, conversation[3].ToolCallID)
+	require.NotNil(t, conversation[4].ToolCallID)
+	assert.Equal(t, "tc-a", *conversation[2].ToolCallID, "synthetics must preserve original tool_calls order")
+	assert.Equal(t, "tc-b", *conversation[3].ToolCallID)
+	assert.Equal(t, "tc-c", *conversation[4].ToolCallID)
+
+	body, err := conversation[2].Content.AsMessageContent0()
+	require.NoError(t, err)
+	assert.Equal(t, services.CancelledToolResponseContent, body)
+
+	close(eventCh)
+	var cancelled []domain.ToolCancelledEvent
+	var queued []domain.MessageQueuedEvent
+	for ev := range eventCh {
+		switch e := ev.(type) {
+		case domain.ToolCancelledEvent:
+			cancelled = append(cancelled, e)
+		case domain.MessageQueuedEvent:
+			queued = append(queued, e)
+		}
+	}
+	require.Len(t, cancelled, 3, "expected 3 ToolCancelledEvents")
+	assert.Equal(t, "tc-a", cancelled[0].ToolCallID)
+	assert.Equal(t, "Read", cancelled[0].ToolName)
+	assert.Equal(t, "tc-c", cancelled[2].ToolCallID)
+	assert.Equal(t, "Tree", cancelled[2].ToolName)
+	assert.Len(t, queued, 1, "expected 1 MessageQueuedEvent for the drained user message")
+
+	require.Equal(t, 4, repo.AddMessageCallCount(), "repo must record 3 synthetics + 1 queued message")
+	assert.Equal(t, sdk.Tool, repo.AddMessageArgsForCall(0).Message.Role, "synthetics must be persisted before the queued user message so JSONL append order matches logical order")
+	assert.Equal(t, sdk.Tool, repo.AddMessageArgsForCall(1).Message.Role)
+	assert.Equal(t, sdk.Tool, repo.AddMessageArgsForCall(2).Message.Role)
+	assert.Equal(t, sdk.User, repo.AddMessageArgsForCall(3).Message.Role)
+}
+
+func TestAgentServiceImpl_BatchDrainQueue_IdempotentOnRepairedConversation(t *testing.T) {
+	idA := "tc-x"
+	toolCalls := []sdk.ChatCompletionMessageToolCall{
+		{ID: idA, Type: sdk.Function, Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Read"}},
+	}
+	conversation := []sdk.Message{
+		{Role: sdk.User, Content: sdk.NewMessageContent("u1")},
+		{Role: sdk.Assistant, Content: sdk.NewMessageContent(""), ToolCalls: &toolCalls},
+		{Role: sdk.Tool, Content: sdk.NewMessageContent(services.CancelledToolResponseContent), ToolCallID: &idA},
+	}
+
+	queue := services.NewMessageQueueService()
+	queue.Enqueue(sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("u2")}, "req-x")
+
+	repo := &domainmocks.FakeConversationRepository{}
+	svc := &AgentServiceImpl{
+		messageQueue:     queue,
+		conversationRepo: repo,
+	}
+
+	eventCh := make(chan domain.ChatEvent, 8)
+	publisher := newEventPublisher("req-x", eventCh)
+
+	drained := svc.batchDrainQueue(&conversation, publisher)
+	assert.Equal(t, 1, drained)
+	require.Len(t, conversation, 4, "no new synthetics should be inserted")
+
+	close(eventCh)
+	var cancelled int
+	for ev := range eventCh {
+		if _, ok := ev.(domain.ToolCancelledEvent); ok {
+			cancelled++
+		}
+	}
+	assert.Equal(t, 0, cancelled, "validator must be a no-op on already-repaired conversation")
 }

--- a/internal/agent/states/approving_tools.go
+++ b/internal/agent/states/approving_tools.go
@@ -65,9 +65,19 @@ func (s *ApprovingToolsState) Handle(event domain.AgentEvent) error {
 	return nil
 }
 
-// processNextTool handles approval and execution of ONE tool sequentially
+// processNextTool handles approval and execution of ONE tool sequentially.
+// Fast-exits if the session context was cancelled, mirroring the
+// drain-then-stop contract in CheckingQueue / PostToolExecution: the
+// remaining approval prompts are skipped and control returns to the state
+// machine, which will short-circuit to Completing.
 func (s *ApprovingToolsState) processNextTool() {
 	defer s.ctx.WaitGroup.Done()
+
+	if s.ctx.AgentCtx.Ctx.Err() != nil {
+		logger.Debug("session cancelled during approval loop", "err", s.ctx.AgentCtx.Ctx.Err())
+		s.ctx.Events <- domain.AllToolsProcessedEvent{}
+		return
+	}
 
 	tc := s.getNextToolForProcessing()
 	if tc == nil {

--- a/internal/agent/states/checking_queue.go
+++ b/internal/agent/states/checking_queue.go
@@ -56,6 +56,17 @@ func (s *CheckingQueueState) Handle(event domain.AgentEvent) error {
 			logger.Debug("batched queued messages", "count", numBatched)
 		}
 
+		if s.ctx.AgentCtx.Ctx.Err() != nil {
+			logger.Debug("session cancelled - completing without next turn",
+				"err", s.ctx.AgentCtx.Ctx.Err())
+			if err := s.ctx.StateMachine.Transition(s.ctx.AgentCtx, domain.StateCompleting); err != nil {
+				logger.Error("failed to transition to completing", "error", err)
+				return err
+			}
+			s.ctx.Events <- domain.CompletionRequestedEvent{}
+			return nil
+		}
+
 		if s.ctx.BackgroundTaskRegistry != nil && s.ctx.BackgroundTaskRegistry.HasPending() {
 			logger.Debug("background tasks pending, waiting")
 			s.ctx.WaitGroup.Add(1)

--- a/internal/agent/states/completing.go
+++ b/internal/agent/states/completing.go
@@ -51,7 +51,11 @@ func (s *CompletingState) Handle(event domain.AgentEvent) error {
 	logger.Debug("no queued messages, completing agent execution")
 
 	logger.Debug("publishing final chat completion event")
-	s.ctx.PublishChatComplete("", []sdk.ChatCompletionMessageToolCall{}, s.ctx.GetMetrics(s.ctx.Request.RequestID))
+	if s.ctx.AgentCtx.Ctx.Err() != nil {
+		s.ctx.PublishChatCancelled(s.ctx.GetMetrics(s.ctx.Request.RequestID))
+	} else {
+		s.ctx.PublishChatComplete("", []sdk.ChatCompletionMessageToolCall{}, s.ctx.GetMetrics(s.ctx.Request.RequestID))
+	}
 
 	if err := s.ctx.StateMachine.Transition(s.ctx.AgentCtx, domain.StateIdle); err != nil {
 		logger.Error("failed to transition to idle", "error", err)

--- a/internal/agent/states/post_tool_execution.go
+++ b/internal/agent/states/post_tool_execution.go
@@ -33,15 +33,7 @@ func (s *PostToolExecutionState) Handle(event domain.AgentEvent) error {
 		"queue_empty", s.ctx.AgentCtx.MessageQueue.IsEmpty())
 
 	if !s.ctx.AgentCtx.MessageQueue.IsEmpty() {
-		logger.Debug("messages queued during tool execution, draining queue")
-		numBatched := s.ctx.BatchDrainQueue()
-		logger.Debug("batched messages after tool execution", "count", numBatched)
-		if err := s.ctx.StateMachine.Transition(s.ctx.AgentCtx, domain.StateCheckingQueue); err != nil {
-			logger.Error("failed to transition to checking queue", "error", err)
-			return err
-		}
-		s.ctx.Events <- domain.MessageReceivedEvent{}
-		return nil
+		return s.handleQueuedMessages()
 	}
 
 	if s.ctx.StateMachine.CanTransition(s.ctx.AgentCtx, domain.StateCompleting) {
@@ -59,5 +51,33 @@ func (s *PostToolExecutionState) Handle(event domain.AgentEvent) error {
 		}
 		s.ctx.Events <- domain.MessageReceivedEvent{}
 	}
+	return nil
+}
+
+// handleQueuedMessages drains queued messages into conversation history. If
+// the session ctx was cancelled (Esc), it short-circuits to Completing so
+// the queued input is preserved without starting another LLM turn —
+// matching the "drain then stop" contract from issue #532.
+func (s *PostToolExecutionState) handleQueuedMessages() error {
+	logger.Debug("messages queued during tool execution, draining queue")
+	numBatched := s.ctx.BatchDrainQueue()
+	logger.Debug("batched messages after tool execution", "count", numBatched)
+
+	if s.ctx.AgentCtx.Ctx.Err() != nil {
+		logger.Debug("session cancelled after drain - completing without next turn",
+			"err", s.ctx.AgentCtx.Ctx.Err())
+		if err := s.ctx.StateMachine.Transition(s.ctx.AgentCtx, domain.StateCompleting); err != nil {
+			logger.Error("failed to transition to completing", "error", err)
+			return err
+		}
+		s.ctx.Events <- domain.CompletionRequestedEvent{}
+		return nil
+	}
+
+	if err := s.ctx.StateMachine.Transition(s.ctx.AgentCtx, domain.StateCheckingQueue); err != nil {
+		logger.Error("failed to transition to checking queue", "error", err)
+		return err
+	}
+	s.ctx.Events <- domain.MessageReceivedEvent{}
 	return nil
 }

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -450,8 +450,8 @@ func isDomainEvent(msg tea.Msg) bool {
 		return true
 
 	// Other domain events
-	case domain.CancelledEvent,
-		domain.MessageQueuedEvent,
+	case domain.MessageQueuedEvent,
+		domain.ToolCancelledEvent,
 		domain.TodoUpdateChatEvent,
 		domain.AgentStatusUpdateEvent,
 		domain.NavigateBackInTimeEvent,

--- a/internal/domain/agent_events.go
+++ b/internal/domain/agent_events.go
@@ -117,4 +117,5 @@ type StateContext struct {
 	GetAgentMode          func() AgentMode
 	PublishChatEvent      func(event ChatEvent)
 	PublishChatComplete   func(reasoning string, toolCalls []sdk.ChatCompletionMessageToolCall, metrics *ChatMetrics)
+	PublishChatCancelled  func(metrics *ChatMetrics)
 }

--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -49,7 +49,10 @@ type ChatChunkEvent struct {
 func (e ChatChunkEvent) GetRequestID() string    { return e.RequestID }
 func (e ChatChunkEvent) GetTimestamp() time.Time { return e.Timestamp }
 
-// ChatCompleteEvent indicates chat completion
+// ChatCompleteEvent indicates chat completion. Cancelled is set when the
+// completion is the result of a user-initiated cancel (Esc) rather than the
+// model finishing on its own — the UI uses this to show "User interrupted"
+// rather than "Response complete".
 type ChatCompleteEvent struct {
 	RequestID        string
 	Timestamp        time.Time
@@ -57,6 +60,7 @@ type ChatCompleteEvent struct {
 	ReasoningContent string
 	ToolCalls        []sdk.ChatCompletionMessageToolCall
 	Metrics          *ChatMetrics
+	Cancelled        bool
 }
 
 func (e ChatCompleteEvent) GetRequestID() string    { return e.RequestID }
@@ -108,16 +112,6 @@ type ToolCallReadyEvent struct {
 
 func (e ToolCallReadyEvent) GetRequestID() string    { return e.RequestID }
 func (e ToolCallReadyEvent) GetTimestamp() time.Time { return e.Timestamp }
-
-// CancelledEvent indicates a request was cancelled
-type CancelledEvent struct {
-	RequestID string
-	Timestamp time.Time
-	Reason    string
-}
-
-func (e CancelledEvent) GetRequestID() string    { return e.RequestID }
-func (e CancelledEvent) GetTimestamp() time.Time { return e.Timestamp }
 
 // OptimizationStatusEvent indicates conversation optimization status
 type OptimizationStatusEvent struct {
@@ -249,6 +243,22 @@ type ToolRejectedEvent struct {
 
 func (e ToolRejectedEvent) GetRequestID() string    { return e.RequestID }
 func (e ToolRejectedEvent) GetTimestamp() time.Time { return e.Timestamp }
+
+// ToolCancelledEvent is published when the conversation validator
+// synthesizes a Tool-role response for an assistant tool_call whose
+// real execution never completed (typically because the user pressed
+// Esc between the model emitting tool_calls and the tools running).
+// The conversation view uses this to surface a "[cancelled]" entry
+// so the user understands why a requested tool never produced output.
+type ToolCancelledEvent struct {
+	RequestID  string
+	Timestamp  time.Time
+	ToolCallID string
+	ToolName   string
+}
+
+func (e ToolCancelledEvent) GetRequestID() string    { return e.RequestID }
+func (e ToolCancelledEvent) GetTimestamp() time.Time { return e.Timestamp }
 
 // ToolApprovalClearedEvent is used for standard tool approval workflow.
 // Computer-use tools use a separate pause/resume mechanism.

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -135,8 +135,6 @@ func (h *ChatHandler) Handle(msg tea.Msg) tea.Cmd { // nolint:cyclop,gocyclo,fun
 		return h.HandleBackgroundShellRequest()
 	case domain.ToolExecutionCompletedEvent:
 		return h.HandleToolExecutionCompletedEvent(m)
-	case domain.CancelledEvent:
-		return h.HandleCancelledEvent(m)
 	case domain.A2AToolCallExecutedEvent:
 		return h.HandleA2AToolCallExecutedEvent(m)
 	case domain.A2ATaskSubmittedEvent:
@@ -151,6 +149,8 @@ func (h *ChatHandler) Handle(msg tea.Msg) tea.Cmd { // nolint:cyclop,gocyclo,fun
 		return h.HandleA2ATaskInputRequiredEvent(m)
 	case domain.MessageQueuedEvent:
 		return h.HandleMessageQueuedEvent(m)
+	case domain.ToolCancelledEvent:
+		return h.HandleToolCancelledEvent(m)
 	case domain.ToolApprovalRequestedEvent:
 		return h.HandleToolApprovalRequestedEvent(m)
 	case domain.ToolApprovalResponseEvent:
@@ -537,12 +537,6 @@ func (h *ChatHandler) HandleToolExecutionCompletedEvent(
 	return h.handleToolExecutionCompleted(msg)
 }
 
-func (h *ChatHandler) HandleCancelledEvent(
-	msg domain.CancelledEvent,
-) tea.Cmd {
-	return h.handleCancelled(msg)
-}
-
 func (h *ChatHandler) HandleA2AToolCallExecutedEvent(
 	msg domain.A2AToolCallExecutedEvent,
 ) tea.Cmd {
@@ -588,6 +582,29 @@ func (h *ChatHandler) HandleMessageQueuedEvent(
 ) tea.Cmd {
 	_, cmd := h.handleMessageQueued(msg)
 	return cmd
+}
+
+// HandleToolCancelledEvent refreshes the conversation view so the
+// synthetic [cancelled] tool entry that the integrity validator just
+// persisted becomes visible. No status-bar message — the cancel that
+// triggered this already drove its own status ("User interrupted").
+func (h *ChatHandler) HandleToolCancelledEvent(
+	_ domain.ToolCancelledEvent,
+) tea.Cmd {
+	var cmds []tea.Cmd
+
+	cmds = append(cmds, func() tea.Msg {
+		history := h.conversationRepo.GetMessages()
+		return domain.UpdateHistoryEvent{
+			History: history,
+		}
+	})
+
+	if chatSession := h.stateManager.GetChatSession(); chatSession != nil && chatSession.EventChannel != nil {
+		cmds = append(cmds, h.ListenForChatEvents(chatSession.EventChannel))
+	}
+
+	return tea.Sequence(cmds...)
 }
 
 func (h *ChatHandler) HandleToolApprovalResponseEvent(
@@ -1106,7 +1123,15 @@ func (h *ChatHandler) handleChatComplete(
 ) tea.Cmd {
 	h.restorePendingModel()
 
-	if len(msg.ToolCalls) == 0 {
+	if msg.Cancelled {
+		// Cancel path absorbs the cleanup that used to live in handleCancelled:
+		// end the chat session, clear active tool execution, and move chat
+		// status to Cancelled so the input area returns to idle.
+		_ = h.stateManager.UpdateChatStatus(domain.ChatStatusCancelled)
+		h.stateManager.EndChatSession()
+		h.stateManager.EndToolExecution()
+		h.SetActiveToolCallID("")
+	} else if len(msg.ToolCalls) == 0 {
 		_ = h.stateManager.UpdateChatStatus(domain.ChatStatusCompleted)
 	}
 
@@ -1134,9 +1159,13 @@ func (h *ChatHandler) handleChatComplete(
 		})
 	}
 
+	statusMessage := "Response complete"
+	if msg.Cancelled {
+		statusMessage = "User interrupted"
+	}
 	cmds = append(cmds, func() tea.Msg {
 		return domain.SetStatusEvent{
-			Message:    "Response complete",
+			Message:    statusMessage,
 			Spinner:    false,
 			StatusType: domain.StatusDefault,
 		}
@@ -1695,23 +1724,6 @@ func (h *ChatHandler) handleA2ATaskInputRequired(
 	}
 
 	return nil, tea.Sequence(cmds...)
-}
-
-func (h *ChatHandler) handleCancelled(
-	msg domain.CancelledEvent,
-) tea.Cmd {
-	_ = h.stateManager.UpdateChatStatus(domain.ChatStatusCancelled)
-	h.stateManager.EndChatSession()
-	h.stateManager.EndToolExecution()
-	h.SetActiveToolCallID("")
-
-	return func() tea.Msg {
-		return domain.SetStatusEvent{
-			Message:    fmt.Sprintf("Request cancelled: %s", msg.Reason),
-			Spinner:    false,
-			StatusType: domain.StatusDefault,
-		}
-	}
 }
 
 func (h *ChatHandler) handleA2AToolCallExecuted(

--- a/internal/services/conversation_validator.go
+++ b/internal/services/conversation_validator.go
@@ -1,0 +1,84 @@
+package services
+
+import (
+	sdk "github.com/inference-gateway/sdk"
+)
+
+// CancelledToolResponseContent is the sentinel body used for synthetic
+// tool responses inserted by EnsureToolCallsClosed. The wording is
+// surfaced to the model in the next turn and to the user via the
+// conversation view, so it must be self-explanatory and stable.
+const CancelledToolResponseContent = "[Tool execution cancelled by user before completion]"
+
+// SyntheticToolResponse pairs a synthesized Tool-role message with the
+// metadata of the assistant tool_call it closes. Callers persist
+// Message to the conversation repository and use ToolCallID / ToolName
+// when emitting UI events.
+type SyntheticToolResponse struct {
+	Message    sdk.Message
+	ToolCallID string
+	ToolName   string
+}
+
+// EnsureToolCallsClosed enforces the OpenAI-style invariant that every
+// assistant message with tool_calls is followed by a Tool-role message
+// for each tool_call_id. For every unmatched tool_call_id it inserts a
+// synthetic Tool-role response with CancelledToolResponseContent at the
+// tail of the existing tool responses for that assistant turn,
+// preserving the original tool_calls order.
+//
+// The returned conversation is a copy; the input slice is not mutated.
+// The returned synthetics list is in insertion order and is non-nil
+// only when at least one synthetic was added.
+//
+// Idempotent: running on an already-repaired conversation returns the
+// input shape with an empty synthetics slice.
+func EnsureToolCallsClosed(conv []sdk.Message) ([]sdk.Message, []SyntheticToolResponse) {
+	if len(conv) == 0 {
+		return conv, nil
+	}
+
+	var synthetics []SyntheticToolResponse
+	repaired := make([]sdk.Message, 0, len(conv))
+
+	for i := 0; i < len(conv); i++ {
+		msg := conv[i]
+		repaired = append(repaired, msg)
+
+		if msg.Role != sdk.Assistant || msg.ToolCalls == nil || len(*msg.ToolCalls) == 0 {
+			continue
+		}
+
+		seen := make(map[string]bool, len(*msg.ToolCalls))
+		j := i + 1
+		for j < len(conv) && conv[j].Role == sdk.Tool {
+			if conv[j].ToolCallID != nil {
+				seen[*conv[j].ToolCallID] = true
+			}
+			repaired = append(repaired, conv[j])
+			j++
+		}
+
+		for _, tc := range *msg.ToolCalls {
+			if tc.ID == "" || seen[tc.ID] {
+				continue
+			}
+			id := tc.ID
+			synth := sdk.Message{
+				Role:       sdk.Tool,
+				Content:    sdk.NewMessageContent(CancelledToolResponseContent),
+				ToolCallID: &id,
+			}
+			repaired = append(repaired, synth)
+			synthetics = append(synthetics, SyntheticToolResponse{
+				Message:    synth,
+				ToolCallID: tc.ID,
+				ToolName:   tc.Function.Name,
+			})
+		}
+
+		i = j - 1
+	}
+
+	return repaired, synthetics
+}

--- a/internal/services/conversation_validator_test.go
+++ b/internal/services/conversation_validator_test.go
@@ -1,0 +1,267 @@
+package services_test
+
+import (
+	"testing"
+
+	services "github.com/inference-gateway/cli/internal/services"
+	sdk "github.com/inference-gateway/sdk"
+)
+
+func assistantWithToolCalls(ids ...string) sdk.Message {
+	calls := make([]sdk.ChatCompletionMessageToolCall, 0, len(ids))
+	for _, id := range ids {
+		calls = append(calls, sdk.ChatCompletionMessageToolCall{
+			ID:   id,
+			Type: sdk.Function,
+			Function: sdk.ChatCompletionMessageToolCallFunction{
+				Name:      "Tool_" + id,
+				Arguments: "{}",
+			},
+		})
+	}
+	return sdk.Message{
+		Role:      sdk.Assistant,
+		Content:   sdk.NewMessageContent("calling tools"),
+		ToolCalls: &calls,
+	}
+}
+
+func toolResponse(id, content string) sdk.Message {
+	idCopy := id
+	return sdk.Message{
+		Role:       sdk.Tool,
+		Content:    sdk.NewMessageContent(content),
+		ToolCallID: &idCopy,
+	}
+}
+
+func userMsg(content string) sdk.Message {
+	return sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent(content)}
+}
+
+func TestEnsureToolCallsClosed_EmptyConversation(t *testing.T) {
+	repaired, synthetics := services.EnsureToolCallsClosed(nil)
+	if len(repaired) != 0 {
+		t.Errorf("expected empty repaired, got %d", len(repaired))
+	}
+	if len(synthetics) != 0 {
+		t.Errorf("expected no synthetics, got %d", len(synthetics))
+	}
+}
+
+func TestEnsureToolCallsClosed_NoToolCalls(t *testing.T) {
+	conv := []sdk.Message{
+		userMsg("hi"),
+		{Role: sdk.Assistant, Content: sdk.NewMessageContent("hello")},
+		userMsg("bye"),
+	}
+	repaired, synthetics := services.EnsureToolCallsClosed(conv)
+	if len(synthetics) != 0 {
+		t.Errorf("expected no synthetics, got %d", len(synthetics))
+	}
+	if len(repaired) != len(conv) {
+		t.Errorf("expected len %d, got %d", len(conv), len(repaired))
+	}
+}
+
+func TestEnsureToolCallsClosed_AllToolCallsResolved(t *testing.T) {
+	conv := []sdk.Message{
+		userMsg("read files"),
+		assistantWithToolCalls("a", "b", "c"),
+		toolResponse("a", "result-a"),
+		toolResponse("b", "result-b"),
+		toolResponse("c", "result-c"),
+		{Role: sdk.Assistant, Content: sdk.NewMessageContent("done")},
+	}
+	repaired, synthetics := services.EnsureToolCallsClosed(conv)
+	if len(synthetics) != 0 {
+		t.Errorf("expected no synthetics, got %d", len(synthetics))
+	}
+	if len(repaired) != len(conv) {
+		t.Errorf("expected len %d, got %d", len(conv), len(repaired))
+	}
+}
+
+func TestEnsureToolCallsClosed_OnePartialResolved(t *testing.T) {
+	conv := []sdk.Message{
+		userMsg("read 3 files"),
+		assistantWithToolCalls("a", "b", "c"),
+		toolResponse("b", "result-b"),
+		userMsg("hi"),
+	}
+	repaired, synthetics := services.EnsureToolCallsClosed(conv)
+	if len(synthetics) != 2 {
+		t.Fatalf("expected 2 synthetics, got %d", len(synthetics))
+	}
+	if synthetics[0].ToolCallID != "a" || synthetics[1].ToolCallID != "c" {
+		t.Errorf("expected synthetics for [a, c] in order, got [%s, %s]",
+			synthetics[0].ToolCallID, synthetics[1].ToolCallID)
+	}
+
+	if len(repaired) != 6 {
+		t.Fatalf("expected len 6, got %d", len(repaired))
+	}
+	if repaired[2].Role != sdk.Tool || repaired[2].ToolCallID == nil || *repaired[2].ToolCallID != "b" {
+		t.Errorf("expected real response b at index 2, got role=%s id=%v", repaired[2].Role, repaired[2].ToolCallID)
+	}
+	if repaired[3].Role != sdk.Tool || repaired[3].ToolCallID == nil || *repaired[3].ToolCallID != "a" {
+		t.Errorf("expected synthetic a at index 3, got role=%s id=%v", repaired[3].Role, repaired[3].ToolCallID)
+	}
+	if repaired[4].Role != sdk.Tool || repaired[4].ToolCallID == nil || *repaired[4].ToolCallID != "c" {
+		t.Errorf("expected synthetic c at index 4, got role=%s id=%v", repaired[4].Role, repaired[4].ToolCallID)
+	}
+	if repaired[5].Role != sdk.User {
+		t.Errorf("expected user msg at index 5, got role=%s", repaired[5].Role)
+	}
+}
+
+func TestEnsureToolCallsClosed_NoneResolved(t *testing.T) {
+	conv := []sdk.Message{
+		userMsg("read files"),
+		assistantWithToolCalls("a", "b", "c"),
+		userMsg("hi"),
+	}
+	repaired, synthetics := services.EnsureToolCallsClosed(conv)
+	if len(synthetics) != 3 {
+		t.Fatalf("expected 3 synthetics, got %d", len(synthetics))
+	}
+	want := []string{"a", "b", "c"}
+	for i, s := range synthetics {
+		if s.ToolCallID != want[i] {
+			t.Errorf("synthetics[%d].ToolCallID = %s, want %s", i, s.ToolCallID, want[i])
+		}
+		body, err := s.Message.Content.AsMessageContent0()
+		if err != nil || body != services.CancelledToolResponseContent {
+			t.Errorf("synthetics[%d].Message.Content = %q (err=%v), want %q",
+				i, body, err, services.CancelledToolResponseContent)
+		}
+	}
+	if len(repaired) != 6 {
+		t.Fatalf("expected len 6, got %d", len(repaired))
+	}
+	if repaired[5].Role != sdk.User {
+		t.Errorf("user message should land after synthetics, got role=%s at index 5", repaired[5].Role)
+	}
+}
+
+func TestEnsureToolCallsClosed_Idempotent(t *testing.T) {
+	conv := []sdk.Message{
+		userMsg("read files"),
+		assistantWithToolCalls("a", "b"),
+		userMsg("hi"),
+	}
+	once, synth1 := services.EnsureToolCallsClosed(conv)
+	if len(synth1) != 2 {
+		t.Fatalf("first pass expected 2 synthetics, got %d", len(synth1))
+	}
+	twice, synth2 := services.EnsureToolCallsClosed(once)
+	if len(synth2) != 0 {
+		t.Errorf("second pass expected 0 synthetics, got %d", len(synth2))
+	}
+	if len(twice) != len(once) {
+		t.Errorf("second pass changed conversation length: %d → %d", len(once), len(twice))
+	}
+}
+
+func TestEnsureToolCallsClosed_MultipleAssistantMessages(t *testing.T) {
+	conv := []sdk.Message{
+		userMsg("first"),
+		assistantWithToolCalls("a1"),
+		userMsg("second"),
+		assistantWithToolCalls("b1", "b2"),
+		toolResponse("b2", "ok"),
+		userMsg("third"),
+	}
+	repaired, synthetics := services.EnsureToolCallsClosed(conv)
+	if len(synthetics) != 2 {
+		t.Fatalf("expected 2 synthetics across 2 assistant turns, got %d", len(synthetics))
+	}
+	if synthetics[0].ToolCallID != "a1" {
+		t.Errorf("first synthetic should close a1, got %s", synthetics[0].ToolCallID)
+	}
+	if synthetics[1].ToolCallID != "b1" {
+		t.Errorf("second synthetic should close b1, got %s", synthetics[1].ToolCallID)
+	}
+
+	if repaired[2].Role != sdk.Tool || *repaired[2].ToolCallID != "a1" {
+		t.Errorf("synthetic for a1 should land at index 2, got role=%s id=%v",
+			repaired[2].Role, repaired[2].ToolCallID)
+	}
+	if repaired[3].Role != sdk.User {
+		t.Errorf("'second' user msg should land at index 3, got role=%s", repaired[3].Role)
+	}
+}
+
+func TestEnsureToolCallsClosed_ReasoningPreserved(t *testing.T) {
+	reasoning := "I should read these files"
+	asst := assistantWithToolCalls("a", "b")
+	asst.Reasoning = &reasoning
+	asst.ReasoningContent = &reasoning
+
+	conv := []sdk.Message{userMsg("read"), asst, userMsg("hi")}
+	repaired, _ := services.EnsureToolCallsClosed(conv)
+
+	if repaired[1].Reasoning == nil || *repaired[1].Reasoning != reasoning {
+		t.Errorf("Reasoning lost: got %v", repaired[1].Reasoning)
+	}
+	if repaired[1].ReasoningContent == nil || *repaired[1].ReasoningContent != reasoning {
+		t.Errorf("ReasoningContent lost: got %v", repaired[1].ReasoningContent)
+	}
+	if repaired[1].ToolCalls == nil || len(*repaired[1].ToolCalls) != 2 {
+		t.Errorf("ToolCalls altered on assistant message")
+	}
+}
+
+func TestEnsureToolCallsClosed_NilToolCallIDIgnored(t *testing.T) {
+	conv := []sdk.Message{
+		userMsg("read"),
+		assistantWithToolCalls("a"),
+		{Role: sdk.Tool, Content: sdk.NewMessageContent("orphan-tool"), ToolCallID: nil},
+		userMsg("hi"),
+	}
+	_, synthetics := services.EnsureToolCallsClosed(conv)
+	if len(synthetics) != 1 {
+		t.Fatalf("expected 1 synthetic (the nil-ID tool message doesn't satisfy 'a'), got %d", len(synthetics))
+	}
+	if synthetics[0].ToolCallID != "a" {
+		t.Errorf("expected synthetic for a, got %s", synthetics[0].ToolCallID)
+	}
+}
+
+func TestEnsureToolCallsClosed_PreservesToolNameForUI(t *testing.T) {
+	calls := []sdk.ChatCompletionMessageToolCall{
+		{
+			ID:   "tc1",
+			Type: sdk.Function,
+			Function: sdk.ChatCompletionMessageToolCallFunction{
+				Name:      "Read",
+				Arguments: `{"file_path":"/x"}`,
+			},
+		},
+	}
+	conv := []sdk.Message{
+		userMsg("read x"),
+		{Role: sdk.Assistant, Content: sdk.NewMessageContent(""), ToolCalls: &calls},
+		userMsg("hi"),
+	}
+	_, synthetics := services.EnsureToolCallsClosed(conv)
+	if len(synthetics) != 1 || synthetics[0].ToolName != "Read" {
+		t.Errorf("expected synthetic with ToolName=Read, got %+v", synthetics)
+	}
+}
+
+func TestEnsureToolCallsClosed_EmptyIDSkipped(t *testing.T) {
+	calls := []sdk.ChatCompletionMessageToolCall{
+		{ID: "", Type: sdk.Function, Function: sdk.ChatCompletionMessageToolCallFunction{Name: "X"}},
+		{ID: "good", Type: sdk.Function, Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Y"}},
+	}
+	conv := []sdk.Message{
+		userMsg("u"),
+		{Role: sdk.Assistant, Content: sdk.NewMessageContent(""), ToolCalls: &calls},
+		userMsg("v"),
+	}
+	_, synthetics := services.EnsureToolCallsClosed(conv)
+	if len(synthetics) != 1 || synthetics[0].ToolCallID != "good" {
+		t.Errorf("empty-ID tool_call should be skipped, only 'good' synthesized; got %+v", synthetics)
+	}
+}

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -729,7 +729,7 @@ func handleCancel(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 
 	return func() tea.Msg {
 		return domain.SetStatusEvent{
-			Message: "Operation cancelled",
+			Message: "User interrupted",
 			Spinner: false,
 		}
 	}


### PR DESCRIPTION
Fixes issues #531 and #532.
- Adds conversation integrity validation to insert synthetic tool responses for orphan tool_call_ids, preventing gateway 400 errors.
- Refactors cancellation into a unified session mechanism (sessionCancel with sync.Once), making Esc press idempotent.
- Implements drain-then-stop semantics so queued user input is preserved when cancelling mid-turn.