### PR TITLE
feat(agent): re-check session rollover inside the turn loop (#549)

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -92,6 +92,8 @@ type AgentSession struct {
 	bgWaiter         *services.BackgroundTasksWaiter
 	requireApproval  bool
 	approvalCh       chan domain.ApprovalResponse
+	rolloverManager  *services.SessionRolloverManager
+	groupKey         string
 }
 
 func RunAgentCommand(cfg *config.Config, modelFlag, taskDescription string, files []string, noSave bool, sessionID string, requireApproval, heartbeat, remote bool) (err error) {
@@ -189,10 +191,10 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 		approvalCh:      make(chan domain.ApprovalResponse, 1),
 	}
 
-	rolloverMgr := svc.GetSessionRolloverManager()
-	groupKey := resolveAndLoadSession(session, rolloverMgr, sessionID, selectedModel)
+	session.rolloverManager = svc.GetSessionRolloverManager()
+	session.groupKey = resolveAndLoadSession(session, session.rolloverManager, sessionID, selectedModel)
 
-	maybeRolloverSession(session, rolloverMgr, selectedModel, groupKey)
+	session.maybeRollover()
 
 	return session.execute(taskDescription, files)
 }
@@ -241,28 +243,30 @@ func resolveAndLoadSession(session *AgentSession, rolloverMgr *services.SessionR
 	return groupKey
 }
 
