### PR TITLE
feat(tools): restrict bash file-write redirects unless whitelisted by pattern

### DIFF
--- a/config/bash_whitelist.go
+++ b/config/bash_whitelist.go
@@ -31,6 +31,12 @@ var benignTrailingRedirectRe = regexp.MustCompile(
 //     command would carry an arbitrary tail.
 //   - Benign trailing redirections (2>&1, 2>/dev/null, …) are stripped per
 //     segment before matching.
+//   - A file-write redirection that survives stripping (>, >>, &>file) restricts
+//     its segment to whole-command pattern matching: the plain command list no
+//     longer applies and a prefix pattern (^git log) will not unlock it, so a
+//     whitelisted command cannot be turned into an arbitrary file write
+//     (echo secret > /etc/passwd). An anchored pattern (^…$) can still allow a
+//     specific redirect.
 //
 // It is the single source of truth consulted by the Bash tool, the approval
 // policy, and agent auto-approval, so all three agree on exactly what runs
@@ -62,6 +68,37 @@ func (c *Config) IsBashCommandWhitelisted(command string) bool {
 	return true
 }
 
+// BashWhitelistRejectionHint returns a short, actionable explanation when
+// command uses a restricted shell construct - command substitution or a
+// file-write redirection - so the model gets precise feedback instead of a bare
+// "not whitelisted". It returns "" when no special explanation applies; callers
+// should surface it only alongside an actual rejection.
+func BashWhitelistRejectionHint(command string) string {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return ""
+	}
+
+	if containsCommandSubstitution(command) {
+		return "command substitution ($(...), backticks, <(...), >(...)) is not permitted; " +
+			"run the inner command directly instead"
+	}
+
+	segments, ok := splitBashSegments(command)
+	if !ok {
+		return ""
+	}
+	for _, seg := range segments {
+		seg = stripBenignTrailingRedirections(strings.TrimSpace(seg))
+		if containsFileRedirect(seg) {
+			return "output redirection to a file ('>' or '>>') is restricted by default " +
+				"(benign forms like '2>&1' or '>/dev/null' are allowed); to permit this exact " +
+				"command, add an anchored regex (^...$) to tools.bash.whitelist.patterns"
+		}
+	}
+	return ""
+}
+
 // dangerousFindActionRe matches find(1) primaries that execute a command or
 // mutate the filesystem (-exec, -delete, …). A bare "find" is whitelisted for
 // read-only discovery, but these actions turn it into an arbitrary-command /
@@ -71,21 +108,35 @@ var dangerousFindActionRe = regexp.MustCompile(
 	`(^|\s)-(execdir|exec|okdir|ok|delete|fprintf|fprint0|fprint|fls)(\s|$)`,
 )
 
