### PR TITLE
Add file explorer panel with tree view, preview, and fuzzy finder

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1212,6 +1212,7 @@ const (
 	NamespaceTextEditing  KeyNamespace = "text_editing"
 	NamespaceTools        KeyNamespace = "tools"
 	NamespaceDiffViewer   KeyNamespace = "diff_viewer"
+	NamespaceExplorer     KeyNamespace = "explorer"
 )
 
 // ActionID constructs a namespaced action ID from namespace and action name

--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -65,6 +65,7 @@ func GetDefaultKeybindings() map[string]KeyBindingEntry {
 	addSelectionBindings(bindings)
 	addHelpBindings(bindings)
 	addDiffViewerBindings(bindings)
+	addExplorerBindings(bindings)
 
 	return bindings
 }
@@ -383,6 +384,34 @@ func addDiffViewerBindings(bindings map[string]KeyBindingEntry) {
 	add("halfpage_down", "scroll the diff down half a page", "ctrl+d")
 	add("patch_apply", "apply the current hunk", "a", "s", "u", "enter", "space")
 	add("cancel", "close the changes panel / exit patch mode", "esc", "q")
+}
+
+// addExplorerBindings registers the configurable keys for the `/explorer` file
+// panel (the VS Code-style tree opened with /explorer). The fuzzy-finder overlay
+// captures its own typing; only the keys below are resolved from these entries.
+func addExplorerBindings(bindings map[string]KeyBindingEntry) {
+	enabled := true
+	add := func(action, desc string, keys ...string) {
+		bindings[ActionID(NamespaceExplorer, action)] = KeyBindingEntry{
+			Keys:        keys,
+			Description: desc,
+			Category:    string(NamespaceExplorer),
+			Enabled:     &enabled,
+		}
+	}
+	add("nav_up", "move selection up", "up", "k")
+	add("nav_down", "move selection down", "down", "j")
+	add("collapse", "collapse the selected folder", "left", "h")
+	add("expand", "expand the selected folder", "right", "l")
+	add("toggle", "expand/collapse a folder", "enter", "space")
+	add("open", "open the selected file in your editor", "v")
+	add("find", "open the fuzzy file finder", "/")
+	add("toggle_hidden", "show/hide hidden and ignored files", ".")
+	add("scroll_up", "scroll the preview up", "pgup")
+	add("scroll_down", "scroll the preview down", "pgdown", "pgdn")
+	add("halfpage_up", "scroll the preview up half a page", "ctrl+u")
+	add("halfpage_down", "scroll the preview down half a page", "ctrl+d")
+	add("cancel", "close the explorer panel", "esc", "q")
 }
 
 // ResolveNamespaceBindings returns the effective key lists for every default

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/muesli/reflow v0.3.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
+	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
 github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
