### PR TITLE
fix(pricing): flag Pro-subscription Ollama Cloud models in model picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,15 @@ The CLI includes hardcoded pricing for 30+ models across all major providers
 (Anthropic, OpenAI, Google, DeepSeek, Groq, Mistral, Cohere, etc.).
 Prices are updated regularly to match current provider pricing.
 
+The model picker groups models into three categories you can filter with the
+`[1] All` / `[2] Free` / `[3] Paid` / `[4] Pro` tabs:
+
+- **Free** — no per-token cost (e.g. local Ollama, Gemma).
+- **Paid** — billed per token at the listed `$input/$output per MTok` rate.
+- **Pro** — gated behind a paid **Pro subscription** (some Ollama Cloud models).
+  These have no per-token price but are not free, so they are marked
+  `pro subscription` instead of `free` to avoid the misleading label.
+
 **Override pricing** for specific models or add pricing for custom models:
 
 ```yaml
@@ -739,7 +748,17 @@ pricing:
     "custom-fine-tuned-model":
       input_price_per_mtoken: 5.00
       output_price_per_mtoken: 15.00
+
+    # Mark a model as Pro-subscription only (no per-token cost, but gated)
+    "ollama_cloud/deepseek-v4-pro":
+      input_price_per_mtoken: 0.0
+      output_price_per_mtoken: 0.0
+      requires_pro: true
 ```
+
+> **Note:** A custom entry fully replaces the default for that model. Omitting
+> `requires_pro` in a custom override resets it to `false`, so re-state
+> `requires_pro: true` if you override a model the CLI flags as Pro by default.
 
 **Via environment variables:**
 