-// isSingleBashCommandAllowed matches one already-split, redirection-free command
-// against the configured command and pattern whitelists.
+// isSingleBashCommandAllowed matches one already-split segment (with benign
+// trailing redirections already stripped) against the configured command and
+// pattern whitelists. A segment that still carries a file-write redirection
+// (>, >>) bypasses the plain command list and is allowed only by a pattern that
+// matches the entire command, so a whitelisted command cannot smuggle in an
+// arbitrary write target.
 func (c *Config) isSingleBashCommandAllowed(command string) bool {
 	if (command == "find" || strings.HasPrefix(command, "find ")) &&
 		dangerousFindActionRe.MatchString(command) {
 		return false
 	}
 
-	for _, allowed := range c.Tools.Bash.Whitelist.Commands {
-		if command == allowed || strings.HasPrefix(command, allowed+" ") {
-			return true
+	hasFileRedirect := containsFileRedirect(command)
+
+	if !hasFileRedirect {
+		for _, allowed := range c.Tools.Bash.Whitelist.Commands {
+			if command == allowed || strings.HasPrefix(command, allowed+" ") {
+				return true
+			}
 		}
 	}
 
 	for _, pattern := range c.Tools.Bash.Whitelist.Patterns {
+		if hasFileRedirect {
+			if matchesEntirePattern(pattern, command) {
+				return true
+			}
+			continue
+		}
 		matched, err := regexp.MatchString(pattern, command)
 		if err == nil && matched {
 			return true
@@ -93,6 +144,15 @@ func (c *Config) isSingleBashCommandAllowed(command string) bool {
 	}
 
 	return false
+}
+
+// matchesEntirePattern reports whether pattern matches command in its entirety,
+// regardless of whether pattern carries its own anchors. It is used for segments
+// that contain a file-write redirection, where a mere prefix match (e.g. ^git
+// log against "git log > /etc/passwd") must not be enough to unlock the command.
+func matchesEntirePattern(pattern, command string) bool {
+	matched, err := regexp.MatchString(`\A(?:`+pattern+`)\z`, command)
+	return err == nil && matched
 }
 
 // stripBenignTrailingRedirections removes any run of trailing benign
@@ -157,6 +217,46 @@ func containsCommandSubstitution(command string) bool {
 				if i+1 < len(runes) && runes[i+1] == '(' {
 					return true
 				}
+			}
+		}
+	}
+
+	return false
+}
+
+// containsFileRedirect reports whether seg contains an unquoted output
+// redirection to a real file (>, >>, &>file, >&file). It is meant to run after
+// stripBenignTrailingRedirections, so any surviving unquoted '>' denotes a write
+// to the filesystem rather than a benign /dev/null or fd-duplication suffix. A
+// '>' inside single or double quotes is a literal argument and is ignored.
+func containsFileRedirect(seg string) bool {
+	var inSingle, inDouble bool
+	runes := []rune(seg)
+
+	for i := 0; i < len(runes); i++ {
+		ch := runes[i]
+		switch {
+		case inSingle:
+			if ch == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			switch ch {
+			case '\\':
+				i++ // backslash escapes the next char inside double quotes
+			case '"':
+				inDouble = false
+			}
+		default:
+			switch ch {
+			case '\\':
+				i++
+			case '\'':
+				inSingle = true
+			case '"':
+				inDouble = true
+			case '>':
+				return true
 			}
 		}
 	}

--- a/config/bash_whitelist_test.go
+++ b/config/bash_whitelist_test.go
@@ -358,3 +358,167 @@ func TestContainsCommandSubstitution(t *testing.T) {
 		}
 	}
 }
