### PR TITLE
fix(explorer): stop render corruption from grapheme-width desync

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -786,6 +786,11 @@ func (app *ChatApplication) View() tea.View {
 	if app.mouseEnabled {
 		v.MouseMode = tea.MouseModeCellMotion
 	}
+
+	switch app.stateManager.GetCurrentView() {
+	case domain.ViewStateExplorer, domain.ViewStateDiffViewer:
+		v.AltScreen = true
+	}
 	return v
 }
 

--- a/internal/ui/components/diffview/highlight.go
+++ b/internal/ui/components/diffview/highlight.go
@@ -31,6 +31,7 @@ func selectLexer(path, content string) chroma.Lexer {
 // plain (uncolored) content, so it never returns an error string.
 func Highlight(path, content string, style *chroma.Style, lineNumbers bool) string {
 	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\t", strings.Repeat(" ", defaultTabWidth))
 	content = strings.TrimSuffix(content, "\n")
 
 	lines, ok := highlightToLines(path, content, style)

--- a/internal/ui/components/diffview/highlight_test.go
+++ b/internal/ui/components/diffview/highlight_test.go
@@ -28,6 +28,28 @@ func TestHighlight_NoLineNumbers(t *testing.T) {
 	}
 }
 
+// TestHighlight_ExpandsTabs guards that tabs are expanded to spaces. A literal
+// tab is measured as 0 cells by ansi.StringWidth but rendered as a tab stop by
+// the terminal; left in place it overflows the fixed-width preview pane and
+// corrupts the explorer layout. Both the plain fallback and the highlighted path
+// must be tab-free.
+func TestHighlight_ExpandsTabs(t *testing.T) {
+	indent := strings.Repeat(" ", defaultTabWidth)
+
+	plain := Highlight("x.go", "\tone\n\t\ttwo", nil, false)
+	if strings.Contains(plain, "\t") {
+		t.Fatalf("plain path left a literal tab: %q", plain)
+	}
+	if plain != indent+"one\n"+indent+indent+"two" {
+		t.Fatalf("tabs not expanded to %d spaces: %q", defaultTabWidth, plain)
+	}
+
+	styled := Highlight("main.go", "\tx := 1", chromastyles.Get("github-dark"), false)
+	if strings.Contains(styled, "\t") {
+		t.Fatalf("highlighted path left a literal tab: %q", styled)
+	}
+}
+
 // TestHighlight_MultilineConstructPreservesLineCount guards the whole-file
 // tokenise-then-split approach: a multi-line raw string must not collapse or
 // add lines (a per-line tokeniser would mis-handle it).

--- a/internal/ui/components/file_explorer.go
+++ b/internal/ui/components/file_explorer.go
@@ -1069,15 +1069,18 @@ func (t *FileExplorerImpl) Render(inputRow string) string {
 	sidebar := t.renderSidebar(t.sidebarWidth, t.height)
 	divider := t.renderDivider(t.height)
 
+	var out string
 	if inputRow == "" {
 		pane := t.renderPane(t.paneWidth, t.height)
-		return t.styleProvider.JoinHorizontal(sidebar, divider, pane)
+		out = t.styleProvider.JoinHorizontal(sidebar, divider, pane)
+	} else {
+		regionHeight := max(t.height-t.styleProvider.GetHeight(inputRow), 1)
+		pane := t.renderPane(t.paneWidth, regionHeight)
+		chatColumn := t.styleProvider.JoinVertical(pane, inputRow)
+		out = t.styleProvider.JoinHorizontal(sidebar, divider, chatColumn)
 	}
 
-	regionHeight := max(t.height-t.styleProvider.GetHeight(inputRow), 1)
-	pane := t.renderPane(t.paneWidth, regionHeight)
-	chatColumn := t.styleProvider.JoinVertical(pane, inputRow)
-	return t.styleProvider.JoinHorizontal(sidebar, divider, chatColumn)
+	return t.styleProvider.ClampToSize(out, t.width, t.height)
 }
 
 func (t *FileExplorerImpl) renderDivider(height int) string {

--- a/internal/ui/components/pty_editor.go
+++ b/internal/ui/components/pty_editor.go
@@ -50,6 +50,20 @@ func (t *vtTerm) readReply(p []byte) (int, error) { return t.em.Read(p) }
 // closeEmulator unblocks readReply so the reply-forwarding goroutine can exit.
 func (t *vtTerm) closeEmulator() { _ = t.em.Close() }
 
+// stopReplies unblocks the reply-forwarding goroutine's blocked Read by closing the
+// emulator's input pipe, which returns EOF. We close the pipe directly rather than
+// calling em.Close because Close also writes the emulator's `closed` flag, which that
+// same goroutine reads inside Read — an unsynchronized access the race detector flags.
+// The io.Pipe gives the writer-close ↔ Read-EOF happens-before; the em.Close fallback
+// only runs if the emulator's pipe type ever changes, so close() never hangs.
+func (t *vtTerm) stopReplies() {
+	if pw, ok := t.em.InputPipe().(*io.PipeWriter); ok {
+		_ = pw.CloseWithError(io.EOF)
+		return
+	}
+	_ = t.em.Close()
+}
+
 // forwardReplies pumps the emulator's query replies back to the child's PTY.
 // The emulator buffers replies in an unbuffered pipe, so without draining it the
 // first reply blocks the write that produced it - freezing the editor (and the
@@ -71,11 +85,12 @@ func forwardReplies(term *vtTerm, w io.Writer) {
 // diff pane. Output is streamed via a re-arming read command; key input is
 // re-encoded and written to the PTY; the pane size drives the PTY window size.
 type ptyEditor struct {
-	pty  *os.File
-	cmd  *exec.Cmd
-	term *vtTerm
-	cols int
-	rows int
+	pty        *os.File
+	cmd        *exec.Cmd
+	term       *vtTerm
+	cols       int
+	rows       int
+	readerDone chan struct{}
 }
 
 // resolveEditor returns the editor argv: $VISUAL, then $EDITOR, else vim.
@@ -134,8 +149,11 @@ func startPTYEditor(absPath, workdir string, cols, rows int, dark bool) (*ptyEdi
 	if err != nil {
 		return nil, nil, err
 	}
-	e := &ptyEditor{pty: f, cmd: cmd, term: newVTTerm(cols, rows), cols: cols, rows: rows}
-	go forwardReplies(e.term, f)
+	e := &ptyEditor{pty: f, cmd: cmd, term: newVTTerm(cols, rows), cols: cols, rows: rows, readerDone: make(chan struct{})}
+	go func() {
+		defer close(e.readerDone)
+		forwardReplies(e.term, f)
+	}()
 	return e, e.readCmd(), nil
 }
 
@@ -180,15 +198,21 @@ func (e *ptyEditor) View(width, height int) string {
 	return e.term.render()
 }
 
-// close kills the child and closes the PTY (unblocking any in-flight read) and
-// the emulator (unblocking the reply-forwarding goroutine).
+// close kills the child and closes the PTY (unblocking the in-flight output read and
+// any reply write), then unblocks the reply-forwarding goroutine via the emulator's
+// input pipe and waits for it to exit. Closing the pipe (rather than the emulator)
+// avoids racing the emulator's `closed` flag against that goroutine's Read; joining on
+// readerDone ensures no emulator access outlives close.
 func (e *ptyEditor) close() {
-	e.term.closeEmulator()
 	if e.cmd != nil && e.cmd.Process != nil {
 		_ = e.cmd.Process.Kill()
 	}
 	if e.pty != nil {
 		_ = e.pty.Close()
+	}
+	e.term.stopReplies()
+	if e.readerDone != nil {
+		<-e.readerDone
 	}
 	if e.cmd != nil {
 		_ = e.cmd.Wait()

--- a/internal/ui/styles/provider.go
+++ b/internal/ui/styles/provider.go
@@ -531,6 +531,16 @@ func (p *Provider) GetWidth(s string) int {
 	return lipgloss.Width(s)
 }
 
+// ClampToSize hard-truncates s to width columns and height rows (ANSI-aware) so a
+// frame containing an over-wide or over-tall line cannot wrap and corrupt the inline
+// (non-alt-screen) render. MaxWidth/MaxHeight truncate rather than pad or wrap.
+func (p *Provider) ClampToSize(s string, width, height int) string {
+	if width <= 0 || height <= 0 {
+		return s
+	}
+	return lipgloss.NewStyle().MaxWidth(width).MaxHeight(height).Render(s)
+}
+
 // Custom rendering - for complex styling needs
 
 // RenderWithColor renders text with a specific hex color


### PR DESCRIPTION
## What

Fixes the `/explorer` view corrupting (duplicated rows, two cursors, stale preview + chat-footer bleeding through) when arrow-ing down onto files containing VS16 emoji - e.g. `CHANGELOG.md`'s `♻️`. The corruption compounded with each cursor move.

## Root cause

Bubble Tea v2's inline (non-alt-screen) renderer tracks the cursor **relatively**, advancing by each grapheme's **uniseg** width. uniseg counts `♻️` (U+267B U+FE0F) as **2 cells**, but many macOS terminals draw it as **1**, so the relative cursor desyncs and every subsequent cell is misplaced. A width clamp can't fix it - `lipgloss.MaxWidth` measures with the same uniseg table, so it shares the blind spot.

## Changes

- **Alt-screen for full-window file-content views** (explorer + diff viewer) via `tea.View.AltScreen`. Alt-screen switches the renderer to **absolute** positioning (`enterAltScreen → SetRelativeCursor(false)`), which re-syncs every line and is immune to width disagreement, and clears the screen (removes the inline bleed-through). Chat stays inline to keep terminal scrollback. Robust to *any* divergent grapheme (CJK, ZWJ, box-drawing), not just `♻️`.
- **Tab expansion** in `diffview.Highlight` - a literal tab is 0 cells in uniseg but a tab stop in the terminal.
- **`Provider.ClampToSize`** applied at the end of `FileExplorerImpl.Render` as a defensive width/height backstop.
- **PTY-editor data race fix** (surfaced by `go test -race` during this work): the reply-forwarding goroutine read the vt emulator's `closed` flag while `close()` wrote it, and was never joined. Now we close the emulator input pipe to unblock the reader (no `closed` write) and join the goroutine before teardown.

## Testing

- `task build`, `go test ./internal/app/... ./internal/ui/...`, `golangci-lint ./internal/app/...` → all green (0 issues).
- `go test -race ./...` → clean (the PTY race previously failed under `-race`).
- Manual: `/explorer` → arrow down onto `CHANGELOG.md` (emoji) and `.go` files; the view stays intact and `esc` restores the chat (like exiting `vim`/`less`).

## Notes

- The **diff viewer** is included in the alt-screen switch (identical structure, same arbitrary-width content) to head off the same bug there.
