### PR TITLE
feat: add npm wrapper to install and run the CLI via npx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: '24'
+          node-version: '24.15.0'
 
       - name: Cache npm global packages
         uses: actions/cache@v5.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v3.2.0
@@ -54,7 +55,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 'lts/*'
+          node-version: '24'
 
       - name: Cache npm global packages
         uses: actions/cache@v5.0.5
@@ -74,6 +75,7 @@ jobs:
             @semantic-release/exec@7.1.0 \
             @semantic-release/git@10.0.1 \
             @semantic-release/github@1.0.0 \
+            @semantic-release/npm@13.1.5 \
             conventional-changelog-conventionalcommits@9.1.0
 
       - name: Check for existing releases
@@ -98,5 +100,10 @@ jobs:
         if: steps.check_releases.outputs.create_initial == 'false'
         env:
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          # Bootstrap: set the NPM_TOKEN secret for the first publish (package
+          # does not exist on npm yet). Once a trusted publisher is configured on
+          # npmjs.com, delete the secret and this resolves to empty so
+          # @semantic-release/npm falls back to OIDC (needs id-token: write above).
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           semantic-release

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,8 @@
+# Generated / non-authored Markdown
+CHANGELOG.md
+AGENTS.md
+CLAUDE.md
+
+# npm wrapper: README.md and LICENSE are copied in from the repo root at
+# publish time (see npm/.gitignore); they are not authored here.
+npm/

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -95,11 +95,17 @@ plugins:
         if [ -z "$NEW_HASH" ]; then echo "ERROR: could not extract vendorHash from nix build output"; exit 1; fi
         sed -i.bak "s|vendorHash = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\";|vendorHash = \"$NEW_HASH\";|" flake.nix && rm flake.nix.bak
         echo "Updated vendorHash to $NEW_HASH"
+        cp LICENSE npm/LICENSE
+        cp README.md npm/README.md
+
+  - - "@semantic-release/npm"
+    - pkgRoot: npm
 
   - - "@semantic-release/git"
     - assets:
         - CHANGELOG.md
         - flake.nix
+        - npm/package.json
       message: |
         chore(release): ${nextRelease.version} [skip ci]
 
@@ -114,7 +120,25 @@ plugins:
 
         ## 📦 Installation
 
-        ### Quick Install (Recommended)
+        ### npm / npx (Recommended)
+
+        Most developers already have Node.js - run `infer` without installing anything. npx downloads the matching native binary on first use:
+
+        ```bash
+        npx @inference-gateway/cli@<%= nextRelease.version %> --help
+        npx @inference-gateway/cli@<%= nextRelease.version %> chat
+        ```
+
+        Or install it globally:
+
+        ```bash
+        npm install -g @inference-gateway/cli@<%= nextRelease.version %>
+        infer --help
+        ```
+
+        > Not recommended for production - prefer the install script, container image, or Nix flake below.
+
+        ### Quick Install (Install Script)
 
         Install the latest version using our install script:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ An agentic command-line assistant that writes code, understands project context,
 - **Inline History Auto-Completion**: Smart command history suggestions with inline completion
 - **GitHub Issue References (`#`)**: Type `#` in chat to open a dropdown of the current
   repo's open issues. Selecting one inserts a `#N` token that is highlighted in the input
-  and, on submit, expanded inline into the issue's title, body, and recent comments — so
+  and, on submit, expanded inline into the issue's title, body, and recent comments - so
   the agent works from full context without a redundant `gh issue view` lookup. Gracefully
   no-ops when `gh` is not installed or the repo has no remote.
 - **Customizable Keybindings**: Fully configurable keyboard shortcuts for the chat interface
@@ -85,6 +85,29 @@ An agentic command-line assistant that writes code, understands project context,
   with a separate configurable system prompt - off by default - [Learn more →](docs/heartbeat.md)
 
 ## Installation
