### PR TITLE
fix(agent): execute approved tools concurrently and freeze tickers on finish

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -761,25 +761,6 @@ func (s *AgentServiceImpl) executeToolCallsParallel( // nolint:funlen
 		time.Sleep(constants.AgentToolExecutionDelay)
 
 		result := s.executeTool(ctx, *at.tool, eventPublisher, isChatMode)
-
-		status := "completed"
-		message := "Completed successfully"
-		var images []domain.ImageAttachment
-		if result.ToolExecution != nil {
-			if !result.ToolExecution.Success {
-				status = "failed"
-				message = "Execution failed"
-			}
-			images = result.ToolExecution.Images
-
-			if at.tool.Function.Name == "GetLatestScreenshot" && len(images) > 0 {
-				logger.Info("Publishing GetLatestScreenshot completion with images",
-					"imageCount", len(images),
-					"status", status)
-			}
-		}
-
-		eventPublisher.publishToolStatusChange(at.tool.ID, at.tool.Function.Name, status, message, images)
 		results[at.index] = result
 	}
 
@@ -810,19 +791,6 @@ func (s *AgentServiceImpl) executeToolCallsParallel( // nolint:funlen
 				time.Sleep(constants.AgentToolExecutionDelay)
 
 				result := s.executeTool(ctx, *toolCall, eventPublisher, isChatMode)
-
-				status := "completed"
-				message := "Completed successfully"
-				var images []domain.ImageAttachment
-				if result.ToolExecution != nil {
-					if !result.ToolExecution.Success {
-						status = "failed"
-						message = "Execution failed"
-					}
-					images = result.ToolExecution.Images
-				}
-
-				eventPublisher.publishToolStatusChange(toolCall.ID, toolCall.Function.Name, status, message, images)
 
 				resultsChan <- IndexedToolResult{
 					Index:  index,
@@ -891,8 +859,20 @@ func (s *AgentServiceImpl) executeToolInternal(
 	eventPublisher *eventPublisher,
 	wasApproved bool,
 	startTime time.Time,
-) domain.ConversationEntry {
+) (finalEntry domain.ConversationEntry) {
 	eventPublisher.publishToolStatusChange(tc.ID, tc.Function.Name, "running", "Executing...", nil)
+
+	defer func() {
+		status, message := "completed", "Completed successfully"
+		var images []domain.ImageAttachment
+		if finalEntry.ToolExecution != nil {
+			if !finalEntry.ToolExecution.Success {
+				status, message = "failed", "Execution failed"
+			}
+			images = finalEntry.ToolExecution.Images
+		}
+		eventPublisher.publishToolStatusChange(tc.ID, tc.Function.Name, status, message, images)
+	}()
 
 	time.Sleep(constants.AgentToolExecutionDelay)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -582,6 +582,7 @@ func (s *AgentServiceImpl) RunWithStream(ctx context.Context, req *domain.AgentR
 
 		agent := NewEventDrivenAgent(
 			s,
+			s.config.GetAgentConfig(),
 			sessionCtx,
 			req,
 			&conversation,

--- a/internal/agent/agent_event_driven.go
+++ b/internal/agent/agent_event_driven.go
@@ -102,6 +102,11 @@ func NewEventDrivenAgent(
 // registerStateHandlers creates and registers all state handlers for the event-driven agent.
 // This method is called during agent initialization to set up the state handler registry.
 func (a *EventDrivenAgent) registerStateHandlers() {
+	maxConcurrentTools := 0
+	if a.service.config != nil {
+		maxConcurrentTools = a.service.config.GetAgentConfig().MaxConcurrentTools
+	}
+
 	ctx := &domain.StateContext{
 		StateMachine:           a.stateMachine,
 		AgentCtx:               a.agentCtx,
@@ -120,6 +125,7 @@ func (a *EventDrivenAgent) registerStateHandlers() {
 		BackgroundTaskRegistry: a.registry,
 		Provider:               a.provider,
 		Model:                  a.model,
+		MaxConcurrentTools:     maxConcurrentTools,
 		ToolExecutor:           &a.toolExecutor,
 		StartStreaming:         a.startStreaming,
 

--- a/internal/agent/agent_event_driven.go
+++ b/internal/agent/agent_event_driven.go
@@ -7,6 +7,7 @@ import (
 
 	sdk "github.com/inference-gateway/sdk"
 
+	config "github.com/inference-gateway/cli/config"
 	states "github.com/inference-gateway/cli/internal/agent/states"
 	constants "github.com/inference-gateway/cli/internal/constants"
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -17,6 +18,7 @@ import (
 type EventDrivenAgent struct {
 	// Core dependencies
 	service        *AgentServiceImpl
+	cfg            *config.AgentConfig
 	stateMachine   domain.AgentStateMachine
 	agentCtx       *domain.AgentContext
 	eventPublisher *eventPublisher
@@ -54,6 +56,7 @@ type EventDrivenAgent struct {
 // NewEventDrivenAgent creates a new event-driven agent
 func NewEventDrivenAgent(
 	service *AgentServiceImpl,
+	cfg *config.AgentConfig,
 	ctx context.Context,
 	req *domain.AgentRequest,
 	conversation *[]sdk.Message,
@@ -72,7 +75,7 @@ func NewEventDrivenAgent(
 		ConversationRepo: service.conversationRepo,
 		ToolCalls:        nil,
 		Turns:            0,
-		MaxTurns:         service.config.GetAgentConfig().MaxTurns,
+		MaxTurns:         cfg.MaxTurns,
 		HasToolResults:   false,
 		ApprovalPolicy:   service.approvalPolicy,
 		Ctx:              ctx,
@@ -81,6 +84,7 @@ func NewEventDrivenAgent(
 
 	agent := &EventDrivenAgent{
 		service:        service,
+		cfg:            cfg,
 		stateMachine:   stateMachine,
 		agentCtx:       agentCtx,
 		eventPublisher: eventPublisher,
@@ -102,11 +106,6 @@ func NewEventDrivenAgent(
 // registerStateHandlers creates and registers all state handlers for the event-driven agent.
 // This method is called during agent initialization to set up the state handler registry.
 func (a *EventDrivenAgent) registerStateHandlers() {
-	maxConcurrentTools := 0
-	if a.service.config != nil {
-		maxConcurrentTools = a.service.config.GetAgentConfig().MaxConcurrentTools
-	}
-
 	ctx := &domain.StateContext{
 		StateMachine:           a.stateMachine,
 		AgentCtx:               a.agentCtx,
@@ -125,7 +124,7 @@ func (a *EventDrivenAgent) registerStateHandlers() {
 		BackgroundTaskRegistry: a.registry,
 		Provider:               a.provider,
 		Model:                  a.model,
-		MaxConcurrentTools:     maxConcurrentTools,
+		MaxConcurrentTools:     a.cfg.MaxConcurrentTools,
 		ToolExecutor:           &a.toolExecutor,
 		StartStreaming:         a.startStreaming,
 

--- a/internal/agent/agent_event_driven_test.go
+++ b/internal/agent/agent_event_driven_test.go
@@ -7,6 +7,7 @@ import (
 
 	assert "github.com/stretchr/testify/assert"
 
+	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	mockdomain "github.com/inference-gateway/cli/tests/mocks/domain"
 	sdk "github.com/inference-gateway/sdk"
@@ -66,6 +67,7 @@ func createTestAgent(mocks *testMocks, ctx *domain.AgentContext) *EventDrivenAge
 
 	agent := &EventDrivenAgent{
 		service:          service,
+		cfg:              config.DefaultConfig().GetAgentConfig(),
 		stateMachine:     mocks.stateMachine,
 		agentCtx:         ctx,
 		eventPublisher:   eventPublisher,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1109,6 +1109,67 @@ func TestEventPublisher_PublishToolStatusChange(t *testing.T) {
 	}
 }
 
+// TestExecuteToolInternal_PublishesTerminalStatus guards the asymmetry that caused the
+// per-tool ticker to keep counting on the approval path: executeToolInternal must publish a
+// terminal "completed"/"failed" status itself (so the UI freezes the elapsed-time ticker),
+// rather than relying on executeToolCallsParallel to publish it externally — the approval path
+// calls executeToolInternal directly and bypasses that.
+func TestExecuteToolInternal_PublishesTerminalStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		success        bool
+		expectedStatus string
+	}{
+		{name: "success publishes completed", success: true, expectedStatus: "completed"},
+		{name: "failure publishes failed", success: false, expectedStatus: "failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeToolService := &domainmocks.FakeToolService{}
+			fakeToolService.ExecuteToolReturns(&domain.ToolExecutionResult{
+				ToolName: "Read",
+				Success:  tt.success,
+			}, nil)
+
+			fakeRepo := &domainmocks.FakeConversationRepository{}
+			fakeRepo.FormatToolResultForLLMReturns("formatted result")
+
+			s := &AgentServiceImpl{
+				toolService:      fakeToolService,
+				conversationRepo: fakeRepo,
+			}
+
+			chatEvents := make(chan domain.ChatEvent, 32)
+			publisher := newEventPublisher("request-123", chatEvents)
+
+			tc := sdk.ChatCompletionMessageToolCall{
+				ID:       "call-1",
+				Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Read", Arguments: "{}"},
+			}
+
+			entry := s.executeToolInternal(context.Background(), tc, publisher, true, time.Now())
+			require.NotNil(t, entry.ToolExecution)
+			assert.Equal(t, tt.success, entry.ToolExecution.Success)
+
+			// Drain published events; the LAST tool-status event must be terminal.
+			var lastStatus string
+		drain:
+			for {
+				select {
+				case event := <-chatEvents:
+					if progress, ok := event.(domain.ToolExecutionProgressEvent); ok {
+						lastStatus = progress.Status
+					}
+				default:
+					break drain
+				}
+			}
+			assert.Equal(t, tt.expectedStatus, lastStatus, "final tool status event should be terminal so the UI freezes the ticker")
+		})
+	}
+}
+
 func TestAgentServiceImpl_CancelRequest_WithCancelChannel(t *testing.T) {
 	agentService := &AgentServiceImpl{
 		activeRequests: make(map[string]context.CancelFunc),

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1152,7 +1152,6 @@ func TestExecuteToolInternal_PublishesTerminalStatus(t *testing.T) {
 			require.NotNil(t, entry.ToolExecution)
 			assert.Equal(t, tt.success, entry.ToolExecution.Success)
 
-			// Drain published events; the LAST tool-status event must be terminal.
 			var lastStatus string
 		drain:
 			for {

--- a/internal/agent/states/approving_tools.go
+++ b/internal/agent/states/approving_tools.go
@@ -2,6 +2,7 @@ package states
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	sdk "github.com/inference-gateway/sdk"
@@ -10,10 +11,25 @@ import (
 	logger "github.com/inference-gateway/cli/internal/logger"
 )
 
+// toolRound holds the per-round state for approving and executing a batch of
+// tool calls. Approval prompts are handled one at a time, but each approved
+// tool's execution is spawned immediately so executions overlap while the
+// remaining tools are still being approved. Results are recorded into
+// index-keyed slots and flushed to the conversation in tool-call order as each
+// contiguous prefix completes, so the UI surfaces each tool result as the user
+// approves the next one (the conversation validator requires tool-call order).
+type toolRound struct {
+	results []domain.ConversationEntry // indexed by tool position
+	ready   []bool                     // ready[i] set once results[i] is filled
+	flushed int                        // next slot index to flush, in order
+	wg      sync.WaitGroup             // tracks spawned executions
+	sem     chan struct{}              // bounds concurrent executions
+}
+
 // ApprovingToolsState handles events in the ApprovingTools state.
 //
-// This state manages sequential tool approval:
-//  1. MessageReceivedEvent → initializes tool processing queue, starts sequential approval
+// This state manages sequential tool approval with overlapping execution:
+//  1. MessageReceivedEvent → initializes the tool round, starts sequential approval
 //  2. AllToolsProcessedEvent → transitions to PostToolExecution
 //  3. ApprovalFailedEvent → handles approval failures
 type ApprovingToolsState struct {
@@ -43,10 +59,16 @@ func (s *ApprovingToolsState) Handle(event domain.AgentEvent) error {
 		*s.ctx.CurrentToolIndex = 0
 		*s.ctx.ToolResults = []domain.ConversationEntry{}
 
-		logger.Debug("starting sequential tool approval", "total_tools", len(*s.ctx.ToolsNeedingApproval))
+		round := &toolRound{
+			results: make([]domain.ConversationEntry, len(*s.ctx.ToolsNeedingApproval)),
+			ready:   make([]bool, len(*s.ctx.ToolsNeedingApproval)),
+			sem:     make(chan struct{}, s.maxConcurrent()),
+		}
+
+		logger.Debug("starting tool approval", "total_tools", len(*s.ctx.ToolsNeedingApproval))
 
 		s.ctx.WaitGroup.Add(1)
-		go s.processNextTool()
+		go s.processNextTool(round)
 
 	case domain.AllToolsProcessedEvent:
 		logger.Debug("all tools processed", "results", len(*s.ctx.ToolResults))
@@ -65,24 +87,24 @@ func (s *ApprovingToolsState) Handle(event domain.AgentEvent) error {
 	return nil
 }
 
-// processNextTool handles approval and execution of ONE tool sequentially.
-// Fast-exits if the session context was cancelled, mirroring the
-// drain-then-stop contract in CheckingQueue / PostToolExecution: the
-// remaining approval prompts are skipped and control returns to the state
-// machine, which will short-circuit to Completing.
-func (s *ApprovingToolsState) processNextTool() {
+// processNextTool requests approval for ONE tool, then — if approved — spawns
+// its execution in the background and immediately moves on to the next
+// approval prompt so executions overlap. Fast-exits if the session context was
+// cancelled, mirroring the drain-then-stop contract in CheckingQueue /
+// PostToolExecution: the remaining approval prompts are skipped and control
+// returns to the state machine via finishApprovals.
+func (s *ApprovingToolsState) processNextTool(round *toolRound) {
 	defer s.ctx.WaitGroup.Done()
 
 	if s.ctx.AgentCtx.Ctx.Err() != nil {
 		logger.Debug("session cancelled during approval loop", "err", s.ctx.AgentCtx.Ctx.Err())
-		s.ctx.Events <- domain.AllToolsProcessedEvent{}
+		s.finishApprovals(round)
 		return
 	}
 
-	tc := s.getNextToolForProcessing()
+	tc, idx := s.getNextToolForProcessing()
 	if tc == nil {
-		logger.Debug("all tools processed", "approved", len(*s.ctx.ToolResults))
-		s.ctx.Events <- domain.AllToolsProcessedEvent{}
+		s.finishApprovals(round)
 		return
 	}
 
@@ -96,9 +118,8 @@ func (s *ApprovingToolsState) processNextTool() {
 	}
 
 	if !approved {
-		s.handleToolRejection(*tc)
-		s.ctx.WaitGroup.Add(1)
-		go s.processNextTool()
+		s.completeSlot(round, idx, s.buildRejectionEntry(*tc))
+		s.continueToNextTool(round)
 		return
 	}
 
@@ -110,33 +131,136 @@ func (s *ApprovingToolsState) processNextTool() {
 	})
 
 	if s.shouldAutoApproveRemaining() {
-		s.executeAllRemainingTools(*tc)
-		s.ctx.Events <- domain.AllToolsProcessedEvent{}
+		s.spawnAllRemaining(round, idx, *tc)
+		s.finishApprovals(round)
 		return
 	}
 
-	s.executeSingleApprovedTool(*tc)
-
-	s.ctx.WaitGroup.Add(1)
-	go s.processNextTool()
+	s.spawnExecution(round, idx, *tc)
+	s.continueToNextTool(round)
 }
 
-// getNextToolForProcessing returns the next tool that needs processing
-func (s *ApprovingToolsState) getNextToolForProcessing() *sdk.ChatCompletionMessageToolCall {
+// continueToNextTool advances the sequential approval loop to the next tool.
+func (s *ApprovingToolsState) continueToNextTool(round *toolRound) {
+	s.ctx.WaitGroup.Add(1)
+	go s.processNextTool(round)
+}
+
+// getNextToolForProcessing returns the next tool that needs processing and its
+// position (used as the result slot index).
+func (s *ApprovingToolsState) getNextToolForProcessing() (*sdk.ChatCompletionMessageToolCall, int) {
 	s.ctx.Mutex.Lock()
 	defer s.ctx.Mutex.Unlock()
 
 	if *s.ctx.CurrentToolIndex >= len(*s.ctx.ToolsNeedingApproval) {
-		return nil
+		return nil, -1
 	}
 
-	tc := &(*s.ctx.ToolsNeedingApproval)[*s.ctx.CurrentToolIndex]
+	idx := *s.ctx.CurrentToolIndex
+	tc := &(*s.ctx.ToolsNeedingApproval)[idx]
 	*s.ctx.CurrentToolIndex++
-	return tc
+	return tc, idx
 }
 
-// handleToolRejection handles when a user rejects a tool call
-func (s *ApprovingToolsState) handleToolRejection(tc sdk.ChatCompletionMessageToolCall) {
+// spawnExecution runs an approved tool in the background, recording its result
+// in the round's slot. Concurrency is bounded by the round semaphore.
+func (s *ApprovingToolsState) spawnExecution(round *toolRound, idx int, tc sdk.ChatCompletionMessageToolCall) {
+	round.wg.Add(1)
+	go func() {
+		defer round.wg.Done()
+		round.sem <- struct{}{}
+		defer func() { <-round.sem }()
+
+		logger.Debug("executing approved tool", "tool", tc.Function.Name)
+		s.completeSlot(round, idx, s.ctx.ExecuteToolInternal(tc, true))
+	}()
+}
+
+// spawnAllRemaining executes the just-approved tool and every remaining tool in
+// auto-accept mode. Each runs in the background (bounded by the semaphore);
+// results are collected in tool-call order.
+func (s *ApprovingToolsState) spawnAllRemaining(round *toolRound, idx int, tc sdk.ChatCompletionMessageToolCall) {
+	logger.Debug("auto-accept mode enabled, auto-approving all remaining tools")
+
+	s.spawnExecution(round, idx, tc)
+
+	s.ctx.Mutex.Lock()
+	start := *s.ctx.CurrentToolIndex
+	tools := *s.ctx.ToolsNeedingApproval
+	s.ctx.Mutex.Unlock()
+
+	for i := start; i < len(tools); i++ {
+		remaining := tools[i]
+		logger.Debug("auto-approving tool", "tool", remaining.Function.Name)
+
+		s.ctx.PublishChatEvent(domain.ToolApprovedEvent{
+			RequestID: s.ctx.Request.RequestID,
+			Timestamp: time.Now(),
+			ToolCall:  remaining,
+		})
+
+		s.spawnExecution(round, i, remaining)
+	}
+
+	s.ctx.Mutex.Lock()
+	*s.ctx.CurrentToolIndex = len(tools)
+	s.ctx.Mutex.Unlock()
+}
+
+// completeSlot records a finished tool result (an executed tool or a rejection)
+// in its slot and flushes any now-contiguous prefix of results. Flushing as
+// results complete - rather than batching at the end - lets the UI surface each
+// tool result as the user approves the next one, while still preserving
+// tool-call order for the conversation.
+func (s *ApprovingToolsState) completeSlot(round *toolRound, idx int, entry domain.ConversationEntry) {
+	s.ctx.Mutex.Lock()
+	defer s.ctx.Mutex.Unlock()
+
+	round.results[idx] = entry
+	round.ready[idx] = true
+	s.flushLocked(round)
+}
+
+// flushReady flushes the contiguous-ready prefix of results. Used after
+// WaitGroup.Wait to drain anything not yet flushed (e.g. on cancellation).
+func (s *ApprovingToolsState) flushReady(round *toolRound) {
+	s.ctx.Mutex.Lock()
+	defer s.ctx.Mutex.Unlock()
+	s.flushLocked(round)
+}
+
+// flushLocked appends every ready result starting at the flush cursor to the
+// conversation, storage, and ToolResults, in tool-call order. The caller must
+// hold s.ctx.Mutex.
+func (s *ApprovingToolsState) flushLocked(round *toolRound) {
+	for round.flushed < len(round.ready) && round.ready[round.flushed] {
+		entry := round.results[round.flushed]
+		round.flushed++
+
+		*s.ctx.ToolResults = append(*s.ctx.ToolResults, entry)
+		*s.ctx.AgentCtx.Conversation = append(*s.ctx.AgentCtx.Conversation, entry.Message)
+		if err := s.ctx.AddMessage(entry); err != nil {
+			logger.Error("failed to store tool result", "error", err)
+		}
+		s.ctx.AgentCtx.HasToolResults = true
+	}
+}
+
+// finishApprovals waits for every spawned execution to complete, drains any
+// remaining results, and signals the state machine. Results are flushed
+// incrementally by completeSlot as they complete; this final drain covers
+// gaps left by cancellation.
+func (s *ApprovingToolsState) finishApprovals(round *toolRound) {
+	round.wg.Wait()
+	s.flushReady(round)
+
+	s.ctx.Events <- domain.AllToolsProcessedEvent{}
+}
+
+// buildRejectionEntry constructs the Tool-role result for a user-rejected tool
+// and publishes the rejection event. The entry is appended to the conversation
+// in order by the flush.
+func (s *ApprovingToolsState) buildRejectionEntry(tc sdk.ChatCompletionMessageToolCall) domain.ConversationEntry {
 	logger.Debug("tool rejected by user", "tool", tc.Function.Name)
 
 	rejectionMessage := sdk.Message{
@@ -145,26 +269,16 @@ func (s *ApprovingToolsState) handleToolRejection(tc sdk.ChatCompletionMessageTo
 		ToolCallID: &tc.ID,
 	}
 
-	*s.ctx.AgentCtx.Conversation = append(*s.ctx.AgentCtx.Conversation, rejectionMessage)
-
-	rejectionEntry := domain.ConversationEntry{
-		Message: rejectionMessage,
-		Time:    time.Now(),
-	}
-
-	if err := s.ctx.AddMessage(rejectionEntry); err != nil {
-		logger.Error("failed to store tool rejection message", "error", err)
-	}
-
 	s.ctx.PublishChatEvent(domain.ToolRejectedEvent{
 		RequestID: s.ctx.Request.RequestID,
 		Timestamp: time.Now(),
 		ToolCall:  tc,
 	})
 
-	s.ctx.Mutex.Lock()
-	s.ctx.AgentCtx.HasToolResults = true
-	s.ctx.Mutex.Unlock()
+	return domain.ConversationEntry{
+		Message: rejectionMessage,
+		Time:    time.Now(),
+	}
 }
 
 // shouldAutoApproveRemaining checks if auto-accept mode is enabled
@@ -172,58 +286,13 @@ func (s *ApprovingToolsState) shouldAutoApproveRemaining() bool {
 	return s.ctx.GetAgentMode() == domain.AgentModeAutoAccept
 }
 
-// executeAllRemainingTools executes the current tool and all remaining tools in auto-accept mode
-func (s *ApprovingToolsState) executeAllRemainingTools(tc sdk.ChatCompletionMessageToolCall) {
-	logger.Debug("auto-accept mode enabled, auto-approving all remaining tools")
-
-	s.ctx.Mutex.Lock()
-	remainingTools := (*s.ctx.ToolsNeedingApproval)[*s.ctx.CurrentToolIndex:]
-	s.ctx.Mutex.Unlock()
-
-	for _, remainingTool := range remainingTools {
-		logger.Debug("auto-approving tool", "tool", remainingTool.Function.Name)
-
-		s.ctx.PublishChatEvent(domain.ToolApprovedEvent{
-			RequestID: s.ctx.Request.RequestID,
-			Timestamp: time.Now(),
-			ToolCall:  remainingTool,
-		})
-
-		result := s.ctx.ExecuteToolInternal(remainingTool, true)
-		s.appendToolResult(result)
+// maxConcurrent returns the bound on concurrently executing tools, clamped to
+// at least 1 so a missing/zero config value cannot deadlock the semaphore.
+func (s *ApprovingToolsState) maxConcurrent() int {
+	if s.ctx.MaxConcurrentTools < 1 {
+		return 1
 	}
-
-	result := s.ctx.ExecuteToolInternal(tc, true)
-	s.appendToolResult(result)
-
-	s.ctx.Mutex.Lock()
-	*s.ctx.CurrentToolIndex = len(*s.ctx.ToolsNeedingApproval)
-	s.ctx.Mutex.Unlock()
-}
-
-// executeSingleApprovedTool executes a single approved tool
-func (s *ApprovingToolsState) executeSingleApprovedTool(tc sdk.ChatCompletionMessageToolCall) {
-	logger.Debug("executing approved tool", "tool", tc.Function.Name)
-
-	result := s.ctx.ExecuteToolInternal(tc, true)
-	s.appendToolResult(result)
-}
-
-// appendToolResult appends a tool execution result to the conversation and storage
-func (s *ApprovingToolsState) appendToolResult(result domain.ConversationEntry) {
-	s.ctx.Mutex.Lock()
-	*s.ctx.ToolResults = append(*s.ctx.ToolResults, result)
-	s.ctx.Mutex.Unlock()
-
-	*s.ctx.AgentCtx.Conversation = append(*s.ctx.AgentCtx.Conversation, result.Message)
-
-	if err := s.ctx.AddMessage(result); err != nil {
-		logger.Error("failed to store tool result", "error", err)
-	}
-
-	s.ctx.Mutex.Lock()
-	s.ctx.AgentCtx.HasToolResults = true
-	s.ctx.Mutex.Unlock()
+	return s.ctx.MaxConcurrentTools
 }
 
 // handleApprovalFailure handles when approval fails (timeout, error, etc.)

--- a/internal/agent/states/approving_tools_test.go
+++ b/internal/agent/states/approving_tools_test.go
@@ -1,0 +1,244 @@
+package states
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+func makeTools(n int) []*sdk.ChatCompletionMessageToolCall {
+	tools := make([]*sdk.ChatCompletionMessageToolCall, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("call-%d", i)
+		tools[i] = &sdk.ChatCompletionMessageToolCall{
+			ID:       id,
+			Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Read", Arguments: "{}"},
+		}
+	}
+	return tools
+}
+
+func toolEntry(tc sdk.ChatCompletionMessageToolCall) domain.ConversationEntry {
+	id := tc.ID
+	return domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:       sdk.Tool,
+			Content:    sdk.NewMessageContent("ok"),
+			ToolCallID: &id,
+		},
+		Time: time.Now(),
+		ToolExecution: &domain.ToolExecutionResult{
+			ToolName: tc.Function.Name,
+			Success:  true,
+		},
+	}
+}
+
+func newApprovingCtx(
+	tools []*sdk.ChatCompletionMessageToolCall,
+	mode domain.AgentMode,
+	execStub func(sdk.ChatCompletionMessageToolCall, bool) domain.ConversationEntry,
+	approveStub func(sdk.ChatCompletionMessageToolCall) (bool, error),
+) (*domain.StateContext, *[]domain.ConversationEntry, *[]sdk.Message, chan domain.AgentEvent) {
+	tna := []sdk.ChatCompletionMessageToolCall{}
+	idx := 0
+	tr := []domain.ConversationEntry{}
+	conv := []sdk.Message{}
+	events := make(chan domain.AgentEvent, 16)
+	wg := &sync.WaitGroup{}
+	mu := &sync.Mutex{}
+
+	ctx := &domain.StateContext{
+		Events:               events,
+		WaitGroup:            wg,
+		Mutex:                mu,
+		CurrentToolCalls:     &tools,
+		ToolsNeedingApproval: &tna,
+		CurrentToolIndex:     &idx,
+		ToolResults:          &tr,
+		MaxConcurrentTools:   5,
+		Request:              &domain.AgentRequest{RequestID: "req-1"},
+		AgentCtx: &domain.AgentContext{
+			Ctx:          context.Background(),
+			Conversation: &conv,
+		},
+		RequestToolApproval: approveStub,
+		ExecuteToolInternal: execStub,
+		PublishChatEvent:    func(domain.ChatEvent) {},
+		AddMessage:          func(domain.ConversationEntry) error { return nil },
+		GetAgentMode:        func() domain.AgentMode { return mode },
+	}
+	return ctx, &tr, &conv, events
+}
+
+func waitForAllToolsProcessed(t *testing.T, events chan domain.AgentEvent) {
+	t.Helper()
+	for {
+		select {
+		case evt := <-events:
+			if _, ok := evt.(domain.AllToolsProcessedEvent); ok {
+				return
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for AllToolsProcessedEvent")
+		}
+	}
+}
+
+// TestApprovingToolsState_OverlapsExecution proves that approved tools execute
+// concurrently while the remaining tools are still being approved. Each tool's
+// execution blocks on a barrier until ALL tools have started executing; if the
+// state serialized execution (running each approved tool to completion before
+// requesting the next approval), only one tool would ever reach the barrier and
+// AllToolsProcessedEvent would never arrive within the timeout.
+func TestApprovingToolsState_OverlapsExecution(t *testing.T) {
+	const n = 3
+	arrivals := make(chan struct{}, n)
+	allArrived := make(chan struct{})
+
+	go func() {
+		for i := 0; i < n; i++ {
+			select {
+			case <-arrivals:
+			case <-time.After(2 * time.Second):
+				return // never closes allArrived -> overlap did not happen
+			}
+		}
+		close(allArrived)
+	}()
+
+	execStub := func(tc sdk.ChatCompletionMessageToolCall, _ bool) domain.ConversationEntry {
+		arrivals <- struct{}{}
+		select {
+		case <-allArrived:
+		case <-time.After(5 * time.Second): // safety so goroutines don't leak on failure
+		}
+		return toolEntry(tc)
+	}
+	approveStub := func(sdk.ChatCompletionMessageToolCall) (bool, error) { return true, nil }
+
+	ctx, _, _, events := newApprovingCtx(makeTools(n), domain.AgentModeStandard, execStub, approveStub)
+	s := &ApprovingToolsState{ctx: ctx}
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+
+	select {
+	case evt := <-events:
+		_, ok := evt.(domain.AllToolsProcessedEvent)
+		assert.True(t, ok, "expected AllToolsProcessedEvent, got %T", evt)
+	case <-time.After(2 * time.Second):
+		t.Fatal("approved tools did not execute concurrently — execution appears serialized")
+	}
+}
+
+// TestApprovingToolsState_PreservesToolCallOrder verifies that even when tools
+// finish out of order, results are appended to ToolResults and the conversation
+// in tool-call order (required by the conversation validator).
+func TestApprovingToolsState_PreservesToolCallOrder(t *testing.T) {
+	execStub := func(tc sdk.ChatCompletionMessageToolCall, _ bool) domain.ConversationEntry {
+		switch tc.ID {
+		case "call-0":
+			time.Sleep(60 * time.Millisecond) // finishes last
+		case "call-1":
+			time.Sleep(30 * time.Millisecond)
+		}
+		return toolEntry(tc)
+	}
+	approveStub := func(sdk.ChatCompletionMessageToolCall) (bool, error) { return true, nil }
+
+	ctx, results, conv, events := newApprovingCtx(makeTools(3), domain.AgentModeStandard, execStub, approveStub)
+	s := &ApprovingToolsState{ctx: ctx}
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+	waitForAllToolsProcessed(t, events)
+
+	require.Len(t, *results, 3)
+	require.Len(t, *conv, 3)
+	for i := 0; i < 3; i++ {
+		want := fmt.Sprintf("call-%d", i)
+		require.NotNil(t, (*results)[i].Message.ToolCallID)
+		assert.Equal(t, want, *(*results)[i].Message.ToolCallID, "ToolResults[%d] out of order", i)
+		require.NotNil(t, (*conv)[i].ToolCallID)
+		assert.Equal(t, want, *(*conv)[i].ToolCallID, "conversation[%d] out of order", i)
+	}
+}
+
+// TestApprovingToolsState_FlushesResultsIncrementally proves a completed tool's
+// result is written to the conversation/storage as soon as it (and the
+// preceding results) finish, rather than being held until the whole batch
+// completes. Tool 2 blocks; tools 0 and 1 must be flushed while tool 2 is still
+// running — the previous batch-at-the-end behavior would time out here.
+func TestApprovingToolsState_FlushesResultsIncrementally(t *testing.T) {
+	block := make(chan struct{})
+	execStub := func(tc sdk.ChatCompletionMessageToolCall, _ bool) domain.ConversationEntry {
+		if tc.ID == "call-2" {
+			<-block
+		}
+		return toolEntry(tc)
+	}
+	approveStub := func(sdk.ChatCompletionMessageToolCall) (bool, error) { return true, nil }
+
+	ctx, _, _, events := newApprovingCtx(makeTools(3), domain.AgentModeStandard, execStub, approveStub)
+
+	added := make(chan string, 8)
+	ctx.AddMessage = func(e domain.ConversationEntry) error {
+		if e.Message.ToolCallID != nil {
+			added <- *e.Message.ToolCallID
+		}
+		return nil
+	}
+
+	s := &ApprovingToolsState{ctx: ctx}
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+
+	got := map[string]bool{}
+	for len(got) < 2 {
+		select {
+		case id := <-added:
+			got[id] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("results were not flushed incrementally (still batched); flushed so far: %v", got)
+		}
+	}
+	assert.True(t, got["call-0"] && got["call-1"], "expected call-0 and call-1 flushed while call-2 still running, got %v", got)
+
+	close(block)
+	waitForAllToolsProcessed(t, events)
+}
+
+// TestApprovingToolsState_AutoAcceptExecutesAll verifies that in auto-accept
+// mode every tool is executed (concurrently) and results are collected in order.
+func TestApprovingToolsState_AutoAcceptExecutesAll(t *testing.T) {
+	var mu sync.Mutex
+	executed := map[string]bool{}
+
+	execStub := func(tc sdk.ChatCompletionMessageToolCall, _ bool) domain.ConversationEntry {
+		mu.Lock()
+		executed[tc.ID] = true
+		mu.Unlock()
+		return toolEntry(tc)
+	}
+	approveStub := func(sdk.ChatCompletionMessageToolCall) (bool, error) { return true, nil }
+
+	ctx, results, _, events := newApprovingCtx(makeTools(3), domain.AgentModeAutoAccept, execStub, approveStub)
+	s := &ApprovingToolsState{ctx: ctx}
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+	waitForAllToolsProcessed(t, events)
+
+	require.Len(t, *results, 3)
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 0; i < 3; i++ {
+		assert.True(t, executed[fmt.Sprintf("call-%d", i)], "call-%d was not executed", i)
+	}
+}

--- a/internal/domain/agent_events.go
+++ b/internal/domain/agent_events.go
@@ -103,6 +103,10 @@ type StateContext struct {
 	Provider               string
 	Model                  string
 
+	// MaxConcurrentTools bounds how many approved tools may execute concurrently
+	// while later tools are still being approved.
+	MaxConcurrentTools int
+
 	// Function callbacks
 	ToolExecutor   *func()
 	StartStreaming func()

--- a/internal/services/toolcoordinator/coordinator.go
+++ b/internal/services/toolcoordinator/coordinator.go
@@ -297,14 +297,19 @@ func (c *Coordinator) progressStatusCmds(msg domain.ToolExecutionProgressEvent) 
 		return c.runningProgressCmds(msg)
 	case "completed", "failed":
 		c.SetActiveToolCallID("")
-		return []tea.Cmd{func() tea.Msg {
-			return domain.SetStatusEvent{
-				Message:    msg.Message,
-				Spinner:    false,
-				StatusType: domain.StatusDefault,
-				ToolName:   "",
-			}
-		}}
+		return []tea.Cmd{
+			func() tea.Msg {
+				return domain.UpdateHistoryEvent{History: c.conversationRepo.GetMessages()}
+			},
+			func() tea.Msg {
+				return domain.SetStatusEvent{
+					Message:    msg.Message,
+					Spinner:    false,
+					StatusType: domain.StatusDefault,
+					ToolName:   "",
+				}
+			},
+		}
 	case "saving":
 		return []tea.Cmd{func() tea.Msg {
 			return domain.SetStatusEvent{

--- a/internal/services/toolcoordinator/coordinator_test.go
+++ b/internal/services/toolcoordinator/coordinator_test.go
@@ -3,11 +3,12 @@ package toolcoordinator
 import (
 	"testing"
 
+	mocksdomain "github.com/inference-gateway/cli/tests/mocks/domain"
+
 	sdk "github.com/inference-gateway/sdk"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
 	services "github.com/inference-gateway/cli/internal/services"
-	mocksdomain "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
 func newCoordinatorForTest() (*Coordinator, *services.InMemoryConversationRepository, *mocksdomain.FakeStateManager, *mocksdomain.FakeDirectExecutionService) {
@@ -159,6 +160,30 @@ func TestCoordinator_HandleToolExecutionProgress(t *testing.T) {
 		}
 	})
 
+	t.Run("completed status emits a history refresh", func(t *testing.T) {
+		c, _, _, _ := newCoordinatorForTest()
+
+		cmds := c.progressStatusCmds(domain.ToolExecutionProgressEvent{
+			ToolCallID: "tc-1",
+			Status:     "completed",
+			Message:    "done",
+		})
+
+		foundHistory := false
+		for _, cmd := range cmds {
+			if cmd == nil {
+				continue
+			}
+			if _, ok := cmd().(domain.UpdateHistoryEvent); ok {
+				foundHistory = true
+				break
+			}
+		}
+		if !foundHistory {
+			t.Errorf("expected an UpdateHistoryEvent cmd on completed status, got none")
+		}
+	})
+
 	t.Run("unknown status returns nil cmd when no channels active", func(t *testing.T) {
 		c, _, state, direct := newCoordinatorForTest()
 		state.GetChatSessionReturns(nil)
@@ -166,7 +191,7 @@ func TestCoordinator_HandleToolExecutionProgress(t *testing.T) {
 		direct.PendingBashChannelReturns(nil)
 
 		cmd := c.HandleToolExecutionProgress(domain.ToolExecutionProgressEvent{
-			Status: "executing", // not in the recognized switch
+			Status: "executing",
 		})
 		if cmd != nil {
 			t.Errorf("expected nil cmd for unknown status with no channels, got %v", cmd)


### PR DESCRIPTION
## Summary

This PR fixes the overlap between tool approval and execution - previously, tools only started executing *after* all approvals were collected, wasting time. Now each approved tool runs immediately as the user approves it, and tools run concurrently.

### Changes

1. **fix(agent): execute approved tools concurrently while approving the rest** (d5598e2)
   - Approval prompts stay sequential, but each approved tool"'s execution is spawned immediately
   - Tools run in parallel (bounded by `agent.max_concurrent_tools`)
   - Results are recorded in index-keyed slots and flushed to the conversation in tool-call order

2. **fix(agent): freeze per-tool ticker when an approved tool finishes** (5caa035)
   - `executeToolInternal` publishes its own terminal completed/failed status via a `defer`
   - The per-tool elapsed-time ticker freezes the moment the tool finishes
   - Removes redundant external publishes from `executeToolCallsParallel` to avoid double-publish flickering

3. **fix(tui): refresh conversation history when a tool finishes executing** (0906249)
   - Tool coordinator now emits an `UpdateHistoryEvent` on completed/failed tool execution
   - Freshly flushed tool results replace their "Approved" placeholder immediately

4. **refactor: inject agent config directly into EventDrivenAgent** (44986f0)
   - Clean up how config is passed to the agent