### PR TITLE
feat(cli): adopt fang for styled help, errors, version and completions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	fang "github.com/charmbracelet/fang"
 	cobra "github.com/spf13/cobra"
 	viper "github.com/spf13/viper"
 
@@ -28,32 +30,25 @@ var rootCmd = &cobra.Command{
 the Inference Gateway. This CLI provides tools for configuration,
 deployment, monitoring, and management of inference services.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if cmd.Flags().Changed("version") {
-			versionCmd.Run(cmd, args)
-			return
-		}
-		if len(args) == 0 && !cmd.Flags().Changed("help") {
-			fmt.Println("Welcome to the Inference Gateway CLI!")
-			fmt.Println("Use 'infer chat' to start interactive chat or --help to see available commands.")
-		} else {
-			fmt.Println("Welcome to the Inference Gateway CLI!")
-			fmt.Println("Use --help to see available commands or 'infer chat' for interactive mode.")
-		}
+		fmt.Println("Welcome to the Inference Gateway CLI!")
+		fmt.Println("Use 'infer chat' to start interactive chat or --help to see available commands.")
 	},
 }
 
 func Execute() {
 	defer logger.Close()
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	// fang wraps Cobra to provide styled help, errors, and `--version`, plus
+	// shell completions, across every subcommand. It also silences Cobra's
+	// default error/usage output and renders the returned error itself, so we
+	// only need to set the exit code here.
+	if err := fang.Execute(context.Background(), rootCmd, fang.WithVersion(version)); err != nil {
 		os.Exit(1)
 	}
 }
 
 func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
-	rootCmd.Flags().BoolP("version", "", false, "print version information")
 
 	cobra.OnInitialize(initConfig)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/BurntSushi/xgbutil v0.0.0-20190907113008-ad855c713046
 	github.com/alecthomas/chroma/v2 v2.24.1
 	github.com/aymanbagabas/go-udiff v0.4.1
+	github.com/charmbracelet/fang v1.0.0
 	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260602025833-85a30b5e440a
 	github.com/charmbracelet/x/vt v0.0.0-20260602025833-85a30b5e440a
@@ -93,6 +94,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/mango v0.1.0 // indirect
+	github.com/muesli/mango-cobra v1.2.0 // indirect
+	github.com/muesli/mango-pflag v0.1.0 // indirect
+	github.com/muesli/roff v0.1.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/oapi-codegen/runtime v1.4.0 // indirect
 	github.com/otiai10/gosseract/v2 v2.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
+github.com/charmbracelet/fang v1.0.0 h1:jESBY40agJOlLYnnv9jE0mLqDGTxEk0hkOnx7YGyRlQ=
+github.com/charmbracelet/fang v1.0.0/go.mod h1:P5/DNb9DddQ0Z0dbc0P3ol4/ix5Po7Ofr2KMBfAqoCo=
 github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 h1:FpSYhY28ucg9ZRr+2wj67FAQ0Ey5yiK0072PmRDJNek=
@@ -195,8 +197,16 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
+github.com/muesli/mango v0.1.0 h1:DZQK45d2gGbql1arsYA4vfg4d7I9Hfx5rX/GCmzsAvI=
+github.com/muesli/mango v0.1.0/go.mod h1:5XFpbC8jY5UUv89YQciiXNlbi+iJgt29VDC5xbzrLL4=
+github.com/muesli/mango-cobra v1.2.0 h1:DQvjzAM0PMZr85Iv9LIMaYISpTOliMEg+uMFtNbYvWg=
+github.com/muesli/mango-cobra v1.2.0/go.mod h1:vMJL54QytZAJhCT13LPVDfkvCUJ5/4jNUKF/8NC2UjA=
+github.com/muesli/mango-pflag v0.1.0 h1:UADqbYgpUyRoBja3g6LUL+3LErjpsOwaC9ywvBWe7Sg=
+github.com/muesli/mango-pflag v0.1.0/go.mod h1:YEQomTxaCUp8PrbhFh10UfbhbQrM/xJ4i2PB8VTLLW0=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
+github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
+github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=


### PR DESCRIPTION
## Summary
Wrap `rootCmd` execution in `fang.Execute()` so every `infer` subcommand gets styled help output, styled error rendering, a styled `--version`, and generated shell completions (bash/zsh/fish/powershell) — for ~one function change.

## Details
- `fang v1.0.0` already targets the `charm.land/lipgloss` v2 stack the CLI uses, so there is **no** duplicate lipgloss module.
- fang sets `SilenceErrors/SilenceUsage` and renders the returned error itself, so `Execute()` only sets the exit code.
- The manual `--version` bool flag + its `Run` branch are removed in favour of `fang.WithVersion()`; the `version` subcommand is kept for backwards compatibility.

## Part of
Charm v2 UX modernization (1/7).

## Test plan
- `flox activate -- task build && task test && task lint` — all green.
- Manual: `./infer --help`, `./infer badcmd` (exit 1, styled error), `./infer --version`, `./infer completion zsh`.

## Docs follow-up
User-facing: new shell-completion subcommand + restyled help/version. Suggest a `[DOCS]` issue for `inference-gateway/docs` covering completion install instructions and updated help screenshots.
