### PR TITLE
fix(compact): skip rollover/auto-compact for unknown context windows

### DIFF
--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1286,7 +1286,7 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("AddMessage: %v", err)
 		}
-		if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
 			t.Fatalf("AddTokenUsage: %v", err)
 		}
 
@@ -1294,7 +1294,7 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 			config:           &config.Config{},
 			conversationRepo: repo,
 			sessionID:        originalID,
-			model:            "unknown-tiny-model",
+			model:            "moonshot/moonshot-v1-8k",
 			rolloverManager:  mgr,
 			groupKey:         "channel-test-group",
 			completedTurns:   7,
@@ -1343,7 +1343,7 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("AddMessage: %v", err)
 		}
-		if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
 			t.Fatalf("AddTokenUsage: %v", err)
 		}
 
@@ -1351,7 +1351,7 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 			config:           &config.Config{},
 			conversationRepo: repo,
 			sessionID:        originalID,
-			model:            "unknown-tiny-model",
+			model:            "moonshot/moonshot-v1-8k",
 			rolloverManager:  mgr,
 		}
 

--- a/config/model_context.go
+++ b/config/model_context.go
@@ -41,6 +41,7 @@ var ContextMatchers = []ModelMatcher{
 	{Patterns: []string{"devstral"}, ContextWindow: 131072},
 	{Patterns: []string{"mistral", "mixtral"}, ContextWindow: 32768},
 	{Patterns: []string{"minimax-m2"}, ContextWindow: 204800},
+	{Patterns: []string{"minimax-m3"}, ContextWindow: 1000000},
 	{Patterns: []string{"glm-4", "glm-5"}, ContextWindow: 200000},
 	{Patterns: []string{"nemotron-3"}, ContextWindow: 262144},
 	{Patterns: []string{"kimi-k2", "kimi-latest"}, ContextWindow: 262144},

--- a/internal/handlers/chat_message_processor_test.go
+++ b/internal/handlers/chat_message_processor_test.go
@@ -461,13 +461,11 @@ func TestChatMessageProcessor_processChatMessage_AsyncRolloverPath(t *testing.T)
 		Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hi")},
 		Time:    time.Now(),
 	}))
-	// LastInputTokens above the 80% threshold for the unknown-model fallback
-	// (30000 * 80 / 100 = 24000) opens the rollover gate without needing a
-	// large conversation in the entries-only estimator.
-	require.NoError(t, repo.AddTokenUsage("unknown-tiny-model", 25000, 100, 25100))
+
+	require.NoError(t, repo.AddTokenUsage("moonshot/moonshot-v1-8k", 25000, 100, 25100))
 
 	mockModel := &mocks.FakeModelService{}
-	mockModel.GetCurrentModelReturns("unknown-tiny-model")
+	mockModel.GetCurrentModelReturns("moonshot/moonshot-v1-8k")
 	stateManager := services.NewStateManager(false)
 	fakeRunner := &mocks.FakeChatCompletionRunner{}
 	fakeRunner.StartReturns(func() tea.Msg { return nil })

--- a/internal/models/context_test.go
+++ b/internal/models/context_test.go
@@ -219,8 +219,9 @@ func TestMistralFamilyContextWindow(t *testing.T) {
 	}
 }
 
