### PR TITLE
feat(tui): rebuild GitHub Action setup wizard with huh forms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.7
 	charm.land/fang/v2 v2.0.1
 	charm.land/glamour/v2 v2.0.0
+	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc
 	github.com/BurntSushi/xgbutil v0.0.0-20190907113008-ad855c713046
@@ -55,12 +56,14 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
+	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
+	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
@@ -92,6 +95,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.11.3 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ charm.land/fang/v2 v2.0.1 h1:zQCM8JQJ1JnQX/66B5jlCYBUxL2as5JXQZ2KJ6EL0mY=
 charm.land/fang/v2 v2.0.1/go.mod h1:S1GmkpcvK+OB5w9caywUnJcsMew45Ot8FXqoz8ALrII=
 charm.land/glamour/v2 v2.0.0 h1:IDBoqLEy7Hdpb9VOXN+khLP/XSxtJy1VsHuW/yF87+U=
 charm.land/glamour/v2 v2.0.0/go.mod h1:kjq9WB0s8vuUYZNYey2jp4Lgd9f4cKdzAw88FZtpj/w=
+charm.land/huh/v2 v2.0.3 h1:2cJsMqEPwSywGHvdlKsJyQKPtSJLVnFKyFbsYZTlLkU=
+charm.land/huh/v2 v2.0.3/go.mod h1:93eEveeeqn47MwiC3tf+2atZ2l7Is88rAtmZNZ8x9Wc=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
 github.com/BurntSushi/freetype-go v0.0.0-20160129220410-b763ddbfe298 h1:1qlsVAQJXZHsaM8b6OLVo6muQUQd4CwkH/D3fnnbHXA=
@@ -16,6 +18,8 @@ github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc h1:7D+Bh06CRPCJO3gr
 github.com/BurntSushi/xgb v0.0.0-20210121224620-deaf085860bc/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/BurntSushi/xgbutil v0.0.0-20190907113008-ad855c713046 h1:O/r2Sj+8QcMF7V5IcmiE2sMFV2q3J47BEirxbXJAdzA=
 github.com/BurntSushi/xgbutil v0.0.0-20190907113008-ad855c713046/go.mod h1:uw9h2sd4WWHOPdJ13MQpwK5qYWKYDumDqxWWIknEQ+k=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
@@ -42,6 +46,8 @@ github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uS
 github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
 github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
 github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/catppuccin/go v0.2.0 h1:ktBeIrIP42b/8FGiScP9sgrWOss3lw0Z5SktRoithGA=
+github.com/catppuccin/go v0.2.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
@@ -52,6 +58,10 @@ github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 h1:FpSYh
 github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654/go.mod h1:hFpumms29Smx3LStRfku8vcCTBe1Kq8aCXtHUJa3mjY=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
+github.com/charmbracelet/x/conpty v0.1.1 h1:s1bUxjoi7EpqiXysVtC+a8RrvPPNcNvAjfi4jxsAuEs=
+github.com/charmbracelet/x/conpty v0.1.1/go.mod h1:OmtR77VODEFbiTzGE9G1XiRJAga6011PIm4u5fTNZpk=
+github.com/charmbracelet/x/errors v0.0.0-20240508181413-e8d8b6e2de86 h1:JSt3B+U9iqk37QUU2Rvb6DSBYRLtWqFqfxf8l5hOZUA=
+github.com/charmbracelet/x/errors v0.0.0-20240508181413-e8d8b6e2de86/go.mod h1:2P0UgXMEa6TsToMSuFqKFQR+fZTO9CNGUNokkPatT/0=
 github.com/charmbracelet/x/exp/charmtone v0.0.0-20260602025833-85a30b5e440a h1:aVvnksCVgxB2igk7jERL9ARIkbDXccp1gXCFqhGlamQ=
 github.com/charmbracelet/x/exp/charmtone v0.0.0-20260602025833-85a30b5e440a/go.mod h1:nsExn0DGyX0lh9LwLHTn2Gg+hafdzfSXnC+QmEJTZFY=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
