### PR TITLE
fix(skills): authenticate GitHub requests in 'infer skills install'

### DIFF
--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -114,8 +114,8 @@ func listSkills(cmd *cobra.Command, _ []string) error {
 
 var skillsInstallCmd = &cobra.Command{
 	Use:   "install <skill | org/skill | github-url>",
-	Short: "Install a skill from a public GitHub repository",
-	Long: `Install a skill folder from a public GitHub repository.
+	Short: "Install a skill from a GitHub repository",
+	Long: `Install a skill folder from a GitHub repository.
 
 You can pass any of the following:
 
@@ -142,8 +142,10 @@ After download, the same frontmatter validator that runs at startup runs
 against the downloaded folder. If validation fails the folder is removed
 and the reason is printed.
 
-Public repositories only. GitHub's unauthenticated API rate limit is 60
-requests per hour per IP.`,
+Requests are unauthenticated by default, which GitHub limits to 60 API
+requests per hour per IP. Set GITHUB_TOKEN (or GH_TOKEN) in the environment
+to authenticate: this raises the limit to 5,000 requests per hour and allows
+installing from private repositories the token can access.`,
 	Args: cobra.ExactArgs(1),
 	RunE: installSkill,
 }

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -85,7 +85,7 @@ were skipped.
 
 ## Installing skills from GitHub
 
-You can install a skill folder directly from a public GitHub repository:
+You can install a skill folder directly from a GitHub repository:
 
 ```bash
 infer skills install https://github.com/anthropics/skills/tree/main/skills/pdf
@@ -110,13 +110,25 @@ validation fails (missing `name`, name doesn't match the directory name,
 etc.) the folder is removed and the reason is printed. There is never a
 half-installed state.
 
+### Authentication
+
+Requests are unauthenticated by default, which GitHub limits to 60 API
+requests per hour per IP - easily exhausted on shared CI runners. Set
+`GITHUB_TOKEN` (or `GH_TOKEN`, matching the `gh` CLI) in the environment to
+authenticate:
+
+```bash
+GITHUB_TOKEN="$MY_TOKEN" infer skills install acme/internal-comms
+```
+
+Authenticating raises the limit to 5,000 requests per hour and lets you
+install from private repositories the token can access.
+
 **Limitations:**
 
-- Public repositories only. Private repos and `GITHUB_TOKEN`
-  authentication are not supported in this version.
-- GitHub's unauthenticated API rate limit is 60 requests per hour per
-  IP. Each install is one API call (the tree enumeration) plus one raw
-  download per file in the skill folder.
+- Each install is one API call (the tree enumeration) plus one raw
+  download per file in the skill folder. Without a token you share the
+  60 requests/hour anonymous limit with everything else on your IP.
 - Refs containing a literal `/` (e.g. `feature/foo` branches) are not
   supported. Use a tag, the default branch, or a single-segment branch.
 

--- a/internal/services/skills/install.go
+++ b/internal/services/skills/install.go
@@ -116,21 +116,45 @@ type treeResponse struct {
 	Truncated bool        `json:"truncated"`
 }
 
-// Installer downloads a skill folder from a public GitHub repo into a local
-// destination directory.
+// Installer downloads a skill folder from a GitHub repo into a local
+// destination directory. When Token is non-empty its requests are
+// authenticated, which raises the GitHub API rate limit from 60 to 5,000
+// requests/hour and allows access to private repositories the token can see.
 type Installer struct {
 	Client  *http.Client
 	APIBase string
 	RawBase string
+	Token   string
 }
 
 // NewInstaller returns an Installer pointed at github.com with a 30s HTTP
-// timeout. Tests substitute APIBase / RawBase to point at httptest.Server.
+// timeout. The GitHub token is read from the environment (GITHUB_TOKEN, then
+// GH_TOKEN); when neither is set requests are made unauthenticated. Tests
+// substitute APIBase / RawBase to point at httptest.Server.
 func NewInstaller() *Installer {
 	return &Installer{
 		Client:  &http.Client{Timeout: installerTimeout},
 		APIBase: githubAPIBase,
 		RawBase: githubRawBase,
+		Token:   githubToken(),
+	}
+}
+
+// githubToken returns the GitHub token from the environment, preferring
+// GITHUB_TOKEN and falling back to GH_TOKEN (matching the gh CLI). It returns
+// "" when neither is set.
+func githubToken() string {
+	if t := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); t != "" {
+		return t
+	}
+	return strings.TrimSpace(os.Getenv("GH_TOKEN"))
+}
+
+// setAuth adds the bearer token to req when the installer is authenticated.
+// GitHub honors the same token on api.github.com and raw.githubusercontent.com.
+func (i *Installer) setAuth(req *http.Request) {
+	if i.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+i.Token)
 	}
 }
 
@@ -227,6 +251,7 @@ func (i *Installer) fetchTree(ctx context.Context, loc *GitHubLocation) (*treeRe
 	}
 	req.Header.Set("User-Agent", installerUA)
 	req.Header.Set("Accept", "application/vnd.github+json")
+	i.setAuth(req)
 
 	resp, err := i.Client.Do(req)
 	if err != nil {
@@ -238,7 +263,10 @@ func (i *Installer) fetchTree(ctx context.Context, loc *GitHubLocation) (*treeRe
 		return nil, fmt.Errorf("repository or ref not found: %s/%s @ %s", loc.Owner, loc.Repo, loc.Ref)
 	}
 	if resp.StatusCode == http.StatusForbidden {
-		return nil, fmt.Errorf("GitHub API rate limit exceeded (60 req/hour for unauthenticated requests); try again later")
+		if i.Token == "" {
+			return nil, fmt.Errorf("GitHub API rate limit exceeded (60 req/hour for unauthenticated requests) - set GITHUB_TOKEN (or GH_TOKEN) to raise the limit to 5,000/hour, or try again later")
+		}
+		return nil, fmt.Errorf("GitHub API request forbidden (403) for %s/%s - the token may lack access or a secondary rate limit was hit; try again later", loc.Owner, loc.Repo)
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -294,6 +322,7 @@ func (i *Installer) downloadFile(ctx context.Context, loc *GitHubLocation, repoP
 		return fmt.Errorf("failed to create request for %s: %w", repoPath, err)
 	}
 	req.Header.Set("User-Agent", installerUA)
+	i.setAuth(req)
 
 	resp, err := i.Client.Do(req)
 	if err != nil {

--- a/internal/services/skills/install_test.go
+++ b/internal/services/skills/install_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	require "github.com/stretchr/testify/require"
@@ -411,6 +412,90 @@ func TestUninstall_RejectsFile(t *testing.T) {
 	_, err := Uninstall("pdf", dest)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not a directory")
+}
+
+func TestGithubToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		githubToken string
+		ghToken     string
+		want        string
+	}{
+		{name: "prefers GITHUB_TOKEN over GH_TOKEN", githubToken: "primary", ghToken: "secondary", want: "primary"},
+		{name: "falls back to GH_TOKEN", githubToken: "", ghToken: "secondary", want: "secondary"},
+		{name: "trims surrounding whitespace", githubToken: "  spaced  ", ghToken: "", want: "spaced"},
+		{name: "empty when neither set", githubToken: "", ghToken: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", tt.githubToken)
+			t.Setenv("GH_TOKEN", tt.ghToken)
+			require.Equal(t, tt.want, githubToken())
+		})
+	}
+}
+
+func TestInstallFromGitHub_Authorization(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		wantAuth string
+	}{
+		{name: "token set sends bearer header on api and raw requests", token: "secret-token", wantAuth: "Bearer secret-token"},
+		{name: "no token sends no authorization header", token: "", wantAuth: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			seen := map[string]string{}
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				seen["tree"] = r.Header.Get("Authorization")
+				mu.Unlock()
+				resp := treeResponse{Tree: []treeEntry{{Path: "skills/pdf/SKILL.md", Type: "blob"}}}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(resp)
+			})
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				seen["raw"] = r.Header.Get("Authorization")
+				mu.Unlock()
+				_, _ = w.Write([]byte(validSkillBody("pdf", "ok")))
+			})
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			inst := &Installer{Client: http.DefaultClient, APIBase: srv.URL, RawBase: srv.URL, Token: tt.token}
+			_, err := inst.InstallFromGitHub(context.Background(),
+				"https://github.com/foo/bar/tree/main/skills/pdf", t.TempDir(), false)
+			require.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.Equal(t, tt.wantAuth, seen["tree"], "tree (api) request Authorization header")
+			require.Equal(t, tt.wantAuth, seen["raw"], "raw file request Authorization header")
+		})
+	}
+}
+
+func TestInstallFromGitHub_AuthenticatedForbidden(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	inst := &Installer{Client: http.DefaultClient, APIBase: srv.URL, RawBase: srv.URL, Token: "tok"}
+	_, err := inst.InstallFromGitHub(context.Background(),
+		"https://github.com/foo/bar/tree/main/skills/pdf", t.TempDir(), false)
+	require.Error(t, err)
+	// Authenticated 403 must not blame the anonymous rate limit.
+	require.Contains(t, err.Error(), "forbidden")
+	require.NotContains(t, err.Error(), "unauthenticated")
 }
 
 func TestInstallFromGitHub_OverwriteReplaces(t *testing.T) {


### PR DESCRIPTION
## Summary

`infer skills install` fetched skill folders from GitHub using **only unauthenticated** requests and had **no way to supply a token**. On shared-IP hosts — notably GitHub-hosted Actions runners, where the anonymous `api.github.com` limit is per-IP and shared across the runner pool — it frequently failed with:

```
Error: GitHub API rate limit exceeded (60 req/hour for unauthenticated requests); try again later
```

It also could never install from private repositories.

## Changes

- Add a `Token` field to `Installer`, populated from `GITHUB_TOKEN` (falling back to `GH_TOKEN`, matching the `gh` CLI) in `NewInstaller()`.
- Send `Authorization: Bearer <token>` on both the tree API request (`fetchTree`) and the raw file downloads (`downloadFile`) when a token is present. Anonymous behavior is preserved when no token is set.
- Make the `403` message actionable: unauthenticated callers are pointed at `GITHUB_TOKEN`; an authenticated `403` no longer blames the anonymous rate limit.
- Update the `install` command help and `docs/skills.md`.

Authenticating raises the limit from 60 to 5,000 requests/hour and allows installing from private repos the token can access.

## Tests

- `TestGithubToken` — env precedence (`GITHUB_TOKEN` > `GH_TOKEN`), trimming, empty.
- `TestInstallFromGitHub_Authorization` — bearer header present on both API and raw requests when a token is set, absent when not.
- `TestInstallFromGitHub_AuthenticatedForbidden` — authenticated `403` doesn't report "unauthenticated".

`go test -race ./internal/services/skills/`, `go vet`, and the repo's pre-commit lint hook all pass.

## Required follow-up (separate repo)

`inference-gateway/infer-action`'s "Install Infer skills" step has no `env:` block, so it must also pass `GITHUB_TOKEN: ${{ inputs.github-token }}` for this fix to take effect in that action. Every other GitHub-touching step there already sets the token; this one is the exception. A companion PR addresses it.

Closes #555
