### PR TITLE
feat(ui): Visualise background A2A agents (#534)

### DIFF
--- a/config/agents.go
+++ b/config/agents.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	utils "github.com/inference-gateway/cli/config/utils"
@@ -38,6 +40,24 @@ const (
 	AgentsFileName    = "agents.yaml"
 	DefaultAgentsPath = ConfigDirName + "/" + AgentsFileName
 )
+
+// ResolveAgentsPath returns the path agents.yaml should be loaded from,
+// matching A2AAgentService's lookup order: project-level
+// `.infer/agents.yaml` wins if present, otherwise the userspace
+// `~/.infer/agents.yaml`, otherwise the project default (which may not
+// exist yet — LoadAgents handles that gracefully).
+func ResolveAgentsPath() string {
+	if _, err := os.Stat(DefaultAgentsPath); err == nil {
+		return DefaultAgentsPath
+	}
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		userspace := filepath.Join(homeDir, ConfigDirName, AgentsFileName)
+		if _, err := os.Stat(userspace); err == nil {
+			return userspace
+		}
+	}
+	return DefaultAgentsPath
+}
 
 // ParseModel parses a model string in the format "provider/model" and returns
 // the provider and model separately. If the format is invalid, returns empty strings.

--- a/docs/a2a-connections.md
+++ b/docs/a2a-connections.md
@@ -146,6 +146,69 @@ background. Only use `A2A_QueryTask` to:
 2. Check tasks submitted outside this session
 3. Get detailed results AFTER you receive a completion notification
 
+#### Background Task Visualisation
+
+While a remote A2A task is running in the background, the CLI shows a live,
+sticky status bar pinned **just above the input box** (below the scrollable
+conversation viewport). It is always visible regardless of where you've
+scrolled the conversation, so you never lose sight of in-flight delegations.
+
+A typical bar looks like:
+
+```text
+… conversation viewport (scrollable) …
+─────────────────────────────────────────────
+◓ Agent(weather-agent=working...)
+> _   (input)
+```
+
+The line updates in place as the task progresses through its lifecycle:
+`submitted` → `working` → `completed` / `failed` / `cancelled`.
+
+On successful completion, the indicator expands to a tree-style block
+showing the `usage` and `execution_stats` JSON taken from the remote
+task's `metadata` (populated by ADK ≥ 0.19.0 agents that have
+`EnableUsageMetadata` enabled - the default). `usage` reports token
+consumption; `execution_stats` reports iterations, messages, tool calls,
+and failed tool calls:
+
+```text
+✓ Agent(weather-agent=completed)
+  ├── usage={"prompt_tokens":156,"completion_tokens":89,"total_tokens":245}
+  └── execution_stats={"iterations":2,"messages":4,"tool_calls":1,"failed_tools":0}
+```
+
+Either or both branches are omitted if the remote agent doesn't emit
+the corresponding metadata (older ADK versions, or
+`EnableUsageMetadata=false`). Failures follow the same layout with an
+additional `error: …` branch.
+
+On failure:
+
+```text
+✗ Agent(weather-agent=failed: connection refused)
+```
+
+The indicator auto-removes itself **5 seconds** after the task reaches a
+terminal state (`completed`, `failed`, or `cancelled`), keeping the bar
+tidy while still giving you time to glance at the usage / error.
+
+Multiple concurrent tasks each get their own line in the bar (one line per
+task, lexicographically ordered by task ID for stability), so a single
+assistant turn that submits several A2A tasks shows independent progress
+lines side-by-side without any reordering between renders.
+
+Notes:
+
+- The indicator is purely a UI element — it is not persisted with the
+  conversation. Reloading a session will not bring back indicators for
+  tasks that have already completed.
+- If the remote agent does not attach `metadata.usage` (older ADK versions,
+  or `EnableUsageMetadata=false`), the completed line omits the `usage=...`
+  suffix.
+- For a full historical record of past tasks, use `A2A_QueryTask` or the
+  in-session task management view.
+
 ### Tool Implementation Details
 
 #### A2A_SubmitTask Tool

--- a/examples/a2a/README.md
+++ b/examples/a2a/README.md
@@ -75,6 +75,45 @@ open vnc://localhost:5900
 **Note:** The X11 display is created by Xvfb when the browser-agent container starts. The VNC server will connect
 automatically and you can view browser automation in real-time.
 
+## What You'll See in the CLI
+
+When the model delegates a task to a configured agent via `A2A_SubmitTask`, a
+live sticky status bar appears **just above the input box** showing the remote
+task's progress:
+
+```text
+… conversation viewport …
+─────────────────────────────────────────────
+◓ Agent(google-calendar-agent=working...)
+> _   (input)
+```
+
+When the remote agent completes, the line expands to a tree-style block
+showing the token usage and execution statistics from the agent's
+`Task.metadata` (populated by ADK ≥ 0.19.0):
+
+```text
+✓ Agent(google-calendar-agent=completed)
+  ├── usage={"prompt_tokens":156,"completion_tokens":89,"total_tokens":245}
+  └── execution_stats={"iterations":2,"messages":4,"tool_calls":1,"failed_tools":0}
+```
+
+The indicator auto-disappears 5 seconds later so the conversation stays tidy.
+Failed tasks show `✗ Agent(<name>=failed: <error>)` and follow the same 5s
+auto-removal.
+
+Try it: ask the CLI a question that requires the calendar agent (e.g.
+"What's on my calendar today?") and watch the indicator appear and then
+auto-clear after the agent responds.
+
+> **Note:** The `usage=…` suffix only appears when the remote agent runs
+> ADK ≥ 0.19.0 with `EnableUsageMetadata` enabled (the default in 0.19.0+).
+> If you see `Agent(name=completed)` with no `usage=…`, the agent image
+> needs to be rebuilt against the newer ADK. The friendly agent name
+> (e.g. `mock-agent` vs the raw URL) is resolved from
+> `~/.infer/agents.yaml` — if you've only registered agents via
+> `INFER_A2A_AGENTS`, the indicator will show the URL instead.
+
 ## Troubleshooting
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-vgo/robotgo v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/inference-gateway/adk v0.18.4
+	github.com/inference-gateway/adk v0.19.0
 	github.com/inference-gateway/sdk v1.16.4
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/lib/pq v1.12.3

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/inference-gateway/adk v0.18.4 h1:AiwGlKTBwpuC3E84EZjA7VjahY70QoUgNqGU2kudsxw=
-github.com/inference-gateway/adk v0.18.4/go.mod h1:0aWSOC2iLSYeSVSu7KC5GWNX+vhdo6/i01K14q46OHc=
+github.com/inference-gateway/adk v0.19.0 h1:Xoo9QGTzL7/7v6hEQDde6w/MhSz7y4oFwdqbjW/EQHE=
+github.com/inference-gateway/adk v0.19.0/go.mod h1:0aWSOC2iLSYeSVSu7KC5GWNX+vhdo6/i01K14q46OHc=
 github.com/inference-gateway/sdk v1.16.4 h1:2iB++slMI2EKq9MMcvQDBrqNsDFvYVAn2mXVi6O/clE=
 github.com/inference-gateway/sdk v1.16.4/go.mod h1:Qcm7duXS/Hz/xvs8yQhxLUbCUTWN/x88+npRWyeRst4=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=

--- a/internal/agent/tools/a2a_task.go
+++ b/internal/agent/tools/a2a_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -606,6 +607,8 @@ func (t *A2ASubmitTaskTool) formatA2ATaskData(data any, metadata map[string]stri
 	}
 	fmt.Fprintf(&dataContent, "State: %s\n", taskData.State)
 
+	t.appendTaskMetadataLines(&dataContent, taskData.Task)
+
 	if isFailedTaskState(adk.TaskState(taskData.State)) {
 		reason := taskData.TaskResult
 		if reason == "" && taskData.Task != nil {
@@ -628,6 +631,49 @@ func (t *A2ASubmitTaskTool) formatA2ATaskData(data any, metadata map[string]stri
 
 	hasMetadata := len(metadata) > 0
 	return dataContent.String(), hasMetadata
+}
+
+// appendTaskMetadataLines writes "Usage:" / "Execution Stats:" lines
+// from Task.Metadata into the formatted result, so the persisted history
+// view shows per-task token consumption and tool counts. Silently no-ops
+// when the remote agent didn't attach metadata (older ADK, or
+// EnableUsageMetadata=false).
+func (t *A2ASubmitTaskTool) appendTaskMetadataLines(builder *strings.Builder, task *adk.Task) {
+	if task == nil || task.Metadata == nil {
+		return
+	}
+	meta := *task.Metadata
+
+	if usageLine := formatMetadataMap(meta, "usage"); usageLine != "" {
+		fmt.Fprintf(builder, "Usage: %s\n", usageLine)
+	}
+	if statsLine := formatMetadataMap(meta, "execution_stats"); statsLine != "" {
+		fmt.Fprintf(builder, "Execution Stats: %s\n", statsLine)
+	}
+}
+
+// formatMetadataMap returns a flat "k1=v1, k2=v2" representation of one
+// top-level metadata map field. Keys are sorted for stable output.
+// Returns "" if the field is absent or empty.
+func formatMetadataMap(meta map[string]any, field string) string {
+	raw, ok := meta[field]
+	if !ok || raw == nil {
+		return ""
+	}
+	m, ok := raw.(map[string]any)
+	if !ok || len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, m[k]))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // formatArtifact formats a single artifact for display

--- a/internal/agent/tools/a2a_task_test.go
+++ b/internal/agent/tools/a2a_task_test.go
@@ -219,6 +219,71 @@ func TestA2ASubmitTaskTool_FormatResult(t *testing.T) {
 	}
 }
 
