### PR TITLE
fix(tools): make bash whitelist shell-aware to fix benign-command rejections (#581)

### DIFF
--- a/config/bash_whitelist.go
+++ b/config/bash_whitelist.go
@@ -1,0 +1,270 @@
+package config
+
+import (
+	"regexp"
+	"strings"
+)
+
+// benignTrailingRedirectRe matches a single trailing shell redirection that only
+// discards or merges output streams — it never writes to or reads from the
+// filesystem. Covered forms: output to /dev/null (>, >>, with an optional fd or
+// the &> "both streams" prefix) and file-descriptor duplications such as 2>&1 or
+// 2>&-. These are stripped before whitelist matching so that benign,
+// reliability-motivated suffixes (which some models append by habit) neither
+// break end-anchored patterns nor act as a policy escape hatch. A redirection to
+// a real file is intentionally NOT matched, so it stays in the command.
+var benignTrailingRedirectRe = regexp.MustCompile(
+	`\s*(?:&>>?\s*/dev/null|[0-9]*>>?\s*/dev/null|[0-9]*>&(?:[0-9]+|-))\s*$`,
+)
+
+// IsBashCommandWhitelisted reports whether command is permitted by the bash
+// whitelist. It understands just enough shell structure to keep the policy
+// coherent rather than relying on naive prefix matching:
+//
+//   - Command substitution — $(...), `...`, and process substitution <(...) /
+//     >(...) — is rejected outright, because it can smuggle an arbitrary command
+//     past an otherwise-whitelisted wrapper (e.g. echo $(rm -rf /)).
+//   - Compound commands (&&, ||, |, |&, ;, &, and newlines) are split at the top
+//     level, honoring quotes, and EVERY segment must be independently
+//     whitelisted. This both enables benign chains (gh issue view 5 && gh issue
+//     comment 5 ...) and closes the prefix-match hole where a whitelisted head
+//     command would carry an arbitrary tail.
+//   - Benign trailing redirections (2>&1, 2>/dev/null, …) are stripped per
+//     segment before matching.
+//
+// It is the single source of truth consulted by the Bash tool, the approval
+// policy, and agent auto-approval, so all three agree on exactly what runs
+// without prompting.
+func (c *Config) IsBashCommandWhitelisted(command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+
+	if containsCommandSubstitution(command) {
+		return false
+	}
+
+	segments, ok := splitBashSegments(command)
+	if !ok {
+		return false
+	}
+
+	for _, seg := range segments {
+		seg = stripBenignTrailingRedirections(strings.TrimSpace(seg))
+		if seg == "" {
+			return false
+		}
+		if !c.isSingleBashCommandAllowed(seg) {
+			return false
+		}
+	}
+	return true
+}
+
+// dangerousFindActionRe matches find(1) primaries that execute a command or
+// mutate the filesystem (-exec, -delete, …). A bare "find" is whitelisted for
+// read-only discovery, but these actions turn it into an arbitrary-command /
+// delete vector, so a find invocation carrying one is not whitelisted (it falls
+// through to approval) — the same stance taken on command substitution.
+var dangerousFindActionRe = regexp.MustCompile(
+	`(^|\s)-(execdir|exec|okdir|ok|delete|fprintf|fprint0|fprint|fls)(\s|$)`,
+)
+
+// isSingleBashCommandAllowed matches one already-split, redirection-free command
+// against the configured command and pattern whitelists.
+func (c *Config) isSingleBashCommandAllowed(command string) bool {
+	if (command == "find" || strings.HasPrefix(command, "find ")) &&
+		dangerousFindActionRe.MatchString(command) {
+		return false
+	}
+
+	for _, allowed := range c.Tools.Bash.Whitelist.Commands {
+		if command == allowed || strings.HasPrefix(command, allowed+" ") {
+			return true
+		}
+	}
+
+	for _, pattern := range c.Tools.Bash.Whitelist.Patterns {
+		matched, err := regexp.MatchString(pattern, command)
+		if err == nil && matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// stripBenignTrailingRedirections removes any run of trailing benign
+// redirections (see benignTrailingRedirectRe) from command, e.g. turning
+// "gh api repos/o/r > /dev/null 2>&1" into "gh api repos/o/r".
+func stripBenignTrailingRedirections(command string) string {
+	for {
+		loc := benignTrailingRedirectRe.FindStringIndex(command)
+		if loc == nil {
+			break
+		}
+		command = command[:loc[0]]
+	}
+	return strings.TrimSpace(command)
+}
+
+// containsCommandSubstitution reports whether command contains a shell construct
+// that executes a nested command: $(...), backticks, or process substitution
+// <(...) / >(...). Single-quoted spans are literal in bash, so constructs inside
+// them are ignored. $(...) and backticks are still active inside double quotes,
+// so those are flagged there; process substitution does not occur inside double
+// quotes, so <(/>( are flagged only when fully unquoted.
+func containsCommandSubstitution(command string) bool {
+	var inSingle, inDouble bool
+	runes := []rune(command)
+
+	for i := 0; i < len(runes); i++ {
+		ch := runes[i]
+		switch {
+		case inSingle:
+			if ch == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			switch ch {
+			case '\\':
+				i++ // backslash escapes the next char inside double quotes
+			case '"':
+				inDouble = false
+			case '`':
+				return true
+			case '$':
+				if i+1 < len(runes) && runes[i+1] == '(' {
+					return true
+				}
+			}
+		default:
+			switch ch {
+			case '\\':
+				i++
+			case '\'':
+				inSingle = true
+			case '"':
+				inDouble = true
+			case '`':
+				return true
+			case '$':
+				if i+1 < len(runes) && runes[i+1] == '(' {
+					return true
+				}
+			case '<', '>':
+				if i+1 < len(runes) && runes[i+1] == '(' {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// splitBashSegments splits command at top-level shell control operators (&&, ||,
+// |, |&, ;, &, and newlines), honoring single quotes, double quotes, and
+// backslash escapes. Redirection operators (>, <, >&, &>) are deliberately NOT
+// split points and remain part of their segment. ok is false when quoting is
+// unbalanced, which the caller treats as not-whitelisted.
+func splitBashSegments(command string) (segments []string, ok bool) {
+	var cur strings.Builder
+	var inSingle, inDouble bool
+	runes := []rune(command)
+
+	flush := func() {
+		segments = append(segments, cur.String())
+		cur.Reset()
+	}
+
+	for i := 0; i < len(runes); i++ {
+		ch := runes[i]
+
+		if inSingle {
+			cur.WriteRune(ch)
+			if ch == '\'' {
+				inSingle = false
+			}
+			continue
+		}
+		if inDouble {
+			if ch == '\\' && i+1 < len(runes) {
+				cur.WriteRune(ch)
+				i++
+				cur.WriteRune(runes[i])
+				continue
+			}
+			cur.WriteRune(ch)
+			if ch == '"' {
+				inDouble = false
+			}
+			continue
+		}
+
+		switch ch {
+		case '\\':
+			cur.WriteRune(ch)
+			if i+1 < len(runes) {
+				i++
+				cur.WriteRune(runes[i])
+			}
+		case '\'':
+			inSingle = true
+			cur.WriteRune(ch)
+		case '"':
+			inDouble = true
+			cur.WriteRune(ch)
+		case ';', '\n', '\r':
+			flush()
+		case '&':
+			i += consumeAmpersand(runes, i, &cur, flush)
+		case '|':
+			// "||" and "|&" are two-char control operators; "|" is a pipe. All split.
+			if i+1 < len(runes) && (runes[i+1] == '|' || runes[i+1] == '&') {
+				i++
+			}
+			flush()
+		default:
+			cur.WriteRune(ch)
+		}
+	}
+
+	if inSingle || inDouble {
+		return nil, false
+	}
+	flush()
+	return segments, true
+}
+
+// consumeAmpersand classifies an unquoted '&' encountered at index i and returns
+// how many extra runes to advance past (i is the '&' itself):
+//
+//   - "&&" → control operator: split, skip the second '&'.
+//   - "&>" → redirection of both streams: keep the '&' in the current segment.
+//   - the '&' completing a ">&" fd-duplication (e.g. the one in 2>&1): keep it.
+//   - a lone trailing/standalone '&' → background operator: split.
+func consumeAmpersand(runes []rune, i int, cur *strings.Builder, flush func()) int {
+	if i+1 < len(runes) && runes[i+1] == '&' {
+		flush()
+		return 1
+	}
+	if i+1 < len(runes) && runes[i+1] == '>' {
+		cur.WriteRune('&')
+		return 0
+	}
+	if endsWithRedirectFD(cur.String()) {
+		cur.WriteRune('&')
+		return 0
+	}
+	flush()
+	return 0
+}
+
+// endsWithRedirectFD reports whether s ends with a '>' (ignoring trailing
+// blanks), meaning an immediately following '&' completes a file-descriptor
+// duplication like "2>&1" rather than starting a background "&".
+func endsWithRedirectFD(s string) bool {
+	return strings.HasSuffix(strings.TrimRight(s, " \t"), ">")
+}

--- a/config/bash_whitelist_test.go
+++ b/config/bash_whitelist_test.go
@@ -119,8 +119,6 @@ func TestIsBashCommandWhitelisted_CommandSubstitution(t *testing.T) {
 		}
 	}
 
-	// Single-quoted substitution syntax is a literal string in bash, so it is
-	// safe and the wrapping command is judged on its own.
 	allowed := []string{
 		"echo '$(rm -rf /)'",
 		"gh issue create --body 'use $(x) verbatim'",
@@ -280,8 +278,8 @@ func TestStripBenignTrailingRedirections(t *testing.T) {
 		{"echo hi >&2", "echo hi"},
 		{"echo hi 2>&-", "echo hi"},
 		{"echo hi", "echo hi"},
-		{"echo /dev/null", "echo /dev/null"},                   // an arg, not a redirect
-		{"gh issue list > out.txt", "gh issue list > out.txt"}, // real file: kept
+		{"echo /dev/null", "echo /dev/null"},
+		{"gh issue list > out.txt", "gh issue list > out.txt"},
 		{"2>&1", ""},
 	}
 	for _, tt := range tests {

--- a/config/bash_whitelist_test.go
+++ b/config/bash_whitelist_test.go
@@ -1,0 +1,362 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// pushCfg builds a config whose only whitelist entries are the end-anchored
+// git-push patterns, mirroring what users configure for branch protection. It
+// exercises the interaction between redirection stripping and "$"-anchored
+// patterns (a redirect suffix must not defeat the anchor).
+func pushCfg() *Config {
+	return &Config{
+		Tools: ToolsConfig{
+			Enabled: true,
+			Bash: BashToolConfig{
+				Enabled: true,
+				Whitelist: ToolWhitelistConfig{
+					Patterns: []string{
+						"^git push( --set-upstream)?( origin)? (feature|fix)/[a-zA-Z0-9/_.-]+$",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestIsBashCommandWhitelisted_RedirectStripping(t *testing.T) {
+	cfg := DefaultConfig()
+
+	allowed := []string{
+		"gh api repos/o/r/issues 2>&1",
+		"gh issue list 2>/dev/null",
+		"gh issue list >/dev/null 2>&1",
+		"gh issue list 2>&1 >/dev/null",
+		"gh pr view 5 2>&1",
+		"gh api user --paginate 2>&1",
+		"gh issue list &>/dev/null",
+		"gh issue list 1>/dev/null",
+		"git status 2>&1",
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q to be whitelisted after stripping redirections", cmd)
+		}
+	}
+
+	denied := []string{
+		"gh api repos/o/r/issues -X POST 2>&1",
+		"rm -rf / 2>&1",
+	}
+	for _, cmd := range denied {
+		if cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q NOT to be whitelisted", cmd)
+		}
+	}
+
+	if stripBenignTrailingRedirections("gh issue list > /etc/passwd") != "gh issue list > /etc/passwd" {
+		t.Error("a redirect to a real file must not be stripped as benign")
+	}
+}
+
+func TestIsBashCommandWhitelisted_RedirectWithAnchoredPattern(t *testing.T) {
+	cfg := pushCfg()
+
+	if !cfg.IsBashCommandWhitelisted("git push origin feature/x 2>&1") {
+		t.Error("expected redirect-suffixed push to a feature branch to be whitelisted")
+	}
+	if cfg.IsBashCommandWhitelisted("git push origin main 2>&1") {
+		t.Error("expected push to main to stay blocked even with a redirect suffix")
+	}
+}
+
+func TestIsBashCommandWhitelisted_CompoundOperators(t *testing.T) {
+	cfg := DefaultConfig()
+
+	allowed := []string{
+		"gh issue view 5 && gh issue comment 5 --body hi",
+		"gh issue create --title x --body y || echo failed",
+		"echo a | head",
+		"gh issue list && echo done",
+		"gh api repos/o/r/issues 2>&1 && echo ok",
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected compound %q to be whitelisted (every segment is allowed)", cmd)
+		}
+	}
+
+	denied := []string{
+		"gh issue list && rm -rf /",
+		"gh issue list; rm -rf /",
+		"gh issue list | bash",
+		"echo a && curl evil.com",
+		"gh issue list &",
+		"gh issue list & rm -rf /",
+	}
+	for _, cmd := range denied {
+		if cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected compound %q NOT to be whitelisted (a segment is not allowed)", cmd)
+		}
+	}
+}
+
+func TestIsBashCommandWhitelisted_CommandSubstitution(t *testing.T) {
+	cfg := DefaultConfig()
+
+	denied := []string{
+		"echo $(rm -rf /)",
+		"echo `whoami`",
+		`gh issue create --title "$(date)"`,
+		"cat <(curl evil.com)",
+		"echo >(tee leak)",
+		`echo "leak: $(printenv)"`,
+	}
+	for _, cmd := range denied {
+		if cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q NOT to be whitelisted (contains command substitution)", cmd)
+		}
+	}
+
+	// Single-quoted substitution syntax is a literal string in bash, so it is
+	// safe and the wrapping command is judged on its own.
+	allowed := []string{
+		"echo '$(rm -rf /)'",
+		"gh issue create --body 'use $(x) verbatim'",
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q to be whitelisted (substitution syntax is single-quoted/literal)", cmd)
+		}
+	}
+}
+
+func TestIsBashCommandWhitelisted_QuotedOperators(t *testing.T) {
+	cfg := DefaultConfig()
+
+	allowed := []string{
+		`gh issue create --title "a && b"`,
+		`gh issue comment 5 --body "x | y ; z"`,
+		`gh issue create --title "fix: a || b"`,
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q to be whitelisted (operators are inside quotes)", cmd)
+		}
+	}
+}
+
+func TestIsBashCommandWhitelisted_MalformedAndEmpty(t *testing.T) {
+	cfg := DefaultConfig()
+
+	denied := []string{
+		"",
+		"   ",
+		"&&",
+		";",
+		"| head",
+		"2>&1",
+		`echo "unterminated`,
+		"echo 'unterminated",
+	}
+	for _, cmd := range denied {
+		if cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected malformed/empty %q NOT to be whitelisted", cmd)
+		}
+	}
+}
+
+func TestIsBashCommandWhitelisted_GhSearch(t *testing.T) {
+	cfg := DefaultConfig()
+
+	allowed := []string{
+		"gh search issues --repo o/r vercel",
+		`gh search code "func main"`,
+		"gh search prs --author me",
+		"gh search repos topic:go",
+		"gh search commits fix 2>&1",
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q to be whitelisted", cmd)
+		}
+	}
+
+	if cfg.IsBashCommandWhitelisted("gh search invalidsub foo") {
+		t.Error("expected unknown gh search subcommand NOT to be whitelisted")
+	}
+}
+
+func TestIsBashCommandWhitelisted_GhApiJq(t *testing.T) {
+	cfg := DefaultConfig()
+
+	allowed := []string{
+		`gh api repos/o/r --jq '.[] | .id'`,
+		`gh api repos/o/r --jq '.[] | select(.draft==false) | .title'`,
+		`gh api repos/o/r/issues -q '.[] | length'`,
+		`gh api repos/o/r/pulls --jq '.[] | {number, title}'`,
+		`gh api repos/o/r --jq ".[] | .name"`,
+		"gh api repos/o/r/issues --jq .[].title",
+		"gh api user --paginate",
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected read-only %q to be whitelisted", cmd)
+		}
+	}
+
+	denied := []string{
+		"gh api repos/o/r/issues -X POST",
+		"gh api repos/o/r/issues --method POST",
+		"gh api -X DELETE repos/o/r",
+		"gh api repos/o/r -f title=x",
+		`gh api repos/o/r/secrets -X POST -f value=$TOKEN`,
+	}
+	for _, cmd := range denied {
+		if cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected mutating %q NOT to be whitelisted", cmd)
+		}
+	}
+}
+
+func TestIsBashCommandWhitelisted_FindActions(t *testing.T) {
+	cfg := DefaultConfig()
+
+	allowed := []string{
+		"find .",
+		"find . -name '*.go'",
+		"find . -type f -name '*.md'",
+		"find . -name '*.txt' | wc -l",
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected read-only %q to be whitelisted", cmd)
+		}
+	}
+
+	denied := []string{
+		"find . -delete",
+		"find . -name secrets.yaml -delete",
+		`find . -exec echo {} \;`,
+		`find /etc -name '*.conf' -exec grep -l SECRET {} \;`,
+		`find . -execdir rm {} \;`,
+		`find . -ok rm {} \;`,
+		"find . -fls /tmp/listing",
+	}
+	for _, cmd := range denied {
+		if cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected dangerous find %q NOT to be whitelisted", cmd)
+		}
+	}
+}
+
+func TestIsBashCommandWhitelisted_GitStatusFlags(t *testing.T) {
+	cfg := DefaultConfig()
+	allowed := []string{
+		"git status",
+		"git status --porcelain",
+		"git status -s",
+		"git status --porcelain --untracked-files=all",
+		"git status -sb 2>&1",
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected read-only %q to be whitelisted", cmd)
+		}
+	}
+}
+
+func TestStripBenignTrailingRedirections(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"gh api repos/o/r 2>&1", "gh api repos/o/r"},
+		{"gh issue list 2>/dev/null", "gh issue list"},
+		{"gh issue list >/dev/null 2>&1", "gh issue list"},
+		{"gh issue list 2>&1 >/dev/null", "gh issue list"},
+		{"gh issue list &>/dev/null", "gh issue list"},
+		{"echo hi >&2", "echo hi"},
+		{"echo hi 2>&-", "echo hi"},
+		{"echo hi", "echo hi"},
+		{"echo /dev/null", "echo /dev/null"},                   // an arg, not a redirect
+		{"gh issue list > out.txt", "gh issue list > out.txt"}, // real file: kept
+		{"2>&1", ""},
+	}
+	for _, tt := range tests {
+		if got := stripBenignTrailingRedirections(tt.in); got != tt.want {
+			t.Errorf("stripBenignTrailingRedirections(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSplitBashSegments(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+		ok   bool
+	}{
+		{"gh issue list", []string{"gh issue list"}, true},
+		{"a && b", []string{"a", "b"}, true},
+		{"a || b", []string{"a", "b"}, true},
+		{"a | b", []string{"a", "b"}, true},
+		{"a |& b", []string{"a", "b"}, true},
+		{"a ; b", []string{"a", "b"}, true},
+		{"a & b", []string{"a", "b"}, true},
+		{"gh api x 2>&1 && echo y", []string{"gh api x 2>&1", "echo y"}, true},
+		{"echo hi >&2", []string{"echo hi >&2"}, true},
+		{"cmd &> /dev/null", []string{"cmd &> /dev/null"}, true},
+		{`echo "a && b"`, []string{`echo "a && b"`}, true},
+		{"echo 'a | b'", []string{"echo 'a | b'"}, true},
+		{`echo "unterminated`, nil, false},
+		{"echo 'unterminated", nil, false},
+	}
+	for _, tt := range tests {
+		got, ok := splitBashSegments(tt.in)
+		if ok != tt.ok {
+			t.Errorf("splitBashSegments(%q) ok = %v, want %v", tt.in, ok, tt.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		trimmed := make([]string, len(got))
+		for i, s := range got {
+			trimmed[i] = strings.TrimSpace(s)
+		}
+		if strings.Join(trimmed, "\x00") != strings.Join(tt.want, "\x00") {
+			t.Errorf("splitBashSegments(%q) = %v, want %v", tt.in, trimmed, tt.want)
+		}
+	}
+}
+
+func TestContainsCommandSubstitution(t *testing.T) {
+	yes := []string{
+		"echo $(x)",
+		"echo `x`",
+		"cat <(x)",
+		"echo >(x)",
+		`echo "$(x)"`,
+		"echo \"`x`\"",
+	}
+	for _, cmd := range yes {
+		if !containsCommandSubstitution(cmd) {
+			t.Errorf("containsCommandSubstitution(%q) = false, want true", cmd)
+		}
+	}
+
+	no := []string{
+		"echo '$(x)'",
+		"echo '`x`'",
+		"gh api repos/o/r --jq '.a | .b'",
+		"echo $HOME",
+		"echo ${HOME}",
+		"gh issue create --title x --body y",
+	}
+	for _, cmd := range no {
+		if containsCommandSubstitution(cmd) {
+			t.Errorf("containsCommandSubstitution(%q) = true, want false", cmd)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -634,7 +634,7 @@ func DefaultConfig() *Config { //nolint:funlen
 						"task", "make", "find",
 					},
 					Patterns: []string{
-						"^git status$",
+						"^git status( |$)",
 						"^git branch( --show-current)?( -[alrvd])?$",
 						"^git log",
 						"^git diff",
@@ -644,7 +644,8 @@ func DefaultConfig() *Config { //nolint:funlen
 						"^gh auth status( |$)",
 						"^gh issue (create|edit|comment)( |$)",
 						"^gh pr create( |$)",
-						`^gh api [^ -][^ ]*( --paginate| --jq [^ ]+| -q [^ ]+)*$`,
+						"^gh search (issues|code|prs|repos|commits)( |$)",
+						`^gh api [^ -][^ ]*( --paginate| --jq (?:'[^']*'|"[^"]*"|[^ ]+)| -q (?:'[^']*'|"[^"]*"|[^ ]+))*$`,
 					},
 				},
 				BackgroundShells: BackgroundShellsConfig{
@@ -1034,25 +1035,9 @@ func ResolveConfigDir() string {
 	return ConfigDirName
 }
 
-// IsBashCommandWhitelisted checks if a specific bash command is whitelisted
-func (c *Config) IsBashCommandWhitelisted(command string) bool {
-	command = strings.TrimSpace(command)
-
-	for _, allowed := range c.Tools.Bash.Whitelist.Commands {
-		if command == allowed || strings.HasPrefix(command, allowed+" ") {
-			return true
-		}
-	}
-
-	for _, pattern := range c.Tools.Bash.Whitelist.Patterns {
-		matched, err := regexp.MatchString(pattern, command)
-		if err == nil && matched {
-			return true
-		}
-	}
-
-	return false
-}
+// IsBashCommandWhitelisted lives in bash_whitelist.go, alongside the shell-aware
+// matching helpers (redirection stripping, compound-command splitting, and
+// command-substitution rejection) it relies on.
 
 // ValidatePathInSandbox checks if a path is within the configured sandbox directories
 func (c *Config) ValidatePathInSandbox(path string) error {

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -192,12 +192,12 @@ func (s *AgentServiceImpl) buildContextInfo(currentTurn int, messages []sdk.Mess
 		s.buildActiveSkillInfo(messages)
 }
 
-// buildGitHubGuidanceInfo steers the model toward the `gh` CLI for GitHub work.
-// There is no built-in GitHub tool; `gh` (via Bash) covers issues, PRs,
-// releases, and the raw API with clearer errors and the standard credential
-// chain. Emitted only when Bash is enabled (otherwise the guidance is moot).
-// Lives in the dynamic context so it reaches existing users regardless of their
-// prompts.yaml override.
+// buildGitHubGuidanceInfo steers the model toward the `gh` CLI for GitHub work
+// and away from shell habits that needlessly trip the Bash whitelist. There is
+// no built-in GitHub tool; `gh` (via Bash) covers issues, PRs, releases, and the
+// raw API with clearer errors and the standard credential chain. Emitted only
+// when Bash is enabled (otherwise the guidance is moot). Lives in the dynamic
+// context so it reaches existing users regardless of their prompts.yaml override.
 func (s *AgentServiceImpl) buildGitHubGuidanceInfo() string {
 	if !s.config.Tools.Bash.Enabled {
 		return ""
@@ -205,8 +205,15 @@ func (s *AgentServiceImpl) buildGitHubGuidanceInfo() string {
 	return "\n\nGITHUB OPERATIONS:\n" +
 		"Use the `gh` CLI via the Bash tool for all GitHub operations - issues, pull requests, " +
 		"releases, repository metadata, and the raw API (e.g. `gh issue view`, `gh pr create`, " +
-		"`gh api repos/<owner>/<repo>/issues`). There is no built-in GitHub tool. " +
-		"Ensure `gh` is authenticated (it uses the standard gh/GITHUB_TOKEN credential chain)."
+		"`gh api repos/<owner>/<repo>/issues`). There is no built-in GitHub tool. Prefer `gh api` " +
+		"over fetching api.github.com directly. " +
+		"Ensure `gh` is authenticated (it uses the standard gh/GITHUB_TOKEN credential chain).\n\n" +
+		"BASH USAGE:\n" +
+		"The Bash tool already captures stdout, stderr, and the exit code. Do NOT append `2>&1`, " +
+		"`2>/dev/null`, or `|| echo ...` to commands - they are unnecessary and can cause an " +
+		"otherwise-allowed command to be rejected by the whitelist. Run one command per call; " +
+		"compound commands (with &&, ||, or |) are permitted only when every segment is " +
+		"independently whitelisted."
 }
 
 // buildToolsInfo lists the tools available to the model for the active agent

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -6,16 +6,16 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	sdk "github.com/inference-gateway/sdk"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	logger "github.com/inference-gateway/cli/internal/logger"
 	utils "github.com/inference-gateway/cli/internal/utils"
-	sdk "github.com/inference-gateway/sdk"
 )
 
 // BashTool handles bash command execution with security validation
@@ -375,24 +375,12 @@ func (t *BashTool) readPipeWithBatching(
 	}
 }
 
-// isCommandAllowed checks if a command is whitelisted
+// isCommandAllowed checks if a command is whitelisted. It delegates to
+// config.IsBashCommandWhitelisted so the Bash tool, the approval policy, and
+// agent auto-approval share one shell-aware matcher (redirection stripping,
+// compound-command splitting, command-substitution rejection).
 func (t *BashTool) isCommandAllowed(command string) bool {
-	command = strings.TrimSpace(command)
-
-	for _, allowed := range t.config.Tools.Bash.Whitelist.Commands {
-		if command == allowed || strings.HasPrefix(command, allowed+" ") {
-			return true
-		}
-	}
-
-	for _, pattern := range t.config.Tools.Bash.Whitelist.Patterns {
-		matched, err := regexp.MatchString(pattern, command)
-		if err == nil && matched {
-			return true
-		}
-	}
-
-	return false
+	return t.config.IsBashCommandWhitelisted(command)
 }
 
 // FormatResult formats tool execution results for different contexts

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/inference-gateway/cli/config"
-	"github.com/inference-gateway/cli/internal/domain"
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 func TestBashTool_Definition(t *testing.T) {
@@ -354,4 +354,42 @@ func TestBashTool_StreamingOutput(t *testing.T) {
 			t.Errorf("Expected successful execution, got error: %s", result.Error)
 		}
 	})
+}
+
+// TestBashTool_Validate_RedirectionAndCompound confirms the tool delegates to
+// config.IsBashCommandWhitelisted: benign redirections and per-segment-allowed
+// compound commands validate, while command substitution and a non-whitelisted
+// segment are rejected.
+func TestBashTool_Validate_RedirectionAndCompound(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Bash: config.BashToolConfig{
+				Enabled: true,
+				Whitelist: config.ToolWhitelistConfig{
+					Commands: []string{"echo"},
+					Patterns: []string{`^gh api [^ -][^ ]*( --jq [^ ]+)*$`},
+				},
+			},
+		},
+	}
+	tool := NewBashTool(cfg, nil)
+
+	tests := []struct {
+		command   string
+		wantError bool
+	}{
+		{"gh api repos/o/r/issues 2>&1", false},
+		{"echo hi && echo bye", false},
+		{"echo hi || echo failed", false},
+		{"echo $(rm -rf /)", true},
+		{"echo hi && rm -rf /", true},
+		{"gh api repos/o/r -X POST", true},
+	}
+	for _, tt := range tests {
+		err := tool.Validate(map[string]any{"command": tt.command})
+		if (err != nil) != tt.wantError {
+			t.Errorf("Validate(%q) error = %v, wantError %v", tt.command, err, tt.wantError)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #581. An `infer` session reported a 36% tool-call success rate because benign, read-only GitHub/git commands were rejected by the bash whitelist — mostly because the model appended `2>&1` / `2>/dev/null` / `|| echo ...`, which broke the (often end-anchored) whitelist patterns. The same naive prefix/regex matching also let a whitelisted *head* command carry an arbitrary tail, so the boundary was both **too strict for benign commands and too loose to be a real boundary**.

This makes the matcher *shell-aware* and unifies the previously-duplicated logic (`bash.go::isCommandAllowed` and `config.go::IsBashCommandWhitelisted`) into a single source of truth — `config.IsBashCommandWhitelisted` — now consulted by the Bash tool, the approval policy, and agent auto-approval, so all three agree on exactly what runs without prompting.

## What changed

**Reliability (the reported failures):**
- **Strip benign trailing redirections** (`2>&1`, `2>/dev/null`, `&>/dev/null`, fd-dups) per segment before matching, so they no longer defeat end-anchored patterns. → fixes `gh api … 2>&1`, `git push … 2>&1`, etc.
- **`gh api --jq`/`-q` now accept quoted, space-containing expressions** — e.g. `gh api repos/o/r --jq '.[] | .id'`, the canonical read idiom (previously rejected because `--jq [^ ]+` forbade spaces).
- **Add read-only `gh search (issues|code|prs|repos|commits)`**.
- **`git status` flags allowed** (`git status --porcelain`) — aligns it with the already-unanchored `git log`/`git diff`/`git show` read patterns.
- **System-prompt guidance**: the Bash tool already captures stdout/stderr/exit code, so don't append `2>&1`, `2>/dev/null`, or `|| echo ...`; prefer `gh api` over fetching `api.github.com` directly. Lives in the dynamic context, so it reaches existing users regardless of their `prompts.yaml` override.

**Security coherence (the "no real boundary" critique):**
- **Compound commands** (`&&`, `||`, `|`, `|&`, `;`, `&`, newlines) are split **quote-aware**, and every segment must be independently whitelisted. Enables benign chains (`gh issue view 5 && gh issue comment 5 …`) while closing the prefix-match hole (`gh issue list && rm -rf /` is now rejected).
- **Reject command substitution**: `$(...)`, backticks, and process substitution `<(...)`/`>(...)` (e.g. `echo $(rm -rf /)`).
- **Reject dangerous `find` primaries** that execute or delete: `-exec`, `-execdir`, `-ok`, `-okdir`, `-delete`, `-fprintf`, … (read-only `find -name`/`-type` is unaffected).

## Verification

- `task test` green; `golangci-lint` reports **0 issues**; markdownlint clean.
- New exhaustive matcher tests cover redirect stripping, compound chains, command substitution, quoted operators, unbalanced quotes, `gh search`, `gh api --jq`, `find` actions, and `git status` flags; plus tokenizer unit tests and a Bash-tool integration test.
- Ran a **6-lens adversarial security review** (multi-agent) and executed every candidate command through the real compiled matcher for ground truth. It reduced confirmed issues from 27 → 17; the remaining 17 are all **pre-existing** and unrelated to the reliability fix.

## Deliberately out of scope (pre-existing; documented, not bundled)

These were surfaced by the adversarial review but **not** changed here because fixing them carries real false-reject cost (the opposite of this issue's goal) or belongs in a separate hardening decision:

- **Bare `$VAR` expansion** (`echo $GITHUB_TOKEN`) — blocking `$` would reject `echo $HOME`, `git log --since=$DATE`, etc.
- **Redirects to real files** (`echo … > /tmp/x`) — blocking would reject legitimate `gh pr diff > out.patch`. The redirect just changes where already-permitted output goes.
- **`git branch` flag loosening** — risky because `-D`/`-m` mutate.

Happy to file a focused follow-up issue for `$VAR`/file-redirect hardening if desired.

> Note: arithmetic expansion (`echo $((1+1))`) is conservatively treated like command substitution and falls through to approval. Negligible in practice.