### PR TITLE
fix(agent): emit structured tool_calls on assistant messages

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -88,6 +88,5 @@ jobs:
           claude_args: |
             --effort max
             --model claude-opus-4-7
-            --system-prompt "Use conventional commit with lowercase format"
             --allowedTools "Bash(task:*),Bash(go:*),Bash(gh:*),Bash(git:*)"
             --mcp-config '{"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp@latest"]}}}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -88,5 +88,6 @@ jobs:
           claude_args: |
             --effort max
             --model claude-opus-4-7
+            --system-prompt "Use conventional commit with lowercase format"
             --allowedTools "Bash(task:*),Bash(go:*),Bash(gh:*),Bash(git:*)"
             --mcp-config '{"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp@latest"]}}}'

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1009,7 +1009,6 @@ func (s *AgentSession) outputMessage(msg ConversationMessage) {
 		for i, toolCall := range *msg.ToolCalls {
 			summaries[i] = formatToolCallSummary(toolCall.Function.Name, toolCall.Function.Arguments)
 		}
-		logMsg.ToolCalls = nil
 		logMsg.Tools = summaries
 	}
 


### PR DESCRIPTION
## Summary

- \`outputMessage\` in \`cmd/agent.go\` was wiping \`ConversationMessage.ToolCalls\` to \`nil\` before writing each JSONL line to stdout when \`VerboseTools=false\` (the default). The struct already declares both \`tool_calls\` and \`tools\` fields, but only the human-readable \`tools\` summaries shipped.
- Programmatic consumers (e.g. \`inference-gateway/infer-action\`'s comment renderer) depend on the structured \`tool_calls\` array to correlate \`tool_call_id\` back to a tool name. Without it, failed tool calls in the bot's PR/issue comment render as the literal string \`unknown\`.
- This change keeps the \`Tools\` summaries (human readers still get the compact form) and stops nilling \`ToolCalls\` so both fields ship. Strictly additive — no UX regression.

**Repro:** see [inference-gateway/typescript-adk#48](https://github.com/inference-gateway/typescript-adk/issues/48) and run \`26594008560\` — the bot's posted comment shows 14 \`**unknown**\` entries in the failed-tool list.