+func TestA2ASubmitTaskTool_FormatResult_IncludesUsageMetadata(t *testing.T) {
+	cfg := &config.Config{}
+	tool := NewA2ASubmitTaskTool(cfg, nil)
+
+	metadata := adk.Struct{
+		"usage": map[string]any{
+			"prompt_tokens":     21695,
+			"completion_tokens": 607,
+			"total_tokens":      22302,
+		},
+		"execution_stats": map[string]any{
+			"iterations":   5,
+			"messages":     4,
+			"tool_calls":   2,
+			"failed_tools": 0,
+		},
+	}
+	task := &adk.Task{
+		ID:       "task-with-meta",
+		Metadata: &metadata,
+		Status:   adk.TaskStatus{State: adk.TaskStateCompleted},
+	}
+	result := &domain.ToolExecutionResult{
+		ToolName: "A2A_SubmitTask",
+		Success:  true,
+		Data: A2ASubmitTaskResult{
+			TaskID:   "task-with-meta",
+			AgentURL: "http://browser-agent",
+			State:    string(adk.TaskStateCompleted),
+			Success:  true,
+			Task:     task,
+		},
+	}
+
+	out := tool.FormatResult(result, domain.FormatterLLM)
+	assert.Contains(t, out, "Usage:")
+	assert.Contains(t, out, "prompt_tokens=21695")
+	assert.Contains(t, out, "completion_tokens=607")
+	assert.Contains(t, out, "total_tokens=22302")
+	assert.Contains(t, out, "Execution Stats:")
+	assert.Contains(t, out, "tool_calls=2")
+	assert.Contains(t, out, "failed_tools=0")
+}
+
+func TestA2ASubmitTaskTool_FormatResult_NoMetadataOmitsLines(t *testing.T) {
+	cfg := &config.Config{}
+	tool := NewA2ASubmitTaskTool(cfg, nil)
+
+	result := &domain.ToolExecutionResult{
+		ToolName: "A2A_SubmitTask",
+		Success:  true,
+		Data: A2ASubmitTaskResult{
+			TaskID:   "no-meta",
+			AgentURL: "http://old-agent",
+			State:    string(adk.TaskStateCompleted),
+			Success:  true,
+			Task:     &adk.Task{ID: "no-meta", Status: adk.TaskStatus{State: adk.TaskStateCompleted}},
+		},
+	}
+
+	out := tool.FormatResult(result, domain.FormatterLLM)
+	assert.NotContains(t, out, "Usage:")
+	assert.NotContains(t, out, "Execution Stats:")
+}
+
 func TestA2ASubmitTaskTool_FormatResult_FailedSurfacesError(t *testing.T) {
 	cfg := &config.Config{}
 	tool := NewA2ASubmitTaskTool(cfg, nil)

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -168,6 +168,7 @@ func NewChatApplication(
 		cv.SetVersionInfo(versionInfo)
 		cv.SetToolCallRenderer(app.toolCallRenderer)
 		cv.SetStateManager(app.stateManager)
+		cv.SetAgentNameResolver(buildAgentNameResolver())
 	}
 
 	app.inputView = factory.CreateInputViewWithConfigDir(app.modelService, configDir)
@@ -1111,6 +1112,14 @@ func (app *ChatApplication) handleA2ATaskManagementCancelled(cmds []tea.Cmd) []t
 	}
 
 	app.focusedComponent = app.inputView
+
+	cmds = append(cmds, func() tea.Msg {
+		return domain.SetStatusEvent{
+			Message:    "",
+			Spinner:    false,
+			StatusType: domain.StatusDefault,
+		}
+	})
 
 	return cmds
 }
@@ -2140,6 +2149,30 @@ After merging, @infer mentions in issues will trigger the bot.
 	}
 
 	return fmt.Sprintf("https://github.com/%s/compare/%s...%s", repo, baseBranch, branch), nil
+}
+
+// buildAgentNameResolver loads ~/.infer/agents.yaml (or the project-level
+// equivalent) once and returns a closure that maps an agent URL to its
+// configured friendly name. Used by the background-agent indicator to show
+// e.g. `Agent(weather-agent=…)` instead of the raw URL. Returns nil on
+// load failure so the conversation view falls back to the URL.
+func buildAgentNameResolver() func(string) string {
+	cfg, err := config.LoadAgents(config.ResolveAgentsPath())
+	if err != nil || cfg == nil {
+		return nil
+	}
+	nameByURL := make(map[string]string, len(cfg.Agents))
+	for _, a := range cfg.Agents {
+		if a.URL != "" && a.Name != "" {
+			nameByURL[a.URL] = a.Name
+		}
+	}
+	if len(nameByURL) == 0 {
+		return nil
+	}
+	return func(url string) string {
+		return nameByURL[url]
+	}
 }
 
 // PrintConversationHistory outputs the full conversation history to stdout

--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -146,6 +146,7 @@ type A2ATaskSubmittedEvent struct {
 	Timestamp time.Time
 	TaskID    string
 	AgentName string
+	AgentURL  string
 	TaskType  string
 }
 
@@ -157,6 +158,7 @@ type A2ATaskStatusUpdateEvent struct {
 	RequestID string
 	Timestamp time.Time
 	TaskID    string
+	AgentURL  string
 	Status    string
 	Progress  float64
 	Message   string

--- a/internal/services/a2a_task_poller.go
+++ b/internal/services/a2a_task_poller.go
@@ -131,6 +131,8 @@ func (m *A2ATaskPoller) monitorSingleTask(ctx context.Context, taskID string, st
 		m.mu.Unlock()
 	}()
 
+	m.emitSubmittedEvent(state)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -220,6 +222,29 @@ func (m *A2ATaskPoller) emitCompletionEvent(taskID string, result *domain.ToolEx
 	}
 }
 
