### PR TITLE
feat(ui): Show elapsed time and model in background A2A indicator

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	sdk "github.com/inference-gateway/sdk"
+
 	config "github.com/inference-gateway/cli/config"
 	tools "github.com/inference-gateway/cli/internal/agent/tools"
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -25,7 +28,6 @@ import (
 	factory "github.com/inference-gateway/cli/internal/ui/components/factory"
 	keybinding "github.com/inference-gateway/cli/internal/ui/keybinding"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
-	sdk "github.com/inference-gateway/sdk"
 )
 
 // ChatApplication represents the main application model using state management
@@ -169,6 +171,7 @@ func NewChatApplication(
 		cv.SetToolCallRenderer(app.toolCallRenderer)
 		cv.SetStateManager(app.stateManager)
 		cv.SetAgentNameResolver(buildAgentNameResolver())
+		cv.SetAgentModelResolver(buildAgentModelResolver())
 	}
 
 	app.inputView = factory.CreateInputViewWithConfigDir(app.modelService, configDir)
@@ -2172,6 +2175,31 @@ func buildAgentNameResolver() func(string) string {
 	}
 	return func(url string) string {
 		return nameByURL[url]
+	}
+}
+
+// buildAgentModelResolver loads ~/.infer/agents.yaml (or the project-level
+// equivalent) once and returns a closure that maps an agent URL to its
+// configured model (e.g. "deepseek/deepseek-v4-flash"). Used by the
+// background-agent indicator to show `model=<...>` in the live status
+// line. Returns nil on load failure or when no agent has a model set,
+// so the conversation view omits the model segment cleanly.
+func buildAgentModelResolver() func(string) string {
+	cfg, err := config.LoadAgents(config.ResolveAgentsPath())
+	if err != nil || cfg == nil {
+		return nil
+	}
+	modelByURL := make(map[string]string, len(cfg.Agents))
+	for _, a := range cfg.Agents {
+		if a.URL != "" && a.Model != "" {
+			modelByURL[a.URL] = a.Model
+		}
+	}
+	if len(modelByURL) == 0 {
+		return nil
+	}
+	return func(url string) string {
+		return modelByURL[url]
 	}
 }
 

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -1513,7 +1513,7 @@ func (cv *ConversationView) formatNonTerminalBody(name, state string, display *B
 	if width <= 0 || model == "" {
 		return body
 	}
-	const iconBudget = 2 // icon + space prepended by caller
+	const iconBudget = 2
 	avail := width - iconBudget
 	if len(body) <= avail {
 		return body

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -47,12 +47,14 @@ type BackgroundTaskDisplay struct {
 	TaskID             string
 	AgentName          string
 	AgentURL           string
+	Model              string
 	State              string
 	Message            string
 	UsageJSON          string
 	ExecutionStatsJSON string
 	ErrorMsg           string
 	IsTerminal         bool
+	StartedAt          time.Time
 	CompletedAt        time.Time
 }
 
@@ -113,6 +115,10 @@ type ConversationView struct {
 	// from ~/.infer/agents.yaml. Optional; falls back to the URL when nil
 	// or when the URL has no matching entry.
 	agentNameResolver func(url string) string
+	// agentModelResolver maps an agent URL to its configured model (e.g.
+	// "deepseek/deepseek-v4-flash") from ~/.infer/agents.yaml. Optional;
+	// when nil or no match, the model segment is omitted from the indicator.
+	agentModelResolver func(url string) string
 }
 
 func NewConversationView(styleProvider *styles.Provider) *ConversationView {
@@ -185,6 +191,13 @@ func (cv *ConversationView) SetKeyHintFormatter(formatter *hints.Formatter) {
 // (the visual then falls back to the agent URL).
 func (cv *ConversationView) SetAgentNameResolver(resolver func(url string) string) {
 	cv.agentNameResolver = resolver
+}
+
+// SetAgentModelResolver injects a URL→model lookup used when rendering
+// the background-agent indicator's "model=" segment. Pass nil to omit
+// that segment (the visual then drops "model=" cleanly).
+func (cv *ConversationView) SetAgentModelResolver(resolver func(url string) string) {
+	cv.agentModelResolver = resolver
 }
 
 func (cv *ConversationView) SetConversation(conversation []domain.ConversationEntry) {
@@ -1201,6 +1214,18 @@ func (cv *ConversationView) handleA2ATaskSubmitted(msg domain.A2ATaskSubmittedEv
 	if display.State == "" {
 		display.State = "submitted"
 	}
+	if display.StartedAt.IsZero() {
+		if !msg.Timestamp.IsZero() {
+			display.StartedAt = msg.Timestamp
+		} else {
+			display.StartedAt = time.Now()
+		}
+	}
+	if display.Model == "" && cv.agentModelResolver != nil && display.AgentURL != "" {
+		if m := cv.agentModelResolver(display.AgentURL); m != "" {
+			display.Model = m
+		}
+	}
 
 	startSpinner := !cv.hasOtherActiveBackgroundTasks(msg.TaskID)
 
@@ -1234,6 +1259,18 @@ func (cv *ConversationView) handleA2ATaskStatusUpdate(msg domain.A2ATaskStatusUp
 	if msg.Message != "" {
 		display.Message = msg.Message
 	}
+	if display.Model == "" && cv.agentModelResolver != nil && display.AgentURL != "" {
+		if m := cv.agentModelResolver(display.AgentURL); m != "" {
+			display.Model = m
+		}
+	}
+	if display.StartedAt.IsZero() {
+		if !msg.Timestamp.IsZero() {
+			display.StartedAt = msg.Timestamp
+		} else {
+			display.StartedAt = time.Now()
+		}
+	}
 
 	if cv.navigationMode != NavigationModeMessageHistory {
 		cv.updateViewportContent()
@@ -1252,6 +1289,9 @@ func (cv *ConversationView) handleA2ATaskCompleted(msg domain.A2ATaskCompletedEv
 	if !exists {
 		display = &BackgroundTaskDisplay{TaskID: msg.TaskID}
 		cv.backgroundTasks[msg.TaskID] = display
+	}
+	if display.StartedAt.IsZero() {
+		display.StartedAt = time.Now()
 	}
 	display.State = "completed"
 	display.IsTerminal = true
@@ -1279,6 +1319,9 @@ func (cv *ConversationView) handleA2ATaskFailed(msg domain.A2ATaskFailedEvent, c
 	if !exists {
 		display = &BackgroundTaskDisplay{TaskID: msg.TaskID}
 		cv.backgroundTasks[msg.TaskID] = display
+	}
+	if display.StartedAt.IsZero() {
+		display.StartedAt = time.Now()
 	}
 	display.State = "failed"
 	display.IsTerminal = true
@@ -1351,8 +1394,10 @@ func (cv *ConversationView) HasBackgroundTasks() bool {
 // RenderBackgroundTasksBar returns the sticky multi-line indicator block
 // rendered above the input area. Each tracked task gets one line. Order is
 // stable (lexicographic by TaskID) so concurrent tasks don't jitter
-// between renders. Returns "" when there are no tasks to show.
-func (cv *ConversationView) RenderBackgroundTasksBar(_ int) string {
+// between renders. Returns "" when there are no tasks to show. The
+// width controls non-terminal truncation of the model= segment; pass 0
+// to disable truncation entirely (used in some tests).
+func (cv *ConversationView) RenderBackgroundTasksBar(width int) string {
 	if len(cv.backgroundTasks) == 0 {
 		return ""
 	}
@@ -1365,7 +1410,7 @@ func (cv *ConversationView) RenderBackgroundTasksBar(_ int) string {
 
 	lines := make([]string, 0, len(ids))
 	for _, id := range ids {
-		if line := cv.renderBackgroundTaskLine(cv.backgroundTasks[id]); line != "" {
+		if line := cv.renderBackgroundTaskLine(cv.backgroundTasks[id], width); line != "" {
 			lines = append(lines, line)
 		}
 	}
@@ -1421,6 +1466,78 @@ func (cv *ConversationView) agentDisplayName(display *BackgroundTaskDisplay) str
 		return shortenAgentURL(display.AgentURL)
 	}
 	return display.TaskID
+}
+
+// formatTerminalHeader builds the single-line header for a terminal-state
+// background-task indicator. Appends the frozen elapsed suffix when
+// available. The model= segment is intentionally omitted in terminal
+// form — by completion, focus shifts to usage= / execution_stats=.
+func (cv *ConversationView) formatTerminalHeader(name, state string, display *BackgroundTaskDisplay) string {
+	elapsed := computeElapsedString(display)
+	if elapsed == "" {
+		return fmt.Sprintf("Agent(%s=%s)", name, state)
+	}
+	return fmt.Sprintf("Agent(%s=%s) %s", name, state, elapsed)
+}
+
+// formatNonTerminalBody assembles the inline body for a non-terminal
+// background-task indicator. Shape:
+//
+//	Agent(<name>=<state>..., model=<model>) <elapsed>
+//
+// The model segment is dropped cleanly when unknown:
+//
+//	Agent(<name>=<state>...) <elapsed>
+//
+// When width > 0 and the assembled body would exceed the available
+// columns, only the model value is truncated with a trailing "...";
+// name, state, and elapsed are preserved verbatim. If even the framing
+// can't fit, the model segment is dropped rather than producing
+// garbled output.
+func (cv *ConversationView) formatNonTerminalBody(name, state string, display *BackgroundTaskDisplay, width int) string {
+	elapsed := computeElapsedString(display)
+	model := strings.TrimSpace(display.Model)
+
+	var body string
+	switch {
+	case model != "" && elapsed != "":
+		body = fmt.Sprintf("Agent(%s=%s..., model=%s) %s", name, state, model, elapsed)
+	case model != "":
+		body = fmt.Sprintf("Agent(%s=%s..., model=%s)", name, state, model)
+	case elapsed != "":
+		body = fmt.Sprintf("Agent(%s=%s...) %s", name, state, elapsed)
+	default:
+		body = fmt.Sprintf("Agent(%s=%s...)", name, state)
+	}
+
+	if width <= 0 || model == "" {
+		return body
+	}
+	const iconBudget = 2 // icon + space prepended by caller
+	avail := width - iconBudget
+	if len(body) <= avail {
+		return body
+	}
+
+	var framing string
+	if elapsed != "" {
+		framing = fmt.Sprintf("Agent(%s=%s..., model=) %s", name, state, elapsed)
+	} else {
+		framing = fmt.Sprintf("Agent(%s=%s..., model=)", name, state)
+	}
+	const ellipsis = "..."
+	modelBudget := avail - len(framing) - len(ellipsis)
+	if modelBudget <= 0 {
+		if elapsed != "" {
+			return fmt.Sprintf("Agent(%s=%s...) %s", name, state, elapsed)
+		}
+		return fmt.Sprintf("Agent(%s=%s...)", name, state)
+	}
+	truncated := model[:modelBudget] + ellipsis
+	if elapsed != "" {
+		return fmt.Sprintf("Agent(%s=%s..., model=%s) %s", name, state, truncated, elapsed)
+	}
+	return fmt.Sprintf("Agent(%s=%s..., model=%s)", name, state, truncated)
 }
 
 // renderTerminalMultiLine emits a multi-line indicator for terminal
@@ -1482,7 +1599,9 @@ func shortenAgentURL(url string) string {
 
 // renderBackgroundTaskLine produces one styled line summarising a background
 // task's current state for inline display under the originating tool call.
-func (cv *ConversationView) renderBackgroundTaskLine(display *BackgroundTaskDisplay) string {
+// The width controls non-terminal truncation of the "model=" segment;
+// pass 0 to disable truncation.
+func (cv *ConversationView) renderBackgroundTaskLine(display *BackgroundTaskDisplay, width int) string {
 	if display == nil {
 		return ""
 	}
@@ -1504,25 +1623,25 @@ func (cv *ConversationView) renderBackgroundTaskLine(display *BackgroundTaskDisp
 	case "completed":
 		return cv.renderTerminalMultiLine(
 			icons.CheckMark, "success", "dim",
-			fmt.Sprintf("Agent(%s=completed)", name),
+			cv.formatTerminalHeader(name, "completed", display),
 			display.UsageJSON, display.ExecutionStatsJSON, "",
 		)
 	case "failed":
 		return cv.renderTerminalMultiLine(
 			icons.CrossMark, "error", "error",
-			fmt.Sprintf("Agent(%s=failed)", name),
+			cv.formatTerminalHeader(name, "failed", display),
 			display.UsageJSON, display.ExecutionStatsJSON, display.ErrorMsg,
 		)
 	case "cancelled", "canceled":
 		icon = icons.CrossMark
 		iconColor = "dim"
 		stateColor = "dim"
-		body = fmt.Sprintf("Agent(%s=cancelled)", name)
+		body = cv.formatTerminalHeader(name, "cancelled", display)
 	default:
 		icon = icons.GetSpinnerFrame(cv.backgroundSpinStep)
 		iconColor = "accent"
 		stateColor = "accent"
-		body = fmt.Sprintf("Agent(%s=%s...)", name, state)
+		body = cv.formatNonTerminalBody(name, state, display, width)
 	}
 
 	styledIcon := cv.styleProvider.RenderWithColor(icon, cv.styleProvider.GetThemeColor(iconColor))
@@ -1598,6 +1717,33 @@ func extractTaskMetadataField(data any, field string) string {
 		return ""
 	}
 	return string(out)
+}
+
+// formatElapsed renders a duration as "17s" for <60s, "1m23s" for >=60s.
+// Negative durations render as "0s".
+func formatElapsed(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	total := int(d.Seconds())
+	if total < 60 {
+		return fmt.Sprintf("%ds", total)
+	}
+	return fmt.Sprintf("%dm%ds", total/60, total%60)
+}
+
+// computeElapsedString returns the trailing "<elapsed>" string for a
+// background-task indicator. Terminal states are frozen at
+// CompletedAt-StartedAt; non-terminal states use time.Since(StartedAt).
+// Returns "" if StartedAt is zero.
+func computeElapsedString(display *BackgroundTaskDisplay) string {
+	if display == nil || display.StartedAt.IsZero() {
+		return ""
+	}
+	if display.IsTerminal && !display.CompletedAt.IsZero() {
+		return formatElapsed(display.CompletedAt.Sub(display.StartedAt))
+	}
+	return formatElapsed(time.Since(display.StartedAt))
 }
 
 // handleDefaultEvents processes all other events

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -6,12 +6,15 @@ import (
 	"testing"
 	"time"
 
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
+
+	lipgloss "github.com/charmbracelet/lipgloss"
+
 	sdk "github.com/inference-gateway/sdk"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
-	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
-	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 )
 
 // stubToolFormatter is a minimal ToolFormatter for tests that need the
@@ -417,7 +420,7 @@ func TestBackgroundTaskDisplay_CompletedCapturesExecutionStats(t *testing.T) {
 		t.Errorf("expected ExecutionStatsJSON to contain failed_tools, got %q", display.ExecutionStatsJSON)
 	}
 
-	out := cv.renderBackgroundTaskLine(display)
+	out := cv.renderBackgroundTaskLine(display, 0)
 	if !strings.Contains(out, "Agent(browser-agent=completed)") {
 		t.Errorf("expected header line, got %q", out)
 	}
@@ -442,7 +445,7 @@ func TestBackgroundTaskDisplay_CompletedWithoutMetadataRendersBareName(t *testin
 		AgentName:  "old-agent",
 		State:      "completed",
 		IsTerminal: true,
-	})
+	}, 0)
 	if !strings.Contains(out, "Agent(old-agent=completed)") {
 		t.Errorf("expected 'Agent(old-agent=completed)' header, got %q", out)
 	}
@@ -459,7 +462,7 @@ func TestBackgroundTaskDisplay_CompletedUsesLastBranchWhenOnlyOneDetail(t *testi
 		State:      "completed",
 		UsageJSON:  `{"total_tokens":10}`,
 		IsTerminal: true,
-	})
+	}, 0)
 	if !strings.Contains(out, "└── usage=") {
 		t.Errorf("expected single detail to use └── branch, got %q", out)
 	}
@@ -578,7 +581,7 @@ func TestBackgroundTaskDisplay_RenderLine_StatesAndIcons(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			line := cv.renderBackgroundTaskLine(tc.display)
+			line := cv.renderBackgroundTaskLine(tc.display, 0)
 			for _, substr := range tc.contains {
 				if !strings.Contains(line, substr) {
 					t.Errorf("expected line to contain %q, got %q", substr, line)
@@ -705,7 +708,7 @@ func TestBackgroundTaskDisplay_NormalizesStateString(t *testing.T) {
 				TaskID:    "t1",
 				AgentName: "weather-agent",
 				State:     c.raw,
-			})
+			}, 0)
 			if !strings.Contains(line, c.contains) {
 				t.Errorf("for raw state %q expected line to contain %q, got %q", c.raw, c.contains, line)
 			}
@@ -761,7 +764,7 @@ func TestBackgroundTaskDisplay_AgentNameResolverUsed(t *testing.T) {
 		TaskID:   "t1",
 		AgentURL: "http://localhost:8081",
 		State:    "working",
-	})
+	}, 0)
 	if !strings.Contains(line, "Agent(weather-agent=working...)") {
 		t.Errorf("expected resolver-mapped name, got %q", line)
 	}
@@ -775,7 +778,7 @@ func TestBackgroundTaskDisplay_AgentNameResolverFallsBackToShortenedURL(t *testi
 		TaskID:   "t1",
 		AgentURL: "http://localhost:9090",
 		State:    "working",
-	})
+	}, 0)
 	if !strings.Contains(line, "Agent(localhost:9090=working...)") {
 		t.Errorf("expected fallback to shortened URL when resolver returns empty, got %q", line)
 	}
@@ -824,7 +827,7 @@ func TestBackgroundTaskDisplay_FallsBackToShortenedURL(t *testing.T) {
 		TaskID:   "t1",
 		AgentURL: "http://localhost:8081",
 		State:    "working",
-	})
+	}, 0)
 	if strings.Contains(line, "http://") {
 		t.Errorf("expected scheme stripped from fallback URL, got %q", line)
 	}