+
+// TestIsBashCommandWhitelisted_FileRedirectRestricted covers issue #560: a
+// whitelisted command (or non-anchored pattern) must not be usable to write to a
+// real file via > / >>. Benign redirects (2>&1, >/dev/null) remain allowed
+// because they are stripped before matching.
+func TestIsBashCommandWhitelisted_FileRedirectRestricted(t *testing.T) {
+	cfg := DefaultConfig()
+
+	denied := []string{
+		"echo hi > /tmp/out",          // whitelisted command + file redirect
+		"echo hi >> /tmp/out",         // append redirect
+		"ls > out.txt",                // whitelisted command + file redirect
+		"git log > /etc/passwd",       // non-anchored pattern must not unlock it
+		"git status > /tmp/x",         // non-anchored pattern must not unlock it
+		"echo x &> out.txt",           // both streams to a file
+		"echo x >& out.txt",           // fd-dup form that targets a file
+		"tail -n 5 /var/log/x > leak", // whitelisted prefix + file redirect
+	}
+	for _, cmd := range denied {
+		if cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q NOT to be whitelisted (writes to a real file)", cmd)
+		}
+	}
+
+	allowed := []string{
+		"gh issue list >/dev/null",          // benign redirect, stripped
+		"git status 2>&1",                   // benign fd-dup, stripped
+		"gh issue list >/dev/null 2>&1",     // stacked benign redirects
+		`gh issue comment 5 --body "a > b"`, // '>' is inside quotes, not a redirect
+		"echo 'write > file'",               // single-quoted, not a redirect
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q to be whitelisted (no real file write)", cmd)
+		}
+	}
+}
+
+// TestIsBashCommandWhitelisted_PatternUnlocksRedirect verifies that a whitelist
+// pattern takes precedence over the redirect restriction, but only when it
+// matches the WHOLE command - a prefix pattern (^git log) must not unlock a
+// redirected variant.
+func TestIsBashCommandWhitelisted_PatternUnlocksRedirect(t *testing.T) {
+	cfg := &Config{
+		Tools: ToolsConfig{
+			Enabled: true,
+			Bash: BashToolConfig{
+				Enabled: true,
+				Whitelist: ToolWhitelistConfig{
+					Commands: []string{"echo"},
+					Patterns: []string{
+						`^echo hi > /tmp/out\.txt$`, // anchored: unlocks one exact redirect
+						`^git log`,                  // prefix pattern: must NOT unlock redirects
+					},
+				},
+			},
+		},
+	}
+
+	allowed := []string{
+		"echo hi > /tmp/out.txt", // matches the anchored redirect pattern
+		"echo hello",             // plain whitelisted command, no redirect
+		"git log",                // prefix pattern, no redirect
+		"git log --oneline -5",   // prefix pattern, no redirect
+	}
+	for _, cmd := range allowed {
+		if !cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q to be whitelisted", cmd)
+		}
+	}
+
+	denied := []string{
+		"echo hi > /tmp/other.txt", // redirect pattern does not match this target
+		"echo bye > /tmp/out.txt",  // redirect pattern does not match this command
+		"git log > /etc/passwd",    // prefix pattern must not unlock a redirect
+	}
+	for _, cmd := range denied {
+		if cfg.IsBashCommandWhitelisted(cmd) {
+			t.Errorf("expected %q NOT to be whitelisted", cmd)
+		}
+	}
+}
+
+// TestIsBashCommandWhitelisted_PipePolicy documents the pipe behavior kept from
+// #581: every segment of a pipeline must be independently whitelisted. This is
+// what already blocks the issue #560 example "ls | xargs rm".
+func TestIsBashCommandWhitelisted_PipePolicy(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if !cfg.IsBashCommandWhitelisted("ls | head") {
+		t.Error("expected \"ls | head\" to be whitelisted (both segments allowed)")
+	}
+	if !cfg.IsBashCommandWhitelisted("echo hi | wc -l") {
+		t.Error("expected \"echo hi | wc -l\" to be whitelisted (both segments allowed)")
+	}
+	if cfg.IsBashCommandWhitelisted("ls | xargs rm") {
+		t.Error("expected \"ls | xargs rm\" NOT to be whitelisted (xargs rm is not allowed)")
+	}
+	if cfg.IsBashCommandWhitelisted("ls | tee out.txt") {
+		t.Error("expected \"ls | tee out.txt\" NOT to be whitelisted (tee is not allowed)")
+	}
+}
+
+func TestContainsFileRedirect(t *testing.T) {
+	// containsFileRedirect runs after benign trailing redirects are stripped, so
+	// it only needs to recognize an unquoted '>' as a write to a real file.
+	tests := []struct {
+		seg  string
+		want bool
+	}{
+		{"echo hi > /tmp/out", true},
+		{"echo hi >> /tmp/out", true},
+		{"echo x &> out.txt", true},
+		{"echo x >& out.txt", true},
+		{"echo a>b", true},
+		{"ls", false},
+		{"git status", false},
+		{`gh issue comment 5 --body "a > b"`, false}, // double-quoted
+		{"echo 'a > b'", false},                      // single-quoted
+	}
+	for _, tt := range tests {
+		t.Run(tt.seg, func(t *testing.T) {
+			if got := containsFileRedirect(tt.seg); got != tt.want {
+				t.Errorf("containsFileRedirect(%q) = %v, want %v", tt.seg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesEntirePattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		command string
+		want    bool
+	}{
+		{`^echo hi > /tmp/out\.txt$`, "echo hi > /tmp/out.txt", true},
+		{`^echo hi > /tmp/out\.txt$`, "echo hi > /tmp/other.txt", false},
+		{`^git log`, "git log", true},                   // no anchor needed, whole string matches
+		{`^git log`, "git log > /etc/passwd", false},    // prefix only - not the whole command
+		{`^git log .*$`, "git log > /etc/passwd", true}, // author opted into the tail explicitly
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			if got := matchesEntirePattern(tt.pattern, tt.command); got != tt.want {
+				t.Errorf("matchesEntirePattern(%q, %q) = %v, want %v", tt.pattern, tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBashWhitelistRejectionHint(t *testing.T) {
+	if h := BashWhitelistRejectionHint("echo hi > /tmp/out"); !strings.Contains(h, "redirection") {
+		t.Errorf("expected a redirection hint, got %q", h)
+	}
+	if h := BashWhitelistRejectionHint("echo $(whoami)"); !strings.Contains(h, "substitution") {
+		t.Errorf("expected a command-substitution hint, got %q", h)
+	}
+	if h := BashWhitelistRejectionHint("ls -la"); h != "" {
+		t.Errorf("expected no hint for a plain command, got %q", h)
+	}
+	if h := BashWhitelistRejectionHint("git status 2>&1"); h != "" {
+		t.Errorf("expected no hint for a benign redirect, got %q", h)
+	}
+}

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -368,7 +368,7 @@ Briefly inspect the project (build system, config files, existing docs) to groun
 func defaultPromptsToolsConfig() PromptsToolsConfig { //nolint:funlen
 	return PromptsToolsConfig{
 		Bash: PromptsToolDescription{
-			Description: `Execute whitelisted bash commands securely. Only pre-approved commands from the whitelist can be executed.`,
+			Description: `Execute whitelisted bash commands securely. Only pre-approved commands from the whitelist can be executed. Each segment of a pipe or &&/||/; chain must itself be whitelisted, and file-write redirections (>, >>) and command substitution ($(...), backticks) are blocked unless an anchored whitelist pattern (^...$) explicitly allows them; benign redirects like 2>&1 or >/dev/null are fine.`,
 		},
 		BashOutput: PromptsToolDescription{
 			Description: `Retrieves output from a running or completed background bash shell. Returns only new output since the last read. Use this to monitor long-running commands that were moved to the background.`,

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -580,6 +580,11 @@ accept comma-separated or newline-separated values:
 - `INFER_TOOLS_BASH_WHITELIST_COMMANDS`: Comma-separated list of whitelisted commands
 - `INFER_TOOLS_BASH_WHITELIST_PATTERNS`: Comma-separated list of regex patterns for whitelisted commands
 
+> The matcher is shell-aware: each segment of a pipe/chain (`|`, `&&`, `||`, `;`) must be whitelisted,
+> file-write redirections (`>`, `>>`) and command substitution (`$(...)`) are blocked unless an anchored
+> pattern (`^...$`) allows the whole command, and benign redirects (`2>&1`, `>/dev/null`) are permitted.
+> See [Bash Tool restricted operators](tools-reference.md#bash-tool) for details.
+
 **Examples:**
 
 ```bash

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -396,6 +396,35 @@ tools:
 - Commands are validated before execution
 - Supports both exact matches and regex patterns
 
+**Restricted operators:**
+
+The matcher is shell-aware, so a whitelisted command cannot be composed into something more
+dangerous:
+
+- **Pipes and chains** (`|`, `&&`, `||`, `;`) are split at the top level and **every segment must be
+  independently whitelisted**. `ls | head` is allowed only if both `ls` and `head` are; `ls | xargs rm`
+  is rejected because `xargs rm` is not.
+- **File-write redirections** (`>`, `>>`, `&>file`, `>&file`) are **blocked by default**, even for a
+  whitelisted command (`echo secret > /etc/passwd` is rejected). They are allowed only when a whitelist
+  **pattern** matches the *entire* command - a prefix pattern such as `^git log` will not unlock
+  `git log > file`.
+- **Benign redirections** that only discard or merge streams (`2>&1`, `>/dev/null`, `2>/dev/null`) are
+  stripped before matching and remain allowed.
+- **Command substitution** (`$(...)`, backticks, `<(...)`, `>(...)`) is always rejected.
+
+To deliberately allow a redirection, add an anchored pattern (`^...$`) that covers the whole command:
+
+```yaml
+tools:
+  bash:
+    whitelist:
+      patterns:
+        - ^echo .+ >> /var/log/app\.log$   # allow appending to one specific file
+```
+
+A rejected command returns explanatory feedback naming the restricted operator and how to whitelist
+it, and (when approval is enabled) still goes through the normal approval prompt.
+
 ---
 
 ## Web Tools

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -140,7 +140,7 @@ func (t *BashTool) Validate(args map[string]any) error {
 	}
 
 	if !t.isCommandAllowed(command) {
-		return fmt.Errorf("command not whitelisted: %s", command)
+		return t.notWhitelistedError(command)
 	}
 
 	return nil
@@ -170,10 +170,11 @@ func (t *BashTool) executeBash(ctx context.Context, command string) (*BashResult
 	wasApproved := domain.IsToolApproved(ctx)
 
 	if !wasApproved && !t.isCommandAllowed(command) {
+		err := t.notWhitelistedError(command)
 		result.ExitCode = -1
 		result.Duration = time.Since(start).String()
-		result.Error = fmt.Sprintf("command not whitelisted: %s", command)
-		return result, fmt.Errorf("command not whitelisted: %s", command)
+		result.Error = err.Error()
+		return result, err
 	}
 
 	outputCallback := domain.GetBashOutputCallback(ctx)
@@ -381,6 +382,17 @@ func (t *BashTool) readPipeWithBatching(
 // compound-command splitting, command-substitution rejection).
 func (t *BashTool) isCommandAllowed(command string) bool {
 	return t.config.IsBashCommandWhitelisted(command)
+}
+
+// notWhitelistedError builds the rejection error for a non-whitelisted command,
+// appending actionable guidance when the command was blocked by a restricted
+// operator (file-write redirection or command substitution) so the model can
+// correct it rather than retrying blindly.
+func (t *BashTool) notWhitelistedError(command string) error {
+	if hint := config.BashWhitelistRejectionHint(command); hint != "" {
+		return fmt.Errorf("command not whitelisted: %s - %s", command, hint)
+	}
+	return fmt.Errorf("command not whitelisted: %s", command)
 }
 
 // FormatResult formats tool execution results for different contexts

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -114,6 +114,13 @@ func TestBashTool_Validate(t *testing.T) {
 			wantError: true,
 		},
 		{
+			name: "file redirect on whitelisted command is rejected",
+			args: map[string]any{
+				"command": "echo hello > /tmp/evil",
+			},
+			wantError: true,
+		},
+		{
 			name:      "missing command parameter",
 			args:      map[string]any{},
 			wantError: true,
@@ -134,6 +141,34 @@ func TestBashTool_Validate(t *testing.T) {
 				t.Errorf("Validate() error = %v, wantError %v", err, tt.wantError)
 			}
 		})
+	}
+}
+
+// TestBashTool_Validate_RedirectFeedback verifies a denied file-redirect command
+// returns actionable guidance (issue #560) rather than a bare "not whitelisted".
+func TestBashTool_Validate_RedirectFeedback(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Bash: config.BashToolConfig{
+				Enabled: true,
+				Whitelist: config.ToolWhitelistConfig{
+					Commands: []string{"echo"},
+				},
+			},
+		},
+	}
+	tool := NewBashTool(cfg, nil)
+
+	err := tool.Validate(map[string]any{"command": "echo secret > /tmp/evil"})
+	if err == nil {
+		t.Fatal("expected an error for a file-redirect command")
+	}
+	if !strings.Contains(err.Error(), "redirection") {
+		t.Errorf("expected redirection guidance in error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "tools.bash.whitelist.patterns") {
+		t.Errorf("expected the error to point at the whitelist patterns, got %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #560.

A whitelisted Bash command could write to an **arbitrary file**, because the matcher prefix-matched the whole command string including a trailing `> file`. With `echo` (or any prefix-matched command) or a non-anchored pattern (`^git log`) whitelisted, these were silently auto-approved:

- `echo secret > /etc/passwd`
- `git log > /etc/passwd`

Pipes (`|`) and command substitution were already handled by the shell-aware matcher added in #581 / #605 — the issue's headline `ls | xargs rm` is already denied (`xargs rm` isn't whitelisted). The remaining, genuine gap was **file-write redirects**, which this PR closes.

## What changed

A segment that still carries a non-benign file-write redirection (`>`, `>>`, `&>file`, `>&file`) now:

- **bypasses the plain command list**, and
- is allowed **only by a whitelist pattern that matches the entire command** (`\A(?:…)\z`), so a prefix pattern like `^git log` cannot unlock a redirected variant, while an anchored `^…$` pattern can opt one in.

Benign redirects (`2>&1`, `>/dev/null`) are still stripped and allowed; command substitution is still rejected. Denied commands now return **actionable feedback** naming the operator and pointing at `tools.bash.whitelist.patterns`.

Per discussion, pipe behavior from #581 is intentionally unchanged (each segment must be independently whitelisted), and restricted-operator commands still flow through the normal approval prompt rather than being hard-denied.

## Acceptance criteria (#560)

- [x] `|`, `>`, `>>` handled — `>`/`>>` restricted (new); `|` segment-split (existing, now covered by tests)
- [x] whitelist patterns take precedence (anchored full-command match)
- [x] documented (`docs/tools-reference.md`, `docs/configuration-reference.md`)
- [x] tested

## Tests

- `config/bash_whitelist_test.go`: redirect restriction, pattern-unlocks-redirect (incl. prefix-pattern must-**not**-unlock), pipe policy (`ls | xargs rm` denied, `ls | head` allowed), `containsFileRedirect`, `matchesEntirePattern`, rejection-hint.
- `internal/agent/tools/bash_test.go`: redirect `Validate` case + error-message assertion.
- `task test` (full suite), `task lint` (golangci-lint 0 issues + markdownlint), `task build` all pass.

## Docs / cross-repo

In-repo `docs/` updated. A matching `[DOCS]` ticket for `inference-gateway/docs` may be warranted if the docs site mirrors these pages - happy to draft it.