### PR TITLE
refactor: move git branch indicator to input view border

### DIFF
--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -2,9 +2,7 @@ package components
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -14,7 +12,6 @@ import (
 	domain "github.com/inference-gateway/cli/internal/domain"
 	models "github.com/inference-gateway/cli/internal/models"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
-	icons "github.com/inference-gateway/cli/internal/ui/styles/icons"
 )
 
 // InputStatusBar displays input status information like model, theme, agents
@@ -32,17 +29,13 @@ type InputStatusBar struct {
 	mcpStatus              *domain.MCPServerStatus
 	styleProvider          *styles.Provider
 	currentInputText       string
-	gitBranchCache         string
-	gitBranchCacheTime     time.Time
-	gitBranchCacheTTL      time.Duration
 }
 
 // NewInputStatusBar creates a new input status bar
 func NewInputStatusBar(styleProvider *styles.Provider) *InputStatusBar {
 	return &InputStatusBar{
-		width:             80,
-		styleProvider:     styleProvider,
-		gitBranchCacheTTL: 5 * time.Second,
+		width:         80,
+		styleProvider: styleProvider,
 	}
 }
 
@@ -118,10 +111,10 @@ func (isb *InputStatusBar) Render() string {
 	return strings.Join(lines, "\n")
 }
 
