### PR TITLE
refactor(version): Simplify --version output to one-liner

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -50,11 +50,7 @@ jobs:
         id: version
         run: |
           VERSION="${{ github.event.release.tag_name }}"
-          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "commit=$COMMIT" >> $GITHUB_OUTPUT
-          echo "date=$DATE" >> $GITHUB_OUTPUT
 
       - name: Build binary (Linux portable - pure Go, no CGO dependencies)
         if: matrix.goos == 'linux'
@@ -64,7 +60,7 @@ jobs:
             -w /workspace \
             -e CGO_ENABLED=0 \
             golang:1.26-alpine3.23 \
-            sh -c "go build -ldflags '-w -s -X github.com/inference-gateway/cli/cmd.version=${{ steps.version.outputs.version }} -X github.com/inference-gateway/cli/cmd.commit=${{ steps.version.outputs.commit }} -X github.com/inference-gateway/cli/cmd.date=${{ steps.version.outputs.date }}' -o infer-${{ matrix.goos }}-${{ matrix.goarch }} ."
+            sh -c "go build -ldflags '-w -s -X github.com/inference-gateway/cli/cmd.version=${{ steps.version.outputs.version }}' -o infer-${{ matrix.goos }}-${{ matrix.goarch }} ."
 
       - name: Computer Use App (macOS only)
         if: matrix.goos == 'darwin'
@@ -78,7 +74,7 @@ jobs:
         env:
           CGO_ENABLED: ${{ matrix.cgo }}
         run: |
-          go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version=${{ steps.version.outputs.version }} -X github.com/inference-gateway/cli/cmd.commit=${{ steps.version.outputs.commit }} -X github.com/inference-gateway/cli/cmd.date=${{ steps.version.outputs.date }}" -o infer-${{ matrix.goos }}-${{ matrix.goarch }} .
+          go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version=${{ steps.version.outputs.version }}" -o infer-${{ matrix.goos }}-${{ matrix.goarch }} .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,7 @@ jobs:
         go build \
           -ldflags "\
             -w -s \
-            -X github.com/inference-gateway/cli/cmd.version=${{ github.ref_name }} \
-            -X github.com/inference-gateway/cli/cmd.commit=${{ github.sha }} \
-            -X github.com/inference-gateway/cli/cmd.date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+            -X github.com/inference-gateway/cli/cmd.version=${{ github.ref_name }}" \
           -o infer .
 
   test:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,7 @@ tasks:
   build:
     desc: Build the CLI binary
     cmds:
-      - go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}} -X github.com/inference-gateway/cli/cmd.commit={{.COMMIT}} -X github.com/inference-gateway/cli/cmd.date={{.DATE}}" -o {{.BINARY_NAME}} {{.MAIN_PACKAGE}}
+      - go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}}" -o {{.BINARY_NAME}} {{.MAIN_PACKAGE}}
     sources:
       - "**/*.go"
       - go.mod
@@ -30,7 +30,7 @@ tasks:
   install:
     desc: Install the CLI from source
     cmds:
-      - go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}} -X github.com/inference-gateway/cli/cmd.commit={{.COMMIT}} -X github.com/inference-gateway/cli/cmd.date={{.DATE}}" -o $(go env GOPATH)/bin/{{.BINARY_NAME}} {{.MAIN_PACKAGE}}
+      - go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}}" -o $(go env GOPATH)/bin/{{.BINARY_NAME}} {{.MAIN_PACKAGE}}
 
   clean:
     desc: Clean build artifacts
@@ -120,7 +120,7 @@ tasks:
         echo "Building for native platform..."
         GOOS=$(go env GOOS)
         GOARCH=$(go env GOARCH)