+
+### Using npm/npx (Recommended)
+
+If you already have Node.js (>= 18), run the CLI with npx - no Go toolchain or manual
+download required. The matching native binary is fetched and cached on first use:
+
+```bash
+# Run without installing
+npx @inference-gateway/cli@latest --help
+npx @inference-gateway/cli@latest chat
+```
+
+Or install it globally:
+
+```bash
+npm install -g @inference-gateway/cli
+infer --help
+```
+
+> **Not recommended for production.** For production or CI, prefer the
+> [install script](#using-install-script), [container image](#using-container-image), or
+> [building from source](#build-from-source). Prebuilt binaries cover Linux and macOS on
+> amd64/arm64 - on Windows, use WSL.
 
 ### Using Go Install
 
@@ -721,9 +744,9 @@ Prices are updated regularly to match current provider pricing.
 The model picker groups models into three categories you can filter with the
 `[1] All` / `[2] Free` / `[3] Paid` / `[4] Pro` tabs:
 
-- **Free** — no per-token cost (e.g. local Ollama, Gemma).
-- **Paid** — billed per token at the listed `$input/$output per MTok` rate.
-- **Pro** — gated behind a paid **Pro subscription** (some Ollama Cloud models).
+- **Free** - no per-token cost (e.g. local Ollama, Gemma).
+- **Paid** - billed per token at the listed `$input/$output per MTok` rate.
+- **Pro** - gated behind a paid **Pro subscription** (some Ollama Cloud models).
   These have no per-token price but are not free, so they are marked
   `pro subscription` instead of `free` to avoid the misleading label.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,7 +57,7 @@ tasks:
     desc: Run linter (requires golangci-lint)
     cmds:
       - golangci-lint run
-      - markdownlint . --ignore '{CHANGELOG,AGENTS,CLAUDE}.md' --fix
+      - markdownlint . --fix
 
   fmt:
     desc: Format Go code

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,11 @@
+# Native binary fetched at install time
+infer
+infer.exe
+
+# Copied from repo root at publish time
+LICENSE
+README.md
+
+# Auth + deps
+.npmrc
+node_modules/

--- a/npm/bin/install.js
+++ b/npm/bin/install.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+"use strict";
+
+// Downloads the native `infer` binary that matches the host platform from the
+// GitHub release matching this package's version, and places it next to this
+// script so `bin/run.js` can exec it. Runs as an npm `postinstall` hook.
+//
+// The CLI publishes raw executables (e.g. `infer-linux-amd64`) plus a
+// `checksums.txt`, so this downloads the binary directly - no archive to extract.
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const crypto = require("crypto");
+
+const REPO = "inference-gateway/cli";
+const { version } = require("../package.json");
+const BASE_URL =
+  process.env.INFER_CLI_BASE_URL ||
+  `https://github.com/${REPO}/releases/download/v${version}`;
+
+// Maps Node's process.platform / process.arch onto the release asset names.
+const PLATFORMS = { linux: "linux", darwin: "darwin" };
+const ARCHES = { x64: "amd64", arm64: "arm64" };
+
+const binName = process.platform === "win32" ? "infer.exe" : "infer";
+const binPath = path.join(__dirname, binName);
+
+function fail(message) {
+  console.error(`\n@inference-gateway/cli: ${message}\n`);
+  process.exit(1);
+}
+
+function resolveAsset() {
+  const goos = PLATFORMS[process.platform];
+  const goarch = ARCHES[process.arch];
+  if (!goos || !goarch) {
+    fail(
+      `unsupported platform ${process.platform}/${process.arch}. ` +
+        `Prebuilt binaries are published for linux and darwin on amd64/arm64 only. ` +
+        `Install from source instead: https://github.com/${REPO}#installation`
+    );
+  }
+  return `infer-${goos}-${goarch}`;
+}
+
+function download(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { "User-Agent": "inference-gateway-cli-npm" } }, (res) => {
+        const { statusCode, headers } = res;
+        if (statusCode >= 300 && statusCode < 400 && headers.location) {
+          res.resume();
+          resolve(download(headers.location));
+          return;
+        }
+        if (statusCode !== 200) {
+          res.resume();
+          reject(new Error(`request to ${url} failed with status ${statusCode}`));
+          return;
+        }
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
+      })
+      .on("error", reject);
+  });
+}
+
+async function verifyChecksum(binary, assetName) {
+  let checksums;
+  try {
+    checksums = (await download(`${BASE_URL}/checksums.txt`)).toString("utf8");
+  } catch (err) {
+    console.warn(
+      `@inference-gateway/cli: could not fetch checksums.txt (${err.message}); skipping integrity check`
+    );
+    return;
+  }
+  const line = checksums.split("\n").find((l) => l.trim().endsWith(assetName));
+  if (!line) {
+    console.warn(
+      `@inference-gateway/cli: no checksum entry for ${assetName}; skipping integrity check`
+    );
+    return;
+  }
+  const expected = line.trim().split(/\s+/)[0];
+  const actual = crypto.createHash("sha256").update(binary).digest("hex");
+  if (expected !== actual) {
+    fail(`checksum mismatch for ${assetName} (expected ${expected}, got ${actual})`);
+  }
+}
+
+async function main() {
+  if (process.env.INFER_CLI_SKIP_DOWNLOAD) {
+    console.log("@inference-gateway/cli: INFER_CLI_SKIP_DOWNLOAD set, skipping binary download");
+    return;
+  }
+  if (fs.existsSync(binPath)) {
+    return;
+  }
+
+  const assetName = resolveAsset();
+  const url = `${BASE_URL}/${assetName}`;
+  console.log(`@inference-gateway/cli: downloading ${assetName} (v${version})`);
+
+  let binary;
+  try {
+    binary = await download(url);
+  } catch (err) {
+    fail(
+      `failed to download ${url}: ${err.message}. ` +
+        `If you are offline, install from source: https://github.com/${REPO}#installation`
+    );
+  }
+
+  await verifyChecksum(binary, assetName);
+
+  fs.mkdirSync(path.dirname(binPath), { recursive: true });
+  fs.writeFileSync(binPath, binary, { mode: 0o755 });
+  fs.chmodSync(binPath, 0o755);
+  console.log(`@inference-gateway/cli: installed infer ${version} to ${binPath}`);
+}
+
+main().catch((err) => fail(err.message));