+// emitSubmittedEvent fires a single A2ATaskSubmittedEvent the first time
+// monitorSingleTask picks up a new polling state, so the UI gets the
+// task's agent identity before any status updates start arriving.
+func (m *A2ATaskPoller) emitSubmittedEvent(state *domain.TaskPollingState) {
+	if state == nil {
+		return
+	}
+
+	event := domain.A2ATaskSubmittedEvent{
+		RequestID: m.requestID,
+		Timestamp: time.Now(),
+		TaskID:    state.TaskID,
+		AgentURL:  state.AgentURL,
+	}
+
+	select {
+	case m.eventChan <- event:
+	default:
+		logger.Warn("Failed to emit A2A submitted event - channel full",
+			"task_id", state.TaskID)
+	}
+}
+
 func (m *A2ATaskPoller) emitStatusUpdateEvent(update *domain.A2ATaskStatusUpdate) {
 	if update == nil {
 		logger.Error("Received nil update in emitStatusUpdateEvent")
@@ -230,6 +255,7 @@ func (m *A2ATaskPoller) emitStatusUpdateEvent(update *domain.A2ATaskStatusUpdate
 		RequestID: m.requestID,
 		Timestamp: time.Now(),
 		TaskID:    update.TaskID,
+		AgentURL:  update.AgentURL,
 		Status:    update.State,
 		Message:   update.Message,
 	}

--- a/internal/ui/components/application_view.go
+++ b/internal/ui/components/application_view.go
@@ -46,7 +46,7 @@ func (r *ApplicationViewRenderer) RenderChatInterface(
 ) string {
 	width, height := data.Width, data.Height
 
-	heights := r.calculateComponentHeights(data, height, helpBar, queueBoxView, todoBoxView, approvalBoxView)
+	heights := r.calculateComponentHeights(data, height, conversationView, helpBar, queueBoxView, todoBoxView, approvalBoxView)
 
 	r.setComponentDimensions(width, conversationView, inputView, autocomplete, inputStatusBar, statusView,
 		modeIndicator, queueBoxView, todoBoxView, approvalBoxView, heights)
@@ -55,7 +55,7 @@ func (r *ApplicationViewRenderer) RenderChatInterface(
 	conversationArea := conversationView.Render()
 	inputArea := inputView.Render()
 
-	components := r.assembleComponents(data, header, conversationArea, inputArea, statusView, modeIndicator,
+	components := r.assembleComponents(data, header, conversationArea, inputArea, conversationView, statusView, modeIndicator,
 		inputView, inputStatusBar, autocomplete, helpBar, queueBoxView, todoBoxView, approvalBoxView, width, heights.statusHeight)
 
 	return strings.Join(components, "\n")
@@ -63,20 +63,22 @@ func (r *ApplicationViewRenderer) RenderChatInterface(
 
 // componentHeights holds calculated heights for various components
 type componentHeights struct {
-	headerHeight       int
-	helpBarHeight      int
-	queueBoxHeight     int
-	todoBoxHeight      int
-	approvalBoxHeight  int
-	conversationHeight int
-	inputHeight        int
-	statusHeight       int
+	headerHeight         int
+	helpBarHeight        int
+	queueBoxHeight       int
+	todoBoxHeight        int
+	approvalBoxHeight    int
+	backgroundTasksLines int
+	conversationHeight   int
+	inputHeight          int
+	statusHeight         int
 }
 
 // calculateComponentHeights calculates the heights for all components
 func (r *ApplicationViewRenderer) calculateComponentHeights(
 	data ChatInterfaceData,
 	totalHeight int,
+	conversationView ui.ConversationRenderer,
 	helpBar ui.HelpBarComponent,
 	queueBoxView *QueueBoxView,
 	todoBoxView *TodoBoxView,
@@ -107,8 +109,13 @@ func (r *ApplicationViewRenderer) calculateComponentHeights(
 		}
 	}
 
+	if cv, ok := conversationView.(*ConversationView); ok && cv.HasBackgroundTasks() {
+		heights.backgroundTasksLines = cv.BackgroundTasksBarHeight()
+	}
+
 	adjustedHeight := totalHeight - heights.headerHeight - heights.helpBarHeight -
-		heights.queueBoxHeight - heights.todoBoxHeight - heights.approvalBoxHeight
+		heights.queueBoxHeight - heights.todoBoxHeight - heights.approvalBoxHeight -
+		heights.backgroundTasksLines
 	heights.conversationHeight = ui.CalculateConversationHeight(adjustedHeight)
 	heights.inputHeight = ui.CalculateInputHeight(adjustedHeight)
 	heights.statusHeight = ui.CalculateStatusHeight(adjustedHeight)
@@ -176,6 +183,7 @@ func (r *ApplicationViewRenderer) renderHeader(_ ChatInterfaceData, width int) s
 func (r *ApplicationViewRenderer) assembleComponents(
 	data ChatInterfaceData,
 	header, conversationArea, inputArea string,
+	conversationView ui.ConversationRenderer,
 	statusView ui.StatusComponent,
 	modeIndicator *ModeIndicator,
 	inputView ui.InputComponent,
@@ -191,6 +199,7 @@ func (r *ApplicationViewRenderer) assembleComponents(
 
 	components = r.appendQueueBox(components, data, queueBoxView)
 	components = r.appendTodoBox(components, todoBoxView)
+	components = r.appendBackgroundTaskBar(components, conversationView, width)
 	components = r.appendModeIndicator(components, modeIndicator)
 	components = r.appendStatusView(components, statusView, statusHeight)
 	components = r.appendApprovalBox(components, approvalBoxView)
@@ -225,6 +234,25 @@ func (r *ApplicationViewRenderer) appendTodoBox(
 		if todoBoxContent := todoBoxView.Render(); todoBoxContent != "" {
 			components = append(components, todoBoxContent)
 		}
+	}
+	return components
+}
+
+// appendBackgroundTaskBar appends the sticky background-task indicator
+// rendered by the ConversationView, when any A2A task is currently tracked.
+// Always visible just above the input until the 5s post-terminal-state
+// auto-removal fires.
+func (r *ApplicationViewRenderer) appendBackgroundTaskBar(
+	components []string,
+	conversationView ui.ConversationRenderer,
+	width int,
+) []string {
+	cv, ok := conversationView.(*ConversationView)
+	if !ok || !cv.HasBackgroundTasks() {
+		return components
+	}
+	if bar := cv.RenderBackgroundTasksBar(width); bar != "" {
+		components = append(components, bar)
 	}
 	return components
 }

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	spinner "github.com/charmbracelet/bubbles/spinner"
 	viewport "github.com/charmbracelet/bubbles/viewport"
@@ -21,6 +23,7 @@ import (
 	hints "github.com/inference-gateway/cli/internal/ui/hints"
 	markdown "github.com/inference-gateway/cli/internal/ui/markdown"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
+	icons "github.com/inference-gateway/cli/internal/ui/styles/icons"
 )
 
 // NavigationMode represents the current navigation state of the conversation view
@@ -32,6 +35,32 @@ const (
 	// NavigationModeMessageHistory is the mode for navigating message history
 	NavigationModeMessageHistory
 )
+
+// backgroundTaskRemovalDelay is how long a terminal-state background-task
+// indicator lingers under the originating tool call before auto-removal.
+const backgroundTaskRemovalDelay = 5 * time.Second
+
+// BackgroundTaskDisplay tracks the live state of a remote A2A task for
+// inline visualisation under the originating A2A_SubmitTask tool result.
+// It is UI-only ephemeral state and is not persisted with the conversation.
+type BackgroundTaskDisplay struct {
+	TaskID             string
+	AgentName          string
+	AgentURL           string
+	State              string
+	Message            string
+	UsageJSON          string
+	ExecutionStatsJSON string
+	ErrorMsg           string
+	IsTerminal         bool
+	CompletedAt        time.Time
+}
+
+// BackgroundTaskRemovalTickMsg is dispatched backgroundTaskRemovalDelay after a
+// task reaches a terminal state to remove its inline indicator from the view.
+type BackgroundTaskRemovalTickMsg struct {
+	TaskID string
+}
 
 // ConversationView handles the chat conversation display
 type ConversationView struct {
@@ -72,6 +101,18 @@ type ConversationView struct {
 	navigationMode       NavigationMode
 	messageSnapshots     []domain.MessageSnapshot
 	historySelectedIndex int
+
+	// Inline background-task indicators for A2A_SubmitTask delegations.
+	// Keyed by remote task ID. Entries are inserted on
+	// A2ATaskSubmittedEvent, updated on status/complete/fail events, and
+	// removed by BackgroundTaskRemovalTickMsg ~5s after a terminal state.
+	backgroundTasks    map[string]*BackgroundTaskDisplay
+	backgroundSpinStep int
+	backgroundSpinner  spinner.Model
+	// agentNameResolver maps an agent URL to its configured friendly name
+	// from ~/.infer/agents.yaml. Optional; falls back to the URL when nil
+	// or when the URL has no matching entry.
+	agentNameResolver func(url string) string
 }
 
 func NewConversationView(styleProvider *styles.Provider) *ConversationView {
@@ -84,6 +125,11 @@ func NewConversationView(styleProvider *styles.Provider) *ConversationView {
 	if themeService := styleProvider.GetThemeService(); themeService != nil {
 		mdRenderer = markdown.NewRenderer(themeService, 80)
 	}
+
+	bgSpin := spinner.New()
+	bgSpinStyle := spinner.Dot
+	bgSpinStyle.FPS = 100 * time.Millisecond
+	bgSpin.Spinner = bgSpinStyle
 
 	return &ConversationView{
 		conversation:           []domain.ConversationEntry{},
@@ -98,6 +144,8 @@ func NewConversationView(styleProvider *styles.Provider) *ConversationView {
 		plainTextLines:         []string{},
 		styleProvider:          styleProvider,
 		markdownRenderer:       mdRenderer,
+		backgroundTasks:        make(map[string]*BackgroundTaskDisplay),
+		backgroundSpinner:      bgSpin,
 	}
 }
 
@@ -130,6 +178,13 @@ func (cv *ConversationView) SetStateManager(stateManager domain.StateManager) {
 // SetKeyHintFormatter sets the key hint formatter for displaying keybinding hints
 func (cv *ConversationView) SetKeyHintFormatter(formatter *hints.Formatter) {
 	cv.keyHintFormatter = formatter
+}
+
+// SetAgentNameResolver injects a URL→friendly-name lookup used when
+// rendering background-agent indicators. Pass nil to disable resolution
+// (the visual then falls back to the agent URL).
+func (cv *ConversationView) SetAgentNameResolver(resolver func(url string) string) {
+	cv.agentNameResolver = resolver
 }
 
 func (cv *ConversationView) SetConversation(conversation []domain.ConversationEntry) {
@@ -994,6 +1049,16 @@ func (cv *ConversationView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return cv.handleStreamingContentEvent(msg, cmd)
 	case domain.ScrollRequestEvent:
 		return cv.handleScrollRequestEvent(msg, cmd)
+	case domain.A2ATaskSubmittedEvent:
+		return cv.handleA2ATaskSubmitted(msg, cmd)
+	case domain.A2ATaskStatusUpdateEvent:
+		return cv.handleA2ATaskStatusUpdate(msg, cmd)
+	case domain.A2ATaskCompletedEvent:
+		return cv.handleA2ATaskCompleted(msg, cmd)
+	case domain.A2ATaskFailedEvent:
+		return cv.handleA2ATaskFailed(msg, cmd)
+	case BackgroundTaskRemovalTickMsg:
+		return cv.handleRemoveBackgroundTask(msg, cmd)
 	case spinner.TickMsg:
 		return cv.handleSpinnerTick(msg, cmd)
 	default:
@@ -1086,19 +1151,453 @@ func (cv *ConversationView) handleScrollRequestEvent(msg domain.ScrollRequestEve
 	return cv, cmd
 }
 
-// handleSpinnerTick processes spinner tick events
+// handleSpinnerTick processes spinner tick events. Tick messages carry a
+// per-spinner ID, so the same tea.Msg may belong to either the
+// ToolCallRenderer's spinner or our own backgroundSpinner — we forward
+// it to both. Whichever one's ID matches advances its frame and returns
+// the next-tick cmd; the other call is a no-op.
 func (cv *ConversationView) handleSpinnerTick(msg spinner.TickMsg, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	var bgCmd tea.Cmd
+	cv.backgroundSpinner, bgCmd = cv.backgroundSpinner.Update(msg)
+	if bgCmd != nil && cv.hasActiveBackgroundTasks() {
+		cv.backgroundSpinStep++
+		cmd = tea.Batch(cmd, bgCmd)
+	}
+
 	if cv.toolCallRenderer != nil {
 		updatedRenderer, rendererCmd := cv.toolCallRenderer.Update(msg)
 		cv.toolCallRenderer = updatedRenderer
-		if cv.navigationMode != NavigationModeMessageHistory && cv.toolCallRenderer.HasActivePreviews() {
+		if cv.navigationMode != NavigationModeMessageHistory &&
+			(cv.toolCallRenderer.HasActivePreviews() || cv.hasActiveBackgroundTasks()) {
 			cv.updateViewportContent()
 		}
 		if rendererCmd != nil {
 			cmd = tea.Batch(cmd, rendererCmd)
 		}
+	} else if cv.navigationMode != NavigationModeMessageHistory && cv.hasActiveBackgroundTasks() {
+		cv.updateViewportContent()
 	}
 	return cv, cmd
+}
+
+// handleA2ATaskSubmitted records a newly submitted A2A task so its live
+// progress can be rendered under the originating tool result.
+func (cv *ConversationView) handleA2ATaskSubmitted(msg domain.A2ATaskSubmittedEvent, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if msg.TaskID == "" {
+		return cv, cmd
+	}
+
+	display, exists := cv.backgroundTasks[msg.TaskID]
+	if !exists {
+		display = &BackgroundTaskDisplay{TaskID: msg.TaskID}
+		cv.backgroundTasks[msg.TaskID] = display
+	}
+	if msg.AgentName != "" {
+		display.AgentName = msg.AgentName
+	}
+	if msg.AgentURL != "" && display.AgentURL == "" {
+		display.AgentURL = msg.AgentURL
+	}
+	if display.State == "" {
+		display.State = "submitted"
+	}
+
+	startSpinner := !cv.hasOtherActiveBackgroundTasks(msg.TaskID)
+
+	if cv.navigationMode != NavigationModeMessageHistory {
+		cv.updateViewportContent()
+	}
+
+	if startSpinner {
+		cmd = tea.Batch(cmd, cv.backgroundSpinner.Tick)
+	}
+	return cv, cmd
+}
+
+// handleA2ATaskStatusUpdate refreshes the live state/message for an in-flight task.
+func (cv *ConversationView) handleA2ATaskStatusUpdate(msg domain.A2ATaskStatusUpdateEvent, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if msg.TaskID == "" {
+		return cv, cmd
+	}
+
+	display, exists := cv.backgroundTasks[msg.TaskID]
+	if !exists {
+		display = &BackgroundTaskDisplay{TaskID: msg.TaskID}
+		cv.backgroundTasks[msg.TaskID] = display
+	}
+	if msg.AgentURL != "" && display.AgentURL == "" {
+		display.AgentURL = msg.AgentURL
+	}
+	if msg.Status != "" {
+		display.State = msg.Status
+	}
+	if msg.Message != "" {
+		display.Message = msg.Message
+	}
+
+	if cv.navigationMode != NavigationModeMessageHistory {
+		cv.updateViewportContent()
+	}
+	return cv, cmd
+}
+
+// handleA2ATaskCompleted marks a task as successfully completed, captures
+// the usage JSON from Task.metadata, and schedules auto-removal.
+func (cv *ConversationView) handleA2ATaskCompleted(msg domain.A2ATaskCompletedEvent, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if msg.TaskID == "" {
+		return cv, cmd
+	}
+
+	display, exists := cv.backgroundTasks[msg.TaskID]
+	if !exists {
+		display = &BackgroundTaskDisplay{TaskID: msg.TaskID}
+		cv.backgroundTasks[msg.TaskID] = display
+	}
+	display.State = "completed"
+	display.IsTerminal = true
+	display.CompletedAt = time.Now()
+	display.UsageJSON = extractA2AUsageJSON(msg.Result.Data)
+	display.ExecutionStatsJSON = extractA2AExecutionStatsJSON(msg.Result.Data)
+	if display.AgentName == "" {
+		display.AgentName = extractA2AAgentName(msg.Result.Data)
+	}
+
+	if cv.navigationMode != NavigationModeMessageHistory {
+		cv.updateViewportContent()
+	}
+	return cv, tea.Batch(cmd, scheduleBackgroundTaskRemoval(msg.TaskID))
+}
+
+// handleA2ATaskFailed marks a task as failed, captures the error, and
+// schedules auto-removal.
+func (cv *ConversationView) handleA2ATaskFailed(msg domain.A2ATaskFailedEvent, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if msg.TaskID == "" {
+		return cv, cmd
+	}
+
+	display, exists := cv.backgroundTasks[msg.TaskID]
+	if !exists {
+		display = &BackgroundTaskDisplay{TaskID: msg.TaskID}
+		cv.backgroundTasks[msg.TaskID] = display
+	}
+	display.State = "failed"
+	display.IsTerminal = true
+	display.CompletedAt = time.Now()
+	display.ErrorMsg = msg.Error
+	if display.AgentName == "" {
+		display.AgentName = extractA2AAgentName(msg.Result.Data)
+	}
+
+	if cv.navigationMode != NavigationModeMessageHistory {
+		cv.updateViewportContent()
+	}
+	return cv, tea.Batch(cmd, scheduleBackgroundTaskRemoval(msg.TaskID))
+}
+
+// handleRemoveBackgroundTask removes a terminal-state task indicator after
+// its 5-second lingering window.
+func (cv *ConversationView) handleRemoveBackgroundTask(msg BackgroundTaskRemovalTickMsg, cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if _, exists := cv.backgroundTasks[msg.TaskID]; !exists {
+		return cv, cmd
+	}
+	delete(cv.backgroundTasks, msg.TaskID)
+
+	if cv.navigationMode != NavigationModeMessageHistory {
+		cv.updateViewportContent()
+	}
+	return cv, cmd
+}
+
+// hasActiveBackgroundTasks reports whether any tracked task has not yet
+// reached a terminal state — used to keep the spinner ticking only while
+// needed.
+func (cv *ConversationView) hasActiveBackgroundTasks() bool {
+	for _, d := range cv.backgroundTasks {
+		if !d.IsTerminal {
+			return true
+		}
+	}
+	return false
+}
+
+// hasOtherActiveBackgroundTasks reports whether any non-terminal task other
+// than `exceptTaskID` is being tracked.
+func (cv *ConversationView) hasOtherActiveBackgroundTasks(exceptTaskID string) bool {
+	for id, d := range cv.backgroundTasks {
+		if id == exceptTaskID {
+			continue
+		}
+		if !d.IsTerminal {
+			return true
+		}
+	}
+	return false
+}
+
+// scheduleBackgroundTaskRemoval returns a tea.Cmd that fires
+// BackgroundTaskRemovalTickMsg after backgroundTaskRemovalDelay.
+func scheduleBackgroundTaskRemoval(taskID string) tea.Cmd {
+	return tea.Tick(backgroundTaskRemovalDelay, func(_ time.Time) tea.Msg {
+		return BackgroundTaskRemovalTickMsg{TaskID: taskID}
+	})
+}
+
+// HasBackgroundTasks reports whether there is at least one tracked
+// background task to render in the sticky indicator bar.
+func (cv *ConversationView) HasBackgroundTasks() bool {
+	return len(cv.backgroundTasks) > 0
+}
+
+// RenderBackgroundTasksBar returns the sticky multi-line indicator block
+// rendered above the input area. Each tracked task gets one line. Order is
+// stable (lexicographic by TaskID) so concurrent tasks don't jitter
+// between renders. Returns "" when there are no tasks to show.
+func (cv *ConversationView) RenderBackgroundTasksBar(_ int) string {
+	if len(cv.backgroundTasks) == 0 {
+		return ""
+	}
+
+	ids := make([]string, 0, len(cv.backgroundTasks))
+	for id := range cv.backgroundTasks {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	lines := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if line := cv.renderBackgroundTaskLine(cv.backgroundTasks[id]); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.Join(lines, "\n")
+}
+
+// BackgroundTasksBarHeight returns the line count the sticky indicator
+// will occupy, for use in the parent layout's height budgeting. Terminal
+// states render across multiple lines (header + usage + execution_stats),
+// so this counts the actual rendered newlines rather than just the task
+// count.
+func (cv *ConversationView) BackgroundTasksBarHeight() int {
+	if len(cv.backgroundTasks) == 0 {
+		return 0
+	}
+	bar := cv.RenderBackgroundTasksBar(cv.width)
+	if bar == "" {
+		return 0
+	}
+	return strings.Count(bar, "\n") + 1
+}
+
+// normalizeTaskState turns ADK enum-style task states like
+// "TASK_STATE_WORKING" into tidy user-facing strings like "working".
+// Already-tidy inputs (e.g. "submitted") are returned unchanged.
+func normalizeTaskState(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	lower := strings.ToLower(s)
+	lower = strings.TrimPrefix(lower, "task_state_")
+	return strings.ReplaceAll(lower, "_", "-")
+}
+
+// agentDisplayName resolves the best available agent name for a display:
+// configured friendly name first, then resolver lookup by URL, then the
+// URL with scheme stripped (e.g. http://localhost:8081 → localhost:8081),
+// then the task ID as a last-resort fallback.
+func (cv *ConversationView) agentDisplayName(display *BackgroundTaskDisplay) string {
+	if display.AgentName != "" {
+		return display.AgentName
+	}
+	if cv.agentNameResolver != nil && display.AgentURL != "" {
+		if resolved := cv.agentNameResolver(display.AgentURL); resolved != "" {
+			return resolved
+		}
+	}
+	if display.AgentURL != "" {
+		return shortenAgentURL(display.AgentURL)
+	}
+	return display.TaskID
+}
+
+// renderTerminalMultiLine emits a multi-line indicator for terminal
+// states: header (icon + Agent(name=state)), then `usage=…`,
+// `execution_stats=…`, and (for failures) `error: …`, each on its own
+// line under a tree branch (├── / └──) — matching the box-drawing
+// hierarchy style used elsewhere in the UI. Detail lines that have no
+// content are dropped, so older agents without usage metadata render
+// just the header.
+func (cv *ConversationView) renderTerminalMultiLine(icon, iconColor, stateColor, header, usageJSON, statsJSON, err string) string {
+	headerStyled := cv.styleProvider.RenderWithColor(icon, cv.styleProvider.GetThemeColor(iconColor)) +
+		" " + cv.styleProvider.RenderWithColor(header, cv.styleProvider.GetThemeColor(stateColor))
+
+	dim := cv.styleProvider.GetThemeColor("dim")
+	errColor := cv.styleProvider.GetThemeColor("error")
+
+	type branch struct {
+		text  string
+		color string
+	}
+	var details []branch
+	if usageJSON != "" {
+		details = append(details, branch{"usage=" + usageJSON, dim})
+	}
+	if statsJSON != "" {
+		details = append(details, branch{"execution_stats=" + statsJSON, dim})
+	}
+	if err != "" {
+		details = append(details, branch{"error: " + err, errColor})
+	}
+
+	if len(details) == 0 {
+		return headerStyled
+	}
+
+	lines := []string{headerStyled}
+	for i, d := range details {
+		prefix := "├── "
+		if i == len(details)-1 {
+			prefix = "└── "
+		}
+		lines = append(lines, "  "+cv.styleProvider.RenderWithColor(prefix+d.text, d.color))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// shortenAgentURL produces a tidier label for an agent URL when no
+// configured friendly name is available. Strips the scheme and any
+// trailing path/query so a raw URL like "http://localhost:8081/api"
+// renders as "localhost:8081".
+func shortenAgentURL(url string) string {
+	url = strings.TrimPrefix(url, "https://")
+	url = strings.TrimPrefix(url, "http://")
+	if idx := strings.IndexAny(url, "/?#"); idx >= 0 {
+		url = url[:idx]
+	}
+	return url
+}
+
+// renderBackgroundTaskLine produces one styled line summarising a background
+// task's current state for inline display under the originating tool call.
+func (cv *ConversationView) renderBackgroundTaskLine(display *BackgroundTaskDisplay) string {
+	if display == nil {
+		return ""
+	}
+
+	name := cv.agentDisplayName(display)
+	state := normalizeTaskState(display.State)
+	if state == "" {
+		state = "submitted"
+	}
+
+	var (
+		icon       string
+		iconColor  string
+		stateColor string
+		body       string
+	)
+
+	switch state {
+	case "completed":
+		return cv.renderTerminalMultiLine(
+			icons.CheckMark, "success", "dim",
+			fmt.Sprintf("Agent(%s=completed)", name),
+			display.UsageJSON, display.ExecutionStatsJSON, "",
+		)
+	case "failed":
+		return cv.renderTerminalMultiLine(
+			icons.CrossMark, "error", "error",
+			fmt.Sprintf("Agent(%s=failed)", name),
+			display.UsageJSON, display.ExecutionStatsJSON, display.ErrorMsg,
+		)
+	case "cancelled", "canceled":
+		icon = icons.CrossMark
+		iconColor = "dim"
+		stateColor = "dim"
+		body = fmt.Sprintf("Agent(%s=cancelled)", name)
+	default:
+		icon = icons.GetSpinnerFrame(cv.backgroundSpinStep)
+		iconColor = "accent"
+		stateColor = "accent"
+		body = fmt.Sprintf("Agent(%s=%s...)", name, state)
+	}
+
+	styledIcon := cv.styleProvider.RenderWithColor(icon, cv.styleProvider.GetThemeColor(iconColor))
+	styledBody := cv.styleProvider.RenderWithColor(body, cv.styleProvider.GetThemeColor(stateColor))
+	return fmt.Sprintf("%s %s", styledIcon, styledBody)
+}
+
+// extractA2AAgentName attempts to derive a short agent identifier from an
+// A2A_SubmitTask tool result. Falls back to the raw agent_url if no
+// friendlier name is encoded.
+func extractA2AAgentName(data any) string {
+	if data == nil {
+		return ""
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+	var probe struct {
+		AgentURL string `json:"agent_url"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return ""
+	}
+	return probe.AgentURL
+}
+
+// extractA2AUsageJSON extracts a compact JSON string for Task.metadata.usage
+// from an A2A_SubmitTask tool result. Returns "" if the metadata is absent
+// (e.g. remote agent has EnableUsageMetadata disabled, or the task ran no
+// LLM calls).
+func extractA2AUsageJSON(data any) string {
+	return extractTaskMetadataField(data, "usage")
+}
+
+// extractA2AExecutionStatsJSON extracts a compact JSON string for
+// Task.metadata.execution_stats from an A2A_SubmitTask tool result. Per
+// ADK ≥ 0.19.0 this is always present on terminal-state tasks when
+// EnableUsageMetadata is on, even if no LLM calls were made (so tool-only
+// agents still report tool_calls / failed_tools).
+func extractA2AExecutionStatsJSON(data any) string {
+	return extractTaskMetadataField(data, "execution_stats")
+}
+
+// extractTaskMetadataField pulls one top-level key out of
+// Task.Metadata via a json round-trip on the A2A_SubmitTask result Data.
+// JSON round-trip avoids importing internal/agent/tools (cyclic).
+func extractTaskMetadataField(data any, field string) string {
+	if data == nil {
+		return ""
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+	var probe struct {
+		Task *struct {
+			Metadata *map[string]any `json:"metadata"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return ""
+	}
+	if probe.Task == nil || probe.Task.Metadata == nil {
+		return ""
+	}
+	val, ok := (*probe.Task.Metadata)[field]
+	if !ok || val == nil {
+		return ""
+	}
+	out, err := json.Marshal(val)
+	if err != nil {
+		return ""
+	}
+	return string(out)
 }
 
 // handleDefaultEvents processes all other events

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,33 @@ import (
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 )
+
+// stubToolFormatter is a minimal ToolFormatter for tests that need the
+// view to render entries containing ToolExecution payloads.
+type stubToolFormatter struct{}
+
+func (s *stubToolFormatter) FormatToolCall(toolName string, _ map[string]any) string {
+	return toolName + "()"
+}
+func (s *stubToolFormatter) FormatToolResultForUI(result *domain.ToolExecutionResult, _ int) string {
+	if result == nil {
+		return ""
+	}
+	return "Tool: " + result.ToolName
+}
+func (s *stubToolFormatter) FormatToolResultExpanded(result *domain.ToolExecutionResult, _ int) string {
+	if result == nil {
+		return ""
+	}
+	return "Tool: " + result.ToolName
+}
+func (s *stubToolFormatter) FormatToolResultForLLM(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return ""
+	}
+	return "Tool: " + result.ToolName
+}
+func (s *stubToolFormatter) ShouldAlwaysExpandTool(_ string) bool { return false }
 
 // createMockStyleProvider creates a mock styles provider for testing
 func createMockStyleProvider() *styles.Provider {
@@ -247,6 +275,579 @@ func TestConversationView_Render(t *testing.T) {
 
 	if output == "" {
 		t.Error("Expected non-empty render output with conversation")
+	}
+}
+
+func TestBackgroundTaskDisplay_SubmittedCreatesEntry(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID:    "task-1",
+		AgentName: "weather-agent",
+	}, nil)
+
+	display, ok := cv.backgroundTasks["task-1"]
+	if !ok {
+		t.Fatal("expected backgroundTasks to contain entry for task-1")
+	}
+	if display.AgentName != "weather-agent" {
+		t.Errorf("expected AgentName 'weather-agent', got %q", display.AgentName)
+	}
+	if display.State != "submitted" {
+		t.Errorf("expected State 'submitted', got %q", display.State)
+	}
+	if display.IsTerminal {
+		t.Error("expected IsTerminal to be false on submission")
+	}
+}
+
+func TestBackgroundTaskDisplay_StatusUpdateChangesState(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID:    "task-1",
+		AgentName: "weather-agent",
+	}, nil)
+	cv.handleA2ATaskStatusUpdate(domain.A2ATaskStatusUpdateEvent{
+		TaskID:  "task-1",
+		Status:  "working",
+		Message: "fetching forecast",
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if display.State != "working" {
+		t.Errorf("expected State 'working', got %q", display.State)
+	}
+	if display.Message != "fetching forecast" {
+		t.Errorf("expected Message 'fetching forecast', got %q", display.Message)
+	}
+	if display.AgentName != "weather-agent" {
+		t.Errorf("expected AgentName preserved as 'weather-agent', got %q", display.AgentName)
+	}
+}
+
+func TestBackgroundTaskDisplay_CompletedCapturesUsage(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID:    "task-1",
+		AgentName: "weather-agent",
+	}, nil)
+
+	resultData := map[string]any{
+		"task_id":   "task-1",
+		"agent_url": "http://example.com",
+		"state":     "completed",
+		"task": map[string]any{
+			"metadata": map[string]any{
+				"usage": map[string]any{
+					"input_tokens":  42,
+					"output_tokens": 100,
+					"total_tokens":  142,
+				},
+			},
+		},
+	}
+	cv.handleA2ATaskCompleted(domain.A2ATaskCompletedEvent{
+		TaskID: "task-1",
+		Result: domain.ToolExecutionResult{
+			ToolName: "A2A_SubmitTask",
+			Success:  true,
+			Data:     resultData,
+		},
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if display.State != "completed" {
+		t.Errorf("expected State 'completed', got %q", display.State)
+	}
+	if !display.IsTerminal {
+		t.Error("expected IsTerminal to be true after completion")
+	}
+	if !strings.Contains(display.UsageJSON, `"input_tokens":42`) {
+		t.Errorf("expected UsageJSON to contain input_tokens, got %q", display.UsageJSON)
+	}
+	if !strings.Contains(display.UsageJSON, `"total_tokens":142`) {
+		t.Errorf("expected UsageJSON to contain total_tokens, got %q", display.UsageJSON)
+	}
+}
+
+func TestBackgroundTaskDisplay_CompletedCapturesExecutionStats(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID:    "task-1",
+		AgentName: "browser-agent",
+	}, nil)
+
+	resultData := map[string]any{
+		"task_id":   "task-1",
+		"agent_url": "http://example.com",
+		"state":     "completed",
+		"task": map[string]any{
+			"metadata": map[string]any{
+				"usage": map[string]any{
+					"prompt_tokens":     12255,
+					"completion_tokens": 502,
+					"total_tokens":      12757,
+				},
+				"execution_stats": map[string]any{
+					"iterations":   2,
+					"messages":     4,
+					"tool_calls":   3,
+					"failed_tools": 1,
+				},
+			},
+		},
+	}
+	cv.handleA2ATaskCompleted(domain.A2ATaskCompletedEvent{
+		TaskID: "task-1",
+		Result: domain.ToolExecutionResult{
+			ToolName: "A2A_SubmitTask",
+			Success:  true,
+			Data:     resultData,
+		},
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if !strings.Contains(display.ExecutionStatsJSON, `"tool_calls":3`) {
+		t.Errorf("expected ExecutionStatsJSON to contain tool_calls, got %q", display.ExecutionStatsJSON)
+	}
+	if !strings.Contains(display.ExecutionStatsJSON, `"failed_tools":1`) {
+		t.Errorf("expected ExecutionStatsJSON to contain failed_tools, got %q", display.ExecutionStatsJSON)
+	}
+
+	out := cv.renderBackgroundTaskLine(display)
+	if !strings.Contains(out, "Agent(browser-agent=completed)") {
+		t.Errorf("expected header line, got %q", out)
+	}
+	if !strings.Contains(out, "├── usage=") {
+		t.Errorf("expected branched usage line, got %q", out)
+	}
+	if !strings.Contains(out, "└── execution_stats=") {
+		t.Errorf("expected branched execution_stats line, got %q", out)
+	}
+	if !strings.Contains(out, `"failed_tools":1`) {
+		t.Errorf("expected failed_tools=1 in output, got %q", out)
+	}
+	if strings.Count(out, "\n") != 2 {
+		t.Errorf("expected exactly 3 lines (2 newlines) when both usage and stats present, got %q", out)
+	}
+}
+
+func TestBackgroundTaskDisplay_CompletedWithoutMetadataRendersBareName(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	out := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
+		TaskID:     "t1",
+		AgentName:  "old-agent",
+		State:      "completed",
+		IsTerminal: true,
+	})
+	if !strings.Contains(out, "Agent(old-agent=completed)") {
+		t.Errorf("expected 'Agent(old-agent=completed)' header, got %q", out)
+	}
+	if strings.Contains(out, "\n") {
+		t.Errorf("expected single-line output when no metadata to show, got %q", out)
+	}
+}
+
+func TestBackgroundTaskDisplay_CompletedUsesLastBranchWhenOnlyOneDetail(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	out := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
+		TaskID:     "t1",
+		AgentName:  "x",
+		State:      "completed",
+		UsageJSON:  `{"total_tokens":10}`,
+		IsTerminal: true,
+	})
+	if !strings.Contains(out, "└── usage=") {
+		t.Errorf("expected single detail to use └── branch, got %q", out)
+	}
+	if strings.Contains(out, "├──") {
+		t.Errorf("did not expect ├── branch with only one detail, got %q", out)
+	}
+}
+
+func TestBackgroundTaskDisplay_FailedCapturesError(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID:    "task-1",
+		AgentName: "weather-agent",
+	}, nil)
+	cv.handleA2ATaskFailed(domain.A2ATaskFailedEvent{
+		TaskID: "task-1",
+		Error:  "connection refused",
+		Result: domain.ToolExecutionResult{
+			ToolName: "A2A_SubmitTask",
+			Success:  false,
+		},
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if display.State != "failed" {
+		t.Errorf("expected State 'failed', got %q", display.State)
+	}
+	if display.ErrorMsg != "connection refused" {
+		t.Errorf("expected ErrorMsg 'connection refused', got %q", display.ErrorMsg)
+	}
+	if !display.IsTerminal {
+		t.Error("expected IsTerminal to be true after failure")
+	}
+}
+
+func TestBackgroundTaskDisplay_RemoveTickDeletesEntry(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cv.backgroundTasks["task-1"] = &BackgroundTaskDisplay{
+		TaskID:     "task-1",
+		State:      "completed",
+		IsTerminal: true,
+	}
+
+	cv.handleRemoveBackgroundTask(BackgroundTaskRemovalTickMsg{TaskID: "task-1"}, nil)
+
+	if _, ok := cv.backgroundTasks["task-1"]; ok {
+		t.Error("expected backgroundTasks entry for task-1 to be deleted")
+	}
+}
+
+func TestBackgroundTaskDisplay_RenderLine_StatesAndIcons(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cases := []struct {
+		name     string
+		display  *BackgroundTaskDisplay
+		contains []string
+	}{
+		{
+			name: "submitted",
+			display: &BackgroundTaskDisplay{
+				TaskID:    "t1",
+				AgentName: "weather-agent",
+				State:     "submitted",
+			},
+			contains: []string{"Agent(weather-agent=submitted...)"},
+		},
+		{
+			name: "working",
+			display: &BackgroundTaskDisplay{
+				TaskID:    "t1",
+				AgentName: "weather-agent",
+				State:     "working",
+			},
+			contains: []string{"Agent(weather-agent=working...)"},
+		},
+		{
+			name: "completed with usage",
+			display: &BackgroundTaskDisplay{
+				TaskID:     "t1",
+				AgentName:  "weather-agent",
+				State:      "completed",
+				UsageJSON:  `{"input_tokens":42,"output_tokens":100,"total_tokens":142}`,
+				IsTerminal: true,
+			},
+			contains: []string{
+				"✓",
+				"Agent(weather-agent=completed)",
+				"└── usage=",
+				`"input_tokens":42`,
+			},
+		},
+		{
+			name: "failed with error",
+			display: &BackgroundTaskDisplay{
+				TaskID:     "t1",
+				AgentName:  "weather-agent",
+				State:      "failed",
+				ErrorMsg:   "connection refused",
+				IsTerminal: true,
+			},
+			contains: []string{"✗", "Agent(weather-agent=failed)", "└── error: connection refused"},
+		},
+		{
+			name: "fallback to shortened agent url when no name",
+			display: &BackgroundTaskDisplay{
+				TaskID:   "t1",
+				AgentURL: "http://example.com",
+				State:    "working",
+			},
+			contains: []string{"Agent(example.com=working...)"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			line := cv.renderBackgroundTaskLine(tc.display)
+			for _, substr := range tc.contains {
+				if !strings.Contains(line, substr) {
+					t.Errorf("expected line to contain %q, got %q", substr, line)
+				}
+			}
+		})
+	}
+}
+
+func TestBackgroundTaskDisplay_BarHidesWhenNoTasks(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	if cv.HasBackgroundTasks() {
+		t.Error("expected HasBackgroundTasks to be false initially")
+	}
+	if got := cv.RenderBackgroundTasksBar(80); got != "" {
+		t.Errorf("expected empty bar with no tasks, got %q", got)
+	}
+	if got := cv.BackgroundTasksBarHeight(); got != 0 {
+		t.Errorf("expected zero bar height with no tasks, got %d", got)
+	}
+}
+
+func TestBackgroundTaskDisplay_BarRendersOneLinePerTask(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.backgroundTasks["task-a"] = &BackgroundTaskDisplay{
+		TaskID:    "task-a",
+		AgentName: "weather-agent",
+		State:     "working",
+	}
+	cv.backgroundTasks["task-b"] = &BackgroundTaskDisplay{
+		TaskID:    "task-b",
+		AgentName: "news-agent",
+		State:     "submitted",
+	}
+
+	if !cv.HasBackgroundTasks() {
+		t.Fatal("expected HasBackgroundTasks true")
+	}
+	if h := cv.BackgroundTasksBarHeight(); h != 2 {
+		t.Errorf("expected bar height 2 for two tasks, got %d", h)
+	}
+
+	bar := cv.RenderBackgroundTasksBar(80)
+	if !strings.Contains(bar, "Agent(weather-agent=working...)") {
+		t.Errorf("expected weather-agent line in bar, got:\n%s", bar)
+	}
+	if !strings.Contains(bar, "Agent(news-agent=submitted...)") {
+		t.Errorf("expected news-agent line in bar, got:\n%s", bar)
+	}
+	if strings.Count(bar, "\n") != 1 {
+		t.Errorf("expected two lines (one newline separator) in bar, got %q", bar)
+	}
+}
+
+func TestBackgroundTaskDisplay_BarOrderIsStable(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	for _, id := range []string{"task-z", "task-a", "task-m"} {
+		cv.backgroundTasks[id] = &BackgroundTaskDisplay{
+			TaskID:    id,
+			AgentName: id,
+			State:     "working",
+		}
+	}
+
+	bar := cv.RenderBackgroundTasksBar(80)
+	idxA := strings.Index(bar, "Agent(task-a")
+	idxM := strings.Index(bar, "Agent(task-m")
+	idxZ := strings.Index(bar, "Agent(task-z")
+	if idxA == -1 || idxM == -1 || idxZ == -1 {
+		t.Fatalf("expected all three task names in bar, got:\n%s", bar)
+	}
+	if idxA >= idxM || idxM >= idxZ {
+		t.Errorf("expected lexicographic order task-a < task-m < task-z, got positions a=%d m=%d z=%d", idxA, idxM, idxZ)
+	}
+}
+
+func TestBackgroundTaskDisplay_BarNotInsideConversationViewport(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetToolFormatter(&stubToolFormatter{})
+	cv.backgroundTasks["task-1"] = &BackgroundTaskDisplay{
+		TaskID:    "task-1",
+		AgentName: "weather-agent",
+		State:     "working",
+	}
+
+	entry := domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:    sdk.Tool,
+			Content: sdk.NewMessageContent("Task delegated"),
+		},
+		Time: time.Now(),
+		ToolExecution: &domain.ToolExecutionResult{
+			ToolName: "A2A_SubmitTask",
+			Success:  true,
+			Data: map[string]any{
+				"task_id":   "task-1",
+				"agent_url": "http://example.com",
+				"state":     "submitted",
+			},
+		},
+	}
+	cv.SetConversation([]domain.ConversationEntry{entry})
+
+	if strings.Contains(cv.renderedContent, "Agent(weather-agent=working") {
+		t.Errorf("did not expect background-task line inside the scrollable viewport, got:\n%s", cv.renderedContent)
+	}
+}
+
+func TestBackgroundTaskDisplay_NormalizesStateString(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cases := []struct {
+		raw      string
+		contains string
+	}{
+		{"TASK_STATE_WORKING", "working..."},
+		{"TASK_STATE_SUBMITTED", "submitted..."},
+		{"TASK_STATE_INPUT_REQUIRED", "input-required..."},
+		{"working", "working..."},
+	}
+	for _, c := range cases {
+		t.Run(c.raw, func(t *testing.T) {
+			line := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
+				TaskID:    "t1",
+				AgentName: "weather-agent",
+				State:     c.raw,
+			})
+			if !strings.Contains(line, c.contains) {
+				t.Errorf("for raw state %q expected line to contain %q, got %q", c.raw, c.contains, line)
+			}
+			if strings.Contains(line, "TASK_STATE_") {
+				t.Errorf("for raw state %q expected normalisation, got raw enum in %q", c.raw, line)
+			}
+		})
+	}
+}
+
+func TestBackgroundTaskDisplay_StatusUpdateCapturesAgentURL(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cv.handleA2ATaskStatusUpdate(domain.A2ATaskStatusUpdateEvent{
+		TaskID:   "task-1",
+		AgentURL: "http://localhost:8081",
+		Status:   "TASK_STATE_WORKING",
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if display.AgentURL != "http://localhost:8081" {
+		t.Errorf("expected AgentURL captured from status update, got %q", display.AgentURL)
+	}
+}
+
+func TestBackgroundTaskDisplay_SubmittedCapturesAgentURL(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID:   "task-1",
+		AgentURL: "http://localhost:8081",
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if display.AgentURL != "http://localhost:8081" {
+		t.Errorf("expected AgentURL captured from submitted event, got %q", display.AgentURL)
+	}
+	if display.State != "submitted" {
+		t.Errorf("expected default state 'submitted', got %q", display.State)
+	}
+}
+
+func TestBackgroundTaskDisplay_AgentNameResolverUsed(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetAgentNameResolver(func(url string) string {
+		if url == "http://localhost:8081" {
+			return "weather-agent"
+		}
+		return ""
+	})
+
+	line := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
+		TaskID:   "t1",
+		AgentURL: "http://localhost:8081",
+		State:    "working",
+	})
+	if !strings.Contains(line, "Agent(weather-agent=working...)") {
+		t.Errorf("expected resolver-mapped name, got %q", line)
+	}
+}
+
+func TestBackgroundTaskDisplay_AgentNameResolverFallsBackToShortenedURL(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetAgentNameResolver(func(_ string) string { return "" })
+
+	line := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
+		TaskID:   "t1",
+		AgentURL: "http://localhost:9090",
+		State:    "working",
+	})
+	if !strings.Contains(line, "Agent(localhost:9090=working...)") {
+		t.Errorf("expected fallback to shortened URL when resolver returns empty, got %q", line)
+	}
+}
+
+// TestBackgroundTaskRemovalTickMsg_TypeNameMatchesDispatcherFilter guards
+// against a regression where the message-name didn't match the parent
+// dispatcher's "Tick" / "domain." substring filter, causing the auto-
+// removal cmd to fire but its message to be silently dropped, leaving
+// terminal-state indicators on screen forever.
+//
+// See internal/app/chat.go updateUIComponentsForUIMessages — only msgs
+// whose %T contains "Tick" or starts with "domain." get routed to
+// component Update() methods.
+func TestBackgroundTaskRemovalTickMsg_TypeNameMatchesDispatcherFilter(t *testing.T) {
+	msg := BackgroundTaskRemovalTickMsg{TaskID: "x"}
+	typeName := fmt.Sprintf("%T", msg)
+	if !strings.Contains(typeName, "Tick") {
+		t.Errorf("BackgroundTaskRemovalTickMsg type %q must contain 'Tick' so the app dispatcher routes it; otherwise auto-removal won't fire", typeName)
+	}
+}
+
+func TestBackgroundTaskDisplay_ShortenAgentURLDropsScheme(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"http://localhost:8081", "localhost:8081"},
+		{"https://api.example.com/v1", "api.example.com"},
+		{"http://mock-agent:8080/", "mock-agent:8080"},
+		{"localhost:8081", "localhost:8081"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.raw, func(t *testing.T) {
+			if got := shortenAgentURL(c.raw); got != c.want {
+				t.Errorf("shortenAgentURL(%q) = %q, want %q", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestBackgroundTaskDisplay_FallsBackToShortenedURL(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	line := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
+		TaskID:   "t1",
+		AgentURL: "http://localhost:8081",
+		State:    "working",
+	})
+	if strings.Contains(line, "http://") {
+		t.Errorf("expected scheme stripped from fallback URL, got %q", line)
+	}
+	if !strings.Contains(line, "Agent(localhost:8081=working...)") {
+		t.Errorf("expected shortened URL, got %q", line)
+	}
+}
+
+func TestBackgroundTaskDisplay_HasActiveBackgroundTasks(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	if cv.hasActiveBackgroundTasks() {
+		t.Error("expected no active tasks initially")
+	}
+
+	cv.backgroundTasks["t1"] = &BackgroundTaskDisplay{IsTerminal: false}
+	if !cv.hasActiveBackgroundTasks() {
+		t.Error("expected active tasks when non-terminal entry present")
+	}
+
+	cv.backgroundTasks["t1"].IsTerminal = true
+	if cv.hasActiveBackgroundTasks() {
+		t.Error("expected no active tasks when all entries are terminal")
 	}
 }
 

--- a/internal/ui/components/task_management_view.go
+++ b/internal/ui/components/task_management_view.go
@@ -413,25 +413,34 @@ func (t *TaskManagerImpl) cancelTaskCmd(task TaskInfo) tea.Cmd {
 	}
 }
 
-// mapTaskStatus maps task state to display status
+// mapTaskStatus maps task state to display status. Covers every
+// adk.TaskState constant so non-terminal states (Working, Submitted,
+// AuthRequired, ...) don't fall through to the raw "TASK_STATE_*"
+// label. Unknown states fall back to a title-cased rendering of the
+// raw value with the "TASK_STATE_" prefix stripped.
 func (t *TaskManagerImpl) mapTaskStatus(state adk.TaskState) string {
 	statusMap := map[adk.TaskState]string{
+		adk.TaskStateSubmitted:     "Submitted",
+		adk.TaskStateWorking:       "Working",
 		adk.TaskStateCompleted:     "Completed",
 		adk.TaskStateFailed:        "Failed",
 		adk.TaskStateCancelled:     "Cancelled",
 		adk.TaskStateRejected:      "Rejected",
 		adk.TaskStateInputRequired: "Input Required",
+		adk.TaskStateAuthRequired:  "Auth Required",
+		adk.TaskStateUnspecified:   "Unknown",
 	}
 
 	if displayName, exists := statusMap[state]; exists {
 		return displayName
 	}
 
-	stateStr := string(state)
-	if len(stateStr) > 0 {
-		return strings.ToUpper(stateStr[:1]) + stateStr[1:]
+	stateStr := strings.TrimPrefix(string(state), "TASK_STATE_")
+	stateStr = strings.ReplaceAll(strings.ToLower(stateStr), "_", " ")
+	if stateStr == "" {
+		return "Unknown"
 	}
-	return "Unknown"
+	return strings.ToUpper(stateStr[:1]) + stateStr[1:]
 }
 
 // mapTaskStateToDisplayStatus maps task state string to display status
@@ -608,25 +617,86 @@ func (t *TaskManagerImpl) renderTaskHistory(content *strings.Builder, task TaskI
 	if task.TaskRef.Task.Status.Message != nil {
 		t.renderFinalResult(content, task)
 	}
+
+	if len(task.TaskRef.Task.Artifacts) > 0 {
+		t.renderTaskArtifacts(content, task)
+	}
 }
 
-// renderHistoryItemRole renders the role prefix for a history item
+// renderTaskArtifacts surfaces the agent's produced artifacts (e.g. screenshots,
+// generated files) in the Task History panel — for many agents this is the
+// real output and Status.Message is empty.
+func (t *TaskManagerImpl) renderTaskArtifacts(content *strings.Builder, task TaskInfo) {
+	accentColor := t.styleProvider.GetThemeColor("accent")
+	dimColor := t.styleProvider.GetThemeColor("dim")
+
+	if len(task.TaskRef.Task.History) > 0 || task.TaskRef.Task.Status.Message != nil {
+		content.WriteString("\n")
+	}
+
+	marker := t.styleProvider.RenderWithColor("◆", accentColor)
+	header := t.styleProvider.RenderWithColor(
+		fmt.Sprintf("Agent (Artifacts, %d produced):", len(task.TaskRef.Task.Artifacts)),
+		dimColor,
+	)
+	fmt.Fprintf(content, "%s %s\n", marker, header)
+
+	for i, artifact := range task.TaskRef.Task.Artifacts {
+		name := "unnamed"
+		if artifact.Name != nil && *artifact.Name != "" {
+			name = *artifact.Name
+		}
+		fmt.Fprintf(content, "  %d. %s", i+1, name)
+
+		if artifact.Metadata != nil {
+			if mimeType, ok := (*artifact.Metadata)["mime_type"].(string); ok && mimeType != "" {
+				fmt.Fprintf(content, "  (%s)", mimeType)
+			}
+			if size, ok := (*artifact.Metadata)["size"].(float64); ok && size > 0 {
+				fmt.Fprintf(content, "  %d bytes", int64(size))
+			}
+		}
+		content.WriteString("\n")
+
+		if artifact.Metadata != nil {
+			if url, ok := (*artifact.Metadata)["url"].(string); ok && url != "" {
+				fmt.Fprintf(content, "     %s\n", t.styleProvider.RenderWithColor(url, dimColor))
+			}
+		}
+	}
+}
+
+// renderHistoryItemRole renders the role prefix for a history item.
+// Handles both ADK enum-style values (ROLE_USER / ROLE_AGENT) and the
+// historical lowercase ones (user / assistant).
 func (t *TaskManagerImpl) renderHistoryItemRole(content *strings.Builder, role string) {
 	accentColor := t.styleProvider.GetThemeColor("accent")
 	dimColor := t.styleProvider.GetThemeColor("dim")
 
 	marker := t.styleProvider.RenderWithColor("◆", accentColor)
 
-	switch role {
-	case "assistant":
-		roleText := t.styleProvider.RenderWithColor("Assistant:", dimColor)
-		fmt.Fprintf(content, "%s %s\n", marker, roleText)
+	label := friendlyRoleLabel(role)
+	roleText := t.styleProvider.RenderWithColor(label+":", dimColor)
+	fmt.Fprintf(content, "%s %s\n", marker, roleText)
+}
+
+// friendlyRoleLabel maps an ADK Role string to a tidy display label.
+// "ROLE_USER" → "User", "ROLE_AGENT" → "Agent", "user" → "User",
+// "assistant" → "Agent", anything else is title-cased as-is.
+func friendlyRoleLabel(role string) string {
+	normalized := strings.ToLower(strings.TrimPrefix(strings.ToUpper(role), "ROLE_"))
+	switch normalized {
 	case "user":
-		roleText := t.styleProvider.RenderWithColor("User:", dimColor)
-		fmt.Fprintf(content, "%s %s\n", marker, roleText)
+		return "User"
+	case "agent":
+		return "Agent"
+	case "unspecified":
+		return "Unknown"
 	default:
-		roleText := t.styleProvider.RenderWithColor(fmt.Sprintf("%s:", role), dimColor)
-		fmt.Fprintf(content, "%s %s\n", marker, roleText)
+		if len(normalized) > 0 {
+			return strings.ToUpper(normalized[:1]) + normalized[1:]
+		}
+		return role
 	}
 }
 
@@ -642,7 +712,7 @@ func (t *TaskManagerImpl) renderFinalResult(content *strings.Builder, task TaskI
 	}
 
 	marker := t.styleProvider.RenderWithColor("◆", accentColor)
-	roleText := t.styleProvider.RenderWithColor("Assistant (Final Result):", dimColor)
+	roleText := t.styleProvider.RenderWithColor("Agent (Final Result):", dimColor)
 	fmt.Fprintf(content, "%s %s\n", marker, roleText)
 
 	for _, part := range task.TaskRef.Task.Status.Message.Parts {


### PR DESCRIPTION
Closes #534.

## Summary

- Live sticky bar above the input shows in-flight A2A delegations: `submitted → working → completed/failed/cancelled`, with token usage and tool counts on terminal states (tree-style multi-line layout, auto-removes 5s after the terminal state).
- ADK bumped to `v0.19.0` so the CLI can consume `Task.metadata.usage` and `.execution_stats`.
- Persisted history `A2A_SubmitTask` block now records `Usage:` and `Execution Stats:` lines so past delegations show their token + tool counts.
- `/tasks` view: full enum→friendly mapping for every `adk.TaskState` (Submitted, Working, AuthRequired, ...), ADK role labels (`ROLE_USER` → `User`, `ROLE_AGENT` → `Agent`, no more "Assistant"), and a new Artifacts section listing each artifact (mime type, size, download URL) for agents that deliver via Artifacts (e.g. browser-agent screenshots).
- Friendly agent name resolution from `~/.infer/agents.yaml`; fallback strips the URL scheme (`http://localhost:8081` → `localhost:8081`).
- Misc: `/tasks` now clears its status spinner on close (was sticking forever); `A2ATaskPoller` emits the previously-missing `A2ATaskSubmittedEvent` and propagates `AgentURL` on status updates so the indicator has identity from the first frame.

## What it looks like

Live indicator (sticky, above the input):

```text
… conversation viewport …
─────────────────────────────────────────────
◓ Agent(browser-agent=working...)
> _   (input)
```

On completion (auto-removes 5s later):

```text
✓ Agent(browser-agent=completed)
  ├── usage={"prompt_tokens":12255,"completion_tokens":502,"total_tokens":12757}
  └── execution_stats={"iterations":2,"messages":4,"tool_calls":3,"failed_tools":1}
```

Persisted in `A2A_SubmitTask` history block:

```text
Task ID: …
State: TASK_STATE_COMPLETED
Usage: completion_tokens=502, prompt_tokens=12255, total_tokens=12757
Execution Stats: failed_tools=1, iterations=2, messages=4, tool_calls=3
```
