### PR TITLE
feat: add 'infer conversations show <id>' subcommand (#547)

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,10 @@ infer conversations list                    # List all saved conversations
 infer conversations list --limit 20         # List first 20 conversations
 infer conversations list --offset 40 -l 20  # Paginate: conversations 41-60
 infer conversations list --format json      # Output as JSON
+
+infer conversations show <session-id>                  # Show a conversation's entries
+infer conversations show <session-id> --include-hidden # Include hidden entries (e.g. system reminders)
+infer conversations show <session-id> --format json    # One JSON object per line (jq-friendly)
 ```
 
 **`infer conversation-title`** - Manage AI-powered conversation titles

--- a/cmd/conversations.go
+++ b/cmd/conversations.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	cobra "github.com/spf13/cobra"
 
 	container "github.com/inference-gateway/cli/internal/container"
+	domain "github.com/inference-gateway/cli/internal/domain"
 	formatting "github.com/inference-gateway/cli/internal/formatting"
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
 )
@@ -45,12 +48,51 @@ Examples:
 	RunE: listConversations,
 }
 
+var conversationsShowCmd = &cobra.Command{
+	Use:   "show <session-id>",
+	Short: "Show the entries of a single conversation",
+	Long: `Print the entries of a saved conversation in chronological order.
+
+Each entry shows its role, timestamp, content, and tool_call_id (for tool
+results). Output works against any configured storage backend (jsonl, sqlite,
+postgres, redis, memory) because it loads through the storage layer rather than
+reading files directly.
+
+Hidden entries — system reminders, plan-approval prompts, drained background-task
+results, and the synthetic verify message injected by 'infer agent' — are omitted
+by default. Pass --include-hidden to surface them.
+
+The session id is resolved the same way as 'infer agent --session-id': a literal
+UUID is used as-is, while any other value is treated as a session group key and
+resolved to that group's current session id (registering the group if it is new).
+
+Examples:
+  # Show a conversation by session id
+  infer conversations show 12345678-1234-1234-1234-123456789abc
+
+  # Show by session group name (e.g. a channel group key)
+  infer conversations show channel-telegram-12345
+
+  # Include hidden entries such as system reminders
+  infer conversations show <session-id> --include-hidden
+
+  # Emit one JSON object per line for piping into jq
+  infer conversations show <session-id> --format json | jq .`,
+	Args: cobra.ExactArgs(1),
+	RunE: showConversation,
+}
+
 func init() {
 	conversationsCmd.AddCommand(conversationsListCmd)
 
 	conversationsListCmd.Flags().IntP("limit", "l", 50, "Maximum number of conversations to display")
 	conversationsListCmd.Flags().Int("offset", 0, "Number of conversations to skip (for pagination)")
 	conversationsListCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
+
+	conversationsCmd.AddCommand(conversationsShowCmd)
+
+	conversationsShowCmd.Flags().Bool("include-hidden", false, "Include hidden entries (system reminders, plan prompts, drained background results, verify message)")
+	conversationsShowCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
 
 	rootCmd.AddCommand(conversationsCmd)
 }
@@ -141,4 +183,154 @@ func renderConversationsTable(conversations []storage.ConversationSummary, limit
 
 	fmt.Print(rendered)
 	return nil
+}
+
+func showConversation(cmd *cobra.Command, args []string) error {
+	services := container.NewServiceContainer(Cfg)
+
+	store := services.GetStorage()
+	if store == nil {
+		return fmt.Errorf("storage is not configured")
+	}
+
+	includeHidden, _ := cmd.Flags().GetBool("include-hidden")
+	format, _ := cmd.Flags().GetString("format")
+
+	sessionID := resolveConversationSessionID(services, args[0])
+
+	ctx := context.Background()
+	entries, _, err := store.LoadConversation(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to load conversation: %w", err)
+	}
+
+	entries = filterConversationEntries(entries, includeHidden)
+
+	if format == "json" {
+		return printConversationShowJSON(entries)
+	}
+	return printConversationShowText(entries, sessionID)
+}
+
+// resolveConversationSessionID mirrors 'infer agent --session-id' resolution:
+// a literal UUID is passed through unchanged, while any other value is resolved
+// via the rollover manager's session-group lookup. Falls back to the raw id when
+// no rollover manager is configured.
+func resolveConversationSessionID(services *container.ServiceContainer, rawID string) string {
+	mgr := services.GetSessionRolloverManager()
+	if mgr == nil {
+		return rawID
+	}
+	if resolved, _, _ := mgr.ResolveSessionID(rawID); resolved != "" {
+		return resolved
+	}
+	return rawID
+}
+
+// filterConversationEntries drops entries marked Hidden unless includeHidden is set.
+func filterConversationEntries(entries []domain.ConversationEntry, includeHidden bool) []domain.ConversationEntry {
+	if includeHidden {
+		return entries
+	}
+	filtered := make([]domain.ConversationEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.Hidden {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
+}
+
+// buildConversationShowText renders entries as a human-friendly plain-text block.
+// It is a pure function: it returns the rendered string and prints nothing.
+func buildConversationShowText(entries []domain.ConversationEntry, sessionID string) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Conversation: %s\n", sessionID)
+	fmt.Fprintf(&b, "Entries: %d\n\n", len(entries))
+
+	if len(entries) == 0 {
+		b.WriteString("(no entries)\n")
+		return b.String()
+	}
+
+	for i, e := range entries {
+		b.WriteString(buildConversationEntryHeader(i, e))
+		b.WriteString(formatting.ExtractTextFromContent(e.Message.Content, e.Images))
+		b.WriteString("\n\n")
+	}
+	return b.String()
+}
+
+// buildConversationEntryHeader builds the single header line for one entry, e.g.
+// "#1 [user] 2026-05-29T10:00:00Z [hidden] [tool_call_id=call_x] [model=gpt-4o]".
+func buildConversationEntryHeader(index int, e domain.ConversationEntry) string {
+	var h strings.Builder
+	fmt.Fprintf(&h, "#%d [%s] %s", index+1, string(e.Message.Role), e.Time.Format(time.RFC3339))
+	if e.Hidden {
+		h.WriteString(" [hidden]")
+	}
+	if e.Message.ToolCallID != nil && *e.Message.ToolCallID != "" {
+		fmt.Fprintf(&h, " [tool_call_id=%s]", *e.Message.ToolCallID)
+	}
+	if e.Model != "" {
+		fmt.Fprintf(&h, " [model=%s]", e.Model)
+	}
+	h.WriteString("\n")
+	return h.String()
+}
+
+// conversationShowEntry is the compact, jq-friendly projection emitted per line by
+// 'conversations show --format json'.
+type conversationShowEntry struct {
+	Role       string `json:"role"`
+	Time       string `json:"time"`
+	Content    string `json:"content"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	Hidden     bool   `json:"hidden,omitempty"`
+	Model      string `json:"model,omitempty"`
+}
+
+func toConversationShowEntry(e domain.ConversationEntry) conversationShowEntry {
+	out := conversationShowEntry{
+		Role:    string(e.Message.Role),
+		Time:    e.Time.Format(time.RFC3339),
+		Content: formatting.ExtractTextFromContent(e.Message.Content, e.Images),
+		Hidden:  e.Hidden,
+		Model:   e.Model,
+	}
+	if e.Message.ToolCallID != nil {
+		out.ToolCallID = *e.Message.ToolCallID
+	}
+	return out
+}
+
+// buildConversationShowJSON returns newline-joined compact JSON, one object per
+// entry (NDJSON), matching the 'infer agent' stdout shape. Pure function.
+func buildConversationShowJSON(entries []domain.ConversationEntry) (string, error) {
+	var b strings.Builder
+	for _, e := range entries {
+		line, err := json.Marshal(toConversationShowEntry(e))
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal conversation entry: %w", err)
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}
+
+func printConversationShowText(entries []domain.ConversationEntry, sessionID string) error {
+	fmt.Print(buildConversationShowText(entries, sessionID))
+	return nil
+}
+
+func printConversationShowJSON(entries []domain.ConversationEntry) error {
+	out, err := buildConversationShowJSON(entries)
+	if err != nil {
+		return err
+	}
+	_, werr := os.Stdout.Write([]byte(out))
+	return werr
 }

--- a/cmd/conversations_test.go
+++ b/cmd/conversations_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/inference-gateway/cli/internal/domain"
-	storage "github.com/inference-gateway/cli/internal/infra/storage"
 	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	storage "github.com/inference-gateway/cli/internal/infra/storage"
 )
 
 func TestRenderConversationsJSON(t *testing.T) {

--- a/cmd/conversations_test.go
+++ b/cmd/conversations_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/inference-gateway/cli/internal/domain"
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
+	sdk "github.com/inference-gateway/sdk"
 )
 
 func TestRenderConversationsJSON(t *testing.T) {
@@ -322,5 +323,173 @@ func TestRenderMarkdown_Table(t *testing.T) {
 	if err != nil {
 		t.Logf("renderMarkdown() with table returned error: %v", err)
 		// Don't fail - may not work in test environment
+	}
+}
+
+// makeShowEntries returns a fixture with a mix of user/assistant/tool/hidden
+// entries used to exercise the `conversations show` helpers.
+func makeShowEntries() []domain.ConversationEntry {
+	t0 := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+	toolID := "call_x"
+	return []domain.ConversationEntry{
+		{
+			Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hello world")},
+			Time:    t0,
+		},
+		{
+			Message: sdk.Message{Role: sdk.Assistant, Content: sdk.NewMessageContent("hi there")},
+			Model:   "gpt-4o",
+			Time:    t0.Add(1 * time.Second),
+		},
+		{
+			Message: sdk.Message{Role: sdk.Tool, Content: sdk.NewMessageContent("tool result body"), ToolCallID: &toolID},
+			Time:    t0.Add(2 * time.Second),
+		},
+		{
+			Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("system reminder injected")},
+			Time:    t0.Add(3 * time.Second),
+			Hidden:  true,
+		},
+	}
+}
+
+func TestFilterConversationEntries_HiddenExcludedByDefault(t *testing.T) {
+	got := filterConversationEntries(makeShowEntries(), false)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 visible entries, got %d", len(got))
+	}
+	for _, e := range got {
+		if e.Hidden {
+			t.Errorf("hidden entry leaked into default output")
+		}
+	}
+}
+
+func TestFilterConversationEntries_HiddenIncluded(t *testing.T) {
+	entries := makeShowEntries()
+	got := filterConversationEntries(entries, true)
+	if len(got) != len(entries) {
+		t.Fatalf("expected all %d entries with include-hidden, got %d", len(entries), len(got))
+	}
+}
+
+func TestBuildConversationShowText_PlainAndHeaders(t *testing.T) {
+	out := buildConversationShowText(makeShowEntries(), "session-123")
+
+	wants := []string{
+		"Conversation: session-123",
+		"Entries: 4",
+		"[user]",
+		"[assistant]",
+		"[model=gpt-4o]",
+		"2026-05-29T10:00:00Z",
+		"hello world",
+		"hi there",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("text output missing %q\n---\n%s", w, out)
+		}
+	}
+}
+
+func TestBuildConversationShowText_HiddenTagAndToolCallID(t *testing.T) {
+	// Include hidden so the [hidden] tag and tool entry are both present.
+	entries := filterConversationEntries(makeShowEntries(), true)
+	out := buildConversationShowText(entries, "s")
+
+	if !strings.Contains(out, "[hidden]") {
+		t.Errorf("expected [hidden] tag in output:\n%s", out)
+	}
+	if !strings.Contains(out, "[tool_call_id=call_x]") {
+		t.Errorf("expected [tool_call_id=call_x] in output:\n%s", out)
+	}
+}
+
+func TestBuildConversationShowText_Empty(t *testing.T) {
+	out := buildConversationShowText(nil, "s")
+	if !strings.Contains(out, "Entries: 0") {
+		t.Errorf("expected 'Entries: 0' for empty conversation:\n%s", out)
+	}
+	if !strings.Contains(out, "(no entries)") {
+		t.Errorf("expected '(no entries)' for empty conversation:\n%s", out)
+	}
+}
+
+func TestBuildConversationShowJSON_OneObjectPerLine(t *testing.T) {
+	entries := makeShowEntries()
+	out, err := buildConversationShowJSON(entries)
+	if err != nil {
+		t.Fatalf("buildConversationShowJSON() failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != len(entries) {
+		t.Fatalf("expected %d JSON lines, got %d", len(entries), len(lines))
+	}
+
+	decoded := make([]conversationShowEntry, 0, len(lines))
+	for i, line := range lines {
+		var e conversationShowEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("line %d not valid JSON object: %v (%q)", i, err, line)
+		}
+		decoded = append(decoded, e)
+	}
+
+	if decoded[0].Role != "user" || decoded[0].Content != "hello world" || decoded[0].Time != "2026-05-29T10:00:00Z" {
+		t.Errorf("unexpected first entry: %+v", decoded[0])
+	}
+	if decoded[1].Model != "gpt-4o" {
+		t.Errorf("expected assistant model gpt-4o, got %q", decoded[1].Model)
+	}
+	if decoded[2].ToolCallID != "call_x" {
+		t.Errorf("expected tool_call_id call_x, got %q", decoded[2].ToolCallID)
+	}
+	if !decoded[3].Hidden {
+		t.Errorf("expected fourth entry to be hidden")
+	}
+}
+
+func TestBuildConversationShowJSON_OmitsEmptyOptionalFields(t *testing.T) {
+	entry := domain.ConversationEntry{
+		Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hey")},
+		Time:    time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC),
+	}
+	out, err := buildConversationShowJSON([]domain.ConversationEntry{entry})
+	if err != nil {
+		t.Fatalf("buildConversationShowJSON() failed: %v", err)
+	}
+
+	for _, omitted := range []string{"tool_call_id", `"hidden"`, `"model"`} {
+		if strings.Contains(out, omitted) {
+			t.Errorf("expected %s to be omitted from JSON: %s", omitted, out)
+		}
+	}
+}
+
+func TestBuildConversationShowJSON_Empty(t *testing.T) {
+	out, err := buildConversationShowJSON(nil)
+	if err != nil {
+		t.Fatalf("buildConversationShowJSON() failed: %v", err)
+	}
+	if out != "" {
+		t.Errorf("expected empty output for no entries, got %q", out)
+	}
+}
+
+func TestToConversationShowEntry_Multimodal(t *testing.T) {
+	// Mirrors how the codebase persists image entries: an Images attachment on
+	// an entry whose Message.Content carries no extractable text.
+	got := toConversationShowEntry(domain.ConversationEntry{
+		Message: sdk.Message{Role: sdk.User},
+		Images: []domain.ImageAttachment{
+			{MimeType: "image/png", DisplayName: "screenshot.png"},
+		},
+		Time: time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC),
+	})
+
+	if !strings.Contains(got.Content, "[Image 1]") {
+		t.Errorf("expected image-only content to render [Image 1], got %q", got.Content)
 	}
 }

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -498,6 +498,50 @@ Check the status of the inference gateway including health checks and resource u
 infer status
 ```
 
+### `infer conversations`
+
+Inspect saved conversation history from the configured storage backend (works with `jsonl`,
+`sqlite`, `postgres`, `redis`, and `memory` — the command loads through the storage layer
+rather than reading files directly).
+
+**Subcommands:**
+
+- `list`: List saved conversations with metadata (id, title, message/request counts, tokens, cost).
+- `show <session-id>`: Print a single conversation's entries in chronological order.
+
+**`show` flags:**
+
+- `--include-hidden`: Include entries marked hidden — system reminders, plan-approval prompts,
+  drained background-task results, and the synthetic verify message injected by `infer agent`.
+  Off by default.
+- `--format text|json`: `text` (default) is human-readable; `json` emits one JSON object per
+  line (NDJSON), matching the `infer agent` stdout shape for piping into `jq` or log scrapers.
+
+The `<session-id>` is resolved the same way as `infer agent --session-id`: a literal UUID is
+used as-is, while any other value is treated as a session group key and resolved to that
+group's current session id (registering the group if it is new).
+
+**Examples:**
+
+```bash
+# List conversations to find a session id
+infer conversations list
+
+# Show a conversation's entries (hidden entries omitted)
+infer conversations show 12345678-1234-1234-1234-123456789abc
+
+# Show by session group name (e.g. a channel group key)
+infer conversations show channel-telegram-12345
+
+# Include hidden entries such as system reminders
+infer conversations show <session-id> --include-hidden
+
+# One JSON object per line for piping into jq
+infer conversations show <session-id> --format json | jq .
+```
+
+See [conversation-storage.md](conversation-storage.md) for backend configuration.
+
 ### `infer conversation-title`
 
 Manage AI-powered conversation title generation. The CLI can automatically generate descriptive titles


### PR DESCRIPTION
## Summary

Closes #547.

Adds a backend-agnostic `infer conversations show <session-id>` subcommand to inspect a saved conversation's entries chronologically. Until now `infer conversations` only had `list`, so inspecting a session (including hidden `system_reminder` entries) meant grepping raw `.jsonl` files — undiscoverable and `jsonl`-only.

## Behavior

- `infer conversations show <session-id>` prints entries chronologically with role, timestamp, content, and `tool_call_id` (for tool results).
- Loads through `storage.ConversationStorage.LoadConversation` (same path as `list`), so it works on **all** backends: `jsonl`, `sqlite`, `postgres`, `redis`, `memory` — not by reading files directly.
- `--include-hidden` (default off) surfaces entries persisted with `Hidden: true`: system reminders, plan-approval prompts, drained background-task results, and the synthetic verify message injected by `infer agent`.
- `--format text|json`: `text` (default) is human-readable with per-entry headers (`#n [role] timestamp [hidden] [tool_call_id=…] [model=…]`); `json` emits one object per line (NDJSON) for `jq`, matching the `infer agent` stdout shape.
- Session-id resolution mirrors `infer agent --session-id` via the rollover manager: literal UUIDs pass through, other values resolve a session group key (so you can show by group name, e.g. `channel-telegram-12345`).