-// TestMiscOpenWeightContextWindow covers GPT-OSS, MiniMax M2, GLM 4/5, and
-// Nemotron 3 - all served via ollama_cloud.
+// TestMiscOpenWeightContextWindow covers GPT-OSS, MiniMax M2/M3, GLM 4/5, and
+// Nemotron 3 - all served via ollama_cloud. MiniMax M2 is 204800 while M3
+// jumps to a 1M window, so the two must resolve to distinct matchers.
 func TestMiscOpenWeightContextWindow(t *testing.T) {
 	testModels := []struct {
 		model    string
@@ -232,6 +233,8 @@ func TestMiscOpenWeightContextWindow(t *testing.T) {
 		{"ollama_cloud/minimax-m2.1", 204800},
 		{"ollama_cloud/minimax-m2.5", 204800},
 		{"ollama_cloud/minimax-m2.7", 204800},
+		{"ollama_cloud/minimax-m3", 1000000},
+		{"ollama_cloud/minimax-m3.1", 1000000},
 		{"ollama_cloud/glm-4.6", 200000},
 		{"ollama_cloud/glm-4.7", 200000},
 		{"ollama_cloud/glm-5", 200000},
@@ -266,6 +269,38 @@ func TestQwenServedVariants(t *testing.T) {
 	for _, tc := range testModels {
 		if got := EstimateContextWindow(tc.model); got != tc.expected {
 			t.Errorf("Model %s: got %d, expected %d", tc.model, got, tc.expected)
+		}
+	}
+}
+
+// TestLookupContextWindow_MatchedFlag covers the matched bool that the session
+// rollover and auto-compaction gates rely on: known models report true, while
+// models with no matcher report false (returning the default fallback as the
+// size) so callers can disable context-based behavior instead of measuring
+// fullness against a wrong window. minimax-m2 (204800) and minimax-m3 (1M)
+// must resolve to their own distinct windows - the m2 pattern must not swallow
+// m3, which was the original ollama_cloud/minimax-m3 bug.
+func TestLookupContextWindow_MatchedFlag(t *testing.T) {
+	testCases := []struct {
+		model         string
+		expectedKnown bool
+		expectedSize  int
+	}{
+		{"ollama_cloud/minimax-m2", true, 204800},
+		{"ollama_cloud/minimax-m3", true, 1000000},
+		{"ollama_cloud/brand-new-model", false, 8192},
+		{"openai/gpt-4", false, 8192},
+		{"anthropic/claude-opus-4-7", true, 1000000},
+		{"moonshot/moonshot-v1-8k", true, 8192},
+	}
+
+	for _, tc := range testCases {
+		size, known := LookupContextWindow(tc.model)
+		if known != tc.expectedKnown {
+			t.Errorf("Model %s: known=%v, expected %v", tc.model, known, tc.expectedKnown)
+		}
+		if size != tc.expectedSize {
+			t.Errorf("Model %s: size=%d, expected %d", tc.model, size, tc.expectedSize)
 		}
 	}
 }

--- a/internal/services/conversation_optimizer.go
+++ b/internal/services/conversation_optimizer.go
@@ -90,7 +90,11 @@ func (co *ConversationOptimizer) estimateTriggerTokens(messages []sdk.Message) i
 	return co.tokenizer.EstimateMessagesTokens(messages)
 }
 
-// OptimizeMessages reduces token usage by intelligently managing conversation history with LLM summarization
+// OptimizeMessages reduces token usage by intelligently managing conversation
+// history with LLM summarization. When force is false it is a no-op unless the
+// model has a configured context window and the conversation has crossed
+// auto_at percent of it; when force is true it always compacts (manual /compact
+// and session rollover both rely on this).
 func (co *ConversationOptimizer) OptimizeMessages(messages []sdk.Message, model string, force bool) []sdk.Message {
 	if len(messages) == 0 {
 		return messages
@@ -100,9 +104,9 @@ func (co *ConversationOptimizer) OptimizeMessages(messages []sdk.Message, model 
 		return messages
 	}
 
-	contextWindow := models.EstimateContextWindow(model)
-	if contextWindow == 0 {
-		contextWindow = 30000
+	contextWindow, known := models.LookupContextWindow(model)
+	if !force && !known {
+		return messages
 	}
 
 	threshold := (contextWindow * co.autoAt) / 100

--- a/internal/services/conversation_optimizer_test.go
+++ b/internal/services/conversation_optimizer_test.go
@@ -383,7 +383,7 @@ func TestOptimizeMessages_EdgeCases(t *testing.T) {
 // and tool definitions) crosses the threshold - even though the entries-only
 // estimate is far below it.
 func TestOptimizeMessages_LastInputTokensTrigger(t *testing.T) {
-	model := "fake-provider/unknown-tiny-model"
+	model := "moonshot/moonshot-v1-8k"
 
 	t.Run("fires when LastInputTokens above threshold", func(t *testing.T) {
 		repo := services.NewInMemoryConversationRepository(nil, nil)
@@ -448,6 +448,82 @@ func TestOptimizeMessages_LastInputTokensTrigger(t *testing.T) {
 		assert.Equal(t, len(messages), len(result),
 			"messages should be returned unchanged when gate does not fire")
 	})
+}
+
+// TestOptimizeMessages_NoAutoCompactForUnknownModel verifies that a model with
+// no configured context window does not auto-compact (force=false), even when
+// the gateway-reported token count is huge. Without this guard the optimizer
+// would measure fullness against the default fallback window and summarize on
+// nearly every turn (this was the minimax-m3 bug, before that model was added
+// to the registry).
+func TestOptimizeMessages_NoAutoCompactForUnknownModel(t *testing.T) {
+	model := "ollama_cloud/some-unlisted-model"
+
+	repo := services.NewInMemoryConversationRepository(nil, nil)
+	require.NoError(t, repo.AddTokenUsage(model, 500000, 100, 500100))
+
+	mockClient := createMockSDKClient(t, "Summary text")
+	optimizer := services.NewConversationOptimizer(services.OptimizerConfig{
+		Enabled:           true,
+		AutoAt:            80,
+		BufferSize:        2,
+		KeepFirstMessages: 2,
+		Client:            mockClient,
+		Config:            &config.Config{},
+		Tokenizer:         nil,
+		Repo:              repo,
+	})
+
+	messages := []sdk.Message{
+		{Role: "user", Content: sdk.NewMessageContent("hi")},
+		{Role: "assistant", Content: sdk.NewMessageContent("hello")},
+		{Role: "user", Content: sdk.NewMessageContent("again")},
+		{Role: "assistant", Content: sdk.NewMessageContent("ack")},
+		{Role: "user", Content: sdk.NewMessageContent("more")},
+	}
+
+	result := optimizer.OptimizeMessages(messages, model, false)
+
+	assert.Equal(t, 0, mockClient.GenerateContentCallCount(),
+		"summarizer must not run for a model with no configured context window")
+	assert.Equal(t, len(messages), len(result),
+		"messages must be returned unchanged when the context window is unknown")
+}
+
+// TestOptimizeMessages_ForcedCompactWorksForUnknownModel verifies that a forced
+// compaction (manual /compact, or session rollover) still runs for a model with
+// no configured context window - only the automatic threshold path is gated.
+func TestOptimizeMessages_ForcedCompactWorksForUnknownModel(t *testing.T) {
+	model := "ollama_cloud/some-unlisted-model"
+
+	repo := services.NewInMemoryConversationRepository(nil, nil)
+
+	mockClient := createMockSDKClient(t, "Summary text")
+	optimizer := services.NewConversationOptimizer(services.OptimizerConfig{
+		Enabled:           true,
+		AutoAt:            80,
+		BufferSize:        2,
+		KeepFirstMessages: 2,
+		Client:            mockClient,
+		Config:            &config.Config{},
+		Tokenizer:         nil,
+		Repo:              repo,
+	})
+
+	messages := []sdk.Message{
+		{Role: "user", Content: sdk.NewMessageContent("hi")},
+		{Role: "assistant", Content: sdk.NewMessageContent("hello")},
+		{Role: "user", Content: sdk.NewMessageContent("again")},
+		{Role: "assistant", Content: sdk.NewMessageContent("ack")},
+		{Role: "user", Content: sdk.NewMessageContent("more")},
+	}
+
+	result := optimizer.OptimizeMessages(messages, model, true)
+
+	assert.Equal(t, 1, mockClient.GenerateContentCallCount(),
+		"forced compaction must run even when the context window is unknown")
+	assert.Less(t, len(result), len(messages),
+		"forced compaction should reduce the message count")
 }
 
 // Helper functions

--- a/internal/services/session_rollover_manager.go
+++ b/internal/services/session_rollover_manager.go
@@ -183,7 +183,9 @@ func (m *SessionRolloverManager) idleTriggerFires(entries []domain.ConversationE
 }
 
 // tokenTriggerFires reports whether the conversation's estimated token count
-// crosses compact.auto_at percent of the model's context window.
+// crosses compact.auto_at percent of the model's context window. Returns false
+// when no context window is configured for the model, since there is no
+// meaningful threshold to compare against.
 //
 // Prefers the gateway-reported LastInputTokens from session stats: that value
 // is the authoritative count of what was actually sent (including system
@@ -196,9 +198,9 @@ func (m *SessionRolloverManager) tokenTriggerFires(entries []domain.Conversation
 		autoAt = 80
 	}
 
-	contextWindow := models.EstimateContextWindow(model)
-	if contextWindow == 0 {
-		contextWindow = 30000
+	contextWindow, known := models.LookupContextWindow(model)
+	if !known {
+		return false
 	}
 	threshold := (contextWindow * autoAt) / 100
 

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -210,16 +210,13 @@ func TestShouldRollover_TokenTriggerFires(t *testing.T) {
 	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
 	defer cleanup()
 
-	// Use a model with a tiny context window so we can blow past 80% with a
-	// few messages. Default fallback is 8192 tokens; 80% = ~6553 tokens.
-	// Each large message ≈ 1000 tokens via the tokenizer's char-based estimate.
-	bigContent := strings.Repeat("token ", 2000) // ~2000 words ≈ many tokens
+	bigContent := strings.Repeat("token ", 2000)
 	for i := 0; i < 10; i++ {
 		addUserMessage(t, repo, bigContent, time.Now())
 	}
 
-	if !mgr.ShouldRollover("unknown-tiny-model") {
-		t.Error("large conversation should trigger token rollover against fallback context window")
+	if !mgr.ShouldRollover("moonshot/moonshot-v1-8k") {
+		t.Error("large conversation should trigger token rollover against known context window")
 	}
 }
 
@@ -231,13 +228,13 @@ func TestShouldRollover_TokenTriggerFiresFromLastInputTokens(t *testing.T) {
 	addUserMessage(t, repo, "hi", time.Now())
 
 	// Simulate the gateway reporting a large prompt_tokens value (system
-	// prompt + tool defs + history). Threshold for unknown-tiny-model is
+	// prompt + tool defs + history). Threshold for moonshot-v1-8k is
 	// 8192*80/100=6553 tokens.
-	if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 
-	if !mgr.ShouldRollover("unknown-tiny-model") {
+	if !mgr.ShouldRollover("moonshot/moonshot-v1-8k") {
 		t.Error("LastInputTokens above threshold should trigger token rollover even when entries-only estimate is small")
 	}
 }
@@ -255,12 +252,36 @@ func TestShouldRollover_TokenTriggerDoesNotFireWhenLastInputBelowThreshold(t *te
 	// …but the gateway-reported count is well below the threshold. The
 	// gateway count must win - its number includes provider-specific
 	// reformatting and is what `/context` shows.
-	if err := repo.AddTokenUsage("unknown-tiny-model", 1000, 100, 1100); err != nil {
+	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 1000, 100, 1100); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 
-	if mgr.ShouldRollover("unknown-tiny-model") {
+	if mgr.ShouldRollover("moonshot/moonshot-v1-8k") {
 		t.Error("LastInputTokens below threshold should not trigger rollover, even if entries-only estimate is large")
+	}
+}
+
+// TestShouldRollover_TokenTriggerSkippedForUnknownModel verifies that a model
+// with no configured context window never trips the token trigger, no matter
+// how large the conversation or the gateway-reported token count. Otherwise the
+// session would roll over against the default fallback window every few messages
+// (this was the minimax-m3 bug, before that model was added to the registry).
+// The idle trigger is disabled here (idleMin=0) to isolate the token path.
+func TestShouldRollover_TokenTriggerSkippedForUnknownModel(t *testing.T) {
+	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
+	defer cleanup()
+
+	bigContent := strings.Repeat("token ", 2000)
+	for i := 0; i < 10; i++ {
+		addUserMessage(t, repo, bigContent, time.Now())
+	}
+	// A gateway-reported count far above any default-window threshold.
+	if err := repo.AddTokenUsage("ollama_cloud/some-unlisted-model", 500000, 100, 500100); err != nil {
+		t.Fatalf("AddTokenUsage: %v", err)
+	}
+
+	if mgr.ShouldRollover("ollama_cloud/some-unlisted-model") {
+		t.Error("model with no configured context window must not trigger token rollover")
 	}
 }
 
@@ -436,11 +457,11 @@ func TestMaybeRollover_FiresAndReturnsNewID(t *testing.T) {
 	originalID := repo.GetCurrentConversationID()
 
 	addUserMessage(t, repo, "hi", time.Now())
-	if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 
-	newID, fired := mgr.MaybeRollover(context.Background(), "unknown-tiny-model", "channel-test-group")
+	newID, fired := mgr.MaybeRollover(context.Background(), "moonshot/moonshot-v1-8k", "channel-test-group")
 	if !fired {
 		t.Fatal("MaybeRollover should have fired with LastInputTokens above threshold")
 	}
@@ -482,11 +503,11 @@ func TestMaybeRollover_PerformRolloverErrorReturnsFalse(t *testing.T) {
 	if err := repo.AddMessage(hidden); err != nil {
 		t.Fatalf("AddMessage: %v", err)
 	}
-	if err := repo.AddTokenUsage("unknown-tiny-model", 7000, 100, 7100); err != nil {
+	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 
-	newID, fired := mgr.MaybeRollover(context.Background(), "unknown-tiny-model", "")
+	newID, fired := mgr.MaybeRollover(context.Background(), "moonshot/moonshot-v1-8k", "")
 	if fired {
 		t.Error("MaybeRollover must return fired=false when PerformRollover errors")
 	}

--- a/internal/shortcuts/core.go
+++ b/internal/shortcuts/core.go
@@ -106,7 +106,7 @@ func (c *ContextShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 	messageCount := c.repo.GetMessageCount()
 	currentModel := c.modelService.GetCurrentModel()
 
-	contextWindowSize := c.estimateContextWindow(currentModel)
+	contextWindowSize, windowKnown := models.LookupContextWindow(currentModel)
 
 	contextTokens := stats.LastInputTokens
 	estimated := false
@@ -130,8 +130,12 @@ func (c *ContextShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 	fmt.Fprintf(&output, "**API Requests:** %d\n", stats.RequestCount)
 	fmt.Fprintf(&output, "**Session Totals:** %d input, %d output\n", stats.TotalInputTokens, stats.TotalOutputTokens)
 
-	if contextWindowSize > 0 && contextTokens > 0 {
+	switch {
+	case windowKnown && contextWindowSize > 0 && contextTokens > 0:
 		output.WriteString(c.formatContextUsage(contextTokens, contextWindowSize))
+	case !windowKnown:
+		output.WriteString("\n**Context Window:** unknown for this model - " +
+			"automatic compaction is disabled. Use `/compact` to compact manually.\n")
 	}
 
 	return ShortcutResult{
@@ -157,11 +161,6 @@ func (c *ContextShortcut) estimateCurrentContextSize() int {
 		sdkMessages = append(sdkMessages, entry.Message)
 	}
 	return c.tokenizer.EstimateMessagesTokens(sdkMessages)
-}
-
-// estimateContextWindow returns an estimated context window size based on model name
-func (c *ContextShortcut) estimateContextWindow(model string) int {
-	return models.EstimateContextWindow(model)
 }
 
 // formatContextUsage formats the context window usage information

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -633,8 +633,8 @@ func (isb *InputStatusBar) getContextUsageIndicator(model string) string {
 		return ""
 	}
 
-	contextWindow := isb.estimateContextWindow(model)
-	if contextWindow == 0 {
+	contextWindow, known := models.LookupContextWindow(model)
+	if !known || contextWindow == 0 {
 		return ""
 	}
 
@@ -653,11 +653,6 @@ func (isb *InputStatusBar) getContextUsageIndicator(model string) string {
 	default:
 		return fmt.Sprintf("Context: %.1f%%", displayPercent)
 	}
-}
-
-// estimateContextWindow returns an estimated context window size based on model name
-func (isb *InputStatusBar) estimateContextWindow(model string) int {
-	return models.EstimateContextWindow(model)
 }
 
 // Bubble Tea interface


### PR DESCRIPTION
## Problem

When a model has no configured context window, the conversation **rollover keeps creating new sessions** on almost every message (and auto-compaction fires constantly).

Root cause: `models.EstimateContextWindow()` never returns `0` - for an unmatched model it returns `config.DefaultContextWindow` (**8192**). Both gates treated that fallback as the model's real window:

- `ollama_cloud/minimax-m3` strips to `minimax-m3`, which the `minimax-m2` pattern does **not** match → window resolves to 8192.
- Threshold = `8192 × 80% ≈ 6553` tokens. Any real conversation exceeds that immediately, and right after a rollover the summary + next message exceed it again → endless new sessions.

The `if contextWindow == 0 { contextWindow = 30000 }` branches were dead code (the value is never 0).

## Fix

Use `LookupContextWindow()`'s `matched` flag at the decision points and treat *unknown* as *don't fire*:

- **`session_rollover_manager.go`** - `tokenTriggerFires` returns `false` for unknown-window models. The **idle trigger is unaffected** (it's time-based, independent of context length).
- **`conversation_optimizer.go`** - `OptimizeMessages` skips auto-compaction for unknown-window models unless `force=true`, so **manual `/compact` and the rollover's forced path still work**.
- **`shortcuts/core.go`** (`/context`) and **`input_status_bar.go`** - report "unknown" / hide the percentage instead of computing a misleading number against the 8192 fallback.

Also **registered `minimax-m3`** with its real **1,000,000-token** window (released 2026-06-01, after the registry was last updated) so it gets real auto-compaction instead of relying on the no-op fallback. MiniMax M2 (204,800) and M3 (1M) resolve to distinct matchers.

## Behavior notes

- Idle-based rollover (`rollover_on_idle_minutes`, default 30) still works for unknown-window models — it can't cause the rapid churn this fixes.
- This is a **general** fix: any model without a matcher now degrades gracefully, not just `minimax-m3`.

## Testing

- Repointed existing token-trigger tests off the `unknown-tiny-model` literal (which leaned on the 8192 fallback) onto a model with a *real* small window (`moonshot-v1-8k` = 8192).
- Added regression tests: unknown-window models don't roll over / don't auto-compact, but **forced** compaction still works; plus `LookupContextWindow` matched-flag coverage (M2 vs M3).
- `go build ./...` clean, `go test ./...` → **0 failures**, `golangci-lint` → **0 issues**.

## Cross-repo impact

None - the context-window registry is CLI-local (not vendored from `schemas`); no `openapi.yaml`/schema changes. No docs ticket required (this is a `fix`, not a `feat`/public-surface `refactor`).