-// buildStatusLines builds the status bar content. Indicators are packed onto the
-// top row(s); the git branch always gets its own dedicated row directly below,
-// left-aligned with the indicators. The bar stays within maxLines rows total -
-// when a branch is shown the indicators get maxLines-1 rows, otherwise maxLines.
+// buildStatusLines builds the status bar content. Indicators are packed onto up
+// to maxLines rows; overflow beyond that is collapsed with an ellipsis. The git
+// branch is rendered separately, in the input box top border (see InputView), so
+// it never competes with these indicators for horizontal space.
 func (isb *InputStatusBar) buildStatusLines() []string {
 	const (
 		maxLines       = 2
@@ -136,31 +129,19 @@ func (isb *InputStatusBar) buildStatusLines() []string {
 	dimColor := isb.styleProvider.GetThemeColor("dim")
 	availableWidth := isb.width - len(leftPadding) - 2
 
-	branchLine := isb.buildGitBranchLine(leftPadding, dimColor)
-
 	parts := isb.getAllIndicatorParts()
-	if len(parts) == 0 && branchLine == "" {
+	if len(parts) == 0 {
 		return []string{leftPadding + "\u00A0"}
 	}
 
-	indicatorMaxLines := maxLines
-	if branchLine != "" {
-		indicatorMaxLines = maxLines - 1
-	}
+	lineGroups := isb.splitPartsIntoLines(parts, availableWidth, maxLines, separatorWidth)
+	lineGroups = capIndicatorLines(lineGroups, maxLines)
 
 	var lines []string
-	if len(parts) > 0 && indicatorMaxLines > 0 {
-		lineGroups := isb.splitPartsIntoLines(parts, availableWidth, indicatorMaxLines, separatorWidth)
-		lineGroups = capIndicatorLines(lineGroups, indicatorMaxLines)
-		for _, lineItems := range lineGroups {
-			lineText := strings.Join(lineItems, " • ")
-			renderedLine := isb.styleProvider.RenderWithColor(lineText, dimColor)
-			lines = append(lines, leftPadding+renderedLine)
-		}
-	}
-
-	if branchLine != "" {
-		lines = append(lines, branchLine)
+	for _, lineItems := range lineGroups {
+		lineText := strings.Join(lineItems, " • ")
+		renderedLine := isb.styleProvider.RenderWithColor(lineText, dimColor)
+		lines = append(lines, leftPadding+renderedLine)
 	}
 
 	if len(lines) == 0 {
@@ -185,9 +166,8 @@ func (isb *InputStatusBar) getAllIndicatorParts() []string {
 }
 
 // buildIndicatorParts builds individual indicator parts without joining them.
-// The git branch is intentionally excluded here - it is rendered on its own
-// dedicated row by buildGitBranchLine so it never competes with these indicators
-// for horizontal space.
+// The git branch is not included here - it is rendered in the input box top
+// border by InputView, not in the status bar.
 func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []string {
 	parts := []string{}
 
@@ -333,12 +313,6 @@ func (isb *InputStatusBar) shouldAddOverflowAndBreak(currentLines, maxLines, cur
 
 func (isb *InputStatusBar) buildModelDisplayText(currentModel string) string {
 	parts := []string{}
-
-	if isb.shouldShowIndicator("git_branch") {
-		if gitBranchPart := isb.buildGitBranchIndicator(); gitBranchPart != "" {
-			parts = append(parts, gitBranchPart)
-		}
-	}
 
 	if isb.shouldShowIndicator("model") {
 		parts = append(parts, currentModel)
@@ -585,65 +559,6 @@ func (isb *InputStatusBar) buildCostIndicator() string {
 	}
 }
 
-// getCurrentGitBranch returns the current git branch with caching
-func (isb *InputStatusBar) getCurrentGitBranch() (string, bool) {
-	if time.Since(isb.gitBranchCacheTime) < isb.gitBranchCacheTTL && isb.gitBranchCache != "" {
-		return isb.gitBranchCache, true
-	}
-
-	cmd := exec.Command("git", "branch", "--show-current")
-	output, err := cmd.Output()
-
-	isb.gitBranchCacheTime = time.Now()
-
-	if err != nil {
-		isb.gitBranchCache = ""
-		return "", false
-	}
-
-	branch := strings.TrimSpace(string(output))
-	isb.gitBranchCache = branch
-	return branch, branch != ""
-}
-
-// InvalidateGitBranchCache clears the git branch cache to force a refresh
-func (isb *InputStatusBar) InvalidateGitBranchCache() {
-	isb.gitBranchCache = ""
-	isb.gitBranchCacheTime = time.Time{}
-}
-
-// buildGitBranchLine renders the git branch as its own status bar row, left-aligned
-// with the indicator row above it. Returns "" when the git_branch indicator is
-// disabled or there is no branch to show (not a repo / detached HEAD), in which case
-// the indicators reclaim the full line budget.
-func (isb *InputStatusBar) buildGitBranchLine(leftPadding, dimColor string) string {
-	if !isb.shouldShowIndicator("git_branch") {
-		return ""
-	}
-
-	part := isb.buildGitBranchIndicator()
-	if part == "" {
-		return ""
-	}
-
-	return leftPadding + isb.styleProvider.RenderWithColor(part, dimColor)
-}
-
-// buildGitBranchIndicator builds the git branch indicator text
-func (isb *InputStatusBar) buildGitBranchIndicator() string {
-	branch, ok := isb.getCurrentGitBranch()
-	if !ok || branch == "" {
-		return ""
-	}
-
-	const maxBranchLength = 35
-	if len(branch) > maxBranchLength {
-		branch = branch[:maxBranchLength] + "..."
-	}
-
-	return fmt.Sprintf("%s %s", icons.GitBranch, branch)
-}
-
 // getToolInfo returns tool count and token information
 func (isb *InputStatusBar) getToolInfo() string {
 	if isb.toolService == nil || isb.tokenEstimator == nil {
@@ -751,11 +666,8 @@ func (isb *InputStatusBar) Init() tea.Cmd { return nil }
 func (isb *InputStatusBar) View() tea.View { return tea.NewView(isb.Render()) }
 
 func (isb *InputStatusBar) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		isb.SetWidth(msg.Width)
-	case domain.BashCommandCompletedEvent:
-		isb.InvalidateGitBranchCache()
+	if windowMsg, ok := msg.(tea.WindowSizeMsg); ok {
+		isb.SetWidth(windowMsg.Width)
 	}
 	return isb, nil
 }

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -3,16 +3,13 @@ package components
 import (
 	"strings"
 	"testing"
-	"time"
 
 	sdk "github.com/inference-gateway/sdk"
 
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
-	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
-	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
 type stubTokenEstimator struct {
@@ -593,57 +590,6 @@ func TestInputStatusBar_BuildModelDisplayText_WithSessionTokens(t *testing.T) {
 	}
 }
 
-func TestInputStatusBar_BuildGitBranchIndicator(t *testing.T) {
-	tests := []struct {
-		name         string
-		branch       string
-		branchExists bool
-		expectedText string
-		expectEmpty  bool
-	}{
-		{
-			name:         "shows branch name when in git repo",
-			branch:       "main",
-			branchExists: true,
-			expectedText: "⎇ main",
-			expectEmpty:  false,
-		},
-		{
-			name:         "shows feature branch",
-			branch:       "feature/git-indicator",
-			branchExists: true,
-			expectedText: "⎇ feature/git-indicator",
-			expectEmpty:  false,
-		},
-		{
-			name:         "truncates very long branch names",
-			branch:       "feature/this-is-a-very-long-branch-name-that-should-be-truncated",
-			branchExists: true,
-			expectedText: "⎇ feature/this-is-a-very-long-branch-...",
-			expectEmpty:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			statusBar := &InputStatusBar{
-				gitBranchCache:     tt.branch,
-				gitBranchCacheTime: time.Now(),
-				gitBranchCacheTTL:  5 * time.Second,
-			}
-
-			result := statusBar.buildGitBranchIndicator()
-
-			if tt.expectEmpty && result != "" {
-				t.Errorf("Expected empty string but got: %s", result)
-			}
-			if !tt.expectEmpty && result != tt.expectedText {
-				t.Errorf("Expected '%s' but got '%s'", tt.expectedText, result)
-			}
-		})
-	}
-}
-
 func TestInputStatusBar_ShouldShowIndicator_GitBranch(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -726,124 +672,20 @@ func TestInputStatusBar_BuildModelDisplayText_AllEnabled(t *testing.T) {
 	}
 }
 
-// newStatusBarStyleProvider builds a real style provider so buildStatusLines does
-// not short-circuit on a nil provider (the path that renders the branch row).
-func newStatusBarStyleProvider() *styles.Provider {
-	fakeTheme := &uimocks.FakeTheme{}
-	fakeThemeService := &domainmocks.FakeThemeService{}
-	fakeThemeService.GetCurrentThemeReturns(fakeTheme)
-	return styles.NewProvider(fakeThemeService)
-}
-
-// newStatusBarWithBranch builds a status bar with the git branch cache pre-seeded
-// so getCurrentGitBranch returns without shelling out to git.
-func newStatusBarWithBranch(t *testing.T, width int, model, branch string, cfg *config.Config) *InputStatusBar {
-	t.Helper()
-
-	modelService := &domainmocks.FakeModelService{}
-	modelService.GetCurrentModelReturns(model)
-
-	themeService := &domainmocks.FakeThemeService{}
-	themeService.GetCurrentThemeNameReturns("tokyo-night")
-
-	return &InputStatusBar{
-		width:              width,
-		styleProvider:      newStatusBarStyleProvider(),
-		modelService:       modelService,
-		themeService:       themeService,
-		config:             cfg,
-		gitBranchCache:     branch,
-		gitBranchCacheTime: time.Now(),
-		gitBranchCacheTTL:  5 * time.Second,
-	}
-}
-
-func TestInputStatusBar_GitBranchOnSeparateRow(t *testing.T) {
-	statusBar := newStatusBarWithBranch(t, 100, "test-model", "feature/some-branch", config.DefaultConfig())
-
-	lines := statusBar.buildStatusLines()
-
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 rows (indicators + branch), got %d: %#v", len(lines), lines)
-	}
-
-	branchRow := lines[len(lines)-1]
-	if !strings.Contains(branchRow, "feature/some-branch") || !strings.Contains(branchRow, "⎇") {
-		t.Errorf("expected branch on the last row, got %q", branchRow)
-	}
-
-	indicatorRow := lines[0]
-	if strings.Contains(indicatorRow, "feature/some-branch") || strings.Contains(indicatorRow, "⎇") {
-		t.Errorf("expected branch NOT on the indicator row, got %q", indicatorRow)
-	}
-	if !strings.Contains(indicatorRow, "test-model") {
-		t.Errorf("expected model on the indicator row, got %q", indicatorRow)
-	}
-}
-
-func TestInputStatusBar_GitBranchDisabled_NoBranchRow(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.Chat.StatusBar.Indicators.GitBranch = false
-
-	statusBar := newStatusBarWithBranch(t, 100, "test-model", "feature/some-branch", cfg)
-
-	lines := statusBar.buildStatusLines()
-	joined := strings.Join(lines, "\n")
-
-	if strings.Contains(joined, "⎇") || strings.Contains(joined, "feature/some-branch") {
-		t.Errorf("expected no branch row when git_branch disabled, got %q", joined)
-	}
-	if !strings.Contains(joined, "test-model") {
-		t.Errorf("expected indicators to still render, got %q", joined)
-	}
-}
-
-func TestInputStatusBar_GitBranchRendersWithoutModel(t *testing.T) {
-	statusBar := newStatusBarWithBranch(t, 100, "", "feature/no-model", config.DefaultConfig())
-
-	lines := statusBar.buildStatusLines()
-
-	if len(lines) != 1 {
-		t.Fatalf("expected only the branch row when no model is set, got %d rows: %#v", len(lines), lines)
-	}
-	if !strings.Contains(lines[0], "feature/no-model") {
-		t.Errorf("expected branch row, got %q", lines[0])
-	}
-}
-
-func TestInputStatusBar_GitBranchStaysTwoRowsWhenNarrow(t *testing.T) {
-	statusBar := newStatusBarWithBranch(t, 24, "some-very-long-model-name", "feature/branch", config.DefaultConfig())
-
-	lines := statusBar.buildStatusLines()
-
-	if len(lines) != 2 {
-		t.Fatalf("expected the bar to stay at 2 rows when narrow, got %d: %#v", len(lines), lines)
-	}
-	if !strings.Contains(lines[len(lines)-1], "feature/branch") {
-		t.Errorf("expected branch to remain on the last row, got %q", lines[len(lines)-1])
-	}
-}
-
 func TestInputStatusBar_NilStyleProviderFallback(t *testing.T) {
 	modelService := &domainmocks.FakeModelService{}
 	modelService.GetCurrentModelReturns("test-model")
 
 	statusBar := &InputStatusBar{
-		width:              100,
-		styleProvider:      nil,
-		modelService:       modelService,
-		config:             config.DefaultConfig(),
-		gitBranchCache:     "feature/branch",
-		gitBranchCacheTime: time.Now(),
-		gitBranchCacheTTL:  5 * time.Second,
+		width:         100,
+		styleProvider: nil,
+		modelService:  modelService,
+		config:        config.DefaultConfig(),
 	}
 
 	lines := statusBar.buildStatusLines()
 
 	if len(lines) != 1 {
 		t.Fatalf("expected a single fallback row with a nil provider, got %d: %#v", len(lines), lines)
-	}
-	if strings.Contains(lines[0], "⎇") {
-		t.Errorf("expected no branch rendering on the nil-provider fallback, got %q", lines[0])
 	}
 }

--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -2,7 +2,9 @@ package components
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -14,6 +16,7 @@ import (
 	inputsyntax "github.com/inference-gateway/cli/internal/ui/inputsyntax"
 	keys "github.com/inference-gateway/cli/internal/ui/keys"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
+	icons "github.com/inference-gateway/cli/internal/ui/styles/icons"
 )
 
 // InputView handles user input with history
@@ -46,6 +49,9 @@ type InputView struct {
 	focused              bool
 	usageHint            string
 	customHint           string
+	gitBranchCache       string
+	gitBranchCacheTime   time.Time
+	gitBranchCacheTTL    time.Duration
 }
 
 func NewInputView(modelService domain.ModelService) *InputView {
@@ -63,16 +69,17 @@ func NewInputViewWithConfigDir(modelService domain.ModelService, configDir strin
 	}
 
 	return &InputView{
-		text:             "",
-		cursor:           0,
-		placeholder:      "Type your message... (Press Enter to send, alt+enter or ctrl+j for newline, ? for help)",
-		width:            80,
-		height:           5,
-		modelService:     modelService,
-		historyManager:   historyManager,
-		themeService:     nil,
-		imageAttachments: []domain.ImageAttachment{},
-		focused:          true,
+		text:              "",
+		cursor:            0,
+		placeholder:       "Type your message... (Press Enter to send, alt+enter or ctrl+j for newline, ? for help)",
+		width:             80,
+		height:            5,
+		modelService:      modelService,
+		historyManager:    historyManager,
+		themeService:      nil,
+		imageAttachments:  []domain.ImageAttachment{},
+		focused:           true,
+		gitBranchCacheTTL: 5 * time.Second,
 	}
 }
 
@@ -176,9 +183,53 @@ func (iv *InputView) Render() string {
 	inputContent := fmt.Sprintf("> %s", displayText)
 
 	focused := isBashMode || isToolsMode
-	borderedInput := iv.styleProvider.RenderInputField(inputContent, iv.width-4, focused)
+	borderedInput := iv.styleProvider.RenderInputField(inputContent, iv.width-4, focused, iv.buildGitBranchLabel())
 
 	return borderedInput
+}
+
+// buildGitBranchLabel returns the "⎇ <branch>" label embedded in the input box
+// top border, or "" when the git_branch indicator is disabled or there is no
+// branch to show (not a repo / detached HEAD). Truncation to fit the border is
+// handled by the style provider, so no length cap is applied here.
+func (iv *InputView) buildGitBranchLabel() string {
+	if iv.config != nil && !iv.config.Chat.StatusBar.Indicators.GitBranch {
+		return ""
+	}
+
+	branch, ok := iv.getCurrentGitBranch()
+	if !ok || branch == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s %s", icons.GitBranch, branch)
+}
+
+// getCurrentGitBranch returns the current git branch with caching.
+func (iv *InputView) getCurrentGitBranch() (string, bool) {
+	if time.Since(iv.gitBranchCacheTime) < iv.gitBranchCacheTTL && iv.gitBranchCache != "" {
+		return iv.gitBranchCache, true
+	}
+
+	cmd := exec.Command("git", "branch", "--show-current")
+	output, err := cmd.Output()
+
+	iv.gitBranchCacheTime = time.Now()
+
+	if err != nil {
+		iv.gitBranchCache = ""
+		return "", false
+	}
+
+	branch := strings.TrimSpace(string(output))
+	iv.gitBranchCache = branch
+	return branch, branch != ""
+}
+
+// InvalidateGitBranchCache clears the git branch cache to force a refresh.
+func (iv *InputView) InvalidateGitBranchCache() {
+	iv.gitBranchCache = ""
+	iv.gitBranchCacheTime = time.Time{}
 }
 
 func (iv *InputView) renderDisplayText() string {
@@ -451,6 +502,9 @@ func (iv *InputView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case domain.SetInputEvent:
 		iv.SetText(msg.Text)
 		iv.SetCursor(len(msg.Text))
+		return iv, nil
+	case domain.BashCommandCompletedEvent:
+		iv.InvalidateGitBranchCache()
 		return iv, nil
 	}
 	return iv, nil

--- a/internal/ui/components/input_view_test.go
+++ b/internal/ui/components/input_view_test.go
@@ -1,12 +1,15 @@
 package components
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	require "github.com/stretchr/testify/require"
 
 	tea "charm.land/bubbletea/v2"
 
+	config "github.com/inference-gateway/cli/config"
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 
@@ -482,4 +485,80 @@ func TestInputView_HistorySuggestions_TabHandling(t *testing.T) {
 	if iv.historySuggestion == firstSuggestion {
 		t.Error("Expected Tab to cycle to different suggestion")
 	}
+}
+
+// newInputViewWithBranch builds an InputView with the git branch cache pre-seeded
+// so getCurrentGitBranch returns without shelling out to git.
+func newInputViewWithBranch(t *testing.T, branch string) *InputView {
+	t.Helper()
+	iv := createInputViewWithTheme(createMockModelService())
+	iv.gitBranchCache = branch
+	iv.gitBranchCacheTime = time.Now()
+	iv.gitBranchCacheTTL = 5 * time.Second
+	return iv
+}
+
+func TestInputView_BuildGitBranchLabel(t *testing.T) {
+	iv := newInputViewWithBranch(t, "main")
+	require.Equal(t, "⎇ main", iv.buildGitBranchLabel())
+}
+
+func TestInputView_BuildGitBranchLabel_DisabledByConfig(t *testing.T) {
+	iv := newInputViewWithBranch(t, "main")
+	cfg := config.DefaultConfig()
+	cfg.Chat.StatusBar.Indicators.GitBranch = false
+	iv.config = cfg
+
+	require.Empty(t, iv.buildGitBranchLabel())
+}
+
+func TestInputView_RenderEmbedsBranchInTopBorder(t *testing.T) {
+	iv := newInputViewWithBranch(t, "feature/test-branch")
+	iv.SetWidth(80)
+
+	topLine, _, _ := strings.Cut(iv.Render(), "\n")
+
+	require.Contains(t, topLine, "⎇")
+	require.Contains(t, topLine, "feature/test-branch")
+	require.Contains(t, topLine, "╮", "top border should keep its rounded right corner")
+}
+
+func TestInputView_RenderTruncatesLongBranchInBorder(t *testing.T) {
+	iv := newInputViewWithBranch(t, "feature/a-really-long-branch-name-that-keeps-going-and-going")
+	iv.SetWidth(80)
+
+	topLine, _, _ := strings.Cut(iv.Render(), "\n")
+
+	require.Contains(t, topLine, "⎇")
+	require.Contains(t, topLine, "...")
+	require.NotContains(t, topLine, "going-and-going")
+}
+
+func TestInputView_RenderDropsBranchWhenTooNarrow(t *testing.T) {
+	iv := newInputViewWithBranch(t, "main")
+	iv.text = "hi"
+	iv.SetWidth(12)
+
+	topLine, _, _ := strings.Cut(iv.Render(), "\n")
+
+	require.NotContains(t, topLine, "⎇")
+}
+
+func TestInputView_RenderOmitsBranchWhenDisabled(t *testing.T) {
+	iv := newInputViewWithBranch(t, "main")
+	cfg := config.DefaultConfig()
+	cfg.Chat.StatusBar.Indicators.GitBranch = false
+	iv.config = cfg
+	iv.SetWidth(80)
+
+	require.NotContains(t, iv.Render(), "⎇")
+}
+
+func TestInputView_BashCommandCompletedInvalidatesBranchCache(t *testing.T) {
+	iv := newInputViewWithBranch(t, "main")
+	require.NotEmpty(t, iv.gitBranchCache)
+
+	_, _ = iv.Update(domain.BashCommandCompletedEvent{})
+
+	require.Empty(t, iv.gitBranchCache)
 }

--- a/internal/ui/styles/provider.go
+++ b/internal/ui/styles/provider.go
@@ -3,8 +3,9 @@ package styles
 import (
 	"strings"
 
-	"charm.land/lipgloss/v2"
-	"github.com/inference-gateway/cli/internal/domain"
+	lipgloss "charm.land/lipgloss/v2"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 // Provider centralizes all styling logic and provides complete abstraction from Lipgloss.
@@ -93,8 +94,10 @@ func (p *Provider) RenderListItemWithDescription(title, description string, sele
 
 // Input styles
 
-// RenderInputField renders an input field with border
-func (p *Provider) RenderInputField(content string, width int, focused bool) string {
+// RenderInputField renders an input field with border. When branchLabel is
+// non-empty it is embedded in the top border, right-aligned, as a titled border
+// (e.g. "╭──────── ⎇ main ─╮"); pass "" for a plain border.
+func (p *Provider) RenderInputField(content string, width int, focused bool, branchLabel string) string {
 	theme := p.themeService.GetCurrentTheme()
 
 	borderColor := theme.GetBorderColor()
@@ -108,7 +111,75 @@ func (p *Provider) RenderInputField(content string, width int, focused bool) str
 		Padding(0, 1).
 		Width(width)
 
-	return style.Render(content)
+	rendered := style.Render(content)
+	if branchLabel == "" {
+		return rendered
+	}
+
+	return p.spliceBranchIntoTopBorder(rendered, branchLabel, borderColor, theme.GetDimColor())
+}
+
+// spliceBranchIntoTopBorder rebuilds the top border line of an already-rendered
+// rounded box so label sits near the right corner, styled distinctly from the
+// border. The label is truncated with an ellipsis when the box is narrow and
+// dropped entirely when there is no reasonable room for it. The rebuilt line
+// keeps the original measured width so the sides and bottom border stay aligned.
+func (p *Provider) spliceBranchIntoTopBorder(box, label, borderColor, labelColor string) string {
+	lines := strings.Split(box, "\n")
+	if len(lines) == 0 {
+		return box
+	}
+
+	const (
+		corners       = 2 // ╭ + ╮
+		rightMargin   = 2 // dashes between label and the right corner
+		minLeftDashes = 1
+		minTitleWidth = 8  // below this, render a plain border instead
+		maxTitleWidth = 40 // cap so a long branch never dominates a wide box
+		spaces        = 2  // one space on each side of the label
+		ellipsis      = "..."
+	)
+
+	boxWidth := lipgloss.Width(lines[0])
+	budget := boxWidth - corners - rightMargin - minLeftDashes
+	if budget < minTitleWidth {
+		return box
+	}
+	if budget > maxTitleWidth {
+		budget = maxTitleWidth
+	}
+
+	label = " " + truncateBorderLabel(label, budget-spaces, ellipsis) + " "
+	labelWidth := lipgloss.Width(label)
+	leftDashes := max(boxWidth-corners-rightMargin-labelWidth, minLeftDashes)
+
+	lines[0] = p.RenderWithColor("╭"+strings.Repeat("─", leftDashes), borderColor) +
+		p.RenderWithColor(label, labelColor) +
+		p.RenderWithColor(strings.Repeat("─", rightMargin)+"╮", borderColor)
+
+	return strings.Join(lines, "\n")
+}
+
+// truncateBorderLabel shortens s to at most maxWidth display columns, appending
+// tail when it has to cut. It walks runes so multi-byte names are never split
+// mid-character and wide runes are accounted for.
+func truncateBorderLabel(s string, maxWidth int, tail string) string {
+	if lipgloss.Width(s) <= maxWidth {
+		return s
+	}
+	target := max(maxWidth-lipgloss.Width(tail), 0)
+
+	var out []rune
+	width := 0
+	for _, r := range s {
+		rw := lipgloss.Width(string(r))
+		if width+rw > target {
+			break
+		}
+		out = append(out, r)
+		width += rw
+	}
+	return string(out) + tail
 }
 
 // RenderInputPlaceholder renders placeholder text


### PR DESCRIPTION
Moved the git branch indicator from the status bar to the input box's top border. This frees up space in the status bar and makes the branch visible in the input area. Updated InputView to cache and render the branch label, and removed related code from InputStatusBar.