-        go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}} -X github.com/inference-gateway/cli/cmd.commit={{.COMMIT}} -X github.com/inference-gateway/cli/cmd.date={{.DATE}}" -o dist/{{.BINARY_NAME}}-${GOOS}-${GOARCH} {{.MAIN_PACKAGE}}
+        go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}}" -o dist/{{.BINARY_NAME}}-${GOOS}-${GOARCH} {{.MAIN_PACKAGE}}
         echo "✓ Built dist/{{.BINARY_NAME}}-${GOOS}-${GOARCH}"
       - cd dist && sha256sum {{.BINARY_NAME}}-* > checksums.txt
       - |
@@ -138,7 +138,7 @@ tasks:
         sh: go env GOARCH
     cmds:
       - mkdir -p dist
-      - GOOS=darwin GOARCH={{.GOARCH}} go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}} -X github.com/inference-gateway/cli/cmd.commit={{.COMMIT}} -X github.com/inference-gateway/cli/cmd.date={{.DATE}}" -o dist/{{.BINARY_NAME}}-darwin-{{.GOARCH}} {{.MAIN_PACKAGE}}
+      - GOOS=darwin GOARCH={{.GOARCH}} go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}}" -o dist/{{.BINARY_NAME}}-darwin-{{.GOARCH}} {{.MAIN_PACKAGE}}
 
   release:build:linux:
     desc: Build portable Linux binary using Docker
@@ -155,7 +155,7 @@ tasks:
           golang:1.26-alpine \
           sh -c 'CGO_ENABLED=0 GOOS=linux GOARCH={{.GOARCH}} \
             go build \
-            -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}} -X github.com/inference-gateway/cli/cmd.commit={{.COMMIT}} -X github.com/inference-gateway/cli/cmd.date={{.DATE}}" \
+            -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}}" \
             -o dist/{{.BINARY_NAME}}-linux-{{.GOARCH}} .'
         echo "✓ Built portable dist/{{.BINARY_NAME}}-linux-{{.GOARCH}} (pure Go, all storage backends supported)"
 

--- a/cmd/channels.go
+++ b/cmd/channels.go
@@ -64,11 +64,7 @@ func RunChannelsCommand(cfg *config.Config) error {
 		}
 	}
 
-	logger.Info("Starting channels-manager",
-		"version", version,
-		"commit", commit,
-		"build_date", date,
-	)
+	logger.Info("Starting channels-manager", "version", version)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,9 +17,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version information",
 	Long:  `Display version information for the Inference Gateway CLI.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("infer version %s\n", version)
-		fmt.Printf("commit: %s\n", commit)
-		fmt.Printf("built at: %s\n", date)
+		fmt.Printf("infer %s\n", version)
 	},
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,11 +6,7 @@ import (
 	cobra "github.com/spf13/cobra"
 )
 
-var (
-	version = "dev"
-	commit  = "unknown"
-	date    = "unknown"
-)
+var version = "dev"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/cmd/version_info.go
+++ b/cmd/version_info.go
@@ -6,7 +6,5 @@ import "github.com/inference-gateway/cli/internal/domain"
 func GetVersionInfo() domain.VersionInfo {
 	return domain.VersionInfo{
 		Version: version,
-		Commit:  commit,
-		Date:    date,
 	}
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,9 @@
 
   outputs =
     {
-      self,
       nixpkgs,
       flake-utils,
+      ...
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -59,7 +59,6 @@
             "-s"
             "-w"
             "-X=github.com/inference-gateway/cli/cmd.version=${version}"
-            "-X=github.com/inference-gateway/cli/cmd.commit=${self.shortRev or "dirty"}"
           ];
 
           preCheck = ''

--- a/internal/domain/version.go
+++ b/internal/domain/version.go
@@ -3,6 +3,4 @@ package domain
 // VersionInfo contains build-time version information
 type VersionInfo struct {
 	Version string
-	Commit  string
-	Date    string
 }


### PR DESCRIPTION
## Summary

- Collapse `infer version` / `infer --version` to a single line: `infer <version>`
- Drops the now-redundant `commit:` and `built at:` lines

Closes #539