## Implementation

- Filtering/formatting live in pure helpers (`filterConversationEntries`, `buildConversationShowText`, `buildConversationShowJSON`) with thin print wrappers — mirroring the existing `renderConversationsTable` build-then-print split, which keeps the handler small and the logic unit-testable.
- Reuses `formatting.ExtractTextFromContent` for content (handles multimodal/image-only) and `SessionRolloverManager.ResolveSessionID` for id resolution. No new domain interfaces → no mock regen.

## Acceptance criteria

- [x] `show <session-id>` prints entries chronologically (role, timestamp, content, tool_call_id).
- [x] Works against every storage backend via the storage layer, not files.
- [x] `--include-hidden` controls `Hidden: true` emission (default off).
- [x] `--format json` is one JSON object per line; `--format text` (default) is human-readable.
- [x] Registered in `cmd/conversations.go` alongside `conversationsListCmd`.
- [x] Session-id resolution mirrors `infer agent --session-id` (UUID passthrough + group-key lookup).
- [x] Tests cover hidden-vs-shown filtering and the json/text split.

## Testing

- `task build`, full `go test ./...`, and `task lint` (0 issues) pass; 9 new unit tests added.
- End-to-end against the `jsonl` backend (seeded a 4-entry conversation incl. a hidden reminder): text omits hidden (3 shown) / `--include-hidden` shows 4 with `[hidden]`; `--format json` is valid NDJSON parsed by `jq`; not-found returns `failed to load conversation: conversation not found: <id>`.

## Notes

- Resolving a *non-UUID* id that doesn't exist yet registers a new (empty) session group — inherited directly from the `ResolveSessionID` path `infer agent` uses (intentional parity, not a divergent read-only variant).
- Docs updated in-repo (`README.md`, `docs/commands-reference.md`). A matching `[DOCS]` follow-up will be filed against `inference-gateway/docs`.