### PR TITLE
feat: add /copy shortcut to copy the current conversation to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,7 @@ actions.
 - `/theme` - Switch chat theme
 - `/cost` - Show session cost breakdown with per-model details
 - `/compact` - Compact conversation
+- `/copy [format]` - Copy current conversation to the system clipboard (text, markdown, or json)
 - `/export` - Export conversation
 
 **Git Shortcuts** (created by `infer init`):

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -187,6 +187,7 @@ words:
   - otiai
   - parenleft
   - parenright
+  - pbcopy
   - perfstat
   - pflag
   - pgdn
@@ -292,11 +293,13 @@ words:
   - wrongowner
   - wtype
   - Wtype
+  - xclip
   - xclipboard
   - xdraw
   - xgbutil
   - xgraphics
   - ximg
+  - xsel
   - xtest
   - xxhash
   - ydotool

--- a/docs/shortcuts-guide.md
+++ b/docs/shortcuts-guide.md
@@ -47,6 +47,7 @@ These shortcuts are available out of the box:
 - `/theme` - Switch chat interface theme or list available themes
 - `/config <show|get|set|reload> [key] [value]` - Manage configuration settings
 - `/compact` - Immediately compact conversation to reduce token usage
+- `/copy [format]` - Copy the current conversation to the system clipboard (formats: `text`, `markdown`, `json`; default `text`)
 - `/export [format]` - Export conversation to markdown
 - `/init` - Set input with project analysis prompt for AGENTS.md generation
 
@@ -64,6 +65,25 @@ The prompt is configurable in your config file under `init.prompt`. The default 
 - Analyze your project structure, build tools, and configuration files
 - Create comprehensive documentation for AI agents
 - Generate an AGENTS.md file with project overview, commands, and conventions
+
+### Copy Shortcut
+
+The `/copy` shortcut copies the current conversation to your system clipboard, so you can move a
+session to another terminal or machine and continue it there. It pairs well with `/compact`:
+
+1. Run `/compact` to summarize the conversation and reduce its size
+2. Run `/copy` to place the (now compact) session on the clipboard
+3. Paste it into another terminal or chat to continue the work
+
+By default `/copy` uses plain `text`; pass a format to override it — `/copy markdown` or
+`/copy json`. The shortcut shells out to your platform's native clipboard utility:
+
+- **macOS:** `pbcopy`
+- **Linux:** one of `wl-copy` (Wayland), `xclip`, or `xsel` (X11) — install at least one
+- **Windows:** `clip`
+- **WSL:** `clip.exe` (writes to the Windows host clipboard)
+
+If none of these utilities is available, `/copy` reports an error naming the ones it looked for.
 
 ---
 

