### PR TITLE
feat: theme collapsed tool result previews

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -439,6 +439,34 @@ func (t *BashTool) FormatPreview(result *domain.ToolExecutionResult) string {
 	return "Command completed"
 }
 
+// FormatResultBody returns the command's primary output for the collapsed preview
+// and the full-on-failure view. Unlike FormatPreview it never truncates, and on a
+// non-zero exit it surfaces the exit code and error so failures are fully visible.
+func (t *BashTool) FormatResultBody(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return ""
+	}
+
+	bashResult, ok := result.Data.(*domain.BashToolResult)
+	if !ok {
+		return ""
+	}
+
+	output := strings.TrimRight(bashResult.Output, "\n")
+	if bashResult.ExitCode == 0 {
+		return output
+	}
+
+	header := fmt.Sprintf("exit %d", bashResult.ExitCode)
+	if bashResult.Error != "" {
+		header += ": " + bashResult.Error
+	}
+	if output == "" {
+		return header
+	}
+	return header + "\n" + output
+}
+
 // FormatForUI formats the result for UI display
 func (t *BashTool) FormatForUI(result *domain.ToolExecutionResult) string {
 	if result == nil {

--- a/internal/agent/tools/read.go
+++ b/internal/agent/tools/read.go
@@ -450,6 +450,19 @@ func (t *ReadTool) FormatPreview(result *domain.ToolExecutionResult) string {
 	return fmt.Sprintf("Read %s", fileName)
 }
 
+// FormatResultBody returns the file content for the collapsed preview.
+func (t *ReadTool) FormatResultBody(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return ""
+	}
+
+	readResult, ok := result.Data.(*domain.FileReadToolResult)
+	if !ok {
+		return ""
+	}
+	return strings.TrimRight(readResult.Content, "\n")
+}
+
 // FormatForUI formats the result for UI display
 func (t *ReadTool) FormatForUI(result *domain.ToolExecutionResult) string {
 	if result == nil {

--- a/internal/agent/tools/tree.go
+++ b/internal/agent/tools/tree.go
@@ -552,6 +552,19 @@ func (t *TreeTool) FormatPreview(result *domain.ToolExecutionResult) string {
 	return status
 }
 
+// FormatResultBody returns the rendered directory tree for the collapsed preview.
+func (t *TreeTool) FormatResultBody(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return ""
+	}
+
+	treeResult, ok := result.Data.(*domain.TreeToolResult)
+	if !ok {
+		return ""
+	}
+	return strings.TrimRight(treeResult.Output, "\n")
+}
+
 // FormatForUI formats the result for UI display
 func (t *TreeTool) FormatForUI(result *domain.ToolExecutionResult) string {
 	if result == nil {

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -250,6 +250,7 @@ func NewChatApplication(
 	app.updateHelpBarShortcuts()
 
 	keyHintFormatter := app.keyBindingManager.GetHintFormatter()
+	toolFormatterService.SetHintFormatter(keyHintFormatter)
 	if cv, ok := app.conversationView.(*components.ConversationView); ok {
 		cv.SetKeyHintFormatter(keyHintFormatter)
 	}

--- a/internal/services/tool_formatter.go
+++ b/internal/services/tool_formatter.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
+	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 	icons "github.com/inference-gateway/cli/internal/ui/styles/icons"
@@ -15,6 +15,41 @@ import (
 type ToolFormatterService struct {
 	toolRegistry  ToolRegistry
 	styleProvider *styles.Provider
+	hintFormatter HintProvider
+}
+
+// HintProvider resolves keybinding hints for tool result affordances.
+// It is satisfied by *hints.Formatter.
+type HintProvider interface {
+	GetKeyOnly(actionID string) string
+}
+
+// SetHintFormatter wires the keybinding hint resolver so the collapsed and expanded
+// views can show the "ctrl+o to expand/collapse" affordance. Nil is safe — the hint
+// is simply omitted.
+func (s *ToolFormatterService) SetHintFormatter(h HintProvider) {
+	s.hintFormatter = h
+}
+
+func (s *ToolFormatterService) toggleKey() string {
+	if s.hintFormatter == nil {
+		return ""
+	}
+	return s.hintFormatter.GetKeyOnly(config.ActionID(config.NamespaceTools, "toggle_tool_expansion"))
+}
+
+func (s *ToolFormatterService) expandHint() string {
+	if k := s.toggleKey(); k != "" {
+		return k + " to expand"
+	}
+	return ""
+}
+
+func (s *ToolFormatterService) collapseHint() string {
+	if k := s.toggleKey(); k != "" {
+		return k + " to collapse"
+	}
+	return ""
 }
 
 // ToolRegistry interface for accessing tools (implemented by tools.Registry)
@@ -82,45 +117,46 @@ func (s *ToolFormatterService) joinArgs(args []string) string {
 	return result
 }
 
-// FormatToolResultForUI formats tool execution results for UI display
-// Uses single-line format with colors (consolidated with live preview format)
+// FormatToolResultForUI formats the collapsed (default) tool result: a themed status
+// line followed by an indented dim output preview (first 3 lines on success, the full
+// output on failure) and a "+N lines · ctrl+o to expand" footer.
 func (s *ToolFormatterService) FormatToolResultForUI(result *domain.ToolExecutionResult, terminalWidth int) string {
 	if result == nil {
 		return "Tool execution result unavailable"
 	}
 
-	var statusIcon string
-	var statusText string
-	var iconColor string
-	var statusColor string
+	lines, more := previewLines(s.resultBody(result), result.Success, contentWidth(terminalWidth))
 
-	if result.Success {
-		statusIcon = icons.CheckMark
-		duration := result.Duration
-		statusText = fmt.Sprintf("completed in %s", s.formatDuration(duration))
-		iconColor = "success"
-		statusColor = "dim"
-	} else {
-		statusIcon = icons.CrossMark
-		duration := result.Duration
-		statusText = fmt.Sprintf("failed after %s", s.formatDuration(duration))
-		iconColor = "error"
-		statusColor = "error"
+	out := make([]string, 0, len(lines)+2)
+	out = append(out, s.statusLine(result))
+
+	dim := s.styleProvider.GetThemeColor("dim")
+	for _, ln := range lines {
+		out = append(out, s.styleProvider.RenderWithColor("    "+ln, dim))
 	}
+	if footer := s.collapsedFooter(more); footer != "" {
+		out = append(out, s.styleProvider.RenderWithColor("    "+footer, dim))
+	}
+	return strings.Join(out, "\n")
+}
+
+// statusLine renders the compact "<icon> Name(args) · <duration>" header.
+func (s *ToolFormatterService) statusLine(result *domain.ToolExecutionResult) string {
+	icon := icons.CheckMark
+	iconColor := "success"
+	if !result.Success {
+		icon = icons.CrossMark
+		iconColor = "error"
+	}
+
+	styledIcon := s.styleProvider.RenderWithColor(icon, s.styleProvider.GetThemeColor(iconColor))
+	styledDur := s.styleProvider.RenderWithColor("· "+formatDurationShort(result.Duration), s.styleProvider.GetThemeColor("dim"))
 
 	argsPreview := s.formatArgsPreview(result.Arguments)
-
-	styledIcon := s.styleProvider.RenderWithColor(statusIcon, s.styleProvider.GetThemeColor(iconColor))
-	styledStatus := s.styleProvider.RenderWithColor(statusText, s.styleProvider.GetThemeColor(statusColor))
-
-	var singleLine string
 	if argsPreview != "" && argsPreview != "{}" {
-		singleLine = fmt.Sprintf("%s %s(%s) %s", styledIcon, result.ToolName, argsPreview, styledStatus)
-	} else {
-		singleLine = fmt.Sprintf("%s %s() %s", styledIcon, result.ToolName, styledStatus)
+		return fmt.Sprintf("%s %s(%s) %s", styledIcon, result.ToolName, argsPreview, styledDur)
 	}
-
-	return singleLine
+	return fmt.Sprintf("%s %s() %s", styledIcon, result.ToolName, styledDur)
 }
 
 // formatArgsPreview formats arguments for compact preview display
@@ -154,29 +190,28 @@ func (s *ToolFormatterService) formatArgsPreview(args map[string]any) string {
 	return preview
 }
 
-// formatDuration formats a duration in human-readable way
-func (s *ToolFormatterService) formatDuration(d time.Duration) string {
-	seconds := d.Seconds()
-	if seconds < 60 {
-		return fmt.Sprintf("%.1fs", seconds)
-	}
-	minutes := int(seconds / 60)
-	remainingSeconds := seconds - float64(minutes*60)
-	return fmt.Sprintf("%dm%.1fs", minutes, remainingSeconds)
-}
-
-// FormatToolResultExpanded formats expanded tool execution results
+// FormatToolResultExpanded formats the expanded (ctrl+o) tool result: the tool's
+// existing detail tree, themed for consistency with the rest of the UI (accent+bold
+// tool-call line, dim connectors, accent field labels), with a dim collapse hint.
+// The underlying tree text is unchanged, so tool-specific bodies (diffs, raw output)
+// are preserved exactly.
 func (s *ToolFormatterService) FormatToolResultExpanded(result *domain.ToolExecutionResult, terminalWidth int) string {
 	if result == nil {
 		return "Tool execution result unavailable"
 	}
 
-	tool, err := s.toolRegistry.GetTool(result.ToolName)
-	if err != nil {
-		return s.formatFallback(result, domain.FormatterLLM)
+	var tree string
+	if tool, err := s.toolRegistry.GetTool(result.ToolName); err != nil {
+		tree = s.formatFallback(result, domain.FormatterLLM)
+	} else {
+		tree = tool.FormatResult(result, domain.FormatterLLM)
 	}
 
-	return tool.FormatResult(result, domain.FormatterLLM)
+	themed := s.themeTreeLines(tree)
+	if hint := s.collapseHintLine(result); hint != "" {
+		themed += "\n" + hint
+	}
+	return themed
 }
 
 // FormatToolResultForLLM formats tool execution results for LLM consumption

--- a/internal/services/tool_formatter.go
+++ b/internal/services/tool_formatter.go
@@ -118,7 +118,7 @@ func (s *ToolFormatterService) joinArgs(args []string) string {
 }
 
 // FormatToolResultForUI formats the collapsed (default) tool result: a themed status
-// line followed by an indented dim output preview (first 3 lines on success, the full
+// line followed by an indented dim output preview (first 5 lines on success, the full
 // output on failure) and a "+N lines · ctrl+o to expand" footer.
 func (s *ToolFormatterService) FormatToolResultForUI(result *domain.ToolExecutionResult, terminalWidth int) string {
 	if result == nil {
@@ -209,7 +209,7 @@ func (s *ToolFormatterService) FormatToolResultExpanded(result *domain.ToolExecu
 
 	themed := s.themeTreeLines(tree)
 	if hint := s.collapseHintLine(result); hint != "" {
-		themed += "\n" + hint
+		return themed + "\n" + hint
 	}
 	return themed
 }

--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -1,0 +1,307 @@
+package services
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
+// fakeTool is a configurable domain.Tool (and ResultBodyProvider) for formatter tests.
+type fakeTool struct {
+	name         string
+	preview      string
+	body         string
+	hasBody      bool
+	llm          string
+	alwaysExpand bool
+}
+
+func (t *fakeTool) Definition() sdk.ChatCompletionTool { return sdk.ChatCompletionTool{} }
+func (t *fakeTool) Execute(context.Context, map[string]any) (*domain.ToolExecutionResult, error) {
+	return nil, nil
+}
+func (t *fakeTool) Validate(map[string]any) error { return nil }
+func (t *fakeTool) IsEnabled() bool               { return true }
+func (t *fakeTool) FormatResult(_ *domain.ToolExecutionResult, ft domain.FormatterType) string {
+	if ft == domain.FormatterLLM {
+		return t.llm
+	}
+	return t.preview
+}
+func (t *fakeTool) FormatPreview(*domain.ToolExecutionResult) string { return t.preview }
+func (t *fakeTool) ShouldCollapseArg(string) bool                    { return false }
+func (t *fakeTool) ShouldAlwaysExpand() bool                         { return t.alwaysExpand }
+
+// FormatResultBody satisfies ResultBodyProvider; returns "" when hasBody is false so
+// resultBody falls back to FormatPreview (simulating summary-only tools).
+func (t *fakeTool) FormatResultBody(*domain.ToolExecutionResult) string {
+	if !t.hasBody {
+		return ""
+	}
+	return t.body
+}
+
+type fakeRegistry struct{ tool domain.Tool }
+
+func (r *fakeRegistry) GetTool(string) (domain.Tool, error) { return r.tool, nil }
+func (r *fakeRegistry) ListAvailableTools() []string        { return nil }
+
+type fakeHint struct{}
+
+func (fakeHint) GetKeyOnly(string) string { return "ctrl+o" }
+
+func newTestStyleProvider() *styles.Provider {
+	theme := &uimocks.FakeTheme{}
+	theme.GetAccentColorReturns("#7aa2f7")
+	theme.GetDimColorReturns("#565f89")
+	theme.GetSuccessColorReturns("#9ece6a")
+	theme.GetErrorColorReturns("#f7768e")
+	theme.GetAssistantColorReturns("#a9b1d6")
+	ts := &domainmocks.FakeThemeService{}
+	ts.GetCurrentThemeReturns(theme)
+	return styles.NewProvider(ts)
+}
+
+func newTestService(tool domain.Tool) *ToolFormatterService {
+	svc := NewToolFormatterService(&fakeRegistry{tool: tool}, newTestStyleProvider())
+	svc.SetHintFormatter(fakeHint{})
+	return svc
+}
+
+func bashResult(success bool, args map[string]any) *domain.ToolExecutionResult {
+	return &domain.ToolExecutionResult{
+		ToolName:  "Bash",
+		Success:   success,
+		Duration:  19 * time.Millisecond,
+		Arguments: args,
+	}
+}
+
+func TestFormatToolResultForUI_CollapsedSuccessTruncatesToThree(t *testing.T) {
+	tool := &fakeTool{name: "Bash", hasBody: true, body: "l1\nl2\nl3\nl4\nl5\nl6"}
+	svc := newTestService(tool)
+
+	out := stripANSI(svc.FormatToolResultForUI(bashResult(true, map[string]any{"command": "git branch"}), 80))
+	lines := strings.Split(out, "\n")
+
+	if !strings.Contains(lines[0], "Bash(command=git branch)") || !strings.Contains(lines[0], "19ms") {
+		t.Fatalf("status line missing name/duration: %q", lines[0])
+	}
+	// status + 3 preview lines + footer = 5 lines
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 lines, got %d: %#v", len(lines), lines)
+	}
+	for i, want := range []string{"l1", "l2", "l3"} {
+		if strings.TrimSpace(lines[1+i]) != want {
+			t.Errorf("preview line %d = %q, want %q", i, lines[1+i], want)
+		}
+		if !strings.HasPrefix(lines[1+i], "    ") {
+			t.Errorf("preview line %d not indented: %q", i, lines[1+i])
+		}
+	}
+	footer := lines[4]
+	if !strings.Contains(footer, "+3 lines") || !strings.Contains(footer, "ctrl+o to expand") {
+		t.Errorf("footer = %q, want +3 lines + expand hint", footer)
+	}
+}
+
+func TestFormatToolResultForUI_FailureShowsFullBody(t *testing.T) {
+	tool := &fakeTool{name: "Bash", hasBody: true, body: "e1\ne2\ne3\ne4\ne5"}
+	svc := newTestService(tool)
+
+	out := stripANSI(svc.FormatToolResultForUI(bashResult(false, map[string]any{"command": "boom"}), 80))
+	lines := strings.Split(out, "\n")
+
+	// status + 5 full lines + footer (hint only, no "+N")
+	if len(lines) != 7 {
+		t.Fatalf("expected 7 lines, got %d: %#v", len(lines), lines)
+	}
+	if strings.Contains(out, "+") && strings.Contains(out, "more") {
+		t.Errorf("failure output should not truncate: %q", out)
+	}
+	if strings.Contains(out, "+5") {
+		t.Errorf("failure output should not show a hidden-line count: %q", out)
+	}
+	if !strings.Contains(lines[len(lines)-1], "ctrl+o to expand") {
+		t.Errorf("footer should still show expand hint: %q", lines[len(lines)-1])
+	}
+}
+
+func TestFormatToolResultForUI_SummaryFallsBackToPreview(t *testing.T) {
+	// hasBody=false -> resultBody falls back to FormatPreview (a one-line summary).
+	tool := &fakeTool{name: "Write", preview: "Created main.go (123 bytes)"}
+	svc := newTestService(tool)
+
+	res := &domain.ToolExecutionResult{ToolName: "Write", Success: true, Duration: 5 * time.Millisecond}
+	out := stripANSI(svc.FormatToolResultForUI(res, 80))
+	lines := strings.Split(out, "\n")
+
+	if len(lines) != 3 {
+		t.Fatalf("expected status + 1 preview + footer = 3 lines, got %d: %#v", len(lines), lines)
+	}
+	if strings.TrimSpace(lines[1]) != "Created main.go (123 bytes)" {
+		t.Errorf("preview line = %q", lines[1])
+	}
+}
+
+func TestFormatToolResultForUI_NoBodyOmitsPreview(t *testing.T) {
+	tool := &fakeTool{name: "Bash", hasBody: true, body: ""} // empty body, e.g. silent success
+	svc := newTestService(tool)
+
+	out := stripANSI(svc.FormatToolResultForUI(bashResult(true, nil), 80))
+	lines := strings.Split(out, "\n")
+
+	// status + footer (hint only); no preview lines
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (status + hint), got %d: %#v", len(lines), lines)
+	}
+	if !strings.Contains(lines[1], "ctrl+o to expand") {
+		t.Errorf("expected expand hint, got %q", lines[1])
+	}
+}
+
+func TestFormatToolResultExpanded_ThemingPreservesTree(t *testing.T) {
+	tree := "Bash(command=git branch)\n" +
+		"├─ Duration: 19ms\n" +
+		"├─ Status: ✓ Success\n" +
+		"└─ Result:\n" +
+		"   Exit Code: 0\n" +
+		"   * main"
+	tool := &fakeTool{name: "Bash", llm: tree}
+	svc := newTestService(tool)
+
+	out := stripANSI(svc.FormatToolResultExpanded(bashResult(true, nil), 80))
+
+	want := tree + "\n· ctrl+o to collapse"
+	if out != want {
+		t.Errorf("themed tree changed content.\n got: %q\nwant: %q", out, want)
+	}
+}
+
+func TestFormatToolResultExpanded_AlwaysExpandOmitsHint(t *testing.T) {
+	tool := &fakeTool{name: "Edit", llm: "Edit(file_path=x)\n└─ Result:\n   diff", alwaysExpand: true}
+	svc := newTestService(tool)
+
+	out := stripANSI(svc.FormatToolResultExpanded(&domain.ToolExecutionResult{ToolName: "Edit", Success: true}, 80))
+	if strings.Contains(out, "ctrl+o") {
+		t.Errorf("always-expand tool should not show a collapse hint: %q", out)
+	}
+}
+
+func TestFormatToolResultForLLM_Unchanged(t *testing.T) {
+	tree := "Bash(command=x)\n├─ Duration: 1ms\n└─ Result:\n   ok"
+	tool := &fakeTool{name: "Bash", llm: tree}
+	svc := newTestService(tool)
+
+	res := bashResult(true, nil)
+	if got := svc.FormatToolResultForLLM(res); got != tree {
+		t.Errorf("LLM format must be unchanged.\n got: %q\nwant: %q", got, tree)
+	}
+}
+
+func TestPreviewLines(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		success   bool
+		wantLines int
+		wantMore  int
+	}{
+		{"success truncates", "a\nb\nc\nd\ne", true, 3, 2},
+		{"success short", "a\nb", true, 2, 0},
+		{"success exact", "a\nb\nc", true, 3, 0},
+		{"failure full", "a\nb\nc\nd\ne", false, 5, 0},
+		{"empty", "", true, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines, more := previewLines(tt.body, tt.success, 100)
+			if len(lines) != tt.wantLines || more != tt.wantMore {
+				t.Errorf("previewLines() = %d lines / more %d, want %d / %d", len(lines), more, tt.wantLines, tt.wantMore)
+			}
+		})
+	}
+}
+
+func TestPreviewLinesWidthCapping(t *testing.T) {
+	lines, _ := previewLines(strings.Repeat("x", 500), true, 30)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if got := len([]rune(lines[0])); got > 30 {
+		t.Errorf("line length %d exceeds width 30", got)
+	}
+}
+
+func TestPluralizeLines(t *testing.T) {
+	if pluralizeLines(1) != "+1 line" {
+		t.Errorf("pluralizeLines(1) = %q", pluralizeLines(1))
+	}
+	if pluralizeLines(3) != "+3 lines" {
+		t.Errorf("pluralizeLines(3) = %q", pluralizeLines(3))
+	}
+}
+
+func TestSplitTreePrefix(t *testing.T) {
+	tests := []struct{ in, prefix, rest string }{
+		{"├─ Duration: 19ms", "├─ ", "Duration: 19ms"},
+		{"│  └─ command: git branch", "│  └─ ", "command: git branch"},
+		{"   Exit Code: 0", "   ", "Exit Code: 0"},
+		{"Bash(command=x)", "", "Bash(command=x)"},
+	}
+	for _, tt := range tests {
+		p, r := splitTreePrefix(tt.in)
+		if p != tt.prefix || r != tt.rest {
+			t.Errorf("splitTreePrefix(%q) = (%q,%q), want (%q,%q)", tt.in, p, r, tt.prefix, tt.rest)
+		}
+	}
+}
+
+func TestIsFieldLine(t *testing.T) {
+	if !isFieldLine("├─ ") || !isFieldLine("│  └─ ") {
+		t.Error("branch-glyph prefixes should be field lines")
+	}
+	if isFieldLine("│  ") || isFieldLine("   ") {
+		t.Error("continuation/body prefixes should not be field lines")
+	}
+}
+
+func TestSplitLabel(t *testing.T) {
+	label, value, ok := splitLabel("Duration: 19ms")
+	if !ok || label != "Duration:" || value != " 19ms" {
+		t.Errorf("splitLabel = (%q,%q,%v)", label, value, ok)
+	}
+	if _, _, ok := splitLabel("no colon here"); ok {
+		t.Error("expected no label for line without colon")
+	}
+}
+
+func TestFormatDurationShort(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{19 * time.Millisecond, "19ms"},
+		{1500 * time.Millisecond, "1.5s"},
+		{90 * time.Second, "1m30s"},
+	}
+	for _, tt := range tests {
+		if got := formatDurationShort(tt.d); got != tt.want {
+			t.Errorf("formatDurationShort(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}

--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -91,8 +91,8 @@ func bashResult(success bool, args map[string]any) *domain.ToolExecutionResult {
 	}
 }
 
-func TestFormatToolResultForUI_CollapsedSuccessTruncatesToThree(t *testing.T) {
-	tool := &fakeTool{name: "Bash", hasBody: true, body: "l1\nl2\nl3\nl4\nl5\nl6"}
+func TestFormatToolResultForUI_CollapsedSuccessTruncatesToFive(t *testing.T) {
+	tool := &fakeTool{name: "Bash", hasBody: true, body: "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8"}
 	svc := newTestService(tool)
 
 	out := stripANSI(svc.FormatToolResultForUI(bashResult(true, map[string]any{"command": "git branch"}), 80))
@@ -101,11 +101,10 @@ func TestFormatToolResultForUI_CollapsedSuccessTruncatesToThree(t *testing.T) {
 	if !strings.Contains(lines[0], "Bash(command=git branch)") || !strings.Contains(lines[0], "19ms") {
 		t.Fatalf("status line missing name/duration: %q", lines[0])
 	}
-	// status + 3 preview lines + footer = 5 lines
-	if len(lines) != 5 {
-		t.Fatalf("expected 5 lines, got %d: %#v", len(lines), lines)
+	if len(lines) != 7 {
+		t.Fatalf("expected 7 lines, got %d: %#v", len(lines), lines)
 	}
-	for i, want := range []string{"l1", "l2", "l3"} {
+	for i, want := range []string{"l1", "l2", "l3", "l4", "l5"} {
 		if strings.TrimSpace(lines[1+i]) != want {
 			t.Errorf("preview line %d = %q, want %q", i, lines[1+i], want)
 		}
@@ -113,9 +112,13 @@ func TestFormatToolResultForUI_CollapsedSuccessTruncatesToThree(t *testing.T) {
 			t.Errorf("preview line %d not indented: %q", i, lines[1+i])
 		}
 	}
-	footer := lines[4]
+	footer := lines[6]
 	if !strings.Contains(footer, "+3 lines") || !strings.Contains(footer, "ctrl+o to expand") {
 		t.Errorf("footer = %q, want +3 lines + expand hint", footer)
+	}
+	// the count must sit on the same line as the hint, dot-separated
+	if !strings.Contains(footer, "+3 lines · ") {
+		t.Errorf("footer = %q, want count and hint side-by-side separated by a dot", footer)
 	}
 }
 
@@ -221,10 +224,10 @@ func TestPreviewLines(t *testing.T) {
 		wantLines int
 		wantMore  int
 	}{
-		{"success truncates", "a\nb\nc\nd\ne", true, 3, 2},
+		{"success truncates", "a\nb\nc\nd\ne\nf\ng\nh", true, 5, 3},
 		{"success short", "a\nb", true, 2, 0},
-		{"success exact", "a\nb\nc", true, 3, 0},
-		{"failure full", "a\nb\nc\nd\ne", false, 5, 0},
+		{"success exact", "a\nb\nc\nd\ne", true, 5, 0},
+		{"failure full", "a\nb\nc\nd\ne\nf\ng\nh", false, 8, 0},
 		{"empty", "", true, 0, 0},
 	}
 	for _, tt := range tests {

--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -116,7 +116,6 @@ func TestFormatToolResultForUI_CollapsedSuccessTruncatesToFive(t *testing.T) {
 	if !strings.Contains(footer, "+3 lines") || !strings.Contains(footer, "ctrl+o to expand") {
 		t.Errorf("footer = %q, want +3 lines + expand hint", footer)
 	}
-	// the count must sit on the same line as the hint, dot-separated
 	if !strings.Contains(footer, "+3 lines · ") {
 		t.Errorf("footer = %q, want count and hint side-by-side separated by a dot", footer)
 	}
@@ -129,7 +128,6 @@ func TestFormatToolResultForUI_FailureShowsFullBody(t *testing.T) {
 	out := stripANSI(svc.FormatToolResultForUI(bashResult(false, map[string]any{"command": "boom"}), 80))
 	lines := strings.Split(out, "\n")
 
-	// status + 5 full lines + footer (hint only, no "+N")
 	if len(lines) != 7 {
 		t.Fatalf("expected 7 lines, got %d: %#v", len(lines), lines)
 	}
@@ -145,7 +143,6 @@ func TestFormatToolResultForUI_FailureShowsFullBody(t *testing.T) {
 }
 
 func TestFormatToolResultForUI_SummaryFallsBackToPreview(t *testing.T) {
-	// hasBody=false -> resultBody falls back to FormatPreview (a one-line summary).
 	tool := &fakeTool{name: "Write", preview: "Created main.go (123 bytes)"}
 	svc := newTestService(tool)
 
@@ -168,7 +165,6 @@ func TestFormatToolResultForUI_NoBodyOmitsPreview(t *testing.T) {
 	out := stripANSI(svc.FormatToolResultForUI(bashResult(true, nil), 80))
 	lines := strings.Split(out, "\n")
 
-	// status + footer (hint only); no preview lines
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines (status + hint), got %d: %#v", len(lines), lines)
 	}

--- a/internal/services/tool_result_view.go
+++ b/internal/services/tool_result_view.go
@@ -10,7 +10,7 @@ import (
 )
 
 // previewLineCount is how many output lines the collapsed tool result shows on success.
-const previewLineCount = 3
+const previewLineCount = 5
 
 // ResultBodyProvider is an optional interface a tool may implement to expose its
 // primary output (command stdout, file content, …) for the collapsed preview and

--- a/internal/services/tool_result_view.go
+++ b/internal/services/tool_result_view.go
@@ -1,0 +1,204 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	formatting "github.com/inference-gateway/cli/internal/formatting"
+)
+
+// previewLineCount is how many output lines the collapsed tool result shows on success.
+const previewLineCount = 3
+
+// ResultBodyProvider is an optional interface a tool may implement to expose its
+// primary output (command stdout, file content, …) for the collapsed preview and
+// the full-on-failure view. It is distinct from FormatPreview (a one-line summary)
+// and FormatForLLM (the full tree) and lives in the services package so adding it
+// does not touch the domain.Tool interface or its generated mocks.
+type ResultBodyProvider interface {
+	FormatResultBody(result *domain.ToolExecutionResult) string
+}
+
+// resultBody returns the tool's primary output text used for the collapsed preview.
+// It prefers a ResultBodyProvider (full, untruncated) and falls back to the tool's
+// short FormatPreview summary.
+func (s *ToolFormatterService) resultBody(result *domain.ToolExecutionResult) string {
+	tool, err := s.toolRegistry.GetTool(result.ToolName)
+	if err != nil {
+		return ""
+	}
+	if bp, ok := tool.(ResultBodyProvider); ok {
+		if body := bp.FormatResultBody(result); body != "" {
+			return strings.TrimRight(body, "\n")
+		}
+	}
+	return strings.TrimRight(tool.FormatPreview(result), "\n")
+}
+
+// previewLines splits the body into the lines shown in the collapsed view and how
+// many additional lines were hidden. On success it shows the first previewLineCount
+// lines; on failure it shows the full body (so errors are immediately visible).
+func previewLines(body string, success bool, width int) (lines []string, more int) {
+	body = strings.TrimRight(body, "\n")
+	if body == "" {
+		return nil, 0
+	}
+
+	all := strings.Split(body, "\n")
+	if !success || len(all) <= previewLineCount {
+		return capLines(all, width), 0
+	}
+	return capLines(all[:previewLineCount], width), len(all) - previewLineCount
+}
+
+// capLines truncates each line to the available width.
+func capLines(lines []string, width int) []string {
+	out := make([]string, len(lines))
+	for i, ln := range lines {
+		out[i] = formatting.TruncateText(ln, width)
+	}
+	return out
+}
+
+// contentWidth is the width available for preview content after reserving room for
+// the left indent and a small right buffer.
+func contentWidth(terminalWidth int) int {
+	w := formatting.GetResponsiveWidth(terminalWidth) - 6
+	if w < 20 {
+		return 20
+	}
+	return w
+}
+
+// pluralizeLines formats the hidden-line count ("+1 line" / "+3 lines").
+func pluralizeLines(n int) string {
+	if n == 1 {
+		return "+1 line"
+	}
+	return fmt.Sprintf("+%d lines", n)
+}
+
+// formatDurationShort renders a duration with sub-second granularity (e.g. "19ms",
+// "1.4s", "2m3s"), matching the expanded tree's Duration field.
+func formatDurationShort(d time.Duration) string {
+	switch {
+	case d < time.Microsecond:
+		return fmt.Sprintf("%dns", d.Nanoseconds())
+	case d < time.Millisecond:
+		return fmt.Sprintf("%dµs", d.Microseconds())
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	default:
+		m := int(d.Minutes())
+		sec := int(d.Seconds()) % 60
+		return fmt.Sprintf("%dm%ds", m, sec)
+	}
+}
+
+// collapsedFooter builds the dim footer for the collapsed view, combining the
+// hidden-line count with the expand hint ("+1 line · ctrl+o to expand").
+func (s *ToolFormatterService) collapsedFooter(more int) string {
+	hint := s.expandHint()
+	switch {
+	case more > 0 && hint != "":
+		return pluralizeLines(more) + " · " + hint
+	case more > 0:
+		return pluralizeLines(more)
+	default:
+		return hint
+	}
+}
+
+// collapseHintLine builds the dim "· ctrl+o to collapse" line appended to the
+// expanded tree. It is omitted for always-expanded tools (which cannot collapse).
+func (s *ToolFormatterService) collapseHintLine(result *domain.ToolExecutionResult) string {
+	if s.ShouldAlwaysExpandTool(result.ToolName) {
+		return ""
+	}
+	hint := s.collapseHint()
+	if hint == "" {
+		return ""
+	}
+	return s.styleProvider.RenderWithColor("· "+hint, s.styleProvider.GetThemeColor("dim"))
+}
+
+// themeTreeLines applies A2A-consistent theming to the raw expanded tree string:
+// the tool-call line is accent+bold, tree connectors are dim, field labels are
+// accent, and any tool-emitted content (status colour, diffs, raw output) is left
+// untouched so it renders exactly as before.
+func (s *ToolFormatterService) themeTreeLines(tree string) string {
+	tree = strings.TrimRight(tree, "\n")
+	if tree == "" {
+		return tree
+	}
+	lines := strings.Split(tree, "\n")
+	for i, line := range lines {
+		lines[i] = s.themeTreeLine(line, i == 0)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// themeTreeLine themes a single tree line. See themeTreeLines for the colour rules.
+func (s *ToolFormatterService) themeTreeLine(line string, isFirst bool) string {
+	if isFirst {
+		return s.styleProvider.RenderWithColorAndBold(line, s.styleProvider.GetThemeColor("accent"))
+	}
+
+	prefix, rest := splitTreePrefix(line)
+	if prefix == "" {
+		return line
+	}
+
+	styledPrefix := s.styleProvider.RenderWithColor(prefix, s.styleProvider.GetThemeColor("dim"))
+
+	// Only field lines (those with a branch glyph) get an accent label; body lines
+	// (spaces / "│  " only) keep their content verbatim, so values containing ":"
+	// (URLs, "Exit Code: 0") and embedded diff/status ANSI are never mis-coloured.
+	if isFieldLine(prefix) {
+		if label, value, ok := splitLabel(rest); ok && !containsANSI(label) {
+			return styledPrefix + s.styleProvider.RenderWithColor(label, s.styleProvider.GetThemeColor("accent")) + value
+		}
+	}
+	return styledPrefix + rest
+}
+
+// splitTreePrefix separates the leading run of indent/connector runes from the rest.
+func splitTreePrefix(line string) (prefix, rest string) {
+	runes := []rune(line)
+	i := 0
+	for i < len(runes) && isTreeRune(runes[i]) {
+		i++
+	}
+	return string(runes[:i]), string(runes[i:])
+}
+
+func isTreeRune(r rune) bool {
+	switch r {
+	case ' ', '│', '├', '└', '─':
+		return true
+	}
+	return false
+}
+
+// isFieldLine reports whether the prefix denotes a structured field (├─ / └─),
+// as opposed to a continuation/body line (spaces or "│ " only).
+func isFieldLine(prefix string) bool {
+	return strings.Contains(prefix, "├─") || strings.Contains(prefix, "└─")
+}
+
+// splitLabel splits "Label: value" at the first colon, keeping the colon on the label.
+func splitLabel(s string) (label, value string, ok bool) {
+	idx := strings.IndexByte(s, ':')
+	if idx < 0 {
+		return "", "", false
+	}
+	return s[:idx+1], s[idx+1:], true
+}
+
+func containsANSI(s string) bool {
+	return strings.Contains(s, "\x1b[")
+}

--- a/internal/services/tool_result_view.go
+++ b/internal/services/tool_result_view.go
@@ -155,9 +155,6 @@ func (s *ToolFormatterService) themeTreeLine(line string, isFirst bool) string {
 
 	styledPrefix := s.styleProvider.RenderWithColor(prefix, s.styleProvider.GetThemeColor("dim"))
 
-	// Only field lines (those with a branch glyph) get an accent label; body lines
-	// (spaces / "│  " only) keep their content verbatim, so values containing ":"
-	// (URLs, "Exit Code: 0") and embedded diff/status ANSI are never mis-coloured.
 	if isFieldLine(prefix) {
 		if label, value, ok := splitLabel(rest); ok && !containsANSI(label) {
 			return styledPrefix + s.styleProvider.RenderWithColor(label, s.styleProvider.GetThemeColor("accent")) + value

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -849,16 +849,7 @@ func (cv *ConversationView) formatEntryContent(entry domain.ConversationEntry, i
 
 func (cv *ConversationView) formatExpandedContent(entry domain.ConversationEntry) string {
 	if entry.ToolExecution != nil && cv.toolFormatter != nil {
-		content := cv.toolFormatter.FormatToolResultExpanded(entry.ToolExecution, cv.width)
-
-		var helpText string
-		if cv.toolFormatter.ShouldAlwaysExpandTool(entry.ToolExecution.ToolName) {
-			helpText = ""
-		} else {
-			helpText = "\n• " + cv.getToggleToolHint("collapse all tool calls")
-		}
-
-		return content + helpText
+		return cv.toolFormatter.FormatToolResultExpanded(entry.ToolExecution, cv.width)
 	}
 	contentStr, err := entry.Message.Content.AsMessageContent0()
 	if err != nil {
@@ -870,11 +861,11 @@ func (cv *ConversationView) formatExpandedContent(entry domain.ConversationEntry
 }
 
 func (cv *ConversationView) formatCompactContent(entry domain.ConversationEntry) string {
-	hint := cv.getHintForEntry(entry)
-	if entry.ToolExecution != nil {
-		content := cv.toolFormatter.FormatToolResultForUI(entry.ToolExecution, cv.width)
-		return content + "\n• " + hint
+	// Tool results own their themed status line, preview and expand hint.
+	if entry.ToolExecution != nil && cv.toolFormatter != nil {
+		return cv.toolFormatter.FormatToolResultForUI(entry.ToolExecution, cv.width)
 	}
+	hint := cv.getHintForEntry(entry)
 	contentStr, err := entry.Message.Content.AsMessageContent0()
 	if err != nil {
 		contentStr = formatting.ExtractTextFromContent(entry.Message.Content, entry.Images)

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -2047,59 +2047,54 @@ func (cv *ConversationView) renderIndentedPlanContent(result *strings.Builder, c
 	}
 }
 
-// renderGenericToolArgs renders tool arguments as JSON
-func (cv *ConversationView) renderGenericToolArgs(args map[string]any) string {
-	argsJSON, _ := json.MarshalIndent(args, "  ", "  ")
-	return fmt.Sprintf("  Arguments:\n  %s\n", string(argsJSON))
-}
-
 func (cv *ConversationView) renderPendingToolEntry(entry domain.ConversationEntry) string {
 	if entry.ToolApprovalStatus == domain.ToolApprovalPending {
 		return ""
 	}
 
-	var result strings.Builder
-
-	var color string
-	var role string
-	switch entry.ToolApprovalStatus {
-	case domain.ToolApprovalApproved:
-		color = cv.styleProvider.GetThemeColor("success")
-		role = "Tool (Approved)"
-	case domain.ToolApprovalRejected:
-		color = cv.styleProvider.GetThemeColor("error")
-		role = "Tool (Rejected)"
-	default:
-		color = cv.getAssistantColor()
-		role = "Tool"
-	}
-
-	roleStyled := cv.styleProvider.RenderWithColor(role+":", color)
-	result.WriteString(roleStyled)
-	result.WriteString("\n")
-
-	toolCall := entry.PendingToolCall
-	toolName := toolCall.Function.Name
+	toolName := entry.PendingToolCall.Function.Name
 
 	var args map[string]any
-	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err == nil {
-		fmt.Fprintf(&result, "  Tool: %s\n", toolName)
+	_ = json.Unmarshal([]byte(entry.PendingToolCall.Function.Arguments), &args)
 
-		switch toolName {
-		case "Edit":
-			result.WriteString(cv.renderEditToolArgs(args))
-		case "Write":
-			result.WriteString(cv.renderWriteToolArgs(args))
-		case "RequestPlanApproval":
-			result.WriteString(cv.renderRequestPlanApprovalArgs(args))
-		default:
-			result.WriteString(cv.renderGenericToolArgs(args))
-		}
-	} else {
-		fmt.Fprintf(&result, "  Tool: %s\n", toolName)
+	var result strings.Builder
+	result.WriteString(cv.renderApprovalHeader(toolName, args, entry.ToolApprovalStatus))
+	result.WriteString("\n")
+
+	switch toolName {
+	case "Edit":
+		result.WriteString(cv.renderEditToolArgs(args))
+	case "Write":
+		result.WriteString(cv.renderWriteToolArgs(args))
+	case "RequestPlanApproval":
+		result.WriteString(cv.renderRequestPlanApprovalArgs(args))
 	}
 
 	return result.String() + "\n"
+}
+
+// renderApprovalHeader renders a themed one-line header for an approved/rejected tool
+// call, mirroring the completed result status line: "<icon> Name(args) · <status>".
+func (cv *ConversationView) renderApprovalHeader(toolName string, args map[string]any, status domain.ToolApprovalStatus) string {
+	icon := icons.CheckMark
+	colorName := "success"
+	label := "Approved"
+	if status == domain.ToolApprovalRejected {
+		icon = icons.CrossMark
+		colorName = "error"
+		label = "Rejected"
+	}
+
+	color := cv.styleProvider.GetThemeColor(colorName)
+	styledIcon := cv.styleProvider.RenderWithColor(icon, color)
+	styledLabel := cv.styleProvider.RenderWithColor("· "+label, color)
+
+	call := toolName + "()"
+	if cv.toolFormatter != nil && len(args) > 0 {
+		call = cv.toolFormatter.FormatToolCall(toolName, args)
+	}
+
+	return fmt.Sprintf("%s %s %s", styledIcon, call, styledLabel)
 }
 
 // handleToolCallRendererEvents processes tool call renderer specific events

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -1169,3 +1169,52 @@ func TestConversationView_ConcurrentStreamingAccess(t *testing.T) {
 		t.Errorf("Expected buffer length 0 after flush, got %d", bufLen)
 	}
 }
+
+func approvalEntry(status domain.ToolApprovalStatus) domain.ConversationEntry {
+	return domain.ConversationEntry{
+		PendingToolCall: &sdk.ChatCompletionMessageToolCall{
+			Function: sdk.ChatCompletionMessageToolCallFunction{
+				Name:      "Bash",
+				Arguments: `{"command":"git status"}`,
+			},
+		},
+		ToolApprovalStatus: status,
+	}
+}
+
+func TestRenderPendingToolEntry_ApprovedThemedHeader(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetToolFormatter(&stubToolFormatter{})
+
+	out := cv.renderPendingToolEntry(approvalEntry(domain.ToolApprovalApproved))
+
+	if !strings.Contains(out, "Approved") {
+		t.Errorf("expected Approved label, got %q", out)
+	}
+	if !strings.Contains(out, "Bash") {
+		t.Errorf("expected tool name in header, got %q", out)
+	}
+
+	if strings.Contains(out, "Tool:") || strings.Contains(out, "Arguments:") {
+		t.Errorf("approval header should not contain raw Tool:/Arguments: block, got %q", out)
+	}
+}
+
+func TestRenderPendingToolEntry_RejectedThemedHeader(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetToolFormatter(&stubToolFormatter{})
+
+	out := cv.renderPendingToolEntry(approvalEntry(domain.ToolApprovalRejected))
+	if !strings.Contains(out, "Rejected") {
+		t.Errorf("expected Rejected label, got %q", out)
+	}
+}
+
+func TestRenderPendingToolEntry_PendingRendersNothing(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetToolFormatter(&stubToolFormatter{})
+
+	if out := cv.renderPendingToolEntry(approvalEntry(domain.ToolApprovalPending)); out != "" {
+		t.Errorf("pending approval should render nothing, got %q", out)
+	}
+}

--- a/internal/ui/components/tool_call_renderer.go
+++ b/internal/ui/components/tool_call_renderer.go
@@ -471,13 +471,13 @@ func (r *ToolCallRenderer) renderBashOutput(tool *ToolRenderState, singleLine st
 
 	truncatedLines := tool.TotalOutputLines - len(tool.OutputBuffer)
 	if truncatedLines > 0 {
-		truncationText := fmt.Sprintf("  +%d more lines", truncatedLines)
+		truncationText := fmt.Sprintf("    +%d more lines", truncatedLines)
 		styledTruncation := r.styleProvider.RenderWithColor(truncationText, dimColor)
 		outputLines = append(outputLines, styledTruncation)
 	}
 
 	for _, line := range tool.OutputBuffer {
-		styledLine := r.styleProvider.RenderWithColor("  "+line, dimColor)
+		styledLine := r.styleProvider.RenderWithColor("    "+line, dimColor)
 		outputLines = append(outputLines, styledLine)
 	}
 


### PR DESCRIPTION
Refactors the tool result formatter so collapsed results show a themed status line, a 3-line body preview on success (full body on failure), and a "ctrl+o to expand" affordance. The expanded view gets A2A-consistent theming (accent+bold tool call header, dim tree connectors, accent field labels). Adds `FormatResultBody` to `BashTool`/`ReadTool`/`TreeTool` so the formatter can preview their outputs without re-running the tool, and centralizes the expand hint rendering in the conversation view.