--- a/npm/bin/run.js
+++ b/npm/bin/run.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+"use strict";
+
+// Locates the native `infer` binary fetched by bin/install.js and execs it,
+// forwarding all arguments, stdio, and the exit code.
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const binName = process.platform === "win32" ? "infer.exe" : "infer";
+const binPath = path.join(__dirname, binName);
+
+if (!fs.existsSync(binPath)) {
+  const install = spawnSync(process.execPath, [path.join(__dirname, "install.js")], {
+    stdio: "inherit",
+  });
+  if (install.status !== 0 || !fs.existsSync(binPath)) {
+    console.error(
+      "@inference-gateway/cli: native binary not found and could not be installed. " +
+        "Reinstall the package or install from source: " +
+        "https://github.com/inference-gateway/cli#installation"
+    );
+    process.exit(1);
+  }
+}
+
+const result = spawnSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  console.error(`@inference-gateway/cli: failed to run binary: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status === null ? 1 : result.status);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@inference-gateway/cli",
+  "version": "0.118.0",
+  "description": "A Git-first CLI coding agent that turns ideas, issues, and tasks into real code changes.",
+  "bin": {
+    "infer": "bin/run.js"
+  },
+  "scripts": {
+    "postinstall": "node bin/install.js"
+  },
+  "files": [
+    "bin/run.js",
+    "bin/install.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "inference-gateway",
+    "cli",
+    "llm",
+    "ai",
+    "agent",
+    "chat",
+    "tui",
+    "a2a",
+    "mcp"
+  ],
+  "homepage": "https://github.com/inference-gateway/cli#readme",
+  "bugs": {
+    "url": "https://github.com/inference-gateway/cli/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inference-gateway/cli.git"
+  },
+  "license": "Apache-2.0",
+  "author": "Inference Gateway",
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "linux",
+    "darwin"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #568. Adds an npm/npx wrapper so the CLI can be run with `npx @inference-gateway/cli` (Node >= 18) - no Go toolchain or manual download. Mirrors the approach already shipping in `inference-gateway/adl-cli`.

This repo ships raw release binaries (`infer-<os>-<arch>`) built by `artifacts.yml`, so the installer downloads the binary directly (no archive to extract) and verifies it against `checksums.txt`.

## What's included

- **`npm/` wrapper (zero runtime deps)**
  - `package.json` - `@inference-gateway/cli`, bin `infer`, `postinstall` hook, `os`/`cpu` gates (linux/darwin, x64/arm64).
  - `bin/install.js` - downloads the matching `infer-<os>-<arch>` release asset, checksum-verifies against `checksums.txt`, caches it next to the script, `chmod +x`. Honors `INFER_CLI_BASE_URL` and `INFER_CLI_SKIP_DOWNLOAD`.
  - `bin/run.js` - locates/installs the binary, execs it, forwards args and exit code.
  - `.gitignore` - excludes the fetched binary and the publish-time README/LICENSE copies.
- **`.releaserc.yaml`** - `@semantic-release/npm` (`pkgRoot: npm`); copies LICENSE/README into `npm/` at release; commits `npm/package.json` so the version stays in sync; adds an "npm / npx" block to the release body.
- **`.github/workflows/release.yml`** - `id-token: write` (OIDC), Node pinned to `24` (npm >= 11.5.1), `@semantic-release/npm@13.1.5`, passes `NPM_TOKEN` for the bootstrap publish.
- **`README.md`** - new "Using npm/npx (Recommended)" install section with a "not recommended for production" caveat.
- **`Taskfile.yml` + `.markdownlintignore`** - moved markdownlint ignores into a config file so they apply for `task lint`, pre-commit, and any direct/CI invocation; the `npm/` publish copies are excluded.

`artifacts.yml` is unchanged - it already produces `infer-{linux,darwin}-{amd64,arm64}` + `checksums.txt`, exactly what the installer consumes.

## Platforms

Linux + macOS on amd64/arm64 (matches adl-cli and this repo's release assets). armv7 and Windows (use WSL) are out of scope.

## Manual prerequisites before the next release publishes to npm (org admin)

1. **Bootstrap:** add a temporary `NPM_TOKEN` secret (npm automation token with publish rights to the `@inference-gateway` scope). The first release publishes `@inference-gateway/cli` using it.
2. **Switch to OIDC:** after the first publish, configure a trusted publisher on npmjs.com for `@inference-gateway/cli` -> repo `inference-gateway/cli`, workflow `.github/workflows/release.yml`, then delete the `NPM_TOKEN` secret so subsequent releases publish via OIDC (same model as `@inference-gateway/adl-cli`).

## Verification

- `install.js` downloaded + checksum-verified `infer-darwin-arm64` from v0.118.0; `run.js` ran it (`infer v0.118.0`, `--help`); re-run no-ops (cached); `INFER_CLI_SKIP_DOWNLOAD` skips.
- `npm pack --dry-run` -> tarball = package.json + bin/{run,install}.js + README + LICENSE (native binary excluded).
- `markdownlint .` and the full pre-commit lint pass.

## Follow-up

Docs ticket filed: inference-gateway/docs#182 (document `npx @inference-gateway/cli`).