--- a/internal/clipboard/text/text.go
+++ b/internal/clipboard/text/text.go
@@ -1,0 +1,96 @@
+// Package text provides a CGO-free, cross-platform clipboard text writer that
+// shells out to the platform's native clipboard utility (pbcopy, wl-copy,
+// xclip, xsel, or clip). It is intentionally separate from the image-focused
+// internal/clipboard package, which relies on CGO and is only built on macOS.
+package text
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Writer copies text to the system clipboard via native CLI utilities.
+type Writer struct{}
+
+// NewWriter creates a new clipboard text Writer.
+func NewWriter() *Writer {
+	return &Writer{}
+}
+
+// candidate is a single clipboard utility invocation (command name + fixed args).
+type candidate struct {
+	name string
+	args []string
+}
+
+// Copy writes text to the system clipboard, trying the platform's clipboard
+// utilities in order and skipping any that are not installed. It returns an
+// actionable error if no working utility is found.
+func (w *Writer) Copy(ctx context.Context, text string) error {
+	candidates := clipboardCandidates()
+	if len(candidates) == 0 {
+		return fmt.Errorf("clipboard copy is not supported on %s", runtime.GOOS)
+	}
+
+	var lastErr error
+	for _, c := range candidates {
+		if _, err := exec.LookPath(c.name); err != nil {
+			lastErr = err
+			continue
+		}
+		if err := runCopy(ctx, c, text); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
+	}
+
+	return fmt.Errorf("no working clipboard utility found (install one of: %s): %w",
+		utilNames(candidates), lastErr)
+}
+
+// runCopy pipes text to the clipboard utility's stdin.
+func runCopy(ctx context.Context, c candidate, text string) error {
+	cmd := exec.CommandContext(ctx, c.name, c.args...)
+	cmd.Stdin = strings.NewReader(text)
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		trimmed := bytes.TrimSpace(out)
+		if len(trimmed) > 0 {
+			return fmt.Errorf("%s failed: %w: %s", c.name, err, trimmed)
+		}
+		return fmt.Errorf("%s failed: %w", c.name, err)
+	}
+	return nil
+}
+
+// clipboardCandidates returns the clipboard utilities to try for the current OS,
+// in priority order.
+func clipboardCandidates() []candidate {
+	switch runtime.GOOS {
+	case "darwin":
+		return []candidate{{name: "pbcopy"}}
+	case "windows":
+		return []candidate{{name: "clip"}}
+	default: // linux, *bsd, etc.
+		return []candidate{
+			{name: "wl-copy"}, // Wayland
+			{name: "xclip", args: []string{"-selection", "clipboard"}}, // X11
+			{name: "xsel", args: []string{"--clipboard", "--input"}},   // X11 alternative
+			{name: "clip.exe"}, // WSL -> Windows host
+		}
+	}
+}
+
+// utilNames joins candidate command names for use in error messages.
+func utilNames(candidates []candidate) string {
+	names := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		names = append(names, c.name)
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/clipboard/text/text_test.go
+++ b/internal/clipboard/text/text_test.go
@@ -1,0 +1,58 @@
+package text
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestClipboardCandidates_PerOS(t *testing.T) {
+	candidates := clipboardCandidates()
+	if len(candidates) == 0 {
+		t.Fatalf("expected at least one candidate on %s", runtime.GOOS)
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		if candidates[0].name != "pbcopy" {
+			t.Errorf("darwin should prefer pbcopy, got %q", candidates[0].name)
+		}
+	case "windows":
+		if candidates[0].name != "clip" {
+			t.Errorf("windows should use clip, got %q", candidates[0].name)
+		}
+	default:
+		if candidates[0].name != "wl-copy" {
+			t.Errorf("linux should prefer wl-copy (Wayland) first, got %q", candidates[0].name)
+		}
+		names := utilNames(candidates)
+		for _, want := range []string{"wl-copy", "xclip", "xsel"} {
+			if !strings.Contains(names, want) {
+				t.Errorf("linux candidates should include %q, got %q", want, names)
+			}
+		}
+	}
+}
+
+func TestUtilNames(t *testing.T) {
+	got := utilNames([]candidate{{name: "a"}, {name: "b"}, {name: "c"}})
+	if got != "a, b, c" {
+		t.Errorf("utilNames = %q, want %q", got, "a, b, c")
+	}
+}
+
+func TestCopy_NoUtilityFound(t *testing.T) {
+	// Point PATH at an empty directory so every exec.LookPath fails and Copy
+	// reports the install-one-of error without touching the real clipboard.
+	t.Setenv("PATH", t.TempDir())
+
+	w := NewWriter()
+	err := w.Copy(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected an error when no clipboard utility is available")
+	}
+	if !strings.Contains(err.Error(), "no working clipboard utility found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/clipboard/text/text_test.go
+++ b/internal/clipboard/text/text_test.go
@@ -43,8 +43,6 @@ func TestUtilNames(t *testing.T) {
 }
 
 func TestCopy_NoUtilityFound(t *testing.T) {
-	// Point PATH at an empty directory so every exec.LookPath fails and Copy
-	// reports the install-one-of error without touching the real clipboard.
 	t.Setenv("PATH", t.TempDir())
 
 	w := NewWriter()

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -14,6 +14,7 @@ import (
 	config "github.com/inference-gateway/cli/config"
 	agent "github.com/inference-gateway/cli/internal/agent"
 	tools "github.com/inference-gateway/cli/internal/agent/tools"
+	clipboardtext "github.com/inference-gateway/cli/internal/clipboard/text"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	adapters "github.com/inference-gateway/cli/internal/infra/adapters"
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
@@ -447,6 +448,7 @@ func (c *ServiceContainer) initializeExtensibility() {
 func (c *ServiceContainer) registerDefaultCommands() {
 	c.shortcutRegistry.Register(shortcuts.NewClearShortcut(c.conversationRepo, c.backgroundTaskRegistry))
 	c.shortcutRegistry.Register(shortcuts.NewCompactShortcut(c.conversationRepo))
+	c.shortcutRegistry.Register(shortcuts.NewCopyShortcut(c.conversationRepo, clipboardtext.NewWriter()))
 	c.shortcutRegistry.Register(shortcuts.NewContextShortcut(c.conversationRepo, c.modelService, c.tokenizer))
 	c.shortcutRegistry.Register(shortcuts.NewCostShortcut(c.conversationRepo))
 	c.shortcutRegistry.Register(shortcuts.NewExitShortcut())

--- a/internal/shortcuts/copy.go
+++ b/internal/shortcuts/copy.go
@@ -1,0 +1,93 @@
+package shortcuts
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// ClipboardWriter copies UTF-8 text to the system clipboard. It is defined here
+// (rather than in internal/domain) so the CopyShortcut can be unit-tested with a
+// hand-written fake without touching the real clipboard or shelling out.
+type ClipboardWriter interface {
+	Copy(ctx context.Context, text string) error
+}
+
+// CopyShortcut copies the current conversation to the system clipboard.
+type CopyShortcut struct {
+	repo      domain.ConversationRepository
+	clipboard ClipboardWriter
+}
+
+// NewCopyShortcut creates a new CopyShortcut.
+func NewCopyShortcut(repo domain.ConversationRepository, clipboard ClipboardWriter) *CopyShortcut {
+	return &CopyShortcut{
+		repo:      repo,
+		clipboard: clipboard,
+	}
+}
+
+func (c *CopyShortcut) GetName() string { return "copy" }
+func (c *CopyShortcut) GetDescription() string {
+	return "Copy the current conversation to the system clipboard"
+}
+func (c *CopyShortcut) GetUsage() string              { return "/copy [text|markdown|json]" }
+func (c *CopyShortcut) CanExecute(args []string) bool { return len(args) <= 1 }
+
+func (c *CopyShortcut) Execute(ctx context.Context, args []string) (ShortcutResult, error) {
+	if c.repo.GetMessageCount() == 0 {
+		return ShortcutResult{
+			Output:  "No conversation to copy - conversation history is empty",
+			Success: true,
+		}, nil
+	}
+
+	format, err := parseCopyFormat(args)
+	if err != nil {
+		return ShortcutResult{Output: err.Error(), Success: false}, nil
+	}
+
+	data, err := c.repo.Export(format)
+	if err != nil {
+		return ShortcutResult{
+			Output:  fmt.Sprintf("Failed to export conversation: %v", err),
+			Success: false,
+		}, nil
+	}
+
+	if err := c.clipboard.Copy(ctx, string(data)); err != nil {
+		return ShortcutResult{
+			Output:  fmt.Sprintf("Failed to copy to clipboard: %v", err),
+			Success: false,
+		}, nil
+	}
+
+	lines := bytes.Count(data, []byte("\n")) + 1
+	return ShortcutResult{
+		Output: fmt.Sprintf("• Copied conversation to clipboard (%s, %d bytes, %d lines)",
+			format, len(data), lines),
+		Success:    true,
+		SideEffect: SideEffectNone,
+	}, nil
+}
+
+// parseCopyFormat resolves the optional format argument, defaulting to plain text.
+func parseCopyFormat(args []string) (domain.ExportFormat, error) {
+	if len(args) == 0 {
+		return domain.ExportText, nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "text", "txt":
+		return domain.ExportText, nil
+	case "markdown", "md":
+		return domain.ExportMarkdown, nil
+	case "json":
+		return domain.ExportJSON, nil
+	default:
+		return "", fmt.Errorf("unknown format %q (use text, markdown, or json)", args[0])
+	}
+}

--- a/internal/shortcuts/copy_test.go
+++ b/internal/shortcuts/copy_test.go
@@ -80,7 +80,6 @@ func TestCopyShortcut_EmptyConversation(t *testing.T) {
 func TestCopyShortcut_SuccessfulDefaultCopy(t *testing.T) {
 	repo := &domainmocks.FakeConversationRepository{}
 	repo.GetMessageCountReturns(2)
-	// 12 bytes, 2 newlines -> reported as 3 lines.
 	exported := []byte("line1\nline2\n")
 	repo.ExportReturns(exported, nil)
 	clip := &fakeClipboard{}

--- a/internal/shortcuts/copy_test.go
+++ b/internal/shortcuts/copy_test.go
@@ -1,0 +1,225 @@
+package shortcuts
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+)
+
+// fakeClipboard is a hand-written ClipboardWriter that records the copied text
+// instead of touching the real system clipboard.
+type fakeClipboard struct {
+	copied string
+	called int
+	err    error
+}
+
+func (f *fakeClipboard) Copy(_ context.Context, text string) error {
+	f.called++
+	f.copied = text
+	return f.err
+}
+
+func TestCopyShortcut_Metadata(t *testing.T) {
+	sc := NewCopyShortcut(&domainmocks.FakeConversationRepository{}, &fakeClipboard{})
+
+	if sc.GetName() != "copy" {
+		t.Errorf("GetName = %q, want %q", sc.GetName(), "copy")
+	}
+	if sc.GetDescription() == "" {
+		t.Error("GetDescription should not be empty")
+	}
+	if !strings.HasPrefix(sc.GetUsage(), "/copy") {
+		t.Errorf("GetUsage = %q, want it to start with /copy", sc.GetUsage())
+	}
+
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{nil, true},
+		{[]string{"markdown"}, true},
+		{[]string{"a", "b"}, false},
+	}
+	for _, tc := range cases {
+		if got := sc.CanExecute(tc.args); got != tc.want {
+			t.Errorf("CanExecute(%v) = %v, want %v", tc.args, got, tc.want)
+		}
+	}
+}
+
+func TestCopyShortcut_EmptyConversation(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.GetMessageCountReturns(0)
+	clip := &fakeClipboard{}
+
+	sc := NewCopyShortcut(repo, clip)
+	res, err := sc.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !res.Success {
+		t.Errorf("expected Success=true for empty conversation, got false")
+	}
+	if !strings.Contains(res.Output, "No conversation to copy") {
+		t.Errorf("expected empty-conversation message, got: %s", res.Output)
+	}
+	if clip.called != 0 {
+		t.Errorf("clipboard should not be called for empty conversation, called %d times", clip.called)
+	}
+	if repo.ExportCallCount() != 0 {
+		t.Errorf("Export should not be called for empty conversation, called %d times", repo.ExportCallCount())
+	}
+}
+
+func TestCopyShortcut_SuccessfulDefaultCopy(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.GetMessageCountReturns(2)
+	// 12 bytes, 2 newlines -> reported as 3 lines.
+	exported := []byte("line1\nline2\n")
+	repo.ExportReturns(exported, nil)
+	clip := &fakeClipboard{}
+
+	sc := NewCopyShortcut(repo, clip)
+	res, err := sc.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if !res.Success {
+		t.Errorf("expected Success=true, got false (output: %s)", res.Output)
+	}
+	if res.SideEffect != SideEffectNone {
+		t.Errorf("expected SideEffectNone, got %v", res.SideEffect)
+	}
+	if repo.ExportCallCount() != 1 {
+		t.Fatalf("expected Export called once, got %d", repo.ExportCallCount())
+	}
+	if got := repo.ExportArgsForCall(0); got != domain.ExportText {
+		t.Errorf("expected default format %v, got %v", domain.ExportText, got)
+	}
+	if clip.called != 1 {
+		t.Fatalf("expected clipboard called once, got %d", clip.called)
+	}
+	if clip.copied != string(exported) {
+		t.Errorf("clipboard received %q, want %q", clip.copied, string(exported))
+	}
+	if !strings.Contains(res.Output, "Copied conversation to clipboard") {
+		t.Errorf("expected success confirmation, got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, "3 lines") {
+		t.Errorf("expected line count in output, got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, "12 bytes") {
+		t.Errorf("expected byte count %d in output, got: %s", len(exported), res.Output)
+	}
+}
+
+func TestCopyShortcut_FormatRouting(t *testing.T) {
+	cases := []struct {
+		name string
+		arg  string
+		want domain.ExportFormat
+	}{
+		{"text", "text", domain.ExportText},
+		{"txt alias", "txt", domain.ExportText},
+		{"markdown", "markdown", domain.ExportMarkdown},
+		{"md alias", "md", domain.ExportMarkdown},
+		{"json", "json", domain.ExportJSON},
+		{"uppercase", "JSON", domain.ExportJSON},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &domainmocks.FakeConversationRepository{}
+			repo.GetMessageCountReturns(1)
+			repo.ExportReturns([]byte("data"), nil)
+			clip := &fakeClipboard{}
+
+			sc := NewCopyShortcut(repo, clip)
+			res, err := sc.Execute(context.Background(), []string{tc.arg})
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if !res.Success {
+				t.Fatalf("expected Success=true, got false (output: %s)", res.Output)
+			}
+			if got := repo.ExportArgsForCall(0); got != tc.want {
+				t.Errorf("format %q routed to %v, want %v", tc.arg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCopyShortcut_UnknownFormat(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.GetMessageCountReturns(1)
+	clip := &fakeClipboard{}
+
+	sc := NewCopyShortcut(repo, clip)
+	res, err := sc.Execute(context.Background(), []string{"xml"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if res.Success {
+		t.Errorf("expected Success=false for unknown format")
+	}
+	if !strings.Contains(res.Output, "unknown format") {
+		t.Errorf("expected unknown-format message, got: %s", res.Output)
+	}
+	if repo.ExportCallCount() != 0 {
+		t.Errorf("Export should not be called for unknown format, called %d times", repo.ExportCallCount())
+	}
+	if clip.called != 0 {
+		t.Errorf("clipboard should not be called for unknown format, called %d times", clip.called)
+	}
+}
+
+func TestCopyShortcut_ExportError(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.GetMessageCountReturns(2)
+	repo.ExportReturns(nil, errors.New("boom"))
+	clip := &fakeClipboard{}
+
+	sc := NewCopyShortcut(repo, clip)
+	res, err := sc.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if res.Success {
+		t.Errorf("expected Success=false when Export fails")
+	}
+	if !strings.Contains(res.Output, "Failed to export conversation") {
+		t.Errorf("expected export-failure message, got: %s", res.Output)
+	}
+	if clip.called != 0 {
+		t.Errorf("clipboard should not be called when Export fails, called %d times", clip.called)
+	}
+}
+
+func TestCopyShortcut_ClipboardError(t *testing.T) {
+	repo := &domainmocks.FakeConversationRepository{}
+	repo.GetMessageCountReturns(2)
+	repo.ExportReturns([]byte("data"), nil)
+	clip := &fakeClipboard{err: errors.New("no util")}
+
+	sc := NewCopyShortcut(repo, clip)
+	res, err := sc.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if res.Success {
+		t.Errorf("expected Success=false when clipboard write fails")
+	}
+	if !strings.Contains(res.Output, "Failed to copy to clipboard") {
+		t.Errorf("expected clipboard-failure message, got: %s", res.Output)
+	}
+}


### PR DESCRIPTION
## Summary

Implements a built-in `/copy` chat shortcut that copies the **current conversation** to the system clipboard, cross-platform. This pairs with `/compact` so a session can be moved to another terminal/machine and continued there.

Closes #562.

## What it does

- `/copy` copies the current conversation to the clipboard (default **plain text**).
- `/copy markdown` and `/copy json` override the format (reuses the same export formats as `/export`).
- The status line confirms what was copied, e.g. `• Copied conversation to clipboard (text, 1234 bytes, 56 lines)`.
- Graceful messaging for the empty-conversation case and when no clipboard utility is available.

## How it works

- **New CGO-free `internal/clipboard/text` package** shells out via `os/exec` to the platform's native clipboard utility, trying each in priority order and falling through if one is missing:
  - macOS → `pbcopy`
  - Linux → `wl-copy` (Wayland) → `xclip` → `xsel` (X11) → `clip.exe` (WSL)
  - Windows → `clip`
  - This avoids CGO entirely (the repo deliberately stays CGO-free), so it adds **no new dependencies**. The existing `internal/clipboard` package is macOS/CGO-only and image-focused, so it is intentionally left untouched.
- **`CopyShortcut`** reuses `ConversationRepository.Export(format)` and is wired into the service container's `registerDefaultCommands()`. `/help` and tab-completion pick it up automatically via the shortcut registry — no extra wiring.
- The clipboard writer is injected through a small package-local `ClipboardWriter` interface, so unit tests never touch the real clipboard or shell out, and **no new domain mock** (counterfeiter) is needed.

## Testing

- `internal/shortcuts/copy_test.go` — table-driven: empty conversation, successful default copy (asserts exact bytes + format + byte/line count), format routing (`text`/`txt`/`markdown`/`md`/`json`/uppercase), unknown format, export error, clipboard error, metadata/`CanExecute` arity.
- `internal/clipboard/text/text_test.go` — candidate ordering per OS and the "no utility found" path (via a `PATH`-stub so `exec.LookPath` fails) — CI/headless safe.
- Verified a real `pbcopy`/`pbpaste` round-trip locally on macOS (throwaway test, not committed).
- `task build`, `task test`, `task lint` (golangci-lint `0 issues` + markdownlint), and `go vet` all pass; `go mod tidy` is a no-op.

## Docs

- `docs/shortcuts-guide.md` — added `/copy` to Core Shortcuts plus a "Copy Shortcut" subsection describing the `/compact` → `/copy` workflow and per-platform utility requirements.
- `README.md` — added `/copy` to the Core built-in shortcuts list.
- `cspell.yaml` — added `pbcopy`, `xclip`, `xsel`.