@@ -239,6 +241,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/shirou/gopsutil/v4 v4.26.2 h1:X8i6sicvUFih4BmYIGT1m2wwgw2VG9YgrDTi7cIRGUI=

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -84,6 +84,7 @@ type ChatApplication struct {
 	toolCallRenderer     *components.ToolCallRenderer
 	initGithubActionView *components.InitGithubActionView
 	diffViewer           *components.DiffViewerImpl
+	fileExplorer         *components.FileExplorerImpl
 
 	// Presentation layer
 	applicationViewRenderer *components.ApplicationViewRenderer
@@ -561,7 +562,8 @@ func (app *ChatApplication) handleViewSpecificMessages(msg tea.Msg) []tea.Cmd {
 		}
 
 		if app.stateManager.GetApprovalUIState() != nil || app.stateManager.GetPlanApprovalUIState() != nil ||
-			inHistoryMode || currentView == domain.ViewStateDiffViewer {
+			inHistoryMode || currentView == domain.ViewStateDiffViewer ||
+			currentView == domain.ViewStateExplorer {
 			inputView.SetDisabled(true)
 		} else {
 			inputView.SetDisabled(false)
@@ -585,6 +587,8 @@ func (app *ChatApplication) handleViewSpecificMessages(msg tea.Msg) []tea.Cmd {
 		return app.handleInitGithubActionView(msg)
 	case domain.ViewStateDiffViewer:
 		return app.handleDiffViewerView(msg)
+	case domain.ViewStateExplorer:
+		return app.handleExplorerView(msg)
 	default:
 		return nil
 	}
@@ -726,6 +730,8 @@ func (app *ChatApplication) viewContent() string {
 		return app.renderGithubActionSetup()
 	case domain.ViewStateDiffViewer:
 		return app.renderDiffViewer()
+	case domain.ViewStateExplorer:
+		return app.renderExplorer()
 	default:
 		return fmt.Sprintf("Unknown view state: %v", currentView)
 	}
@@ -1372,6 +1378,84 @@ func (app *ChatApplication) renderDiffViewerInput() string {
 	}
 	iv.SetCustomHint(app.diffViewer.HintText())
 	iv.SetWidth(app.diffViewer.PaneWidth())
+	return app.inputView.Render()
+}
+
+// handleExplorerView drives the VS Code-style file explorer panel. It is lazily
+// constructed on first entry and re-initialized when reopened, mirroring the
+// diff viewer.
+func (app *ChatApplication) handleExplorerView(msg tea.Msg) []tea.Cmd {
+	var cmds []tea.Cmd
+
+	if app.fileExplorer == nil {
+		styleProvider := styles.NewProvider(app.themeService)
+		cwd, err := os.Getwd()
+		if err != nil {
+			cwd = "."
+		}
+		app.fileExplorer = components.NewFileExplorer(cwd, styleProvider, app.themeService, app.config.Chat.Keybindings)
+		if cmd := app.fileExplorer.Init(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+
+	if app.fileExplorer.IsDone() || app.fileExplorer.IsCancelled() {
+		app.fileExplorer.Reset()
+		if cmd := app.fileExplorer.Init(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+
+	model, cmd := app.fileExplorer.Update(msg)
+	app.fileExplorer = model.(*components.FileExplorerImpl)
+	if cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+
+	return app.handleExplorerClose(cmds)
+}
+
+func (app *ChatApplication) handleExplorerClose(cmds []tea.Cmd) []tea.Cmd {
+	if !app.fileExplorer.IsCancelled() {
+		return cmds
+	}
+
+	if err := app.stateManager.TransitionToView(domain.ViewStateChat); err != nil {
+		return []tea.Cmd{tea.Quit}
+	}
+
+	if iv, ok := app.inputView.(*components.InputView); ok {
+		iv.SetDisabled(false)
+		iv.ClearCustomHint()
+	}
+	app.focusedComponent = app.inputView
+
+	cmds = append(cmds, func() tea.Msg {
+		return domain.SetStatusEvent{Message: "", Spinner: false, StatusType: domain.StatusDefault}
+	})
+	return cmds
+}
+
+func (app *ChatApplication) renderExplorer() string {
+	if app.fileExplorer == nil {
+		return "Loading explorer…"
+	}
+
+	width, height := app.stateManager.GetDimensions()
+	app.fileExplorer.SetWidth(width)
+	app.fileExplorer.SetHeight(height)
+	return app.fileExplorer.Render(app.renderExplorerInput())
+}
+
+// renderExplorerInput renders the chat input (disabled, with a hint) sized to the
+// preview pane width, so it sits beneath the pane to the right of the sidebar.
+func (app *ChatApplication) renderExplorerInput() string {
+	iv, ok := app.inputView.(*components.InputView)
+	if !ok {
+		return ""
+	}
+	iv.SetCustomHint(app.fileExplorer.HintText())
+	iv.SetWidth(app.fileExplorer.PaneWidth())
 	return app.inputView.Render()
 }
 

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -463,6 +463,7 @@ func (c *ServiceContainer) registerDefaultCommands() {
 	c.shortcutRegistry.Register(shortcuts.NewThemeShortcut(c.themeService))
 	c.shortcutRegistry.Register(shortcuts.NewHelpShortcut(c.shortcutRegistry))
 	c.shortcutRegistry.Register(shortcuts.NewDiffShortcut())
+	c.shortcutRegistry.Register(shortcuts.NewExplorerShortcut())
 
 	if persistentRepo, ok := c.conversationRepo.(*services.PersistentConversationRepository); ok {
 		adapter := adapters.NewPersistentConversationAdapter(persistentRepo)

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -71,6 +71,7 @@ const (
 	ViewStatePlanApproval
 	ViewStateGithubActionSetup
 	ViewStateDiffViewer
+	ViewStateExplorer
 )
 
 // AgentMode represents the operational mode of the agent
@@ -105,6 +106,8 @@ func (v ViewState) String() string {
 		return "GithubActionSetup"
 	case ViewStateDiffViewer:
 		return "DiffViewer"
+	case ViewStateExplorer:
+		return "Explorer"
 	default:
 		return "Unknown"
 	}
@@ -437,6 +440,7 @@ func (s *ApplicationState) isValidTransition(from, to ViewState) bool {
 			ViewStatePlanApproval,
 			ViewStateGithubActionSetup,
 			ViewStateDiffViewer,
+			ViewStateExplorer,
 		},
 		ViewStateFileSelection:         {ViewStateChat},
 		ViewStateConversationSelection: {ViewStateChat},
@@ -445,6 +449,7 @@ func (s *ApplicationState) isValidTransition(from, to ViewState) bool {
 		ViewStatePlanApproval:          {ViewStateChat},
 		ViewStateGithubActionSetup:     {ViewStateChat},
 		ViewStateDiffViewer:            {ViewStateChat},
+		ViewStateExplorer:              {ViewStateChat},
 	}
 
 	allowed, exists := validTransitions[from]

--- a/internal/handlers/chat_shortcut_handler.go
+++ b/internal/handlers/chat_shortcut_handler.go
@@ -211,6 +211,8 @@ func (s *ChatShortcutHandler) handleShortcutSideEffect(sideEffect shortcuts.Side
 		return s.handleShowA2ATaskManagementSideEffect()
 	case shortcuts.SideEffectShowDiffViewer:
 		return s.handleShowDiffViewerSideEffect()
+	case shortcuts.SideEffectShowExplorer:
+		return s.handleShowExplorerSideEffect()
 	case shortcuts.SideEffectSetInput:
 		return s.handleSetInputSideEffect(data)
 	case shortcuts.SideEffectGenerateSnippet:
@@ -420,6 +422,25 @@ func (s *ChatShortcutHandler) handleShowDiffViewerSideEffect() tea.Msg {
 
 	return domain.SetStatusEvent{
 		Message:    "Changes panel - ↑/↓ select · a stage · u unstage · c commit · esc back",
+		Spinner:    false,
+		StatusType: domain.StatusDefault,
+	}
+}
+
+// handleShowExplorerSideEffect opens the file explorer panel. Unlike the diff
+// viewer, it has no git-repository gate — it browses the working directory via
+// the filesystem, so it works in any directory (git or not).
+func (s *ChatShortcutHandler) handleShowExplorerSideEffect() tea.Msg {
+	if err := s.handler.stateManager.TransitionToView(domain.ViewStateExplorer); err != nil {
+		logger.Error("Failed to transition to explorer view", "error", err)
+		return domain.ShowErrorEvent{
+			Error:  fmt.Sprintf("Failed to open explorer: %v", err),
+			Sticky: false,
+		}
+	}
+
+	return domain.SetStatusEvent{
+		Message:    "Explorer - ↑/↓ select · →/← expand/collapse · / find · v open · esc back",
 		Spinner:    false,
 		StatusType: domain.StatusDefault,
 	}

--- a/internal/shortcuts/explorer.go
+++ b/internal/shortcuts/explorer.go
@@ -1,0 +1,28 @@
+package shortcuts
+
+import (
+	"context"
+)
+
+// ExplorerShortcut opens the file explorer panel (VS Code-style tree + fuzzy
+// finder). It is a pure view trigger with no dependencies — the side effect
+// transitions the UI to the explorer, which walks the working directory itself.
+type ExplorerShortcut struct{}
+
+// NewExplorerShortcut creates a new explorer shortcut.
+func NewExplorerShortcut() *ExplorerShortcut { return &ExplorerShortcut{} }
+
+func (e *ExplorerShortcut) GetName() string { return "explorer" }
+func (e *ExplorerShortcut) GetDescription() string {
+	return "Open the file explorer (tree + fuzzy finder)"
+}
+func (e *ExplorerShortcut) GetUsage() string              { return "/explorer" }
+func (e *ExplorerShortcut) CanExecute(args []string) bool { return len(args) == 0 }
+
+func (e *ExplorerShortcut) Execute(_ context.Context, _ []string) (ShortcutResult, error) {
+	return ShortcutResult{
+		Output:     "",
+		Success:    true,
+		SideEffect: SideEffectShowExplorer,
+	}, nil
+}

--- a/internal/shortcuts/interfaces.go
+++ b/internal/shortcuts/interfaces.go
@@ -45,6 +45,7 @@ const (
 	SideEffectEmbedImages
 	SideEffectSendMessageWithModel
 	SideEffectShowDiffViewer
+	SideEffectShowExplorer
 )
 
 // PersistentConversationRepository interface for conversation persistence

--- a/internal/ui/components/diffview/highlight.go
+++ b/internal/ui/components/diffview/highlight.go
@@ -1,0 +1,77 @@
+package diffview
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+// selectLexer picks a chroma lexer for the given path/content, falling back to
+// content analysis and finally the plaintext lexer, then coalesces runs of the
+// same token type. Used by the single-file Highlight helper (the in-line diff
+// highlighter has its own cached, two-path variant in DiffView.lexer).
+func selectLexer(path, content string) chroma.Lexer {
+	l := lexers.Match(path)
+	if l == nil {
+		l = lexers.Analyse(content)
+	}
+	if l == nil {
+		l = lexers.Fallback
+	}
+	return chroma.Coalesce(l)
+}
+
+// Highlight renders a whole file's contents as ANSI-styled, optionally
+// line-numbered text for a preview pane (NOT a diff). It reuses the same chroma
+// formatter as the in-line diff highlighter, so colors stay consistent. A nil
+// style disables colorization; any tokenise/format error falls back to the
+// plain (uncolored) content, so it never returns an error string.
+func Highlight(path, content string, style *chroma.Style, lineNumbers bool) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.TrimSuffix(content, "\n")
+
+	lines, ok := highlightToLines(path, content, style)
+	if !ok {
+		lines = strings.Split(content, "\n")
+	}
+	if !lineNumbers {
+		return strings.Join(lines, "\n")
+	}
+
+	digits := len(strconv.Itoa(len(lines)))
+	var b strings.Builder
+	for i, ln := range lines {
+		fmt.Fprintf(&b, "%*d │ %s\n", digits, i+1, ln)
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+// highlightToLines tokenises the whole file once (so multi-line strings and
+// comments lex correctly), splits the token stream into lines, and formats each
+// line independently into an ANSI-styled string. Splitting into lines first is
+// required because chromaFormatter trims trailing newlines per token; feeding it
+// the whole file would drop the line breaks. Returns ok=false when highlighting
+// is unavailable (nil style, or a lexer/format error) so the caller falls back.
+func highlightToLines(path, content string, style *chroma.Style) ([]string, bool) {
+	if style == nil {
+		return nil, false
+	}
+	it, err := selectLexer(path, content).Tokenise(nil, content)
+	if err != nil {
+		return nil, false
+	}
+	f := chromaFormatter("")
+	tokenLines := chroma.SplitTokensIntoLines(it.Tokens())
+	out := make([]string, 0, len(tokenLines))
+	for _, lineTokens := range tokenLines {
+		var sb strings.Builder
+		if err := f.Format(&sb, style, chroma.Literator(lineTokens...)); err != nil {
+			return nil, false
+		}
+		out = append(out, sb.String())
+	}
+	return out, true
+}

--- a/internal/ui/components/diffview/highlight_test.go
+++ b/internal/ui/components/diffview/highlight_test.go
@@ -1,0 +1,45 @@
+package diffview
+
+import (
+	"strings"
+	"testing"
+
+	chromastyles "github.com/alecthomas/chroma/v2/styles"
+)
+
+func TestHighlight_PlainPassthrough(t *testing.T) {
+	out := Highlight("x.txt", "alpha\nbeta", nil, true)
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d: %q", len(lines), out)
+	}
+	if !strings.Contains(lines[0], "alpha") || !strings.Contains(lines[1], "beta") {
+		t.Fatalf("content not preserved: %q", out)
+	}
+	if !strings.Contains(lines[0], "1") || !strings.Contains(lines[1], "2") {
+		t.Fatalf("expected a line-number gutter: %q", out)
+	}
+}
+
+func TestHighlight_NoLineNumbers(t *testing.T) {
+	out := Highlight("x.txt", "one\ntwo", nil, false)
+	if out != "one\ntwo" {
+		t.Fatalf("want plain join, got %q", out)
+	}
+}
+
+// TestHighlight_MultilineConstructPreservesLineCount guards the whole-file
+// tokenise-then-split approach: a multi-line raw string must not collapse or
+// add lines (a per-line tokeniser would mis-handle it).
+func TestHighlight_MultilineConstructPreservesLineCount(t *testing.T) {
+	src := "package main\n\nvar s = `line1\nline2\nline3`\n\nfunc main() {}\n"
+	style := chromastyles.Get("github-dark")
+
+	out := Highlight("main.go", src, style, false)
+
+	gotLines := strings.Count(out, "\n") + 1
+	wantLines := strings.Count(strings.TrimSuffix(src, "\n"), "\n") + 1
+	if gotLines != wantLines {
+		t.Fatalf("styled line count = %d, want %d\nout=%q", gotLines, wantLines, out)
+	}
+}

--- a/internal/ui/components/file_explorer.go
+++ b/internal/ui/components/file_explorer.go
@@ -1,0 +1,968 @@
+package components
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	viewport "charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+
+	chroma "github.com/alecthomas/chroma/v2"
+	chromastyles "github.com/alecthomas/chroma/v2/styles"
+	ignore "github.com/sabhiram/go-gitignore"
+	fuzzy "github.com/sahilm/fuzzy"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	diffview "github.com/inference-gateway/cli/internal/ui/components/diffview"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+// explorerRefreshInterval is how often the explorer re-reads the expanded
+// directories so created/removed/renamed files show up "live".
+const explorerRefreshInterval = time.Second
+
+const (
+	explorerSidebarMinWidth = 24
+	explorerSidebarMaxWidth = 44
+	explorerMinPaneWidth    = 20
+	explorerMaxPreviewBytes = 1 << 20 // 1 MiB; larger files are not previewed
+	explorerMaxFindFiles    = 50000   // cap on the fuzzy-finder candidate walk
+	explorerMaxFindResults  = 200     // cap on displayed fuzzy matches
+)
+
+// gitignoreDefaults are always-ignored entries, matching internal/agent/tools/tree.go.
+var gitignoreDefaults = []string{".git/", ".DS_Store", ".infer/"}
+
+// Configurable action IDs for the explorer panel (defaults in
+// config.addExplorerBindings; users override them in keybindings.yaml).
+var (
+	actExpNavUp        = config.ActionID(config.NamespaceExplorer, "nav_up")
+	actExpNavDown      = config.ActionID(config.NamespaceExplorer, "nav_down")
+	actExpCollapse     = config.ActionID(config.NamespaceExplorer, "collapse")
+	actExpExpand       = config.ActionID(config.NamespaceExplorer, "expand")
+	actExpToggle       = config.ActionID(config.NamespaceExplorer, "toggle")
+	actExpOpen         = config.ActionID(config.NamespaceExplorer, "open")
+	actExpFind         = config.ActionID(config.NamespaceExplorer, "find")
+	actExpToggleHidden = config.ActionID(config.NamespaceExplorer, "toggle_hidden")
+	actExpScrollUp     = config.ActionID(config.NamespaceExplorer, "scroll_up")
+	actExpScrollDown   = config.ActionID(config.NamespaceExplorer, "scroll_down")
+	actExpHalfUp       = config.ActionID(config.NamespaceExplorer, "halfpage_up")
+	actExpHalfDown     = config.ActionID(config.NamespaceExplorer, "halfpage_down")
+	actExpCancel       = config.ActionID(config.NamespaceExplorer, "cancel")
+)
+
+// explorerNode is one filesystem entry (the cached, sorted children of a dir).
+type explorerNode struct {
+	relPath string // path relative to root; the stable identity key
+	name    string // filepath.Base, for display
+	isDir   bool
+}
+
+// explorerRow is one rendered line of the flattened tree.
+type explorerRow struct {
+	node     explorerNode
+	depth    int
+	expanded bool // dirs only: whether currently expanded
+}
+
+// explorerTickMsg drives the periodic live refresh.
+type explorerTickMsg struct{}
+
+// explorerWalkDoneMsg carries the result of the async fuzzy-finder file walk.
+type explorerWalkDoneMsg struct {
+	paths     []string
+	truncated bool
+}
+
+// FileExplorerImpl is the VS Code-style file explorer side panel: a left tree of
+// the working directory (lazy, collapsible, .gitignore-aware) plus a scrollable,
+// syntax-highlighted preview of the selected file. A `/` fuzzy finder jumps to any
+// file; `v` opens the selection in the user's real editor. It owns its full
+// [sidebar | divider | pane] region; the chat input is composed beneath the pane.
+type FileExplorerImpl struct {
+	root          string
+	styleProvider *styles.Provider
+	themeService  domain.ThemeService
+	keymap        diffKeymap
+
+	width        int
+	height       int
+	sidebarWidth int
+	paneWidth    int
+
+	// Lazy tree model, keyed by path relative to root ("" = root).
+	children map[string][]explorerNode // dir relPath -> immediate children (cached on expand)
+	expanded map[string]bool           // dir relPath -> expanded? (root is always expanded)
+	rows     []explorerRow             // flattened visible rows
+
+	cursor        int
+	selectedKey   string // relPath of the selected row, for re-anchor across refresh
+	sidebarScroll int
+
+	showHidden bool          // include dotfiles + gitignored entries
+	ignore     *ignoreFilter // current gitignore matcher (rebuilt on showHidden toggle)
+
+	// Preview pane.
+	viewport     viewport.Model
+	previewKey   string
+	previewWidth int
+	dirtyPreview bool
+
+	// Fuzzy finder (find mode).
+	findMode      bool
+	findQuery     string
+	candidates    []string
+	filtered      []string
+	findCursor    int
+	walking       bool
+	walkTruncated bool
+
+	// Edit mode — the user's real editor runs in a PTY rendered into the pane.
+	editMode bool
+	editor   *ptyEditor
+
+	loadErr error
+	done    bool
+	cancel  bool
+}
+
+// NewFileExplorer creates an explorer rooted at the given working directory.
+func NewFileExplorer(root string, styleProvider *styles.Provider, themeService domain.ThemeService, kb config.KeybindingsConfig) *FileExplorerImpl {
+	vp := viewport.New(viewport.WithWidth(80), viewport.WithHeight(20))
+	vp.SetContent("")
+	vp.MouseWheelEnabled = true
+	vp.MouseWheelDelta = 3
+
+	t := &FileExplorerImpl{
+		root:          root,
+		styleProvider: styleProvider,
+		themeService:  themeService,
+		keymap:        diffKeymap{keys: config.ResolveNamespaceBindings(kb, config.NamespaceExplorer)},
+		children:      make(map[string][]explorerNode),
+		expanded:      make(map[string]bool),
+		viewport:      vp,
+		dirtyPreview:  true,
+		ignore:        newIgnoreFilter(root, false),
+	}
+	t.ensureChildren("")
+	t.flatten()
+	t.reanchorSelection()
+	return t
+}
+
+func (t *FileExplorerImpl) Init() tea.Cmd { return t.tickCmd() }
+
+// Reset clears state so the panel can be reused on a later open.
+func (t *FileExplorerImpl) Reset() {
+	t.done = false
+	t.cancel = false
+	t.loadErr = nil
+	t.children = make(map[string][]explorerNode)
+	t.expanded = make(map[string]bool)
+	t.rows = nil
+	t.cursor = 0
+	t.selectedKey = ""
+	t.sidebarScroll = 0
+	t.showHidden = false
+	t.ignore = newIgnoreFilter(t.root, false)
+	t.previewKey = ""
+	t.dirtyPreview = true
+	t.findMode = false
+	t.findQuery = ""
+	t.candidates = nil
+	t.filtered = nil
+	t.findCursor = 0
+	t.walking = false
+	t.walkTruncated = false
+	if t.editor != nil {
+		t.editor.close()
+	}
+	t.editMode = false
+	t.editor = nil
+	t.ensureChildren("")
+	t.flatten()
+	t.reanchorSelection()
+}
+
+func (t *FileExplorerImpl) IsDone() bool      { return t.done }
+func (t *FileExplorerImpl) IsCancelled() bool { return t.cancel }
+
+// PaneWidth returns the current preview-pane width so the caller can size the
+// input row that sits beneath the pane.
+func (t *FileExplorerImpl) PaneWidth() int { return t.paneWidth }
+
+func (t *FileExplorerImpl) SetWidth(w int) {
+	t.width = w
+	sidebar := clampInt(w*30/100, explorerSidebarMinWidth, explorerSidebarMaxWidth)
+	if sidebar > w-explorerMinPaneWidth {
+		sidebar = max(w-explorerMinPaneWidth, 1)
+	}
+	t.sidebarWidth = sidebar
+	t.paneWidth = max(w-sidebar-1, 1)
+}
+
+func (t *FileExplorerImpl) SetHeight(h int) { t.height = h }
+
+// HintText returns the footer hint for the current mode.
+func (t *FileExplorerImpl) HintText() string {
+	if t.editMode && t.editor != nil {
+		return "(editor) — :wq to save & return"
+	}
+	if t.findMode {
+		return "type to filter · ↑/↓ select · enter open · esc back to tree"
+	}
+	return fmt.Sprintf("%s/%s select · %s/%s expand · %s find · %s open · %s hidden · %s back",
+		t.keymap.display(actExpNavUp), t.keymap.display(actExpNavDown),
+		t.keymap.display(actExpExpand), t.keymap.display(actExpCollapse),
+		t.keymap.display(actExpFind), t.keymap.display(actExpOpen),
+		t.keymap.display(actExpToggleHidden), t.keymap.display(actExpCancel))
+}
+
+// --- update ---
+
+func (t *FileExplorerImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if t.editMode {
+		return t.updateEditor(msg)
+	}
+	switch m := msg.(type) {
+	case explorerTickMsg:
+		t.handleTick()
+		return t, t.tickCmd()
+	case explorerWalkDoneMsg:
+		t.handleWalkDone(m)
+		return t, nil
+	case tea.WindowSizeMsg:
+		t.SetWidth(m.Width)
+		t.SetHeight(m.Height)
+		t.dirtyPreview = true
+		return t, nil
+	case tea.MouseWheelMsg:
+		t.handleWheel(m)
+		return t, nil
+	case tea.KeyMsg:
+		return t.handleKey(m)
+	}
+	return t, nil
+}
+
+func (t *FileExplorerImpl) handleWheel(msg tea.MouseWheelMsg) {
+	switch msg.Button {
+	case tea.MouseWheelUp:
+		t.viewport.ScrollUp(t.viewport.MouseWheelDelta)
+	case tea.MouseWheelDown:
+		t.viewport.ScrollDown(t.viewport.MouseWheelDelta)
+	}
+}
+
+func (t *FileExplorerImpl) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if t.findMode {
+		return t.handleFindKey(msg)
+	}
+	pressed := normalizeKey(msg.String())
+	if pressed == "ctrl+c" { // universal escape; intentionally not remappable
+		t.cancel = true
+		return t, nil
+	}
+	switch t.keymap.match(pressed,
+		actExpNavUp, actExpNavDown, actExpToggle, actExpExpand, actExpCollapse,
+		actExpOpen, actExpFind, actExpToggleHidden,
+		actExpScrollUp, actExpScrollDown, actExpHalfUp, actExpHalfDown, actExpCancel) {
+	case actExpCancel:
+		t.cancel = true
+	case actExpNavUp:
+		t.moveCursor(-1)
+	case actExpNavDown:
+		t.moveCursor(1)
+	case actExpToggle:
+		t.toggleSelected()
+	case actExpExpand:
+		t.setExpanded(true)
+	case actExpCollapse:
+		t.setExpanded(false)
+	case actExpOpen:
+		return t, t.enterEditCmd()
+	case actExpFind:
+		return t, t.enterFind()
+	case actExpToggleHidden:
+		t.toggleHidden()
+	case actExpScrollUp:
+		t.viewport.ScrollUp(10)
+	case actExpScrollDown:
+		t.viewport.ScrollDown(10)
+	case actExpHalfUp:
+		t.viewport.ScrollUp(5)
+	case actExpHalfDown:
+		t.viewport.ScrollDown(5)
+	}
+	return t, nil
+}
+
+func (t *FileExplorerImpl) moveCursor(delta int) {
+	if len(t.rows) == 0 {
+		return
+	}
+	prev := t.selectedFilePath()
+	t.cursor = clampInt(t.cursor+delta, 0, len(t.rows)-1)
+	t.selectedKey = t.rows[t.cursor].node.relPath
+	if t.selectedFilePath() != prev {
+		t.dirtyPreview = true
+	}
+}
+
+// toggleSelected expands/collapses a folder; on a file it is a no-op (the
+// preview already follows the selection).
+func (t *FileExplorerImpl) toggleSelected() {
+	row, ok := t.currentRow()
+	if !ok || !row.node.isDir {
+		return
+	}
+	t.setExpandedKey(row.node.relPath, !t.expanded[row.node.relPath])
+}
+
+func (t *FileExplorerImpl) setExpanded(expanded bool) {
+	row, ok := t.currentRow()
+	if !ok || !row.node.isDir {
+		return
+	}
+	t.setExpandedKey(row.node.relPath, expanded)
+}
+
+func (t *FileExplorerImpl) setExpandedKey(rel string, expanded bool) {
+	if expanded {
+		t.expanded[rel] = true
+		t.ensureChildren(rel)
+	} else {
+		delete(t.expanded, rel)
+	}
+	t.flatten()
+	t.reanchorSelection()
+}
+
+// toggleHidden flips inclusion of dotfiles/gitignored entries and reloads.
+func (t *FileExplorerImpl) toggleHidden() {
+	t.showHidden = !t.showHidden
+	t.ignore = newIgnoreFilter(t.root, t.showHidden)
+	t.children = make(map[string][]explorerNode)
+	t.candidates = nil // force a fresh fuzzy walk under the new filter
+	t.ensureChildren("")
+	t.flatten()
+	t.reanchorSelection()
+}
+
+func (t *FileExplorerImpl) handleTick() {
+	// Drop the cache and re-flatten: flatten() re-reads only the visible
+	// (expanded) directories via ensureChildren, so new/removed files there show
+	// up; collapsed directories are not re-read until expanded.
+	t.children = make(map[string][]explorerNode)
+	t.ensureChildren("")
+	t.flatten()
+	t.reanchorSelection()
+	t.dirtyPreview = true
+}
+
+func (t *FileExplorerImpl) tickCmd() tea.Cmd {
+	return tea.Tick(explorerRefreshInterval, func(_ time.Time) tea.Msg {
+		return explorerTickMsg{}
+	})
+}
+
+// --- edit mode (real editor in a PTY) ---
+
+// enterEditCmd launches the user's editor ($VISUAL/$EDITOR/vim) on the selected
+// file in a PTY rendered into the pane. The returned cmd streams the editor's
+// terminal output back as ptyOutputMsg/ptyExitMsg.
+func (t *FileExplorerImpl) enterEditCmd() tea.Cmd {
+	rel := t.selectedFilePath()
+	if rel == "" {
+		return nil
+	}
+	abs := filepath.Join(t.root, rel)
+	editor, readCmd, err := startPTYEditor(abs, t.root, t.paneWidth, max(t.height-1, 1))
+	if err != nil {
+		t.loadErr = fmt.Errorf("failed to open editor: %w", err)
+		return nil
+	}
+	t.editor = editor
+	t.editMode = true
+	return readCmd
+}
+
+// updateEditor drives the embedded editor: it forwards keys to the PTY, feeds
+// PTY output into the emulator (re-arming the reader), and on child exit closes
+// the editor and refreshes the tree so any change shows immediately.
+func (t *FileExplorerImpl) updateEditor(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case ptyOutputMsg:
+		t.editor.term.write(m.data)
+		return t, t.editor.readCmd()
+	case ptyExitMsg:
+		t.editor.close()
+		t.editor = nil
+		t.editMode = false
+		t.dirtyPreview = true
+		t.handleTick()
+		return t, nil
+	case tea.KeyPressMsg:
+		t.editor.write(encodeKey(m))
+		return t, nil
+	case explorerTickMsg:
+		// Keep the live-refresh tick chain alive while editing.
+		return t, t.tickCmd()
+	case tea.WindowSizeMsg:
+		t.SetWidth(m.Width)
+		t.SetHeight(m.Height)
+	}
+	return t, nil
+}
+
+// --- fuzzy finder ---
+
+func (t *FileExplorerImpl) enterFind() tea.Cmd {
+	t.findMode = true
+	t.findQuery = ""
+	t.findCursor = 0
+	if t.candidates == nil && !t.walking {
+		t.walking = true
+		return t.startWalkCmd()
+	}
+	t.applyFilter()
+	return nil
+}
+
+func (t *FileExplorerImpl) exitFind() {
+	t.findMode = false
+	t.findQuery = ""
+	t.findCursor = 0
+}
+
+func (t *FileExplorerImpl) handleFindKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch normalizeKey(msg.String()) {
+	case "ctrl+c":
+		t.cancel = true
+		return t, nil
+	case "esc":
+		t.exitFind()
+		return t, nil
+	case "up":
+		t.findCursor = clampInt(t.findCursor-1, 0, max(len(t.filtered)-1, 0))
+		return t, nil
+	case "down":
+		t.findCursor = clampInt(t.findCursor+1, 0, max(len(t.filtered)-1, 0))
+		return t, nil
+	case "enter":
+		t.acceptFind()
+		return t, nil
+	case "backspace":
+		if r := []rune(t.findQuery); len(r) > 0 {
+			t.findQuery = string(r[:len(r)-1])
+			t.applyFilter()
+		}
+		return t, nil
+	}
+	if kp, ok := msg.(tea.KeyPressMsg); ok && kp.Text != "" {
+		t.findQuery += kp.Text
+		t.applyFilter()
+	}
+	return t, nil
+}
+
+func (t *FileExplorerImpl) applyFilter() {
+	t.findCursor = 0
+	t.filtered = t.filtered[:0]
+	if t.findQuery == "" {
+		for i, p := range t.candidates {
+			if i >= explorerMaxFindResults {
+				break
+			}
+			t.filtered = append(t.filtered, p)
+		}
+		return
+	}
+	for i, m := range fuzzy.Find(t.findQuery, t.candidates) {
+		if i >= explorerMaxFindResults {
+			break
+		}
+		t.filtered = append(t.filtered, m.Str)
+	}
+}
+
+// acceptFind reveals the highlighted match in the tree (expanding its ancestor
+// folders), selects it, and exits find mode.
+func (t *FileExplorerImpl) acceptFind() {
+	if t.findCursor < 0 || t.findCursor >= len(t.filtered) {
+		t.exitFind()
+		return
+	}
+	t.revealPath(t.filtered[t.findCursor])
+	t.exitFind()
+}
+
+func (t *FileExplorerImpl) revealPath(rel string) {
+	parts := strings.Split(rel, "/")
+	cur := ""
+	for i := 0; i < len(parts)-1; i++ {
+		if cur == "" {
+			cur = parts[i]
+		} else {
+			cur += "/" + parts[i]
+		}
+		t.expanded[cur] = true
+	}
+	t.flatten()
+	if i, ok := t.indexOfRel(rel); ok {
+		t.cursor = i
+		t.selectedKey = rel
+		t.dirtyPreview = true
+	}
+}
+
+func (t *FileExplorerImpl) handleWalkDone(msg explorerWalkDoneMsg) {
+	t.walking = false
+	t.candidates = msg.paths
+	t.walkTruncated = msg.truncated
+	if t.findMode {
+		t.applyFilter()
+	}
+}
+
+func (t *FileExplorerImpl) startWalkCmd() tea.Cmd {
+	root := t.root
+	showHidden := t.showHidden
+	return func() tea.Msg {
+		paths, truncated := walkProject(root, showHidden)
+		return explorerWalkDoneMsg{paths: paths, truncated: truncated}
+	}
+}
+
+// --- tree model ---
+
+// ensureChildren reads and caches a directory's immediate children (filtered and
+// sorted) the first time it is needed. Read errors cache an empty list so we
+// don't retry every frame.
+func (t *FileExplorerImpl) ensureChildren(rel string) {
+	if _, ok := t.children[rel]; ok {
+		return
+	}
+	dirAbs := filepath.Join(t.root, rel)
+	entries, err := os.ReadDir(dirAbs)
+	if err != nil {
+		t.children[rel] = []explorerNode{}
+		return
+	}
+	nodes := make([]explorerNode, 0, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		childRel := name
+		if rel != "" {
+			childRel = rel + "/" + name
+		}
+		if t.ignore.shouldHide(childRel, name, dirAbs, e.IsDir()) {
+			continue
+		}
+		nodes = append(nodes, explorerNode{relPath: childRel, name: name, isDir: e.IsDir()})
+	}
+	sortNodes(nodes)
+	t.children[rel] = nodes
+}
+
+// sortNodes orders directories before files, then case-insensitively by name.
+func sortNodes(nodes []explorerNode) {
+	sort.SliceStable(nodes, func(i, j int) bool {
+		if nodes[i].isDir != nodes[j].isDir {
+			return nodes[i].isDir
+		}
+		return strings.ToLower(nodes[i].name) < strings.ToLower(nodes[j].name)
+	})
+}
+
+func (t *FileExplorerImpl) flatten() {
+	t.rows = t.rows[:0]
+	t.flattenInto("", 0)
+}
+
+func (t *FileExplorerImpl) flattenInto(rel string, depth int) {
+	for _, n := range t.children[rel] {
+		expanded := n.isDir && t.expanded[n.relPath]
+		t.rows = append(t.rows, explorerRow{node: n, depth: depth, expanded: expanded})
+		if expanded {
+			t.ensureChildren(n.relPath)
+			t.flattenInto(n.relPath, depth+1)
+		}
+	}
+}
+
+func (t *FileExplorerImpl) reanchorSelection() {
+	if len(t.rows) == 0 {
+		t.cursor = 0
+		t.selectedKey = ""
+		return
+	}
+	if i, ok := t.indexOfRel(t.selectedKey); ok {
+		t.cursor = i
+	} else {
+		t.cursor = clampInt(t.cursor, 0, len(t.rows)-1)
+	}
+	t.selectedKey = t.rows[t.cursor].node.relPath
+}
+
+func (t *FileExplorerImpl) indexOfRel(rel string) (int, bool) {
+	if rel == "" {
+		return 0, false
+	}
+	for i, r := range t.rows {
+		if r.node.relPath == rel {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func (t *FileExplorerImpl) currentRow() (explorerRow, bool) {
+	if t.cursor < 0 || t.cursor >= len(t.rows) {
+		return explorerRow{}, false
+	}
+	return t.rows[t.cursor], true
+}
+
+// selectedFilePath returns the relative path of the selected row if it is a
+// file, else "".
+func (t *FileExplorerImpl) selectedFilePath() string {
+	if r, ok := t.currentRow(); ok && !r.node.isDir {
+		return r.node.relPath
+	}
+	return ""
+}
+
+// --- preview ---
+
+// chromaStyle picks a chroma highlighting style by the active theme's brightness.
+func (t *FileExplorerImpl) chromaStyle() *chroma.Style {
+	if theme := t.styleProvider.GetCurrentTheme(); theme != nil && isLightTheme(theme) {
+		return chromastyles.Get("github")
+	}
+	return chromastyles.Get("github-dark")
+}
+
+// ensurePreview (re)renders the selected file into the viewport, gated so the
+// read + highlight only run when the selection or width actually changed.
+func (t *FileExplorerImpl) ensurePreview(rel string, width int) {
+	if !t.dirtyPreview && rel == t.previewKey && width == t.previewWidth {
+		return
+	}
+	content := t.computePreview(rel)
+	changed := rel != t.previewKey
+	t.previewKey = rel
+	t.previewWidth = width
+	t.dirtyPreview = false
+	t.viewport.SetContent(content)
+	if changed {
+		t.viewport.GotoTop()
+	}
+}
+
+func (t *FileExplorerImpl) computePreview(rel string) string {
+	abs := filepath.Join(t.root, rel)
+	info, err := os.Stat(abs)
+	if err != nil {
+		return t.styleProvider.RenderErrorText("Failed to read file: " + err.Error())
+	}
+	if info.Size() > explorerMaxPreviewBytes {
+		return t.styleProvider.RenderDimText("⊘ Binary or large file — not shown")
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return t.styleProvider.RenderErrorText("Failed to read file: " + err.Error())
+	}
+	if bytes.IndexByte(data, 0) >= 0 {
+		return t.styleProvider.RenderDimText("⊘ Binary or large file — not shown")
+	}
+	return diffview.Highlight(rel, string(data), t.chromaStyle(), true)
+}
+
+// --- rendering ---
+
+// View satisfies tea.Model. The app composes the real layout via Render.
+func (t *FileExplorerImpl) View() tea.View {
+	return tea.NewView(t.Render(""))
+}
+
+// Render lays out the full region: a full-height sidebar and divider on the
+// left, and on the right the preview pane with the (already-rendered) input row
+// stacked beneath it. Pass "" for inputRow to render the pane at full height.
+func (t *FileExplorerImpl) Render(inputRow string) string {
+	if t.width <= 0 || t.height <= 0 {
+		return ""
+	}
+	sidebar := t.renderSidebar(t.sidebarWidth, t.height)
+	divider := t.renderDivider(t.height)
+
+	if inputRow == "" {
+		pane := t.renderPane(t.paneWidth, t.height)
+		return t.styleProvider.JoinHorizontal(sidebar, divider, pane)
+	}
+
+	regionHeight := max(t.height-t.styleProvider.GetHeight(inputRow), 1)
+	pane := t.renderPane(t.paneWidth, regionHeight)
+	chatColumn := t.styleProvider.JoinVertical(pane, inputRow)
+	return t.styleProvider.JoinHorizontal(sidebar, divider, chatColumn)
+}
+
+func (t *FileExplorerImpl) renderDivider(height int) string {
+	line := t.styleProvider.RenderDimText("│")
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = line
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (t *FileExplorerImpl) renderSidebar(width, height int) string {
+	lines := t.sidebarLines(width)
+
+	start := 0
+	if len(lines) > height {
+		start = clampInt(t.cursor-height/2, 0, len(lines)-height)
+	}
+	t.sidebarScroll = start
+
+	blank := strings.Repeat(" ", width)
+	out := make([]string, height)
+	for i := range height {
+		if idx := start + i; idx < len(lines) {
+			out[i] = lines[idx]
+		} else {
+			out[i] = blank
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func (t *FileExplorerImpl) sidebarLines(width int) []string {
+	if len(t.rows) == 0 {
+		return []string{t.padPlain(t.styleProvider.RenderDimText("(empty)"), "(empty)", width)}
+	}
+	lines := make([]string, len(t.rows))
+	for i, r := range t.rows {
+		lines[i] = t.rowLine(r, width, i == t.cursor)
+	}
+	return lines
+}
+
+func (t *FileExplorerImpl) rowLine(r explorerRow, width int, selected bool) string {
+	cursor := "  "
+	if selected {
+		cursor = "❯ "
+	}
+	indent := strings.Repeat("  ", r.depth)
+	marker := "• "
+	if r.node.isDir {
+		marker = chevron(!r.expanded) + " "
+	}
+	plain := cursor + indent + marker + r.node.name
+	plain = truncateRunes(plain, width)
+	styled := t.styleRow(r, plain, selected)
+	if pad := width - len([]rune(plain)); pad > 0 {
+		styled += strings.Repeat(" ", pad)
+	}
+	return styled
+}
+
+func (t *FileExplorerImpl) styleRow(r explorerRow, text string, selected bool) string {
+	switch {
+	case selected:
+		return t.styleProvider.RenderWithColorAndBold(text, t.styleProvider.GetThemeColor("accent"))
+	case r.node.isDir:
+		return t.styleProvider.RenderBoldText(text)
+	default:
+		if color := t.fileColor(r.node.name); color != "" {
+			return t.styleProvider.RenderWithColor(text, color)
+		}
+		return t.styleProvider.RenderAssistantText(text)
+	}
+}
+
+// fileColor returns a theme color key conveying a file's type (code/config/docs),
+// or "" for the default text color. Coloring is alignment-safe, so it works as a
+// "file-type glyph" without requiring nerd-font icons.
+func (t *FileExplorerImpl) fileColor(name string) string {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".go", ".js", ".jsx", ".ts", ".tsx", ".py", ".rs", ".java", ".c", ".h", ".cpp", ".rb", ".sh", ".bash":
+		return t.styleProvider.GetThemeColor("accent")
+	case ".json", ".yaml", ".yml", ".toml", ".ini", ".env", ".conf":
+		return t.styleProvider.GetThemeColor("status")
+	case ".md", ".txt", ".rst", ".adoc":
+		return t.styleProvider.GetThemeColor("success")
+	default:
+		return ""
+	}
+}
+
+func (t *FileExplorerImpl) renderPane(width, height int) string {
+	switch {
+	case t.editMode && t.editor != nil:
+		return t.editor.View(width, height)
+	case t.findMode:
+		return t.renderFindResults(width, height)
+	case t.loadErr != nil:
+		return t.styleProvider.PlaceCenter(width, height, t.styleProvider.RenderErrorText(t.loadErr.Error()))
+	}
+
+	rel := t.selectedFilePath()
+	if rel == "" {
+		return t.styleProvider.PlaceCenter(width, height, t.styleProvider.RenderDimText("Select a file to preview"))
+	}
+	t.ensurePreview(rel, width)
+	t.viewport.SetWidth(width)
+	t.viewport.SetHeight(height)
+	return t.viewport.View()
+}
+
+func (t *FileExplorerImpl) renderFindResults(width, height int) string {
+	var b strings.Builder
+	prompt := "❯ " + t.findQuery
+	b.WriteString(t.styleProvider.RenderWithColorAndBold(truncateRunes(prompt, width), t.styleProvider.GetThemeColor("accent")))
+	b.WriteByte('\n')
+
+	if t.walking {
+		b.WriteString(t.styleProvider.RenderDimText("indexing…"))
+		return b.String()
+	}
+
+	status := fmt.Sprintf("%d of %d", len(t.filtered), len(t.candidates))
+	if t.walkTruncated {
+		status += fmt.Sprintf(" (capped at %d)", explorerMaxFindFiles)
+	}
+	b.WriteString(t.styleProvider.RenderDimText(status))
+	b.WriteByte('\n')
+
+	rows := max(height-2, 0)
+	for i := 0; i < len(t.filtered) && i < rows; i++ {
+		b.WriteString(t.renderHit(t.filtered[i], i == t.findCursor, width))
+		if i < len(t.filtered)-1 && i < rows-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func (t *FileExplorerImpl) renderHit(path string, selected bool, width int) string {
+	prefix := "  "
+	if selected {
+		prefix = "❯ "
+	}
+	text := truncateRunes(path, max(width-2, 1))
+	if selected {
+		return t.styleProvider.RenderWithColorAndBold(prefix+text, t.styleProvider.GetThemeColor("accent"))
+	}
+	return prefix + t.styleProvider.RenderAssistantText(text)
+}
+
+// --- small helpers ---
+
+func (t *FileExplorerImpl) padPlain(styled, plain string, width int) string {
+	if pad := width - len([]rune(plain)); pad > 0 {
+		return styled + strings.Repeat(" ", pad)
+	}
+	return styled
+}
+
+// ignoreFilter decides which entries to hide, honoring the root .gitignore,
+// per-directory nested .gitignore files, and a set of always-ignored defaults.
+// It is self-contained (no shared mutable state) so it can be used both on the
+// UI goroutine (the tree) and inside the fuzzy-finder walk goroutine.
+type ignoreFilter struct {
+	root       string
+	showHidden bool
+	rootIgnore *ignore.GitIgnore
+	cache      map[string]*ignore.GitIgnore // dir abs path -> compiled (nil = none)
+}
+
+func newIgnoreFilter(root string, showHidden bool) *ignoreFilter {
+	rootIg, err := ignore.CompileIgnoreFileAndLines(filepath.Join(root, ".gitignore"), gitignoreDefaults...)
+	if err != nil {
+		rootIg = ignore.CompileIgnoreLines(gitignoreDefaults...)
+	}
+	return &ignoreFilter{
+		root:       root,
+		showHidden: showHidden,
+		rootIgnore: rootIg,
+		cache:      make(map[string]*ignore.GitIgnore),
+	}
+}
+
+// shouldHide reports whether the entry named `name` (rel = path relative to
+// root; dirAbs = absolute path of the containing directory) should be hidden.
+func (f *ignoreFilter) shouldHide(rel, name, dirAbs string, isDir bool) bool {
+	if f.showHidden {
+		return false
+	}
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	matchRel := rel
+	if isDir {
+		matchRel = rel + "/"
+	}
+	if f.rootIgnore != nil && f.rootIgnore.MatchesPath(matchRel) {
+		return true
+	}
+	if dirIg := f.dirIgnore(dirAbs); dirIg != nil && dirIg.MatchesPath(name) {
+		return true
+	}
+	return false
+}
+
+func (f *ignoreFilter) dirIgnore(dirAbs string) *ignore.GitIgnore {
+	if cached, ok := f.cache[dirAbs]; ok {
+		return cached
+	}
+	var gi *ignore.GitIgnore
+	p := filepath.Join(dirAbs, ".gitignore")
+	if _, err := os.Stat(p); err == nil {
+		if compiled, err := ignore.CompileIgnoreFile(p); err == nil {
+			gi = compiled
+		}
+	}
+	f.cache[dirAbs] = gi
+	return gi
+}
+
+// walkProject walks the tree under root (honoring .gitignore unless showHidden),
+// returning file paths relative to root. It stops at explorerMaxFindFiles and
+// reports truncation. Pure and self-contained for safe use in a goroutine.
+func walkProject(root string, showHidden bool) ([]string, bool) {
+	f := newIgnoreFilter(root, showHidden)
+	var paths []string
+	truncated := false
+	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil || p == root {
+			return nil //nolint:nilerr // skip unreadable entries rather than abort
+		}
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			return nil
+		}
+		if f.shouldHide(rel, d.Name(), filepath.Dir(p), d.IsDir()) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		paths = append(paths, rel)
+		if len(paths) >= explorerMaxFindFiles {
+			truncated = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return paths, truncated
+}

--- a/internal/ui/components/file_explorer_test.go
+++ b/internal/ui/components/file_explorer_test.go
@@ -1,0 +1,361 @@
+package components
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+func newTestExplorer(t *testing.T, root string) *FileExplorerImpl {
+	t.Helper()
+	ts := domain.NewThemeProvider()
+	e := NewFileExplorer(root, styles.NewProvider(ts), ts, config.KeybindingsConfig{})
+	e.SetWidth(120)
+	e.SetHeight(40)
+	return e
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func rowRels(e *FileExplorerImpl) []string {
+	rels := make([]string, len(e.rows))
+	for i, r := range e.rows {
+		rels[i] = r.node.relPath
+	}
+	return rels
+}
+
+func explorerHasRow(e *FileExplorerImpl, rel string) bool {
+	_, ok := e.indexOfRel(rel)
+	return ok
+}
+
+func mustRowIndex(t *testing.T, e *FileExplorerImpl, rel string) int {
+	t.Helper()
+	i, ok := e.indexOfRel(rel)
+	if !ok {
+		t.Fatalf("row %q not found in %v", rel, rowRels(e))
+	}
+	return i
+}
+
+func TestExplorer_FlattenRootDirsFirst(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "b.txt"), "b")
+	writeTestFile(t, filepath.Join(root, "z.txt"), "z")
+	writeTestFile(t, filepath.Join(root, "alpha", "c.txt"), "c")
+
+	e := newTestExplorer(t, root)
+
+	want := []string{"alpha", "b.txt", "z.txt"}
+	if got := rowRels(e); !reflect.DeepEqual(got, want) {
+		t.Fatalf("rows = %v, want %v (dirs first, then files)", got, want)
+	}
+	if explorerHasRow(e, "alpha/c.txt") {
+		t.Fatal("alpha/c.txt should be hidden while alpha is collapsed")
+	}
+}
+
+func TestExplorer_ExpandLoadsChildrenLazily(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "alpha", "c.txt"), "c")
+
+	e := newTestExplorer(t, root)
+	if _, ok := e.children["alpha"]; ok {
+		t.Fatal("alpha children should not be read before it is expanded")
+	}
+
+	e.cursor = mustRowIndex(t, e, "alpha")
+	e.setExpanded(true)
+
+	if _, ok := e.children["alpha"]; !ok {
+		t.Fatal("alpha children should be cached after expand")
+	}
+	if !explorerHasRow(e, "alpha/c.txt") {
+		t.Fatalf("alpha/c.txt should be visible after expand; rows=%v", rowRels(e))
+	}
+}
+
+func TestExplorer_CollapseHidesChildren(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "alpha", "c.txt"), "c")
+
+	e := newTestExplorer(t, root)
+	e.cursor = mustRowIndex(t, e, "alpha")
+	e.setExpanded(true)
+	if !explorerHasRow(e, "alpha/c.txt") {
+		t.Fatal("precondition: child visible after expand")
+	}
+
+	e.cursor = mustRowIndex(t, e, "alpha")
+	e.setExpanded(false)
+	if explorerHasRow(e, "alpha/c.txt") {
+		t.Fatal("child should be hidden after collapse")
+	}
+}
+
+func TestExplorer_GitignoreHonored(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ".gitignore"), "ignored/\n*.log\n")
+	writeTestFile(t, filepath.Join(root, "ignored", "x.txt"), "x")
+	writeTestFile(t, filepath.Join(root, "keep.txt"), "k")
+	writeTestFile(t, filepath.Join(root, "debug.log"), "l")
+
+	e := newTestExplorer(t, root)
+	rels := rowRels(e)
+
+	if explorerHasRow(e, "ignored") {
+		t.Errorf("gitignored dir should be hidden; rows=%v", rels)
+	}
+	if explorerHasRow(e, "debug.log") {
+		t.Errorf("*.log file should be hidden; rows=%v", rels)
+	}
+	if !explorerHasRow(e, "keep.txt") {
+		t.Errorf("keep.txt should be visible; rows=%v", rels)
+	}
+}
+
+func TestExplorer_ShowHiddenToggle(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ".env"), "secret")
+	writeTestFile(t, filepath.Join(root, "visible.txt"), "v")
+
+	e := newTestExplorer(t, root)
+	if explorerHasRow(e, ".env") {
+		t.Fatal(".env should be hidden by default")
+	}
+
+	e.toggleHidden()
+	if !explorerHasRow(e, ".env") {
+		t.Fatalf(".env should appear after toggle; rows=%v", rowRels(e))
+	}
+
+	e.toggleHidden()
+	if explorerHasRow(e, ".env") {
+		t.Fatal(".env should be hidden again after toggling back")
+	}
+}
+
+func TestExplorer_ReanchorAcrossRefresh(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "a.txt"), "a")
+	writeTestFile(t, filepath.Join(root, "b.txt"), "b")
+
+	e := newTestExplorer(t, root)
+	e.cursor = mustRowIndex(t, e, "b.txt")
+	e.selectedKey = "b.txt"
+
+	writeTestFile(t, filepath.Join(root, "a2.txt"), "a2")
+	e.handleTick()
+	if got := e.rows[e.cursor].node.relPath; got != "b.txt" {
+		t.Fatalf("selection should stay on b.txt across refresh, got %q", got)
+	}
+
+	if err := os.Remove(filepath.Join(root, "b.txt")); err != nil {
+		t.Fatal(err)
+	}
+	e.handleTick()
+	if e.cursor < 0 || e.cursor >= len(e.rows) {
+		t.Fatalf("cursor out of range after the selected file was removed: %d (rows=%d)", e.cursor, len(e.rows))
+	}
+}
+
+func TestExplorer_TickPicksUpNewFileInExpandedDir(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "dir", "old.txt"), "o")
+
+	e := newTestExplorer(t, root)
+	e.cursor = mustRowIndex(t, e, "dir")
+	e.setExpanded(true)
+
+	writeTestFile(t, filepath.Join(root, "dir", "new.txt"), "n")
+	e.handleTick()
+
+	if !explorerHasRow(e, "dir/new.txt") {
+		t.Fatalf("new file in an expanded dir should appear after a tick; rows=%v", rowRels(e))
+	}
+}
+
+func TestExplorer_TickIgnoresNewFileInCollapsedDir(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "dir", "old.txt"), "o")
+
+	e := newTestExplorer(t, root) // dir is collapsed by default
+
+	writeTestFile(t, filepath.Join(root, "dir", "new.txt"), "n")
+	e.handleTick()
+
+	if explorerHasRow(e, "dir/new.txt") {
+		t.Fatal("a file in a collapsed dir should not be read/shown on refresh")
+	}
+}
+
+func TestExplorer_Navigation(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "a.txt"), "a")
+	writeTestFile(t, filepath.Join(root, "b.txt"), "b")
+
+	e := newTestExplorer(t, root)
+	start := e.cursor
+
+	e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'}) // nav_down
+	if e.cursor != start+1 {
+		t.Fatalf("nav_down: cursor = %d, want %d", e.cursor, start+1)
+	}
+	e.Update(tea.KeyPressMsg{Text: "k", Code: 'k'}) // nav_up
+	if e.cursor != start {
+		t.Fatalf("nav_up: cursor = %d, want %d", e.cursor, start)
+	}
+}
+
+func TestExplorer_FuzzyFilterRanking(t *testing.T) {
+	root := t.TempDir()
+	e := newTestExplorer(t, root)
+	e.candidates = []string{"internal/ui/chat.go", "cmd/main.go", "README.md"}
+
+	e.findQuery = "main"
+	e.applyFilter()
+
+	if len(e.filtered) == 0 {
+		t.Fatal("expected at least one match for 'main'")
+	}
+	if e.filtered[0] != "cmd/main.go" {
+		t.Fatalf("top match = %q, want cmd/main.go", e.filtered[0])
+	}
+}
+
+func TestExplorer_WalkProjectHonorsGitignore(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, ".gitignore"), "ignored/\n")
+	writeTestFile(t, filepath.Join(root, "ignored", "x.txt"), "x")
+	writeTestFile(t, filepath.Join(root, "src", "main.go"), "package main")
+
+	paths, truncated := walkProject(root, false)
+	if truncated {
+		t.Fatal("small tree should not truncate")
+	}
+	for _, p := range paths {
+		if strings.HasPrefix(p, "ignored") {
+			t.Fatalf("walk returned a gitignored path: %q", p)
+		}
+	}
+	want := filepath.Join("src", "main.go")
+	if !slices.Contains(paths, want) {
+		t.Fatalf("expected %q in walk results: %v", want, paths)
+	}
+}
+
+func TestExplorer_RevealPathExpandsAncestors(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "a", "b", "c.txt"), "c")
+
+	e := newTestExplorer(t, root)
+	e.revealPath("a/b/c.txt")
+
+	if !e.expanded["a"] || !e.expanded["a/b"] {
+		t.Fatalf("ancestors should be expanded: a=%v a/b=%v", e.expanded["a"], e.expanded["a/b"])
+	}
+	if got := e.rows[e.cursor].node.relPath; got != "a/b/c.txt" {
+		t.Fatalf("cursor should land on the revealed file, got %q", got)
+	}
+}
+
+func TestExplorer_FindModeKeyCapture(t *testing.T) {
+	root := t.TempDir()
+	e := newTestExplorer(t, root)
+	e.candidates = []string{} // non-nil so enterFind does not kick off a walk
+
+	if cmd := e.enterFind(); cmd != nil {
+		t.Fatal("enterFind should not start a walk when candidates are already loaded")
+	}
+	if !e.findMode {
+		t.Fatal("should be in find mode")
+	}
+
+	e.Update(tea.KeyPressMsg{Text: "a", Code: 'a'})
+	e.Update(tea.KeyPressMsg{Text: "b", Code: 'b'})
+	if e.findQuery != "ab" {
+		t.Fatalf("findQuery = %q, want ab", e.findQuery)
+	}
+
+	e.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if e.findQuery != "a" {
+		t.Fatalf("after backspace findQuery = %q, want a", e.findQuery)
+	}
+
+	e.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if e.findMode {
+		t.Fatal("esc should exit find mode (back to the tree)")
+	}
+}
+
+// TestExplorer_RenderSmoke exercises every render path (tree, preview, find) to
+// catch panics the model-level tests miss.
+func TestExplorer_RenderSmoke(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "main.go"), "package main\n\nfunc main() {}\n")
+	writeTestFile(t, filepath.Join(root, "dir", "nested.txt"), "hi")
+
+	e := newTestExplorer(t, root)
+
+	if out := e.Render(""); out == "" {
+		t.Fatal("tree render should be non-empty")
+	}
+	if out := e.Render("input-row"); out == "" {
+		t.Fatal("render with input row should be non-empty")
+	}
+
+	// Select the file and render the preview pane.
+	e.cursor = mustRowIndex(t, e, "main.go")
+	e.selectedKey = "main.go"
+	e.dirtyPreview = true
+	if out := e.Render(""); !strings.Contains(out, "main") {
+		t.Fatalf("preview should show file content; got %q", out)
+	}
+
+	// Find mode render.
+	e.candidates = []string{"main.go", "dir/nested.txt"}
+	e.enterFind()
+	e.findQuery = "main"
+	e.applyFilter()
+	if out := e.Render(""); out == "" {
+		t.Fatal("find-mode render should be non-empty")
+	}
+}
+
+func TestExplorer_BinaryPreviewPlaceholder(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "bin"), "abc\x00def")
+
+	e := newTestExplorer(t, root)
+	if out := e.computePreview("bin"); !strings.Contains(out, "Binary or large file") {
+		t.Fatalf("expected binary placeholder, got %q", out)
+	}
+}
+
+func TestExplorer_OversizedPreviewPlaceholder(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "big.txt"), strings.Repeat("a", explorerMaxPreviewBytes+1))
+
+	e := newTestExplorer(t, root)
+	if out := e.computePreview("big.txt"); !strings.Contains(out, "Binary or large file") {
+		t.Fatalf("expected oversized placeholder, got %q", out)
+	}
+}


### PR DESCRIPTION
Adds a VS Code-style file explorer panel accessible via "/explorer". It provides a collapsible tree view of the working directory, syntax-highlighted file preview, and a fuzzy file finder. The panel supports keyboard navigation, live refresh, and can open files in the user's editor.

Closes #588 