@@ -848,6 +851,219 @@ func TestBackgroundTaskDisplay_HasActiveBackgroundTasks(t *testing.T) {
 	cv.backgroundTasks["t1"].IsTerminal = true
 	if cv.hasActiveBackgroundTasks() {
 		t.Error("expected no active tasks when all entries are terminal")
+	}
+}
+
+func TestBackgroundTaskDisplay_RenderLine_IncludesModelAndElapsed(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	display := &BackgroundTaskDisplay{
+		TaskID:    "t1",
+		AgentName: "browser-agent",
+		State:     "working",
+		Model:     "deepseek/deepseek-v4-flash",
+		StartedAt: time.Now().Add(-17 * time.Second),
+	}
+	line := cv.renderBackgroundTaskLine(display, 0)
+
+	wantBody := "Agent(browser-agent=working..., model=deepseek/deepseek-v4-flash)"
+	if !strings.Contains(line, wantBody) {
+		t.Errorf("expected line to contain %q, got %q", wantBody, line)
+	}
+	if !strings.Contains(line, "17s") {
+		t.Errorf("expected elapsed 17s, got %q", line)
+	}
+	idxModel := strings.Index(line, "model=")
+	idxElapsed := strings.LastIndex(line, "17s")
+	if idxModel < 0 || idxElapsed < 0 || idxModel >= idxElapsed {
+		t.Errorf("expected 'model=' before elapsed in %q (idxModel=%d, idxElapsed=%d)", line, idxModel, idxElapsed)
+	}
+}
+
+func TestBackgroundTaskDisplay_RenderLine_OmitsModelWhenUnknown(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	display := &BackgroundTaskDisplay{
+		TaskID:    "t1",
+		AgentName: "browser-agent",
+		State:     "working",
+		Model:     "",
+		StartedAt: time.Now().Add(-5 * time.Second),
+	}
+	line := cv.renderBackgroundTaskLine(display, 0)
+
+	if !strings.Contains(line, "Agent(browser-agent=working...) 5s") {
+		t.Errorf("expected no-model form 'Agent(browser-agent=working...) 5s', got %q", line)
+	}
+	if strings.Contains(line, "model=") {
+		t.Errorf("expected no 'model=' segment when model is unknown, got %q", line)
+	}
+	if strings.Contains(line, ",") {
+		t.Errorf("expected no trailing comma artefact when model is unknown, got %q", line)
+	}
+}
+
+func TestBackgroundTaskDisplay_RenderLine_FreezesElapsedOnTerminal(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	started := time.Now().Add(-42 * time.Second)
+	completed := started.Add(42 * time.Second)
+	display := &BackgroundTaskDisplay{
+		TaskID:      "t1",
+		AgentName:   "browser-agent",
+		State:       "completed",
+		Model:       "deepseek/deepseek-v4-flash",
+		StartedAt:   started,
+		CompletedAt: completed,
+		IsTerminal:  true,
+	}
+
+	line := cv.renderBackgroundTaskLine(display, 0)
+	if !strings.Contains(line, "Agent(browser-agent=completed) 42s") {
+		t.Errorf("expected frozen elapsed 'Agent(browser-agent=completed) 42s', got %q", line)
+	}
+	if strings.Contains(line, "model=") {
+		t.Errorf("terminal form must not include 'model=', got %q", line)
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+	line2 := cv.renderBackgroundTaskLine(display, 0)
+	if !strings.Contains(line2, "42s") {
+		t.Errorf("expected elapsed to stay frozen at 42s on re-render, got %q", line2)
+	}
+	if strings.Contains(line2, "43s") {
+		t.Errorf("expected elapsed to NOT tick past 42s after terminal transition, got %q", line2)
+	}
+}
+
+func TestBackgroundTaskDisplay_RenderLine_FormatElapsedMinutes(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	display := &BackgroundTaskDisplay{
+		TaskID:    "t1",
+		AgentName: "x",
+		State:     "working",
+		StartedAt: time.Now().Add(-83 * time.Second),
+	}
+	line := cv.renderBackgroundTaskLine(display, 0)
+	if !strings.Contains(line, "1m23s") {
+		t.Errorf("expected elapsed '1m23s' for 83s, got %q", line)
+	}
+}
+
+func TestBackgroundTaskDisplay_RenderLine_TruncatesLongModel(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	display := &BackgroundTaskDisplay{
+		TaskID:    "t1",
+		AgentName: "browser-agent",
+		State:     "working",
+		Model:     "extremely-long-vendor-name/very-verbose-model-identifier-v42-flash-preview-experimental",
+		StartedAt: time.Now().Add(-3 * time.Second),
+	}
+	const width = 60
+	line := cv.renderBackgroundTaskLine(display, width)
+
+	if got := lipgloss.Width(line); got > width {
+		t.Errorf("expected visible width <= %d, got %d for line %q", width, got, line)
+	}
+	if !strings.Contains(line, "Agent(browser-agent=working..., model=") {
+		t.Errorf("expected name and state preserved with model prefix, got %q", line)
+	}
+	if !strings.Contains(line, "...) 3s") {
+		t.Errorf("expected truncated model ending with '...) 3s', got %q", line)
+	}
+	if !strings.Contains(line, "browser-agent") {
+		t.Errorf("expected name preserved verbatim, got %q", line)
+	}
+	if !strings.Contains(line, "working...") {
+		t.Errorf("expected state preserved verbatim, got %q", line)
+	}
+}
+
+func TestBackgroundTaskDisplay_SubmittedPopulatesStartedAtFromTimestamp(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	ts := time.Now().Add(-2 * time.Second)
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID:    "task-1",
+		AgentURL:  "http://localhost:8081",
+		Timestamp: ts,
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if display == nil {
+		t.Fatal("expected display entry for task-1")
+	}
+	if !display.StartedAt.Equal(ts) {
+		t.Errorf("expected StartedAt=%v from event timestamp, got %v", ts, display.StartedAt)
+	}
+}
+
+func TestBackgroundTaskDisplay_SubmittedFallsBackToNowWhenTimestampZero(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+
+	before := time.Now()
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID: "task-1",
+	}, nil)
+	after := time.Now()
+
+	display := cv.backgroundTasks["task-1"]
+	if display == nil {
+		t.Fatal("expected display entry for task-1")
+	}
+	if display.StartedAt.Before(before) || display.StartedAt.After(after) {
+		t.Errorf("expected StartedAt within [%v, %v], got %v", before, after, display.StartedAt)
+	}
+}
+
+func TestBackgroundTaskDisplay_AgentModelResolverPopulatesOnSubmit(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetAgentModelResolver(func(url string) string {
+		if url == "http://localhost:8081" {
+			return "deepseek/deepseek-v4-flash"
+		}
+		return ""
+	})
+
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+		TaskID:   "task-1",
+		AgentURL: "http://localhost:8081",
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if display == nil {
+		t.Fatal("expected display entry for task-1")
+	}
+	if display.Model != "deepseek/deepseek-v4-flash" {
+		t.Errorf("expected resolver-populated Model 'deepseek/deepseek-v4-flash', got %q", display.Model)
+	}
+}
+
+func TestBackgroundTaskDisplay_AgentModelResolverPopulatesOnLateStatusUpdate(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetAgentModelResolver(func(url string) string {
+		if url == "http://localhost:8081" {
+			return "deepseek/deepseek-v4-flash"
+		}
+		return ""
+	})
+
+	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{TaskID: "task-1"}, nil)
+	if got := cv.backgroundTasks["task-1"].Model; got != "" {
+		t.Errorf("expected empty Model before AgentURL is known, got %q", got)
+	}
+
+	cv.handleA2ATaskStatusUpdate(domain.A2ATaskStatusUpdateEvent{
+		TaskID:   "task-1",
+		AgentURL: "http://localhost:8081",
+		Status:   "TASK_STATE_WORKING",
+	}, nil)
+
+	display := cv.backgroundTasks["task-1"]
+	if display.Model != "deepseek/deepseek-v4-flash" {
+		t.Errorf("expected late resolver to populate Model 'deepseek/deepseek-v4-flash', got %q", display.Model)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extends the inline sticky-bar A2A indicator (added in #534) with **elapsed seconds** since submission and the **remote agent's configured model**, addressing #536.
- Non-terminal line: `◓ Agent(browser-agent=working..., model=deepseek/deepseek-v4-flash) 17s`. Terminal line freezes elapsed at `CompletedAt-StartedAt` and omits `model=`: `✓ Agent(browser-agent=completed) 42s`.
- Model source is `~/.infer/agents.yaml` (`AgentEntry.Model` already exists for spawning OCI agents); wired via a new `SetAgentModelResolver` that mirrors the existing name resolver.
- Re-render cadence reuses the existing 100ms spinner tick — no new ticker. The chain self-terminates when the task map empties.
- Long model identifiers truncate with `...`; name, state, and elapsed are preserved. Width is now threaded from `RenderBackgroundTasksBar` through `renderBackgroundTaskLine`.

Closes #536