@@ -60,6 +70,8 @@ github.com/charmbracelet/x/exp/ordered v0.1.0 h1:55/qLwjIh0gL0Vni+QAWk7T/qRVP6sB
 github.com/charmbracelet/x/exp/ordered v0.1.0/go.mod h1:5UHwmG+is5THxMyCJHNPCn2/ecI07aKNrW+LcResjJ8=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf h1:rLG0Yb6MQSDKdB52aGX55JT1oi0P0Kuaj7wi1bLUpnI=
 github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf/go.mod h1:B3UgsnsBZS/eX42BlaNiJkD1pPOUa+oF1IYC6Yd2CEU=
+github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 h1:qko3AQ4gK1MTS/de7F5hPGx6/k1u0w4TeYmBFwzYVP4=
+github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=
@@ -68,6 +80,8 @@ github.com/charmbracelet/x/vt v0.0.0-20260602025833-85a30b5e440a h1:CAPfrIHOKex4
 github.com/charmbracelet/x/vt v0.0.0-20260602025833-85a30b5e440a/go.mod h1:u1LOIABor9JqY54oZdktK3TCRrgzP6tzHrDYx1nd3wY=
 github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2/jYn2GuM=
 github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
+github.com/charmbracelet/x/xpty v0.1.3 h1:eGSitii4suhzrISYH50ZfufV3v085BXQwIytcOdFSsw=
+github.com/charmbracelet/x/xpty v0.1.3/go.mod h1:poPYpWuLDBFCKmKLDnhBp51ATa0ooD8FhypRwEFtH3Y=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
@@ -192,6 +206,8 @@ github.com/metoro-io/mcp-golang v0.16.1 h1:0tXO9FrPweQz/M8dNFhTiAIri2g1ikvJ3O2P3
 github.com/metoro-io/mcp-golang v0.16.1/go.mod h1:ifLP9ZzKpN1UqFWNTpAHOqSvNkMK6b7d1FSZ5Lu0lN0=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -891,6 +891,10 @@ func (app *ChatApplication) handleGithubActionSetupTrigger() []tea.Cmd {
 	}
 
 	app.initGithubActionView.SetRepositoryInfo(owner, isOrg)