-// maybeRolloverSession checks the idle/token thresholds and, if either fires,
-// performs the rollover (summary + new conversation file) and reloads the
-// session into the in-memory AgentSession. Mirrors chat-mode /compact behavior.
-func maybeRolloverSession(session *AgentSession, rolloverMgr *services.SessionRolloverManager, selectedModel, groupKey string) {
-	if rolloverMgr == nil || !rolloverMgr.ShouldRollover(selectedModel) {
+// maybeRollover delegates to SessionRolloverManager.MaybeRollover for the
+// shared gate-then-perform-then-log path that chat mode also uses (see
+// internal/handlers/chat_message_processor.go), then performs the agent-mode
+// post-rollover work: emits a status message, swaps s.sessionID, reloads the
+// in-memory conversation from the new session file via initializeSession.
+//
+// Called both at startup (before the turn loop) and at the top of every turn
+// iteration. s.completedTurns is intentionally preserved across rollover so
+// that --max-turns N stays a hard ceiling and injectSystemReminderIfDue keeps
+// its cadence. The idle trigger is structurally a no-op inside an active loop
+// because every preceding executeTurn appended a fresh-timestamped message.
+func (s *AgentSession) maybeRollover() {
+	newID, fired := s.rolloverManager.MaybeRollover(context.Background(), s.model, s.groupKey)
+	if !fired {
 		return
 	}
 
-	newID, err := rolloverMgr.PerformRollover(context.Background(), selectedModel, groupKey)
-	if err != nil {
-		logger.Warn("Auto-rollover failed, continuing with current session",
-			"error", err, "session_id", session.sessionID)
-		return
-	}
-
-	session.outputStatusMessage("info", "Rolled over to new session (summary preserved)", map[string]any{
-		"previous_session_id": session.sessionID,
+	s.outputStatusMessage("info", "Rolled over to new session (summary preserved)", map[string]any{
+		"previous_session_id": s.sessionID,
 		"new_session_id":      newID,
 	})
-	session.sessionID = newID
-	session.conversation = nil
-	if _, err := session.initializeSession(newID); err != nil {
+	s.sessionID = newID
+	s.conversation = nil
+	if _, err := s.initializeSession(newID); err != nil {
 		logger.Warn("Failed to reload session after rollover", "error", err, "session_id", newID)
 	}
 }
@@ -369,6 +373,7 @@ func (s *AgentSession) execute(taskDescription string, files []string) error {
 	consecutiveNoToolCalls := 0
 
 	for s.completedTurns < s.maxTurns {
+		s.maybeRollover()
 		s.injectSystemReminderIfDue(s.completedTurns + 1)
 
 		if err := s.executeTurn(); err != nil {

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1141,9 +1141,6 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 		}
 		originalID := repo.GetCurrentConversationID()
 
-		// Hidden:true messages cross the ShouldRollover gate (via the
-		// gateway-reported LastInputTokens) but get filtered by PerformRollover,
-		// driving the "no visible messages to rollover" error path.
 		if err := repo.AddMessage(domain.ConversationEntry{
 			Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hidden")},
 			Time:    time.Now(),

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -16,6 +17,8 @@ import (
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	storage "github.com/inference-gateway/cli/internal/infra/storage"
+	services "github.com/inference-gateway/cli/internal/services"
 	streamevent "github.com/inference-gateway/cli/internal/streamevent"
 )
 
@@ -974,6 +977,196 @@ func TestInjectSystemReminderIfDue(t *testing.T) {
 		}
 		if buf.Len() != 0 {
 			t.Errorf("expected no stream event, got %q", buf.String())
+		}
+	})
+}
+
+// rolloverFakeOptimizer is a minimal ConversationOptimizer used to exercise
+// the in-loop rollover path. It returns a single summary message regardless
+// of input - the rollover machinery only cares that something is returned
+// that PerformRollover can re-add to the new conversation.
+type rolloverFakeOptimizer struct{ calls int }
+
+func (f *rolloverFakeOptimizer) OptimizeMessages(_ []sdk.Message, _ string, _ bool) []sdk.Message {
+	f.calls++
+	return []sdk.Message{
+		{Role: sdk.Assistant, Content: sdk.NewMessageContent("--- Context Summary ---\nfake summary\n--- End Summary ---")},
+	}
+}
+
+// newAgentRolloverFixture stands up a real SessionRolloverManager backed by
+// an in-memory SQLite PersistentConversationRepository and an in-memory
+// SessionGroupStorage. The same pattern is used in
+// internal/services/session_rollover_manager_test.go - inlined here so the
+// cmd-package test stays self-contained.
+func newAgentRolloverFixture(t *testing.T) (*services.SessionRolloverManager, *services.PersistentConversationRepository, storage.SessionGroupStorage, func()) {
+	t.Helper()
+
+	storageBackend, err := storage.NewSQLiteStorage(storage.SQLiteConfig{Path: ":memory:"})
+	if err != nil {
+		t.Fatalf("create sqlite storage: %v", err)
+	}
+	repo := services.NewPersistentConversationRepository(&services.ToolFormatterService{}, nil, storageBackend)
+
+	cfg := &config.Config{}
+	cfg.Compact.Enabled = true
+	cfg.Compact.AutoAt = 80
+	cfg.Compact.RolloverOnIdleMinutes = 0
+	cfg.Compact.KeepFirstMessages = 2
+
+	groupStore := storage.NewMemorySessionGroupStorage()
+	mgr := services.NewSessionRolloverManager(
+		cfg,
+		&rolloverFakeOptimizer{},
+		repo,
+		services.NewTokenizerService(services.DefaultTokenizerConfig()),
+		groupStore,
+	)
+
+	cleanup := func() {
+		_ = repo.Close()
+		_ = storageBackend.Close()
+	}
+	return mgr, repo, groupStore, cleanup
+}
+
+func TestMaybeRolloverInLoop(t *testing.T) {
+	t.Run("no-op when rolloverManager is nil", func(t *testing.T) {
+		s := &AgentSession{
+			sessionID: "orig-id",
+			model:     "openai/gpt-4",
+		}
+		out := captureStdout(t, func() { s.maybeRollover() })
+
+		if s.sessionID != "orig-id" {
+			t.Errorf("sessionID must not change when rolloverManager is nil; got %q", s.sessionID)
+		}
+		if out != "" {
+			t.Errorf("expected no stdout output, got %q", out)
+		}
+	})
+
+	t.Run("no-op when ShouldRollover returns false", func(t *testing.T) {
+		mgr, repo, _, cleanup := newAgentRolloverFixture(t)
+		defer cleanup()
+
+		if err := repo.StartNewConversation("Initial"); err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		originalID := repo.GetCurrentConversationID()
+
+		s := &AgentSession{
+			config:           &config.Config{},
+			conversationRepo: repo,
+			sessionID:        originalID,
+			model:            "openai/gpt-4",
+			rolloverManager:  mgr,
+		}
+
+		out := captureStdout(t, func() { s.maybeRollover() })
+
+		if s.sessionID != originalID {
+			t.Errorf("sessionID must not change when ShouldRollover is false; got %q want %q", s.sessionID, originalID)
+		}
+		if out != "" {
+			t.Errorf("expected no stdout output, got %q", out)
+		}
+	})
+
+	t.Run("token trigger fires mid-loop: swaps sessionID, preserves groupKey, preserves completedTurns", func(t *testing.T) {
+		mgr, repo, groupStore, cleanup := newAgentRolloverFixture(t)
+		defer cleanup()
+
+		if _, _, err := mgr.ResolveSessionID("channel-test-group"); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if err := repo.StartNewConversation("Initial"); err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		originalID := repo.GetCurrentConversationID()
+
+		if err := repo.AddMessage(domain.ConversationEntry{
+			Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hi")},
+			Time:    time.Now(),
+		}); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+		if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+			t.Fatalf("AddTokenUsage: %v", err)
+		}
+
+		s := &AgentSession{
+			config:           &config.Config{},
+			conversationRepo: repo,
+			sessionID:        originalID,
+			model:            "unknown-tiny-model",
+			rolloverManager:  mgr,
+			groupKey:         "channel-test-group",
+			completedTurns:   7,
+		}
+
+		captureStdout(t, func() { s.maybeRollover() })
+
+		if s.sessionID == "" || s.sessionID == originalID {
+			t.Errorf("sessionID must be swapped to a new id; got %q (original %q)", s.sessionID, originalID)
+		}
+		if got := repo.GetCurrentConversationID(); got != s.sessionID {
+			t.Errorf("repo must be aligned with new session: got %q want %q", got, s.sessionID)
+		}
+		if s.groupKey != "channel-test-group" {
+			t.Errorf("groupKey must be preserved across rollover; got %q", s.groupKey)
+		}
+		if s.completedTurns != 7 {
+			t.Errorf("completedTurns must NOT be reset on rollover; got %d want 7", s.completedTurns)
+		}
+
+		entry, ok, err := groupStore.GetSessionGroup(context.Background(), "channel-test-group")
+		if err != nil || !ok {
+			t.Fatalf("GetSessionGroup: ok=%v err=%v", ok, err)
+		}
+		if entry.CurrentSessionID != s.sessionID {
+			t.Errorf("group index must point at new id %q, got %q", s.sessionID, entry.CurrentSessionID)
+		}
+		if len(entry.History) == 0 || entry.History[len(entry.History)-1] != originalID {
+			t.Errorf("group history must record previous id %q, got %v", originalID, entry.History)
+		}
+	})
+
+	t.Run("PerformRollover error: no swap, sessionID unchanged", func(t *testing.T) {
+		mgr, repo, _, cleanup := newAgentRolloverFixture(t)
+		defer cleanup()
+
+		if err := repo.StartNewConversation("Initial"); err != nil {
+			t.Fatalf("start: %v", err)
+		}
+		originalID := repo.GetCurrentConversationID()
+
+		// Hidden:true messages cross the ShouldRollover gate (via the
+		// gateway-reported LastInputTokens) but get filtered by PerformRollover,
+		// driving the "no visible messages to rollover" error path.
+		if err := repo.AddMessage(domain.ConversationEntry{
+			Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hidden")},
+			Time:    time.Now(),
+			Hidden:  true,
+		}); err != nil {
+			t.Fatalf("AddMessage: %v", err)
+		}
+		if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+			t.Fatalf("AddTokenUsage: %v", err)
+		}
+
+		s := &AgentSession{
+			config:           &config.Config{},
+			conversationRepo: repo,
+			sessionID:        originalID,
+			model:            "unknown-tiny-model",
+			rolloverManager:  mgr,
+		}
+
+		captureStdout(t, func() { s.maybeRollover() })
+
+		if s.sessionID != originalID {
+			t.Errorf("sessionID must not change on PerformRollover error; got %q want %q", s.sessionID, originalID)
 		}
 	})
 }

--- a/internal/handlers/chat_message_processor.go
+++ b/internal/handlers/chat_message_processor.go
@@ -9,7 +9,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	domain "github.com/inference-gateway/cli/internal/domain"
-	logger "github.com/inference-gateway/cli/internal/logger"
 	sdk "github.com/inference-gateway/sdk"
 )
 
@@ -236,15 +235,12 @@ func (p *ChatMessageProcessor) processChatMessage(
 	// fires on a 30-min idle gap or 80% context fill - both rare edge cases.
 	// If this becomes noticeable we can move it into an async tea.Cmd that
 	// dispatches a synthetic continuation event.
-	if p.handler.sessionRolloverManager != nil &&
-		p.handler.sessionRolloverManager.ShouldRollover(p.handler.modelService.GetCurrentModel()) {
-		if _, err := p.handler.sessionRolloverManager.PerformRollover(
+	if p.handler.sessionRolloverManager != nil {
+		p.handler.sessionRolloverManager.MaybeRollover(
 			context.Background(),
 			p.handler.modelService.GetCurrentModel(),
 			"",
-		); err != nil {
-			logger.Warn("auto-rollover failed, continuing with current session", "error", err)
-		}
+		)
 	}
 
 	userEntry := domain.ConversationEntry{

--- a/internal/services/session_rollover_manager.go
+++ b/internal/services/session_rollover_manager.go
@@ -112,6 +112,23 @@ func (m *SessionRolloverManager) ResolveSessionID(rawID string) (string, string,
 	return rawID, groupKey, nil
 }
 
+// MaybeRollover combines the ShouldRollover gate with PerformRollover and the
+// uniform warn-on-failure fallback that both `chat` and `infer agent` need.
+// Returns the new session id and true if a rollover fired; "" and false
+// otherwise (whether because the gate was closed or because PerformRollover
+// errored - callers do not need to distinguish).
+func (m *SessionRolloverManager) MaybeRollover(ctx context.Context, model, groupKey string) (string, bool) {
+	if m == nil || !m.ShouldRollover(model) {
+		return "", false
+	}
+	newID, err := m.PerformRollover(ctx, model, groupKey)
+	if err != nil {
+		logger.Warn("auto-rollover failed, continuing with current session", "error", err)
+		return "", false
+	}
+	return newID, true
+}
+
 // ShouldRollover checks the currently loaded conversation in the repo against
 // both rollover triggers (idle and token threshold) and returns true if either
 // fires. Returns false on a fresh/empty conversation, when the optimizer is

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -411,8 +411,6 @@ func TestMaybeRollover_GateClosedReturnsFalse(t *testing.T) {
 	mgr, _, opt, _, cleanup := newRolloverManagerForTest(t, 80, 30)
 	defer cleanup()
 
-	// Empty conversation, idle threshold not crossed, no token usage recorded.
-	// ShouldRollover returns false, so MaybeRollover must short-circuit.
 	newID, fired := mgr.MaybeRollover(context.Background(), "openai/gpt-4", "")
 	if fired {
 		t.Error("MaybeRollover with closed gate must return fired=false")
@@ -476,10 +474,6 @@ func TestMaybeRollover_PerformRolloverErrorReturnsFalse(t *testing.T) {
 	}
 	originalID := repo.GetCurrentConversationID()
 
-	// Hidden:true entries pass the ShouldRollover gate (the trigger inspects
-	// entry count + token usage, not Hidden) but PerformRollover filters them
-	// out and returns "no visible messages to rollover". Exercising this path
-	// verifies MaybeRollover swallows the error and returns ("", false).
 	hidden := domain.ConversationEntry{
 		Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hidden")},
 		Time:    time.Now(),

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -395,3 +395,111 @@ func TestConcurrentRolloversForDifferentGroups(t *testing.T) {
 		t.Errorf("expected %d groups after concurrent registration, got %d", groupCount, len(all))
 	}
 }
+
+func TestMaybeRollover_NilReceiverReturnsFalse(t *testing.T) {
+	var mgr *SessionRolloverManager
+	newID, fired := mgr.MaybeRollover(context.Background(), "openai/gpt-4", "")
+	if fired {
+		t.Error("nil receiver must return fired=false")
+	}
+	if newID != "" {
+		t.Errorf("nil receiver must return empty newID, got %q", newID)
+	}
+}
+
+func TestMaybeRollover_GateClosedReturnsFalse(t *testing.T) {
+	mgr, _, opt, _, cleanup := newRolloverManagerForTest(t, 80, 30)
+	defer cleanup()
+
+	// Empty conversation, idle threshold not crossed, no token usage recorded.
+	// ShouldRollover returns false, so MaybeRollover must short-circuit.
+	newID, fired := mgr.MaybeRollover(context.Background(), "openai/gpt-4", "")
+	if fired {
+		t.Error("MaybeRollover with closed gate must return fired=false")
+	}
+	if newID != "" {
+		t.Errorf("MaybeRollover with closed gate must return empty newID, got %q", newID)
+	}
+	if opt.calls != 0 {
+		t.Errorf("optimizer must not be called when gate is closed; got %d", opt.calls)
+	}
+}
+
+func TestMaybeRollover_FiresAndReturnsNewID(t *testing.T) {
+	mgr, repo, opt, groupStore, cleanup := newRolloverManagerForTest(t, 80, 0)
+	defer cleanup()
+
+	if _, _, err := mgr.ResolveSessionID("channel-test-group"); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if err := repo.StartNewConversation("Initial"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	originalID := repo.GetCurrentConversationID()
+
+	addUserMessage(t, repo, "hi", time.Now())
+	if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+		t.Fatalf("AddTokenUsage: %v", err)
+	}
+
+	newID, fired := mgr.MaybeRollover(context.Background(), "unknown-tiny-model", "channel-test-group")
+	if !fired {
+		t.Fatal("MaybeRollover should have fired with LastInputTokens above threshold")
+	}
+	if newID == "" || newID == originalID {
+		t.Errorf("MaybeRollover must return a new session id; got %q (original %q)", newID, originalID)
+	}
+	if opt.calls != 1 {
+		t.Errorf("optimizer should have been called once via PerformRollover, got %d", opt.calls)
+	}
+	if got := repo.GetCurrentConversationID(); got != newID {
+		t.Errorf("repo should point at new session: got %q want %q", got, newID)
+	}
+	entry, ok, err := groupStore.GetSessionGroup(context.Background(), "channel-test-group")
+	if err != nil || !ok {
+		t.Fatalf("GetSessionGroup: ok=%v err=%v", ok, err)
+	}
+	if entry.CurrentSessionID != newID {
+		t.Errorf("group index must point at new id %q, got %q", newID, entry.CurrentSessionID)
+	}
+	if len(entry.History) == 0 || entry.History[len(entry.History)-1] != originalID {
+		t.Errorf("group history must record previous id %q, got %v", originalID, entry.History)
+	}
+}
+
+func TestMaybeRollover_PerformRolloverErrorReturnsFalse(t *testing.T) {
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
+	defer cleanup()
+
+	if err := repo.StartNewConversation("Initial"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	originalID := repo.GetCurrentConversationID()
+
+	// Hidden:true entries pass the ShouldRollover gate (the trigger inspects
+	// entry count + token usage, not Hidden) but PerformRollover filters them
+	// out and returns "no visible messages to rollover". Exercising this path
+	// verifies MaybeRollover swallows the error and returns ("", false).
+	hidden := domain.ConversationEntry{
+		Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hidden")},
+		Time:    time.Now(),
+		Hidden:  true,
+	}
+	if err := repo.AddMessage(hidden); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+		t.Fatalf("AddTokenUsage: %v", err)
+	}
+
+	newID, fired := mgr.MaybeRollover(context.Background(), "unknown-tiny-model", "")
+	if fired {
+		t.Error("MaybeRollover must return fired=false when PerformRollover errors")
+	}
+	if newID != "" {
+		t.Errorf("MaybeRollover must return empty newID on error, got %q", newID)
+	}
+	if got := repo.GetCurrentConversationID(); got != originalID {
+		t.Errorf("repo must not be rolled over on PerformRollover error; got %q want %q", got, originalID)
+	}
+}


### PR DESCRIPTION
Closes #549.

## Summary

- `infer agent` previously evaluated `SessionRolloverManager.ShouldRollover` only at session start (`cmd/agent.go:195`). A long agent run could cross both the token-fill (`compact.auto_at`) and idle (`compact.rollover_on_idle_minutes`) thresholds without ever producing a new session file with a summary — the persisted conversation grew monotonically across e.g. a 50-turn run.
- Chat mode already re-evaluates rollover before every user message at `internal/handlers/chat_message_processor.go:239-248`. This PR brings agent mode in line by re-evaluating rollover at the top of every turn-loop iteration.
- The trigger logic that chat and agent now share is lifted onto `*services.SessionRolloverManager` as a new `MaybeRollover(ctx, model, groupKey) (newID string, fired bool)` method so both modes go through the same `ShouldRollover → PerformRollover → warn-on-fail` path.

## Notable design decisions

- **`s.completedTurns` is preserved across rollover.** `--max-turns N` is a user-set hard ceiling; resetting on every rollover would silently extend it and also disrupt the cadence of `injectSystemReminderIfDue`. Documented in the doc comment on `maybeRollover`.
- **The in-loop call sits *before* `injectSystemReminderIfDue`.** A rollover swaps `s.conversation`; if the reminder were injected first, it would be summarised away by the rollover that immediately follows. Placing the rollover first means the next reminder cycle lands cleanly in the new conversation.
- **The idle trigger is structurally a no-op inside an active loop** because every preceding `executeTurn` appends a fresh-timestamped message — the asymmetry is documented near the call site rather than guarded with dead-code branching, per the issue's "confirm and document the asymmetry, or guard explicitly" criterion.

## Code changes

| File | Change |
| --- | --- |
| `internal/services/session_rollover_manager.go` | New `MaybeRollover` method |
| `internal/handlers/chat_message_processor.go` | Consume `MaybeRollover`; behavior unchanged |
| `cmd/agent.go` | Two new `AgentSession` fields (`rolloverManager`, `groupKey`); `maybeRolloverSession` package function becomes `(*AgentSession).maybeRollover`; new `s.maybeRollover()` call at the top of the turn-loop body |
| `cmd/agent_test.go` | `TestMaybeRolloverInLoop` — four cases covering the issue's acceptance criteria |
| `internal/services/session_rollover_manager_test.go` | Four cases for the new `MaybeRollover` method |

## Known limitations (out of scope for #549, mentioned for follow-up)

- **`BackgroundTasksWaiter` retains the pre-rollover session id.** Constructed once at `cmd/agent.go:181-187` with the original `newSessionID`. After mid-loop rollover, in-flight A2A and background-bash tasks continue to be tracked under the pre-rollover id. Will file a follow-up issue if needed.
- **Async persistence race window.** `addMessage` at `cmd/agent.go:993-1005` kicks off a goroutine for `conversationRepo.AddMessage`. If a goroutine from turn N is still in-flight when the loop iterates back into `maybeRollover` and that rollover calls `repo.StartNewConversation`, the late-arriving message may land in the new conversation file. This race exists pre-change for `/compact` flows too; no new exposure.

## Docs follow-up

Per the org's docs follow-up rule: this is a public-surface change (new `MaybeRollover` method + new agent runtime behavior). A `[DOCS]` ticket for `inference-gateway/docs` will reference this PR.
