### PR TITLE
refactor: Separate git branch into own status bar row

### DIFF
--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -118,7 +118,10 @@ func (isb *InputStatusBar) Render() string {
 	return strings.Join(lines, "\n")
 }
 
-// buildStatusLines builds status bar content across multiple lines (max 2 lines, dynamically fit based on width)
+// buildStatusLines builds the status bar content. Indicators are packed onto the
+// top row(s); the git branch always gets its own dedicated row directly below,
+// left-aligned with the indicators. The bar stays within maxLines rows total -
+// when a branch is shown the indicators get maxLines-1 rows, otherwise maxLines.
 func (isb *InputStatusBar) buildStatusLines() []string {
 	const (
 		maxLines       = 2
@@ -130,22 +133,34 @@ func (isb *InputStatusBar) buildStatusLines() []string {
 		return []string{leftPadding + "\u00A0"}
 	}
 
-	parts := isb.getAllIndicatorParts()
+	dimColor := isb.styleProvider.GetThemeColor("dim")
 	availableWidth := isb.width - len(leftPadding) - 2
 
-	if len(parts) == 0 {
+	branchLine := isb.buildGitBranchLine(leftPadding, dimColor)
+
+	parts := isb.getAllIndicatorParts()
+	if len(parts) == 0 && branchLine == "" {
 		return []string{leftPadding + "\u00A0"}
 	}
 
-	dimColor := isb.styleProvider.GetThemeColor("dim")
-
-	lineGroups := isb.splitPartsIntoLines(parts, availableWidth, maxLines, separatorWidth)
+	indicatorMaxLines := maxLines
+	if branchLine != "" {
+		indicatorMaxLines = maxLines - 1
+	}
 
 	var lines []string
-	for _, lineItems := range lineGroups {
-		lineText := strings.Join(lineItems, " • ")
-		renderedLine := isb.styleProvider.RenderWithColor(lineText, dimColor)
-		lines = append(lines, leftPadding+renderedLine)
+	if len(parts) > 0 && indicatorMaxLines > 0 {
+		lineGroups := isb.splitPartsIntoLines(parts, availableWidth, indicatorMaxLines, separatorWidth)
+		lineGroups = capIndicatorLines(lineGroups, indicatorMaxLines)
+		for _, lineItems := range lineGroups {
+			lineText := strings.Join(lineItems, " • ")
+			renderedLine := isb.styleProvider.RenderWithColor(lineText, dimColor)
+			lines = append(lines, leftPadding+renderedLine)
+		}
+	}
+
+	if branchLine != "" {
+		lines = append(lines, branchLine)
 	}
 
 	if len(lines) == 0 {
@@ -169,15 +184,12 @@ func (isb *InputStatusBar) getAllIndicatorParts() []string {
 	return isb.buildIndicatorParts(currentModel)
 }
 
-// buildIndicatorParts builds individual indicator parts without joining them
+// buildIndicatorParts builds individual indicator parts without joining them.
+// The git branch is intentionally excluded here - it is rendered on its own
+// dedicated row by buildGitBranchLine so it never competes with these indicators
+// for horizontal space.
 func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []string {
 	parts := []string{}
-
-	if isb.shouldShowIndicator("git_branch") {
-		if gitBranchPart := isb.buildGitBranchIndicator(); gitBranchPart != "" {
-			parts = append(parts, gitBranchPart)
-		}
-	}
 
 	if isb.shouldShowIndicator("model") {
 		parts = append(parts, currentModel)
@@ -280,6 +292,27 @@ func (isb *InputStatusBar) splitPartsIntoLines(parts []string, availableWidth, m
 	}
 
 	return lineGroups
+}
+
+// capIndicatorLines hard-caps the indicator rows at maxLines. splitPartsIntoLines
+// can emit one row beyond its budget at the cap boundary; this guarantees the
+// indicators never exceed their share of the status bar so the branch row keeps
+// the bar at a stable height. When rows are dropped, an ellipsis is appended to
+// the last kept row to signal the overflow.
+func capIndicatorLines(lineGroups [][]string, maxLines int) [][]string {
+	if maxLines <= 0 {
+		return nil
+	}
+	if len(lineGroups) <= maxLines {
+		return lineGroups
+	}
+
+	capped := lineGroups[:maxLines]
+	last := capped[maxLines-1]
+	if n := len(last); n == 0 || (last[n-1] != "…" && last[n-1] != "...") {
+		capped[maxLines-1] = append(last, "…")
+	}
+	return capped
 }
 
 // shouldAddOverflowAndBreak checks if we've reached max lines and adds overflow indicator if needed
@@ -577,6 +610,23 @@ func (isb *InputStatusBar) getCurrentGitBranch() (string, bool) {
 func (isb *InputStatusBar) InvalidateGitBranchCache() {
 	isb.gitBranchCache = ""
 	isb.gitBranchCacheTime = time.Time{}
+}
+
+// buildGitBranchLine renders the git branch as its own status bar row, left-aligned
+// with the indicator row above it. Returns "" when the git_branch indicator is
+// disabled or there is no branch to show (not a repo / detached HEAD), in which case
+// the indicators reclaim the full line budget.
+func (isb *InputStatusBar) buildGitBranchLine(leftPadding, dimColor string) string {
+	if !isb.shouldShowIndicator("git_branch") {
+		return ""
+	}
+
+	part := isb.buildGitBranchIndicator()
+	if part == "" {
+		return ""
+	}
+
+	return leftPadding + isb.styleProvider.RenderWithColor(part, dimColor)
 }
 
 // buildGitBranchIndicator builds the git branch indicator text

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -812,8 +812,6 @@ func TestInputStatusBar_GitBranchRendersWithoutModel(t *testing.T) {
 }
 
 func TestInputStatusBar_GitBranchStaysTwoRowsWhenNarrow(t *testing.T) {
-	// A narrow width forces the indicators to overflow their single row; the bar
-	// must still stay at exactly two rows (truncated indicators + branch).
 	statusBar := newStatusBarWithBranch(t, 24, "some-very-long-model-name", "feature/branch", config.DefaultConfig())
 
 	lines := statusBar.buildStatusLines()

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -8,9 +8,11 @@ import (
 	sdk "github.com/inference-gateway/sdk"
 
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
 type stubTokenEstimator struct {
@@ -721,5 +723,129 @@ func TestInputStatusBar_BuildModelDisplayText_AllEnabled(t *testing.T) {
 	}
 	if !strings.Contains(result, "test-model") {
 		t.Error("Expected output to contain model information")
+	}
+}
+
+// newStatusBarStyleProvider builds a real style provider so buildStatusLines does
+// not short-circuit on a nil provider (the path that renders the branch row).
+func newStatusBarStyleProvider() *styles.Provider {
+	fakeTheme := &uimocks.FakeTheme{}
+	fakeThemeService := &domainmocks.FakeThemeService{}
+	fakeThemeService.GetCurrentThemeReturns(fakeTheme)
+	return styles.NewProvider(fakeThemeService)
+}
+
+// newStatusBarWithBranch builds a status bar with the git branch cache pre-seeded
+// so getCurrentGitBranch returns without shelling out to git.
+func newStatusBarWithBranch(t *testing.T, width int, model, branch string, cfg *config.Config) *InputStatusBar {
+	t.Helper()
+
+	modelService := &domainmocks.FakeModelService{}
+	modelService.GetCurrentModelReturns(model)
+
+	themeService := &domainmocks.FakeThemeService{}
+	themeService.GetCurrentThemeNameReturns("tokyo-night")
+
+	return &InputStatusBar{
+		width:              width,
+		styleProvider:      newStatusBarStyleProvider(),
+		modelService:       modelService,
+		themeService:       themeService,
+		config:             cfg,
+		gitBranchCache:     branch,
+		gitBranchCacheTime: time.Now(),
+		gitBranchCacheTTL:  5 * time.Second,
+	}
+}
+
+func TestInputStatusBar_GitBranchOnSeparateRow(t *testing.T) {
+	statusBar := newStatusBarWithBranch(t, 100, "test-model", "feature/some-branch", config.DefaultConfig())
+
+	lines := statusBar.buildStatusLines()
+
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 rows (indicators + branch), got %d: %#v", len(lines), lines)
+	}
+
+	branchRow := lines[len(lines)-1]
+	if !strings.Contains(branchRow, "feature/some-branch") || !strings.Contains(branchRow, "⎇") {
+		t.Errorf("expected branch on the last row, got %q", branchRow)
+	}
+
+	indicatorRow := lines[0]
+	if strings.Contains(indicatorRow, "feature/some-branch") || strings.Contains(indicatorRow, "⎇") {
+		t.Errorf("expected branch NOT on the indicator row, got %q", indicatorRow)
+	}
+	if !strings.Contains(indicatorRow, "test-model") {
+		t.Errorf("expected model on the indicator row, got %q", indicatorRow)
+	}
+}
+
+func TestInputStatusBar_GitBranchDisabled_NoBranchRow(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Chat.StatusBar.Indicators.GitBranch = false
+
+	statusBar := newStatusBarWithBranch(t, 100, "test-model", "feature/some-branch", cfg)
+
+	lines := statusBar.buildStatusLines()
+	joined := strings.Join(lines, "\n")
+
+	if strings.Contains(joined, "⎇") || strings.Contains(joined, "feature/some-branch") {
+		t.Errorf("expected no branch row when git_branch disabled, got %q", joined)
+	}
+	if !strings.Contains(joined, "test-model") {
+		t.Errorf("expected indicators to still render, got %q", joined)
+	}
+}
+
+func TestInputStatusBar_GitBranchRendersWithoutModel(t *testing.T) {
+	statusBar := newStatusBarWithBranch(t, 100, "", "feature/no-model", config.DefaultConfig())
+
+	lines := statusBar.buildStatusLines()
+
+	if len(lines) != 1 {
+		t.Fatalf("expected only the branch row when no model is set, got %d rows: %#v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "feature/no-model") {
+		t.Errorf("expected branch row, got %q", lines[0])
+	}
+}
+
+func TestInputStatusBar_GitBranchStaysTwoRowsWhenNarrow(t *testing.T) {
+	// A narrow width forces the indicators to overflow their single row; the bar
+	// must still stay at exactly two rows (truncated indicators + branch).
+	statusBar := newStatusBarWithBranch(t, 24, "some-very-long-model-name", "feature/branch", config.DefaultConfig())
+
+	lines := statusBar.buildStatusLines()
+
+	if len(lines) != 2 {
+		t.Fatalf("expected the bar to stay at 2 rows when narrow, got %d: %#v", len(lines), lines)
+	}
+	if !strings.Contains(lines[len(lines)-1], "feature/branch") {
+		t.Errorf("expected branch to remain on the last row, got %q", lines[len(lines)-1])
+	}
+}
+
+func TestInputStatusBar_NilStyleProviderFallback(t *testing.T) {
+	modelService := &domainmocks.FakeModelService{}
+	modelService.GetCurrentModelReturns("test-model")
+
+	statusBar := &InputStatusBar{
+		width:              100,
+		styleProvider:      nil,
+		modelService:       modelService,
+		config:             config.DefaultConfig(),
+		gitBranchCache:     "feature/branch",
+		gitBranchCacheTime: time.Now(),
+		gitBranchCacheTTL:  5 * time.Second,
+	}
+
+	lines := statusBar.buildStatusLines()
+
+	if len(lines) != 1 {
+		t.Fatalf("expected a single fallback row with a nil provider, got %d: %#v", len(lines), lines)
+	}
+	if strings.Contains(lines[0], "⎇") {
+		t.Errorf("expected no branch rendering on the nil-provider fallback, got %q", lines[0])
 	}
 }


### PR DESCRIPTION
Moves the git branch indicator to its own row in the status bar, preventing horizontal overflow when the branch name is long. Adds `capIndicatorLines` to limit indicator rows and ensure stable bar height. Updates tests to cover new behavior and nil-style provider fallback.