+	app.initGithubActionView.Reset()
+	if cmd := app.initGithubActionView.Init(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 
 	if err := app.stateManager.TransitionToView(domain.ViewStateGithubActionSetup); err != nil {
 		cmds = append(cmds, func() tea.Msg {

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -2343,7 +2343,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Run Infer Agent
-        uses: inference-gateway/infer-action@v0.4.0
+        uses: inference-gateway/infer-action@v0.11.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           trigger-phrase: "@infer"
@@ -2411,7 +2411,7 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
 
       - name: Run Infer Agent
-        uses: inference-gateway/infer-action@v0.4.0
+        uses: inference-gateway/infer-action@v0.11.2
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           trigger-phrase: "@infer"

--- a/internal/ui/components/init_github_action_view.go
+++ b/internal/ui/components/init_github_action_view.go
@@ -4,16 +4,28 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	huh "charm.land/huh/v2"
 
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
-// InitGithubActionView implements the Init GitHub Action setup wizard UI
+// wizardPhase identifies which huh form is currently driving the wizard.
+type wizardPhase int
+
+const (
+	phaseConfirm wizardPhase = iota // "do you already have a GitHub App?"
+	phaseDetails                    // App ID + (conditionally) private key
+)
+
+// InitGithubActionView drives the GitHub App setup wizard with huh forms. The
+// flow is split across two forms so that the browser can be opened between the
+// "create a new app?" answer and the App ID prompt: confirm -> (open browser
+// when creating new) -> App ID -> private key (skipped when org secrets already
+// exist for that App ID).
 type InitGithubActionView struct {
 	width         int
 	height        int
@@ -21,410 +33,182 @@ type InitGithubActionView struct {
 	done          bool
 	cancelled     bool
 
-	// Wizard state
-	step           int // 0=ask existing, 2=enter app ID manually, 3=private key input
+	phase         wizardPhase
+	form          *huh.Form
+	browserOpened bool
+
+	// Form-bound results.
 	hasExisting    bool
+	appID          string
 	privateKeyPath string
-	inputBuffer    string
-	cursorPos      int
+	err            error
 
-	// File selection
-	showingFilePicker bool
-	filePickerFiles   []string
-	filePickerIndex   int
-
-	// Results
-	appID      string
-	privateKey string
-	err        error
-
-	// Repository information
+	// Repository information.
 	repoOwner string
 	isOrgRepo bool
 
-	// Callback to check if org secrets already exist
+	// Callback to check if org secrets already exist for an App ID.
 	checkSecretsExist func(appID string) bool
 }
 
-// NewInitGithubActionView creates a new Init GitHub Action setup wizard
+// NewInitGithubActionView creates a new GitHub App setup wizard.
 func NewInitGithubActionView(styleProvider *styles.Provider) *InitGithubActionView {
-	return &InitGithubActionView{
+	v := &InitGithubActionView{
 		width:         80,
 		height:        24,
 		styleProvider: styleProvider,
-		step:          0,
+		phase:         phaseConfirm,
 	}
+	v.form = v.buildConfirmForm()
+	return v
+}
+
+func (v *InitGithubActionView) buildConfirmForm() *huh.Form {
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Key("hasExisting").
+				Title("Do you already have a GitHub App for infer-action?").
+				Description("Tip: you can reuse one GitHub App across multiple repositories.").
+				Affirmative("Yes, I have one").
+				Negative("No, create a new one").
+				Value(&v.hasExisting),
+		),
+	).WithShowHelp(true).WithWidth(v.width)
+}
+
+func (v *InitGithubActionView) buildDetailsForm() *huh.Form {
+	appIDInput := huh.NewInput().
+		Key("appID").
+		Title("GitHub App ID").
+		Description("Find it on your app's page: " + v.getGithubActionsURL()).
+		Validate(validateAppID).
+		Value(&v.appID)
+
+	keyPicker := huh.NewFilePicker().
+		Key("privateKey").
+		Title("Private key (.pem)").
+		Description("Generate one under your app's 'Private keys' section, then pick the file.").
+		CurrentDirectory(".").
+		AllowedTypes([]string{".pem"}).
+		ShowHidden(false).
+		Height(10).
+		Value(&v.privateKeyPath)
+
+	return huh.NewForm(
+		huh.NewGroup(appIDInput),
+		huh.NewGroup(keyPicker).WithHideFunc(func() bool {
+			return v.checkSecretsExist != nil && v.checkSecretsExist(v.appID)
+		}),
+	).WithShowHelp(true).WithWidth(v.width)
 }
 
 func (v *InitGithubActionView) Init() tea.Cmd {
-	return nil
+	return v.form.Init()
 }
 
 func (v *InitGithubActionView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		v.width = msg.Width
-		v.height = msg.Height
-		return v, nil
-
-	case tea.KeyMsg:
-		return v.handleKeyInput(msg)
+	if wsm, ok := msg.(tea.WindowSizeMsg); ok {
+		v.width = wsm.Width
+		v.height = wsm.Height
 	}
 
-	return v, nil
-}
-
-func (v *InitGithubActionView) handleKeyInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if v.showingFilePicker {
-		return v.handleFilePickerKeys(msg)
+	form, cmd := v.form.Update(msg)
+	if f, ok := form.(*huh.Form); ok {
+		v.form = f
 	}
 
-	switch msg.String() {
-	case "ctrl+c", "esc":
-		return v.handleCancel()
-	case "enter":
-		return v.handleEnter()
-	case "tab", "ctrl+f":
-		return v.handleFilePicker()
-	case "y", "Y":
-		return v.handleYesInput()
-	case "n", "N":
-		return v.handleNoInput()
-	case "left":
-		return v.handleLeftArrow()
-	case "right":
-		return v.handleRightArrow()
-	case "backspace", "delete":
-		return v.handleBackspace()
-	default:
-		return v.handleTextInput(msg)
-	}
-}
-
-func (v *InitGithubActionView) handleCancel() (tea.Model, tea.Cmd) {
-	v.cancelled = true
-	v.done = true
-	return v, nil
-}
-
-func (v *InitGithubActionView) handleFilePicker() (tea.Model, tea.Cmd) {
-	if v.step == 3 {
-		v.showingFilePicker = true
-		v.loadPemFiles()
-	}
-	return v, nil
-}
-
-func (v *InitGithubActionView) handleYesInput() (tea.Model, tea.Cmd) {
-	if v.step == 0 {
-		v.hasExisting = true
-		v.step = 2
-		v.inputBuffer = ""
-		v.cursorPos = 0
-	}
-	return v, nil
-}
-
-func (v *InitGithubActionView) handleNoInput() (tea.Model, tea.Cmd) {
-	if v.step == 0 {
-		v.hasExisting = false
-		_ = openGithubActionCreationURL(v.repoOwner, v.isOrgRepo)
-		v.step = 2
-		v.inputBuffer = ""
-		v.cursorPos = 0
-	}
-	return v, nil
-}
-
-func (v *InitGithubActionView) handleLeftArrow() (tea.Model, tea.Cmd) {
-	if (v.step == 2 || v.step == 3) && v.cursorPos > 0 {
-		v.cursorPos--
-	}
-	return v, nil
-}
-
-func (v *InitGithubActionView) handleRightArrow() (tea.Model, tea.Cmd) {
-	if (v.step == 2 || v.step == 3) && v.cursorPos < len(v.inputBuffer) {
-		v.cursorPos++
-	}
-	return v, nil
-}
-
-func (v *InitGithubActionView) handleBackspace() (tea.Model, tea.Cmd) {
-	if (v.step == 2 || v.step == 3) && v.cursorPos > 0 {
-		v.inputBuffer = v.inputBuffer[:v.cursorPos-1] + v.inputBuffer[v.cursorPos:]
-		v.cursorPos--
-	}
-	return v, nil
-}
-
-func (v *InitGithubActionView) handleTextInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if v.step != 2 && v.step != 3 {
-		return v, nil
-	}
-
-	// Bubble Tea v2: KeyMsg is an interface; printable text lives in
-	// Key.Text rather than the v1 Runes field. KeyPressMsg embeds Key.
-	if press, ok := msg.(tea.KeyPressMsg); ok && press.Text != "" {
-		input := v.sanitizeInput(press.Text)
-		if len(input) > 0 {
-			v.inputBuffer = v.inputBuffer[:v.cursorPos] + input + v.inputBuffer[v.cursorPos:]
-			v.cursorPos += len(input)
-		}
-	}
-	return v, nil
-}
-
-func (v *InitGithubActionView) sanitizeInput(input string) string {
-	input = strings.ReplaceAll(input, "[", "")
-	input = strings.ReplaceAll(input, "]", "")
-
-	if v.step == 2 {
-		var filtered strings.Builder
-		for _, r := range input {
-			if r >= '0' && r <= '9' {
-				filtered.WriteRune(r)
-			}
-		}
-		return filtered.String()
-	}
-
-	return input
-}
-
-func (v *InitGithubActionView) handleFilePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc":
-		v.showingFilePicker = false
-		return v, nil
-
-	case "up", "k":
-		if v.filePickerIndex > 0 {
-			v.filePickerIndex--
-		}
-		return v, nil
-
-	case "down", "j":
-		if v.filePickerIndex < len(v.filePickerFiles)-1 {
-			v.filePickerIndex++
-		}
-		return v, nil
-
-	case "enter":
-		if len(v.filePickerFiles) > 0 && v.filePickerIndex < len(v.filePickerFiles) {
-			selectedFile := v.filePickerFiles[v.filePickerIndex]
-			v.inputBuffer = selectedFile
-			v.cursorPos = len(selectedFile)
-			v.showingFilePicker = false
-		}
-		return v, nil
-	}
-
-	return v, nil
-}
-
-func (v *InitGithubActionView) loadPemFiles() {
-	v.filePickerFiles = []string{}
-	v.filePickerIndex = 0
-
-	// Only search in current directory
-	files, err := filepath.Glob("*.pem")
-	if err == nil {
-		v.filePickerFiles = files
-	}
-}
-
-func (v *InitGithubActionView) handleEnter() (tea.Model, tea.Cmd) {
-	switch v.step {
-	case 2:
-		if len(v.inputBuffer) > 0 {
-			v.appID = v.inputBuffer
-			v.inputBuffer = ""
-			v.cursorPos = 0
-
-			if v.checkSecretsExist != nil && v.checkSecretsExist(v.appID) {
-				v.done = true
-			} else {
-				v.step = 3
-			}
-		}
-		return v, nil
-
-	case 3:
-		v.privateKeyPath = v.inputBuffer
+	switch v.form.State {
+	case huh.StateCompleted:
+		return v, v.advance()
+	case huh.StateAborted:
+		v.cancelled = true
 		v.done = true
 		return v, nil
+	default:
+		return v, cmd
+	}
+}
+
+// advance moves the wizard to the next phase when a form completes. After the
+// confirm form it opens the GitHub App creation page in the browser (only when
+// the user is creating a new app) and switches to the details form; after the
+// details form the wizard is done.
+func (v *InitGithubActionView) advance() tea.Cmd {
+	if v.phase == phaseConfirm {
+		if !v.hasExisting && !v.browserOpened {
+			_ = openGithubActionCreationURL(v.repoOwner, v.isOrgRepo)
+			v.browserOpened = true
+		}
+		v.phase = phaseDetails
+		v.form = v.buildDetailsForm()
+		return v.form.Init()
 	}
 
-	return v, nil
+	v.done = true
+	return nil
 }
 
 func (v *InitGithubActionView) View() tea.View {
-	return tea.NewView(v.viewContent())
-}
-
-func (v *InitGithubActionView) viewContent() string {
 	if v.done {
 		if v.cancelled {
-			return "Setup cancelled.\n"
+			return tea.NewView("Setup cancelled.\n")
 		}
-		return "Setup complete!\n"
+		return tea.NewView("Setup complete!\n")
 	}
 
 	var b strings.Builder
-
-	accentColor := v.styleProvider.GetThemeColor("accent")
-	b.WriteString(v.styleProvider.RenderWithColor("Init GitHub Action Setup Wizard", accentColor))
+	b.WriteString(v.styleProvider.RenderWithColor("Init GitHub Action Setup Wizard", v.styleProvider.GetThemeColor("accent")))
 	b.WriteString("\n\n")
-
-	switch v.step {
-	case 0:
-		v.renderStepAskExisting(&b)
-	case 2:
-		v.renderStepManualAppID(&b)
-	case 3:
-		v.renderStepPrivateKey(&b)
-	}
-
-	b.WriteString("\n\n")
-	b.WriteString(v.styleProvider.RenderDimText("Press Esc to cancel"))
-
-	return b.String()
+	b.WriteString(v.form.View())
+	return tea.NewView(b.String())
 }
 
-func (v *InitGithubActionView) renderStepAskExisting(b *strings.Builder) {
-	b.WriteString("Do you already have a GitHub App for infer-action?\n\n")
-	b.WriteString("Tip: You can reuse one GitHub App across multiple repositories!\n\n")
-	b.WriteString("Press Y for Yes, N for No")
-}
-
-func (v *InitGithubActionView) renderStepManualAppID(b *strings.Builder) {
-	if v.hasExisting {
-		b.WriteString("Enter your GitHub App ID\n\n")
-		b.WriteString("You can find your App ID at:\n")
-
-		accentColor := v.styleProvider.GetThemeColor("accent")
-		appsURL := v.getGithubActionsURL()
-		link := v.styleProvider.RenderWithColor(appsURL, accentColor)
-		b.WriteString("  ")
-		b.WriteString(link)
-		b.WriteString("\n\n")
-
-		b.WriteString("Click on your app name to see the App ID\n\n")
-	} else {
-		b.WriteString("Browser opened with pre-filled GitHub App creation form\n\n")
-		b.WriteString("After creating your app, copy the App ID and paste it below.\n\n")
+// validateAppID requires a non-empty, all-numeric App ID, mirroring the
+// numeric-only input sanitisation of the previous wizard.
+func validateAppID(s string) error {
+	if s == "" {
+		return fmt.Errorf("app ID is required")
 	}
-
-	before := v.inputBuffer[:v.cursorPos]
-	after := v.inputBuffer[v.cursorPos:]
-	b.WriteString("App ID: > ")
-	b.WriteString(before)
-	b.WriteString("_")
-	b.WriteString(after)
-	b.WriteString("\n\n")
-	b.WriteString("Press Enter when done")
-}
-
-func (v *InitGithubActionView) renderStepPrivateKey(b *strings.Builder) {
-	fmt.Fprintf(b, "Selected App ID: %s\n\n", v.appID)
-	b.WriteString("Private Key Required\n\n")
-
-	if v.showingFilePicker {
-		v.renderFilePicker(b)
-		return
-	}
-
-	b.WriteString("To download your private key:\n")
-	accentColor := v.styleProvider.GetThemeColor("accent")
-	appsPageURL := v.getGithubActionsURL()
-	link := v.styleProvider.RenderWithColor(appsPageURL, accentColor)
-	b.WriteString("  1. Go to ")
-	b.WriteString(link)
-	b.WriteString("\n")
-	b.WriteString("  2. Click on your app name from the list\n")
-	b.WriteString("  3. Scroll to 'Private keys' section\n")
-	b.WriteString("  4. Click 'Generate a private key' (if you haven't already)\n")
-	b.WriteString("  5. Save the downloaded .pem file\n\n")
-
-	b.WriteString("Enter the full path to the .pem file:\n")
-	b.WriteString("(e.g., /Users/yourname/Downloads/app-name.2024-01-01.private-key.pem)\n")
-
-	before := v.inputBuffer[:v.cursorPos]
-	after := v.inputBuffer[v.cursorPos:]
-	b.WriteString("> ")
-	b.WriteString(before)
-	b.WriteString("_")
-	b.WriteString(after)
-	b.WriteString("\n\n")
-
-	tabHint := v.styleProvider.RenderDimText("Press Tab to browse .pem files in current directory")
-	b.WriteString(tabHint)
-	b.WriteString(" | Press Enter when done")
-}
-
-func (v *InitGithubActionView) renderFilePicker(b *strings.Builder) {
-	b.WriteString("Select a .pem file (from current directory):\n\n")
-
-	if len(v.filePickerFiles) == 0 {
-		b.WriteString(v.styleProvider.RenderDimText("No .pem files found in current directory\n\n"))
-		b.WriteString("Press Esc to go back and enter path manually")
-		return
-	}
-
-	accentColor := v.styleProvider.GetThemeColor("accent")
-
-	maxVisible := 10
-	start := min(v.filePickerIndex, len(v.filePickerFiles)-maxVisible)
-	start = max(start, 0)
-
-	for i := start; i < len(v.filePickerFiles) && i < start+maxVisible; i++ {
-		file := v.filePickerFiles[i]
-		if i == v.filePickerIndex {
-			b.WriteString(v.styleProvider.RenderWithColor("> "+file, accentColor))
-			b.WriteString("\n")
-		} else {
-			b.WriteString("  ")
-			b.WriteString(file)
-			b.WriteString("\n")
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return fmt.Errorf("app ID must be numeric")
 		}
 	}
-
-	b.WriteString("\n")
-	b.WriteString(v.styleProvider.RenderDimText("Use ↑↓ or j/k to navigate, enter to select, esc to cancel"))
+	return nil
 }
 
-// IsDone returns whether the wizard is complete
+// IsDone returns whether the wizard is complete.
 func (v *InitGithubActionView) IsDone() bool {
 	return v.done
 }
 
-// IsCancelled returns whether the wizard was cancelled
+// IsCancelled returns whether the wizard was cancelled.
 func (v *InitGithubActionView) IsCancelled() bool {
 	return v.cancelled
 }
 
-// GetResult returns the wizard result
+// GetResult returns the wizard result.
 func (v *InitGithubActionView) GetResult() (appID, privateKeyPath string, err error) {
 	return v.appID, v.privateKeyPath, v.err
 }
 
-// SetWidth sets the width of the view
+// SetWidth sets the width of the view.
 func (v *InitGithubActionView) SetWidth(width int) {
 	v.width = width
 }
 
-// SetHeight sets the height of the view
+// SetHeight sets the height of the view.
 func (v *InitGithubActionView) SetHeight(height int) {
 	v.height = height
 }
 
-// SetSecretsExistChecker sets the callback to check if org secrets exist
+// SetSecretsExistChecker sets the callback to check if org secrets exist.
 func (v *InitGithubActionView) SetSecretsExistChecker(checker func(appID string) bool) {
 	v.checkSecretsExist = checker
 }
 
-// SetRepositoryInfo sets the repository owner and whether it's an org
+// SetRepositoryInfo sets the repository owner and whether it's an org.
 func (v *InitGithubActionView) SetRepositoryInfo(owner string, isOrg bool) {
 	v.repoOwner = owner
 	v.isOrgRepo = isOrg
@@ -438,18 +222,17 @@ func (v *InitGithubActionView) getGithubActionsURL() string {
 	return "https://github.com/settings/apps"
 }
 
-// Reset resets the view state for reuse
+// Reset resets the view state for reuse.
 func (v *InitGithubActionView) Reset() {
 	v.done = false
 	v.cancelled = false
-	v.step = 0
+	v.phase = phaseConfirm
 	v.hasExisting = false
-	v.privateKeyPath = ""
-	v.inputBuffer = ""
-	v.cursorPos = 0
 	v.appID = ""
-	v.privateKey = ""
+	v.privateKeyPath = ""
+	v.browserOpened = false
 	v.err = nil
+	v.form = v.buildConfirmForm()
 }
 
 // openGithubActionCreationURL opens the GitHub App creation page with pre-filled parameters

--- a/internal/ui/components/init_github_action_view.go
+++ b/internal/ui/components/init_github_action_view.go
@@ -17,8 +17,8 @@ import (
 type wizardPhase int
 
 const (
-	phaseConfirm wizardPhase = iota // "do you already have a GitHub App?"
-	phaseDetails                    // App ID + (conditionally) private key
+	phaseConfirm wizardPhase = iota
+	phaseDetails
 )
 
 // InitGithubActionView drives the GitHub App setup wizard with huh forms. The

--- a/internal/ui/components/init_github_action_view_test.go
+++ b/internal/ui/components/init_github_action_view_test.go
@@ -1,0 +1,95 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestInitWizard_RendersTitleAndConfirm(t *testing.T) {
+	v := NewInitGithubActionView(createMockStyleProviderForHelpBar())
+	v.Init() // the chat app initializes the form when the wizard is shown
+	out := v.View().Content
+	if !strings.Contains(out, "Init GitHub Action Setup Wizard") {
+		t.Fatalf("expected wizard title in view, got:\n%s", out)
+	}
+	if !strings.Contains(out, "GitHub App") {
+		t.Fatalf("expected confirm question in view, got:\n%s", out)
+	}
+}
+
+func TestInitWizard_CtrlCCancels(t *testing.T) {
+	v := NewInitGithubActionView(createMockStyleProviderForHelpBar())
+
+	model, _ := v.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	v = model.(*InitGithubActionView)
+
+	if !v.IsCancelled() || !v.IsDone() {
+		t.Fatalf("expected ctrl+c to cancel the wizard, got cancelled=%v done=%v", v.IsCancelled(), v.IsDone())
+	}
+}
+
+func TestInitWizard_ResetClearsState(t *testing.T) {
+	v := NewInitGithubActionView(createMockStyleProviderForHelpBar())
+	v.done = true
+	v.cancelled = true
+	v.phase = phaseDetails
+	v.appID = "12345"
+	v.privateKeyPath = "/tmp/key.pem"
+	v.browserOpened = true
+
+	v.Reset()
+
+	if v.done || v.cancelled {
+		t.Fatalf("expected clean state after Reset, got done=%v cancelled=%v", v.done, v.cancelled)
+	}
+	if v.phase != phaseConfirm {
+		t.Fatalf("expected phaseConfirm after Reset, got %v", v.phase)
+	}
+	if v.appID != "" || v.privateKeyPath != "" || v.browserOpened {
+		t.Fatalf("expected results cleared after Reset, got appID=%q key=%q browser=%v", v.appID, v.privateKeyPath, v.browserOpened)
+	}
+	if v.form == nil {
+		t.Fatal("expected a rebuilt form after Reset")
+	}
+}
+
+func TestInitWizard_GithubURLs(t *testing.T) {
+	v := NewInitGithubActionView(createMockStyleProviderForHelpBar())
+
+	if got := v.getGithubActionsURL(); got != "https://github.com/settings/apps" {
+		t.Fatalf("expected personal apps URL, got %q", got)
+	}
+
+	v.SetRepositoryInfo("acme", true)
+	if got := v.getGithubActionsURL(); got != "https://github.com/organizations/acme/settings/apps" {
+		t.Fatalf("expected org apps URL, got %q", got)
+	}
+
+	install := v.GetInstallationURL("acme", "infra")
+	if !strings.Contains(install, "acme") || !strings.Contains(install, "infra") {
+		t.Fatalf("expected installation URL to include owner and repo, got %q", install)
+	}
+}
+
+func TestValidateAppID(t *testing.T) {
+	cases := []struct {
+		in    string
+		valid bool
+	}{
+		{"", false},
+		{"12345", true},
+		{"12a45", false},
+		{"abc", false},
+	}
+	for _, c := range cases {
+		err := validateAppID(c.in)
+		if c.valid && err != nil {
+			t.Errorf("validateAppID(%q): expected valid, got %v", c.in, err)
+		}
+		if !c.valid && err == nil {
+			t.Errorf("validateAppID(%q): expected error, got nil", c.in)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Replace the hand-rolled step machine (manual input buffer, cursor tracking, key handling and an ad-hoc `.pem` picker) in the GitHub App setup wizard with `charm.land/huh/v2` forms.

## Details
- The flow is split across two huh forms so the browser still opens at the right moment: a Confirm ("do you already have an app?"), then — after opening the GitHub App creation page when creating a new one — an App ID Input (numeric validation) and a FilePicker for the `.pem` key.
- The private-key group is hidden via `WithHideFunc` when org secrets already exist for the entered App ID (preserves the previous skip behaviour).
- Cancellation is huh's native **ctrl+c** (`StateAborted`).
- `huh/v2` targets the same `charm.land/bubbletea` v2 stack, so the form embeds directly as a sub-model; the chat trigger now `Reset()`+`Init()`s the view on show.
- Adds a test suite (render, ctrl+c cancel, reset, URLs, App ID validation) the wizard previously lacked.

## Part of
Charm v2 UX modernization (6/7).

## Test plan
- `flox activate -- task build && task test && task lint` — all green.
- Manual (needs a GitHub repo context): run the `infer init` GitHub Action setup flow end-to-end, incl. cancel via ctrl+c.

## Docs follow-up
User-facing: the setup flow now uses huh forms and the cancel key is **ctrl+c**. Suggest a `[DOCS]` issue for `inference-gateway/docs` to update the GitHub Action setup walkthrough.