--- a/config/pricing.go
+++ b/config/pricing.go
@@ -11,6 +11,11 @@ type PricingConfig struct {
 type CustomPricing struct {
 	InputPricePerMToken  float64 `yaml:"input_price_per_mtoken" mapstructure:"input_price_per_mtoken"`
 	OutputPricePerMToken float64 `yaml:"output_price_per_mtoken" mapstructure:"output_price_per_mtoken"`
+	// RequiresPro marks a model as gated behind a paid Pro subscription
+	// (e.g. some Ollama Cloud models). Such models have no per-token price
+	// but are not freely available. Omitting this in a custom entry resets
+	// it to false, overriding any default flag for that model.
+	RequiresPro bool `yaml:"requires_pro" mapstructure:"requires_pro"`
 }
 
 // ModelPricing represents pricing information for a specific model.
@@ -21,6 +26,9 @@ type ModelPricing struct {
 	InputPricePerMToken  float64
 	OutputPricePerMToken float64
 	Currency             string
+	// RequiresPro marks a model as gated behind a paid Pro subscription
+	// (e.g. some Ollama Cloud models) even though it has no per-token price.
+	RequiresPro bool
 }
 
 // GetDefaultPricingConfig returns the default pricing configuration.
@@ -567,6 +575,7 @@ var DefaultModelPricing = map[string]ModelPricing{
 		InputPricePerMToken:  0.00,
 		OutputPricePerMToken: 0.00,
 		Currency:             "USD",
+		RequiresPro:          true,
 	},
 	"ollama_cloud/deepseek-v4-pro": {
 		Provider:             "ollama_cloud",
@@ -574,6 +583,7 @@ var DefaultModelPricing = map[string]ModelPricing{
 		InputPricePerMToken:  0.00,
 		OutputPricePerMToken: 0.00,
 		Currency:             "USD",
+		RequiresPro:          true,
 	},
 	"ollama_cloud/gemini-3-flash-preview": {
 		Provider:             "ollama_cloud",

--- a/internal/domain/pricing.go
+++ b/internal/domain/pricing.go
@@ -1,5 +1,7 @@
 package domain
 
+import "strings"
+
 // ModelCostStats tracks cost statistics for a specific model within a session.
 // This allows detailed breakdown when multiple models are used in the same conversation.
 type ModelCostStats struct {
@@ -40,9 +42,41 @@ type PricingService interface {
 	// CalculateCost computes the total cost for a given number of input and output tokens.
 	CalculateCost(model string, inputTokens, outputTokens int) (inputCost, outputCost, totalCost float64)
 
+	// RequiresPro reports whether the model is gated behind a paid Pro
+	// subscription (e.g. some Ollama Cloud models). Resolves custom prices
+	// first, then defaults. Returns false when pricing is disabled or the
+	// model has no entry.
+	RequiresPro(model string) bool
+
 	// FormatModelPricing returns a formatted string describing the model's pricing.
 	// Returns empty string if pricing is disabled or the model has no pricing entry.
 	// Returns "free" only when an explicit pricing entry sets both prices to 0.0.
 	// Returns "$X.XX/$Y.YY per MTok" for paid models.
 	FormatModelPricing(model string) string
+}
+
+// FormatModelPricingLabel builds a human-readable pricing/availability label for
+// a model, combining the per-token price with a Pro-subscription marker. A Pro
+// model has no per-token price ($0/$0 → "free"), which would be misleading, so
+// the bare "free" token is replaced by "pro subscription". A model that is
+// both priced and Pro keeps its price and gains the marker. Returns "" when
+// there is nothing to show (pricing disabled, no entry, and not Pro).
+func FormatModelPricingLabel(pricingService PricingService, model string) string {
+	if pricingService == nil {
+		return ""
+	}
+
+	parts := make([]string, 0, 2)
+	pricing := pricingService.FormatModelPricing(model)
+	requiresPro := pricingService.RequiresPro(model)
+
+	// Keep the price token, except suppress a Pro model's misleading "free".
+	if pricing != "" && (!requiresPro || pricing != "free") {
+		parts = append(parts, pricing)
+	}
+	if requiresPro {
+		parts = append(parts, "pro subscription")
+	}
+
+	return strings.Join(parts, ", ")
 }

--- a/internal/services/pricing_service.go
+++ b/internal/services/pricing_service.go
@@ -38,6 +38,27 @@ func (p *PricingServiceImpl) resolvePricing(model string) (input, output float64
 	return 0.0, 0.0, false
 }
 
+// resolveRequiresPro returns whether a model is gated behind a Pro subscription.
+// Custom prices take precedence over defaults, matching resolvePricing.
+func (p *PricingServiceImpl) resolveRequiresPro(model string) bool {
+	if customPrice, exists := p.config.CustomPrices[model]; exists {
+		return customPrice.RequiresPro
+	}
+	if defaultPrice, exists := p.defaultPrices[model]; exists {
+		return defaultPrice.RequiresPro
+	}
+	return false
+}
+
+// RequiresPro reports whether the model is gated behind a paid Pro subscription.
+// Returns false when pricing is disabled or the model has no entry.
+func (p *PricingServiceImpl) RequiresPro(model string) bool {
+	if !p.config.Enabled {
+		return false
+	}
+	return p.resolveRequiresPro(model)
+}
+
 // GetInputPrice retrieves the input price per million tokens for a specific model.
 // Returns 0.0 for unknown models (e.g., Ollama, custom models).
 func (p *PricingServiceImpl) GetInputPrice(model string) float64 {

--- a/internal/services/pricing_service_test.go
+++ b/internal/services/pricing_service_test.go
@@ -3,8 +3,10 @@ package services
 import (
 	"testing"
 
-	"github.com/inference-gateway/cli/config"
-	"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/assert"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 func TestPricingService_FormatModelPricing(t *testing.T) {
@@ -142,6 +144,188 @@ func TestPricingService_IsEnabled(t *testing.T) {
 
 			service := NewPricingService(cfg)
 			result := service.IsEnabled()
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPricingService_RequiresPro(t *testing.T) {
+	tests := []struct {
+		name         string
+		enabled      bool
+		model        string
+		customPrices map[string]config.CustomPricing
+		expected     bool
+	}{
+		{
+			name:     "pricing disabled returns false even for pro default",
+			enabled:  false,
+			model:    "ollama_cloud/deepseek-v4-pro",
+			expected: false,
+		},
+		{
+			name:    "custom entry marked pro returns true",
+			enabled: true,
+			model:   "custom-model",
+			customPrices: map[string]config.CustomPricing{
+				"custom-model": {RequiresPro: true},
+			},
+			expected: true,
+		},
+		{
+			name:    "custom entry overrides default pro to false",
+			enabled: true,
+			model:   "ollama_cloud/deepseek-v4-pro",
+			customPrices: map[string]config.CustomPricing{
+				"ollama_cloud/deepseek-v4-pro": {
+					InputPricePerMToken:  0.0,
+					OutputPricePerMToken: 0.0,
+					RequiresPro:          false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "default pro model returns true",
+			enabled:  true,
+			model:    "ollama_cloud/deepseek-v4-pro",
+			expected: true,
+		},
+		{
+			name:     "default flash pro model returns true",
+			enabled:  true,
+			model:    "ollama_cloud/deepseek-v4-flash",
+			expected: true,
+		},
+		{
+			name:     "default free ollama cloud model returns false",
+			enabled:  true,
+			model:    "ollama_cloud/kimi-k2.5",
+			expected: false,
+		},
+		{
+			name:     "unknown model returns false",
+			enabled:  true,
+			model:    "unknown-model",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.PricingConfig{
+				Enabled:      tt.enabled,
+				CustomPrices: tt.customPrices,
+			}
+
+			service := NewPricingService(cfg)
+			result := service.RequiresPro(tt.model)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestPricingService_OllamaCloudProDefaults guards the curated set of Ollama
+// Cloud models that are gated behind a Pro subscription. Only the two named in
+// issue #590 should be flagged; the rest of the ollama_cloud catalog is free.
+func TestPricingService_OllamaCloudProDefaults(t *testing.T) {
+	proModels := []string{
+		"ollama_cloud/deepseek-v4-pro",
+		"ollama_cloud/deepseek-v4-flash",
+	}
+	for _, model := range proModels {
+		t.Run("pro/"+model, func(t *testing.T) {
+			entry, ok := config.DefaultModelPricing[model]
+			assert.True(t, ok, "expected default pricing entry for %s", model)
+			assert.True(t, entry.RequiresPro, "expected %s to require Pro", model)
+		})
+	}
+
+	freeModels := []string{
+		"ollama_cloud/kimi-k2.5",
+		"ollama_cloud/qwen3-coder:480b",
+		"ollama_cloud/gpt-oss:120b",
+		"ollama_cloud/glm-5.1",
+		"ollama_cloud/deepseek-v3.2",
+	}
+	for _, model := range freeModels {
+		t.Run("free/"+model, func(t *testing.T) {
+			entry, ok := config.DefaultModelPricing[model]
+			assert.True(t, ok, "expected default pricing entry for %s", model)
+			assert.False(t, entry.RequiresPro, "expected %s to be free, not Pro", model)
+		})
+	}
+}
+
+// TestFormatModelPricingLabel exercises the shared label helper that the model
+// view and autocomplete both use: it must suppress the misleading "free" token
+// for Pro models and keep the price for paid+Pro models.
+func TestFormatModelPricingLabel(t *testing.T) {
+	tests := []struct {
+		name         string
+		enabled      bool
+		model        string
+		customPrices map[string]config.CustomPricing
+		expected     string
+	}{
+		{
+			name:     "default pro model shows pro marker, free suppressed",
+			enabled:  true,
+			model:    "ollama_cloud/deepseek-v4-pro",
+			expected: "pro subscription",
+		},
+		{
+			name:    "free non-pro model shows free",
+			enabled: true,
+			model:   "free-model",
+			customPrices: map[string]config.CustomPricing{
+				"free-model": {InputPricePerMToken: 0.0, OutputPricePerMToken: 0.0},
+			},
+			expected: "free",
+		},
+		{
+			name:    "paid model shows price",
+			enabled: true,
+			model:   "paid-model",
+			customPrices: map[string]config.CustomPricing{
+				"paid-model": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0},
+			},
+			expected: "$3.00/$15.00 per MTok",
+		},
+		{
+			name:    "paid and pro model shows both",
+			enabled: true,
+			model:   "paid-pro-model",
+			customPrices: map[string]config.CustomPricing{
+				"paid-pro-model": {InputPricePerMToken: 3.0, OutputPricePerMToken: 15.0, RequiresPro: true},
+			},
+			expected: "$3.00/$15.00 per MTok, pro subscription",
+		},
+		{
+			name:     "unknown model shows nothing",
+			enabled:  true,
+			model:    "unknown-model",
+			expected: "",
+		},
+		{
+			name:     "pricing disabled shows nothing",
+			enabled:  false,
+			model:    "ollama_cloud/deepseek-v4-pro",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.PricingConfig{
+				Enabled:      tt.enabled,
+				CustomPrices: tt.customPrices,
+			}
+
+			service := NewPricingService(cfg)
+			result := domain.FormatModelPricingLabel(service, tt.model)
 
 			assert.Equal(t, tt.expected, result)
 		})

--- a/internal/ui/autocomplete/autocomplete.go
+++ b/internal/ui/autocomplete/autocomplete.go
@@ -144,7 +144,7 @@ func (a *AutocompleteImpl) loadModels() {
 	for _, model := range models {
 		description := ""
 		if a.pricingService != nil {
-			description = a.pricingService.FormatModelPricing(model)
+			description = domain.FormatModelPricingLabel(a.pricingService, model)
 		}
 		a.suggestions = append(a.suggestions, ShortcutOption{
 			Shortcut:    model,

--- a/internal/ui/components/model_selection_view.go
+++ b/internal/ui/components/model_selection_view.go
@@ -18,7 +18,8 @@ type ModelViewMode int
 const (
 	ModelViewAll ModelViewMode = iota
 	ModelViewFree
-	ModelViewProprietary
+	ModelViewPaid
+	ModelViewPro
 )
 
 // ModelSelectorImpl implements model selection UI
@@ -97,7 +98,7 @@ func (m *ModelSelectorImpl) handleKeyInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		return m.handleCharacterInput(msg)
 	case "backspace":
 		return m.handleBackspace()
-	case "1", "2", "3":
+	case "1", "2", "3", "4":
 		m.handleViewSwitch(msg.String())
 		return m, nil
 	default:
@@ -171,7 +172,9 @@ func (m *ModelSelectorImpl) handleViewSwitch(key string) {
 	case "2":
 		m.currentView = ModelViewFree
 	case "3":
-		m.currentView = ModelViewProprietary
+		m.currentView = ModelViewPaid
+	case "4":
+		m.currentView = ModelViewPro
 	}
 	m.selected = 0
 	m.applyFilters()
@@ -260,7 +263,7 @@ func (m *ModelSelectorImpl) viewContent() string {
 	if m.searchMode {
 		b.WriteString(m.styleProvider.RenderDimText("Type to search, ↑↓ to navigate, Enter to select, Esc to clear search"))
 	} else {
-		b.WriteString(m.styleProvider.RenderDimText("Use ↑↓ arrows to navigate, Enter to select, / to search, 1-3 to filter, Esc/Ctrl+C to cancel"))
+		b.WriteString(m.styleProvider.RenderDimText("Use ↑↓ arrows to navigate, Enter to select, / to search, 1-4 to filter, Esc/Ctrl+C to cancel"))
 	}
 
 	return b.String()
@@ -279,10 +282,8 @@ func (m *ModelSelectorImpl) formatModelSuffix(model string) string {
 		parts = append(parts, "?")
 	}
 
-	if m.pricingService != nil {
-		if pricing := m.pricingService.FormatModelPricing(model); pricing != "" {
-			parts = append(parts, pricing)
-		}
+	if label := domain.FormatModelPricingLabel(m.pricingService, model); label != "" {
+		parts = append(parts, label)
 	}
 
 	return fmt.Sprintf("(%s)", strings.Join(parts, ", "))
@@ -320,10 +321,17 @@ func (m *ModelSelectorImpl) applyFilters() {
 				baseModels = append(baseModels, model)
 			}
 		}
-	case ModelViewProprietary:
+	case ModelViewPaid:
 		baseModels = make([]string, 0)
 		for _, model := range m.models {
-			if !m.isModelFree(model) {
+			if !m.isModelFree(model) && !m.isModelPro(model) {
+				baseModels = append(baseModels, model)
+			}
+		}
+	case ModelViewPro:
+		baseModels = make([]string, 0)
+		for _, model := range m.models {
+			if m.isModelPro(model) {
 				baseModels = append(baseModels, model)
 			}
 		}
@@ -344,10 +352,15 @@ func (m *ModelSelectorImpl) applyFilters() {
 	}
 }
 
-// isModelFree checks if a model is free (both input and output prices are 0.0)
-// Returns false if pricing is disabled or not configured
+// isModelFree checks if a model is free (both input and output prices are 0.0).
+// Pro-subscription models are also $0/$0 but are not free, so they are excluded.
+// Returns false if pricing is disabled or not configured.
 func (m *ModelSelectorImpl) isModelFree(model string) bool {
 	if m.pricingService == nil || !m.pricingService.IsEnabled() {
+		return false
+	}
+
+	if m.isModelPro(model) {
 		return false
 	}
 
@@ -355,6 +368,16 @@ func (m *ModelSelectorImpl) isModelFree(model string) bool {
 	outputPrice := m.pricingService.GetOutputPrice(model)
 
 	return inputPrice == 0.0 && outputPrice == 0.0
+}
+
+// isModelPro reports whether a model is gated behind a paid Pro subscription.
+// Returns false if pricing is disabled or not configured.
+func (m *ModelSelectorImpl) isModelPro(model string) bool {
+	if m.pricingService == nil || !m.pricingService.IsEnabled() {
+		return false
+	}
+
+	return m.pricingService.RequiresPro(model)
 }
 
 // IsSelected returns true if a model was selected
@@ -391,18 +414,21 @@ func (m *ModelSelectorImpl) writeViewTabs(b *strings.Builder) {
 
 	allStyle := "[1] All"
 	freeStyle := "[2] Free"
-	proprietaryStyle := "[3] Proprietary"
+	paidStyle := "[3] Paid"
+	proStyle := "[4] Pro"
 
 	switch m.currentView {
 	case ModelViewAll:
 		allStyle = m.styleProvider.RenderWithColor("[1] All", accentColor)
 	case ModelViewFree:
 		freeStyle = m.styleProvider.RenderWithColor("[2] Free", accentColor)
-	case ModelViewProprietary:
-		proprietaryStyle = m.styleProvider.RenderWithColor("[3] Proprietary", accentColor)
+	case ModelViewPaid:
+		paidStyle = m.styleProvider.RenderWithColor("[3] Paid", accentColor)
+	case ModelViewPro:
+		proStyle = m.styleProvider.RenderWithColor("[4] Pro", accentColor)
 	}
 
-	tabs := fmt.Sprintf("%s  %s  %s", allStyle, freeStyle, proprietaryStyle)
+	tabs := fmt.Sprintf("%s  %s  %s  %s", allStyle, freeStyle, paidStyle, proStyle)
 	dimTabs := m.styleProvider.RenderDimText(tabs)
 	fmt.Fprintf(b, "%s\n", dimTabs)
 

--- a/internal/ui/components/model_selection_view_test.go
+++ b/internal/ui/components/model_selection_view_test.go
@@ -1,0 +1,84 @@
+package components
+
+import (
+	"testing"
+
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+// newFilterTestSelector builds a selector backed by a fake pricing service with
+// three representative models: a per-token paid model, a genuinely free model,
+// and a Pro-subscription model ($0/$0 but gated).
+func newFilterTestSelector(models []string) *ModelSelectorImpl {
+	pricing := &domainmocks.FakePricingService{}
+	pricing.IsEnabledReturns(true)
+	pricing.GetInputPriceStub = func(model string) float64 {
+		if model == "paid-model" {
+			return 3.0
+		}
+		return 0.0
+	}
+	pricing.GetOutputPriceStub = func(model string) float64 {
+		if model == "paid-model" {
+			return 15.0
+		}
+		return 0.0
+	}
+	pricing.RequiresProStub = func(model string) bool {
+		return model == "pro-model"
+	}
+	pricing.FormatModelPricingStub = func(model string) string {
+		switch model {
+		case "paid-model":
+			return "$3.00/$15.00 per MTok"
+		case "free-model", "pro-model":
+			return "free"
+		default:
+			return ""
+		}
+	}
+	return NewModelSelector(models, nil, pricing, nil, nil)
+}
+
+func filteredFor(view ModelViewMode, models []string) []string {
+	m := newFilterTestSelector(models)
+	m.currentView = view
+	m.applyFilters()
+	return m.filteredModels
+}
+
+// TestModelSelector_FilterBuckets verifies the four filter views are disjoint
+// and exhaustive: free / paid / pro are mutually exclusive and All is the union.
+func TestModelSelector_FilterBuckets(t *testing.T) {
+	models := []string{"paid-model", "free-model", "pro-model"}
+
+	assert.ElementsMatch(t, models, filteredFor(ModelViewAll, models))
+	assert.ElementsMatch(t, []string{"free-model"}, filteredFor(ModelViewFree, models))
+	assert.ElementsMatch(t, []string{"paid-model"}, filteredFor(ModelViewPaid, models))
+	assert.ElementsMatch(t, []string{"pro-model"}, filteredFor(ModelViewPro, models))
+}
+
+// TestModelSelector_ProModelExcludedFromFree is the core bug fix for issue #590:
+// a Pro model is $0/$0 but must never be shown under the Free tab.
+func TestModelSelector_ProModelExcludedFromFree(t *testing.T) {
+	models := []string{"pro-model"}
+
+	assert.NotContains(t, filteredFor(ModelViewFree, models), "pro-model")
+	assert.Contains(t, filteredFor(ModelViewPro, models), "pro-model")
+}
+
+// TestModelSelector_FormatModelSuffixPro checks the per-row marker: a Pro model
+// shows "pro subscription" and suppresses the misleading "free" token, while a
+// genuinely free model still shows "free".
+func TestModelSelector_FormatModelSuffixPro(t *testing.T) {
+	m := newFilterTestSelector([]string{"pro-model", "free-model"})
+
+	proSuffix := m.formatModelSuffix("pro-model")
+	assert.Contains(t, proSuffix, "pro subscription")
+	assert.NotContains(t, proSuffix, "free")
+
+	freeSuffix := m.formatModelSuffix("free-model")
+	assert.Contains(t, freeSuffix, "free")
+	assert.NotContains(t, freeSuffix, "pro subscription")
+}

--- a/tests/mocks/domain/fake_pricing_service.go
+++ b/tests/mocks/domain/fake_pricing_service.go
@@ -68,6 +68,17 @@ type FakePricingService struct {
 	isEnabledReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	RequiresProStub        func(string) bool
+	requiresProMutex       sync.RWMutex
+	requiresProArgsForCall []struct {
+		arg1 string
+	}
+	requiresProReturns struct {
+		result1 bool
+	}
+	requiresProReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -373,6 +384,67 @@ func (fake *FakePricingService) IsEnabledReturnsOnCall(i int, result1 bool) {
 		})
 	}
 	fake.isEnabledReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakePricingService) RequiresPro(arg1 string) bool {
+	fake.requiresProMutex.Lock()
+	ret, specificReturn := fake.requiresProReturnsOnCall[len(fake.requiresProArgsForCall)]
+	fake.requiresProArgsForCall = append(fake.requiresProArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.RequiresProStub
+	fakeReturns := fake.requiresProReturns
+	fake.recordInvocation("RequiresPro", []interface{}{arg1})
+	fake.requiresProMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePricingService) RequiresProCallCount() int {
+	fake.requiresProMutex.RLock()
+	defer fake.requiresProMutex.RUnlock()
+	return len(fake.requiresProArgsForCall)
+}
+
+func (fake *FakePricingService) RequiresProCalls(stub func(string) bool) {
+	fake.requiresProMutex.Lock()
+	defer fake.requiresProMutex.Unlock()
+	fake.RequiresProStub = stub
+}
+
+func (fake *FakePricingService) RequiresProArgsForCall(i int) string {
+	fake.requiresProMutex.RLock()
+	defer fake.requiresProMutex.RUnlock()
+	argsForCall := fake.requiresProArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakePricingService) RequiresProReturns(result1 bool) {
+	fake.requiresProMutex.Lock()
+	defer fake.requiresProMutex.Unlock()
+	fake.RequiresProStub = nil
+	fake.requiresProReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakePricingService) RequiresProReturnsOnCall(i int, result1 bool) {
+	fake.requiresProMutex.Lock()
+	defer fake.requiresProMutex.Unlock()
+	fake.RequiresProStub = nil
+	if fake.requiresProReturnsOnCall == nil {
+		fake.requiresProReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.requiresProReturnsOnCall[i] = struct {
 		result1 bool
 	}{result1}
 }


### PR DESCRIPTION
## Summary

Closes #590.

Ollama Cloud models that require a paid **Pro subscription** were all labelled **free** in the model picker, because the label was derived purely from per-token price (`$0/$0`). Starting a chat with one then failed with an API error ("only available for pro users"). The pricing display was misleading.

This adds an explicit, config-overridable **Pro** axis (orthogonal to price) and surfaces three distinct categories in the picker.

## Changes

- **`config/pricing.go`** — `RequiresPro bool` on `ModelPricing` + `CustomPricing`; flag `ollama_cloud/deepseek-v4-pro` and `-flash` by default.
- **`internal/domain/pricing.go`** — `RequiresPro(model)` on the `PricingService` interface + shared `FormatModelPricingLabel` helper (composes the marker, suppresses the misleading "free").
- **`internal/services/pricing_service.go`** — `resolveRequiresPro` (custom→default precedence) + `RequiresPro` impl; `FormatModelPricing` stays price-only.
- **`internal/ui/components/model_selection_view.go`** — filter tabs `[1] All  [2] Free  [3] Paid  [4] Pro` (renamed `Proprietary`→`Paid`), key `4`, `isModelPro`, Free now excludes Pro, disjoint filter buckets, `pro subscription` row marker.
- **`internal/ui/autocomplete/autocomplete.go`** — `/model` suggestions show `pro subscription`.
- **Tests** — `pricing_service_test.go` (RequiresPro + default-data guard + label helper); new `model_selection_view_test.go` (filter buckets + suffix + the bug-fix assertion).
- **`tests/mocks/domain/fake_pricing_service.go`** — regenerated via `task mocks:generate`.
- **`README.md`** — documents the three categories and the `requires_pro` override caveat.

### Picker now renders

```
ollama_cloud/deepseek-v4-pro   (1M, pro subscription)
ollama_cloud/deepseek-v4-flash (1M, pro subscription)
ollama_cloud/deepseek-v3.2     (128K, free)
deepseek/deepseek-v4-pro       (1M, $1.74/$3.48 per MTok)
```

## Notes

- **Why hardcoded + overridable:** Ollama publishes no stable per-model tier badge (Pro = "access to larger, more powerful models" + higher limits), so the gated set is maintainer-curated data, modelled exactly like the existing pricing. Expanding it later is just flipping `RequiresPro: true` in defaults or via `custom_prices`.
- **Cross-repo impact:** none — CLI-only (no `openapi.yaml`/SDK/operator changes).
- A `[DOCS]` follow-up will be filed against `inference-gateway/docs` for the `requires_pro` config field and the model-view categories.

## Verification

`task fmt` ✓ · `task test` (full suite) ✓ · `task lint` (0 issues) ✓ · `task build` ✓