### PR TITLE
feat(storage): add Cloudflare D1 conversation storage driver

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -207,6 +207,11 @@ storage:
     db: 0
   jsonl:
     path: .infer/conversations
+  d1:
+    account_id: ""
+    database_id: ""
+    api_token: ""
+    base_url: https://api.cloudflare.com/client/v4
 conversation:
   title_generation:
     enabled: true

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -20,9 +20,10 @@ var migrateCmd = &cobra.Command{
 This command applies any pending migrations to your database. Migrations are tracked
 in the schema_migrations table to ensure they are only applied once.
 
-The command automatically detects your database backend (SQLite, PostgreSQL, JSONL, Redis, Memory)
-and applies the appropriate migrations. Note that JSONL, Redis, and Memory storage backends
-do not require migrations as they do not use a relational schema.`,
+The command automatically detects your database backend (SQLite, PostgreSQL, Cloudflare D1, JSONL,
+Redis, Memory) and applies the appropriate migrations. Note that JSONL, Redis, and Memory storage
+backends do not require migrations as they do not use a relational schema; Cloudflare D1 creates its
+schema automatically on connect.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		status, _ := cmd.Flags().GetBool("status")
 		if status {
@@ -58,6 +59,10 @@ func runMigrations() error {
 		fmt.Printf("%s PostgreSQL database migrations are up to date\n", icons.CheckMarkStyle.Render(icons.CheckMark))
 		fmt.Println("   All migrations have been applied automatically")
 		return nil
+	case *storage.D1Storage:
+		fmt.Printf("%s Cloudflare D1 database migrations are up to date\n", icons.CheckMarkStyle.Render(icons.CheckMark))
+		fmt.Println("   The schema is created automatically on connect")
+		return nil
 	case *storage.JsonlStorage:
 		fmt.Println("JSONL storage does not require migrations")
 		return nil
@@ -89,6 +94,9 @@ func showMigrationStatus() error {
 		return showSQLiteMigrationStatus(s)
 	case *storage.PostgresStorage:
 		return showPostgresMigrationStatus(s)
+	case *storage.D1Storage:
+		fmt.Println("Cloudflare D1 storage applies its schema automatically on connect")
+		return nil
 	case *storage.JsonlStorage:
 		fmt.Println("JSONL storage does not require migrations")
 		return nil

--- a/config/config.go
+++ b/config/config.go
@@ -497,6 +497,7 @@ const (
 	StorageTypePostgres StorageType = "postgres"
 	StorageTypeRedis    StorageType = "redis"
 	StorageTypeJsonl    StorageType = "jsonl"
+	StorageTypeD1       StorageType = "d1"
 )
 
 // StorageConfig contains storage backend configuration
@@ -507,6 +508,7 @@ type StorageConfig struct {
 	Postgres PostgresStorageConfig `yaml:"postgres,omitempty" mapstructure:"postgres,omitempty"`
 	Redis    RedisStorageConfig    `yaml:"redis,omitempty" mapstructure:"redis,omitempty"`
 	Jsonl    JsonlStorageConfig    `yaml:"jsonl,omitempty" mapstructure:"jsonl,omitempty"`
+	D1       D1StorageConfig       `yaml:"d1,omitempty" mapstructure:"d1,omitempty"`
 }
 
 // SQLiteStorageConfig contains SQLite-specific configuration
@@ -535,6 +537,16 @@ type RedisStorageConfig struct {
 // JsonlStorageConfig contains JSONL-specific configuration
 type JsonlStorageConfig struct {
 	Path string `yaml:"path" mapstructure:"path"`
+}
+
+// D1StorageConfig contains Cloudflare D1-specific configuration. D1 is SQLite
+// over an HTTP query API; the api_token is a secret and is normally injected
+// via INFER_STORAGE_D1_API_TOKEN rather than written to the config file.
+type D1StorageConfig struct {
+	AccountID  string `yaml:"account_id" mapstructure:"account_id"`
+	DatabaseID string `yaml:"database_id" mapstructure:"database_id"`
+	APIToken   string `yaml:"api_token" mapstructure:"api_token"`
+	BaseURL    string `yaml:"base_url,omitempty" mapstructure:"base_url,omitempty"`
 }
 
 // A2AAgentInfo contains information about an A2A agent connection
@@ -810,6 +822,12 @@ func DefaultConfig() *Config { //nolint:funlen
 				Port:     6379,
 				Password: "",
 				DB:       0,
+			},
+			D1: D1StorageConfig{
+				AccountID:  "",
+				DatabaseID: "",
+				APIToken:   "",
+				BaseURL:    "https://api.cloudflare.com/client/v4",
 			},
 		},
 		Conversation: ConversationConfig{

--- a/internal/infra/storage/d1.go
+++ b/internal/infra/storage/d1.go
@@ -1,0 +1,687 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	migrations "github.com/inference-gateway/cli/internal/infra/storage/migrations"
+)
+
+// D1Storage implements ConversationStorage and SessionGroupStorage on top of
+// Cloudflare D1. D1 is SQLite exposed over an HTTP query API, so this driver
+// issues the exact same SQL as SQLiteStorage but ships it over the network via
+// POST /accounts/{account}/d1/database/{database}/query instead of a local
+// file handle. Timestamps are stored as UTC RFC3339 strings so ORDER BY sorts
+// chronologically regardless of the runner's timezone and external readers get
+// unambiguous ISO-8601 values.
+type D1Storage struct {
+	accountID  string
+	databaseID string
+	apiToken   string
+	baseURL    string
+	httpClient *http.Client
+}
+
+const (
+	d1DefaultBaseURL = "https://api.cloudflare.com/client/v4"
+	d1HTTPTimeout    = 30 * time.Second
+)
+
+var (
+	_ ConversationStorage = (*D1Storage)(nil)
+	_ SessionGroupStorage = (*D1Storage)(nil)
+)
+
+// d1RequestBody is the JSON body of a D1 /query request.
+type d1RequestBody struct {
+	SQL    string `json:"sql"`
+	Params []any  `json:"params"`
+}
+
+// d1Meta carries per-statement execution metadata; we only need the affected
+// row count to detect not-found on DELETE/UPDATE.
+type d1Meta struct {
+	Changes int64 `json:"changes"`
+}
+
+// d1QueryResult is one statement's result within the envelope.
+type d1QueryResult struct {
+	Results []map[string]any `json:"results"`
+	Success bool             `json:"success"`
+	Meta    d1Meta           `json:"meta"`
+}
+
+// d1APIError is a single error from the D1 API envelope.
+type d1APIError struct {
+	Message string `json:"message"`
+}
+
+// d1Envelope is the top-level Cloudflare API response wrapper.
+type d1Envelope struct {
+	Success bool            `json:"success"`
+	Errors  []d1APIError    `json:"errors"`
+	Result  []d1QueryResult `json:"result"`
+}
+
+// NewD1Storage creates a new Cloudflare D1 storage instance and ensures the
+// schema exists (idempotent CREATE ... IF NOT EXISTS, byte-for-byte identical
+// to the SQLite migrations).
+func NewD1Storage(config D1Config) (*D1Storage, error) {
+	if config.AccountID == "" || config.DatabaseID == "" || config.APIToken == "" {
+		return nil, fmt.Errorf("d1 storage requires account_id, database_id, and api_token")
+	}
+
+	baseURL := strings.TrimRight(config.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = d1DefaultBaseURL
+	}
+
+	s := &D1Storage{
+		accountID:  config.AccountID,
+		databaseID: config.DatabaseID,
+		apiToken:   config.APIToken,
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: d1HTTPTimeout},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), d1HTTPTimeout)
+	defer cancel()
+	if err := s.runMigrations(ctx); err != nil {
+		return nil, fmt.Errorf("failed to run migrations: %w", err)
+	}
+
+	return s, nil
+}
+
+// runMigrations applies the SQLite schema over HTTP. The migration SQL is
+// reused verbatim from the SQLite migrations to guarantee schema parity; each
+// statement is sent individually so it works whether or not D1 accepts
+// multi-statement queries.
+func (s *D1Storage) runMigrations(ctx context.Context) error {
+	for _, m := range migrations.GetSQLiteMigrations() {
+		for _, stmt := range splitSQLStatements(m.UpSQL) {
+			if _, err := s.exec(ctx, stmt); err != nil {
+				return fmt.Errorf("migration %s (%s) failed: %w", m.Version, m.Description, err)
+			}
+		}
+	}
+	return nil
+}
+
+// splitSQLStatements breaks a migration block into individual statements. The
+// migration DDL contains no semicolons inside string literals, so a plain split
+// is safe.
+func splitSQLStatements(sqlText string) []string {
+	parts := strings.Split(sqlText, ";")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// do posts a single SQL statement to the D1 /query endpoint and returns the
+// first (and only) result set. D1 returns HTTP 200 with success=false for SQL
+// errors, so the envelope is inspected even on a 2xx response.
+func (s *D1Storage) do(ctx context.Context, query string, params []any) (*d1QueryResult, error) {
+	if params == nil {
+		params = []any{}
+	}
+
+	payload, err := json.Marshal(d1RequestBody{SQL: query, Params: params})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal d1 request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/accounts/%s/d1/database/%s/query", s.baseURL, s.accountID, s.databaseID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create d1 request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("d1 request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var env d1Envelope
+	decodeErr := json.NewDecoder(resp.Body).Decode(&env)
+	if resp.StatusCode != http.StatusOK {
+		if decodeErr == nil && len(env.Errors) > 0 {
+			return nil, fmt.Errorf("d1 API error (status %d): %s", resp.StatusCode, env.Errors[0].Message)
+		}
+		return nil, fmt.Errorf("d1 API returned status %d", resp.StatusCode)
+	}
+	if decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode d1 response: %w", decodeErr)
+	}
+	if !env.Success {
+		if len(env.Errors) > 0 {
+			return nil, fmt.Errorf("d1 query failed: %s", env.Errors[0].Message)
+		}
+		return nil, fmt.Errorf("d1 query failed")
+	}
+	if len(env.Result) == 0 {
+		return nil, fmt.Errorf("d1 returned no result set")
+	}
+	return &env.Result[0], nil
+}
+
+// exec runs a mutating statement and returns the number of affected rows.
+func (s *D1Storage) exec(ctx context.Context, query string, args ...any) (int64, error) {
+	res, err := s.do(ctx, query, d1Params(args...))
+	if err != nil {
+		return 0, err
+	}
+	return res.Meta.Changes, nil
+}
+
+// queryRows runs a SELECT and returns the result rows as decoded JSON objects.
+func (s *D1Storage) queryRows(ctx context.Context, query string, args ...any) ([]map[string]any, error) {
+	res, err := s.do(ctx, query, d1Params(args...))
+	if err != nil {
+		return nil, err
+	}
+	return res.Results, nil
+}
+
+// d1Params converts Go bind values into the JSON-safe scalars D1 accepts.
+func d1Params(args ...any) []any {
+	out := make([]any, len(args))
+	for i, a := range args {
+		out[i] = d1Param(a)
+	}
+	return out
+}
+
+// d1Param maps a single bind value: bools become 0/1 (matching SQLite BOOLEAN
+// storage and the `= FALSE`/`= TRUE` predicates), times become UTC RFC3339
+// strings (zero/nil → SQL NULL), and everything else passes through.
+func d1Param(a any) any {
+	switch v := a.(type) {
+	case bool:
+		if v {
+			return 1
+		}
+		return 0
+	case time.Time:
+		if v.IsZero() {
+			return nil
+		}
+		return v.UTC().Format(time.RFC3339)
+	case *time.Time:
+		if v == nil || v.IsZero() {
+			return nil
+		}
+		return v.UTC().Format(time.RFC3339)
+	default:
+		return v
+	}
+}
+
+// asString reads a TEXT/NULL column value as a string.
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// asInt reads an INTEGER column value (decoded from JSON as float64).
+func asInt(v any) int {
+	if f, ok := v.(float64); ok {
+		return int(f)
+	}
+	return 0
+}
+
+// asBool reads a BOOLEAN column value stored as 0/1.
+func asBool(v any) bool {
+	if f, ok := v.(float64); ok {
+		return f != 0
+	}
+	return false
+}
+
+// asTime parses a DATETIME column written by this driver (UTC RFC3339).
+func asTime(v any) time.Time {
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// asTimePtr returns nil for a NULL/zero DATETIME, otherwise a pointer to the parsed time.
+func asTimePtr(v any) *time.Time {
+	t := asTime(v)
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+// SaveConversation saves a conversation with its entries using the simplified schema.
+func (s *D1Storage) SaveConversation(ctx context.Context, conversationID string, entries []domain.ConversationEntry, metadata ConversationMetadata) error {
+	modelsUsed := make(map[string]bool)
+
+	for _, entry := range entries {
+		if entry.Model != "" {
+			modelsUsed[entry.Model] = true
+		}
+	}
+
+	messagesJSON, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("failed to marshal messages: %w", err)
+	}
+
+	var models []string
+	for model := range modelsUsed {
+		models = append(models, model)
+	}
+	modelsJSON, err := json.Marshal(models)
+	if err != nil {
+		return fmt.Errorf("failed to marshal models: %w", err)
+	}
+
+	tagsJSON, err := json.Marshal(metadata.Tags)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tags: %w", err)
+	}
+
+	costStatsJSON, err := json.Marshal(metadata.CostStats)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cost stats: %w", err)
+	}
+
+	_, err = s.exec(ctx, `
+		INSERT INTO conversations (id, title, count, messages, total_input_tokens, total_output_tokens,
+		                          request_count, cost_stats, models, tags, title_generated, title_invalidated, title_generation_time,
+		                          created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			title = excluded.title,
+			count = excluded.count,
+			messages = excluded.messages,
+			total_input_tokens = excluded.total_input_tokens,
+			total_output_tokens = excluded.total_output_tokens,
+			request_count = excluded.request_count,
+			cost_stats = excluded.cost_stats,
+			models = excluded.models,
+			tags = excluded.tags,
+			title_generated = excluded.title_generated,
+			title_invalidated = excluded.title_invalidated,
+			title_generation_time = excluded.title_generation_time,
+			updated_at = excluded.updated_at
+	`, conversationID, metadata.Title, len(entries), string(messagesJSON), metadata.TokenStats.TotalInputTokens, metadata.TokenStats.TotalOutputTokens,
+		metadata.TokenStats.RequestCount, string(costStatsJSON), string(modelsJSON), string(tagsJSON), metadata.TitleGenerated, metadata.TitleInvalidated,
+		metadata.TitleGenerationTime, metadata.CreatedAt, metadata.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("failed to save conversation: %w", err)
+	}
+
+	return nil
+}
+
+// LoadConversation loads a conversation by its ID using the simplified schema.
+func (s *D1Storage) LoadConversation(ctx context.Context, conversationID string) ([]domain.ConversationEntry, ConversationMetadata, error) {
+	metadata, messagesJSON, err := s.loadConversationMetadata(ctx, conversationID)
+	if err != nil {
+		return nil, metadata, err
+	}
+
+	var entries []domain.ConversationEntry
+	if err := json.Unmarshal([]byte(messagesJSON), &entries); err != nil {
+		return nil, metadata, fmt.Errorf("failed to unmarshal messages: %w", err)
+	}
+
+	return entries, metadata, nil
+}
+
+// loadConversationMetadata loads the full metadata for a conversation.
+func (s *D1Storage) loadConversationMetadata(ctx context.Context, conversationID string) (ConversationMetadata, string, error) {
+	var metadata ConversationMetadata
+
+	rows, err := s.queryRows(ctx, `
+		SELECT id, title, count, messages, total_input_tokens, total_output_tokens,
+		       request_count, cost_stats, models, tags, title_generated, title_invalidated, title_generation_time,
+		       created_at, updated_at
+		FROM conversations WHERE id = ?
+	`, conversationID)
+	if err != nil {
+		return metadata, "", fmt.Errorf("failed to load conversation: %w", err)
+	}
+	if len(rows) == 0 {
+		return metadata, "", fmt.Errorf("conversation not found: %s", conversationID)
+	}
+	r := rows[0]
+
+	metadata.ID = asString(r["id"])
+	metadata.Title = asString(r["title"])
+	metadata.MessageCount = asInt(r["count"])
+	metadata.TitleGenerated = asBool(r["title_generated"])
+	metadata.TitleInvalidated = asBool(r["title_invalidated"])
+	metadata.TitleGenerationTime = asTimePtr(r["title_generation_time"])
+	metadata.CreatedAt = asTime(r["created_at"])
+	metadata.UpdatedAt = asTime(r["updated_at"])
+
+	totalInputTokens := asInt(r["total_input_tokens"])
+	totalOutputTokens := asInt(r["total_output_tokens"])
+	metadata.TokenStats = domain.SessionTokenStats{
+		TotalInputTokens:  totalInputTokens,
+		TotalOutputTokens: totalOutputTokens,
+		TotalTokens:       totalInputTokens + totalOutputTokens,
+		RequestCount:      asInt(r["request_count"]),
+	}
+
+	costStatsJSON := asString(r["cost_stats"])
+	if costStatsJSON != "" && costStatsJSON != "{}" {
+		if err := json.Unmarshal([]byte(costStatsJSON), &metadata.CostStats); err != nil {
+			metadata.CostStats = domain.SessionCostStats{}
+		}
+	}
+
+	modelsJSON := asString(r["models"])
+	if modelsJSON != "" && modelsJSON != "[]" {
+		var models []string
+		if err := json.Unmarshal([]byte(modelsJSON), &models); err == nil && len(models) > 0 {
+			metadata.Model = models[0]
+		}
+	}
+
+	tagsJSON := asString(r["tags"])
+	if tagsJSON != "" && tagsJSON != "[]" {
+		_ = json.Unmarshal([]byte(tagsJSON), &metadata.Tags)
+	}
+
+	return metadata, asString(r["messages"]), nil
+}
+
+// ListConversations returns a list of conversation summaries (lean: no models/tags/title fields).
+func (s *D1Storage) ListConversations(ctx context.Context, limit, offset int) ([]ConversationSummary, error) {
+	rows, err := s.queryRows(ctx, `
+		SELECT id, title, created_at, updated_at, count, total_input_tokens, total_output_tokens, request_count, cost_stats
+		FROM conversations
+		ORDER BY updated_at DESC
+		LIMIT ? OFFSET ?
+	`, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query conversations: %w", err)
+	}
+
+	var summaries []ConversationSummary
+	for _, r := range rows {
+		var summary ConversationSummary
+		summary.ID = asString(r["id"])
+		summary.Title = asString(r["title"])
+		summary.CreatedAt = asTime(r["created_at"])
+		summary.UpdatedAt = asTime(r["updated_at"])
+		summary.MessageCount = asInt(r["count"])
+
+		totalInputTokens := asInt(r["total_input_tokens"])
+		totalOutputTokens := asInt(r["total_output_tokens"])
+		summary.TokenStats = domain.SessionTokenStats{
+			TotalInputTokens:  totalInputTokens,
+			TotalOutputTokens: totalOutputTokens,
+			TotalTokens:       totalInputTokens + totalOutputTokens,
+			RequestCount:      asInt(r["request_count"]),
+		}
+
+		costStatsJSON := asString(r["cost_stats"])
+		if costStatsJSON != "" && costStatsJSON != "{}" {
+			if err := json.Unmarshal([]byte(costStatsJSON), &summary.CostStats); err != nil {
+				summary.CostStats = domain.SessionCostStats{}
+			}
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	return summaries, nil
+}
+
+// ListConversationsNeedingTitles returns conversations that need title generation.
+// It carries Model/Tags/TitleGenerated/TitleInvalidated/TitleGenerationTime (the
+// title-generation batch path needs them) and therefore uses a dedicated mapper
+// rather than the lean ListConversations one.
+func (s *D1Storage) ListConversationsNeedingTitles(ctx context.Context, limit int) ([]ConversationSummary, error) {
+	rows, err := s.queryRows(ctx, `
+		SELECT id, title, created_at, updated_at, count, total_input_tokens, total_output_tokens,
+		       models, tags, title_generated, title_invalidated, title_generation_time
+		FROM conversations
+		WHERE (title_generated = FALSE OR title_invalidated = TRUE)
+		  AND count >= 2  -- Only conversations with at least 2 messages (user + assistant)
+		ORDER BY updated_at DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query conversations needing titles: %w", err)
+	}
+
+	var summaries []ConversationSummary
+	for _, r := range rows {
+		summaries = append(summaries, mapTitleSummaryRow(r))
+	}
+
+	return summaries, nil
+}
+
+// mapTitleSummaryRow maps a title-generation summary row, carrying the full
+// model/tags/title field set.
+func mapTitleSummaryRow(r map[string]any) ConversationSummary {
+	var summary ConversationSummary
+	summary.ID = asString(r["id"])
+	summary.Title = asString(r["title"])
+	summary.CreatedAt = asTime(r["created_at"])
+	summary.UpdatedAt = asTime(r["updated_at"])
+	summary.MessageCount = asInt(r["count"])
+	summary.TitleGenerated = asBool(r["title_generated"])
+	summary.TitleInvalidated = asBool(r["title_invalidated"])
+	summary.TitleGenerationTime = asTimePtr(r["title_generation_time"])
+
+	totalInputTokens := asInt(r["total_input_tokens"])
+	totalOutputTokens := asInt(r["total_output_tokens"])
+	summary.TokenStats = domain.SessionTokenStats{
+		TotalInputTokens:  totalInputTokens,
+		TotalOutputTokens: totalOutputTokens,
+		TotalTokens:       totalInputTokens + totalOutputTokens,
+		RequestCount:      summary.MessageCount / 2,
+	}
+
+	modelsJSON := asString(r["models"])
+	if modelsJSON != "" && modelsJSON != "[]" {
+		var models []string
+		if err := json.Unmarshal([]byte(modelsJSON), &models); err == nil && len(models) > 0 {
+			summary.Model = models[0]
+		}
+	}
+
+	tagsJSON := asString(r["tags"])
+	if tagsJSON != "" && tagsJSON != "[]" {
+		_ = json.Unmarshal([]byte(tagsJSON), &summary.Tags)
+	}
+
+	return summary
+}
+
+// DeleteConversation removes a conversation by its ID.
+func (s *D1Storage) DeleteConversation(ctx context.Context, conversationID string) error {
+	changes, err := s.exec(ctx, "DELETE FROM conversations WHERE id = ?", conversationID)
+	if err != nil {
+		return fmt.Errorf("failed to delete conversation: %w", err)
+	}
+	if changes == 0 {
+		return fmt.Errorf("conversation not found: %s", conversationID)
+	}
+	return nil
+}
+
+// UpdateConversationMetadata updates metadata for a conversation.
+func (s *D1Storage) UpdateConversationMetadata(ctx context.Context, conversationID string, metadata ConversationMetadata) error {
+	tagsJSON, err := json.Marshal(metadata.Tags)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tags: %w", err)
+	}
+
+	costStatsJSON, err := json.Marshal(metadata.CostStats)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cost stats: %w", err)
+	}
+
+	modelsJSON := "[]"
+	if metadata.Model != "" {
+		models := []string{metadata.Model}
+		if modelsData, err := json.Marshal(models); err == nil {
+			modelsJSON = string(modelsData)
+		}
+	}
+
+	changes, err := s.exec(ctx, `
+		UPDATE conversations
+		SET title = ?, updated_at = ?, models = ?, tags = ?,
+		    total_input_tokens = ?, total_output_tokens = ?, request_count = ?, cost_stats = ?,
+		    title_generated = ?, title_invalidated = ?, title_generation_time = ?
+		WHERE id = ?
+	`, metadata.Title, metadata.UpdatedAt, modelsJSON, string(tagsJSON),
+		metadata.TokenStats.TotalInputTokens, metadata.TokenStats.TotalOutputTokens, metadata.TokenStats.RequestCount, string(costStatsJSON),
+		metadata.TitleGenerated, metadata.TitleInvalidated, metadata.TitleGenerationTime, conversationID)
+	if err != nil {
+		return fmt.Errorf("failed to update conversation metadata: %w", err)
+	}
+	if changes == 0 {
+		return fmt.Errorf("conversation not found: %s", conversationID)
+	}
+	return nil
+}
+
+// Close releases resources. D1 holds no persistent connection, so this is a no-op.
+func (s *D1Storage) Close() error {
+	return nil
+}
+
+// Health checks that the D1 database is reachable and answering queries.
+func (s *D1Storage) Health(ctx context.Context) error {
+	rows, err := s.queryRows(ctx, "SELECT 1 AS ok")
+	if err != nil {
+		return fmt.Errorf("d1 health check failed: %w", err)
+	}
+	if len(rows) == 0 {
+		return fmt.Errorf("d1 health check returned no rows")
+	}
+	return nil
+}
+
+// GetSessionGroup returns the entry for groupKey or (_, false, nil) if missing.
+func (s *D1Storage) GetSessionGroup(ctx context.Context, groupKey string) (SessionGroupEntry, bool, error) {
+	rows, err := s.queryRows(ctx, `
+		SELECT current_session_id, history, last_rollover, updated_at
+		FROM session_groups
+		WHERE group_key = ?
+	`, groupKey)
+	if err != nil {
+		return SessionGroupEntry{}, false, fmt.Errorf("query session group %s: %w", groupKey, err)
+	}
+	if len(rows) == 0 {
+		return SessionGroupEntry{}, false, nil
+	}
+	r := rows[0]
+
+	history, err := decodeHistory(asString(r["history"]), groupKey)
+	if err != nil {
+		return SessionGroupEntry{}, false, err
+	}
+
+	entry := SessionGroupEntry{
+		CurrentSessionID: asString(r["current_session_id"]),
+		History:          history,
+		UpdatedAt:        asTime(r["updated_at"]),
+	}
+	if lr := asTimePtr(r["last_rollover"]); lr != nil {
+		entry.LastRollover = *lr
+	}
+	return entry, true, nil
+}
+
+// PutSessionGroup creates or replaces the entry for groupKey via UPSERT.
+func (s *D1Storage) PutSessionGroup(ctx context.Context, groupKey string, entry SessionGroupEntry) error {
+	historyJSON, err := json.Marshal(entry.History)
+	if err != nil {
+		return fmt.Errorf("encode history for %s: %w", groupKey, err)
+	}
+	if len(historyJSON) == 0 || string(historyJSON) == "null" {
+		historyJSON = []byte("[]")
+	}
+
+	_, err = s.exec(ctx, `
+		INSERT INTO session_groups(group_key, current_session_id, history, last_rollover, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(group_key) DO UPDATE SET
+			current_session_id = excluded.current_session_id,
+			history            = excluded.history,
+			last_rollover      = excluded.last_rollover,
+			updated_at         = excluded.updated_at
+	`, groupKey, entry.CurrentSessionID, string(historyJSON), entry.LastRollover, entry.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("upsert session group %s: %w", groupKey, err)
+	}
+	return nil
+}
+
+// ListSessionGroups returns all session-group entries.
+func (s *D1Storage) ListSessionGroups(ctx context.Context) (map[string]SessionGroupEntry, error) {
+	rows, err := s.queryRows(ctx, `
+		SELECT group_key, current_session_id, history, last_rollover, updated_at
+		FROM session_groups
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list session groups: %w", err)
+	}
+
+	out := make(map[string]SessionGroupEntry)
+	for _, r := range rows {
+		groupKey := asString(r["group_key"])
+		history, err := decodeHistory(asString(r["history"]), groupKey)
+		if err != nil {
+			return nil, err
+		}
+
+		entry := SessionGroupEntry{
+			CurrentSessionID: asString(r["current_session_id"]),
+			History:          history,
+			UpdatedAt:        asTime(r["updated_at"]),
+		}
+		if lr := asTimePtr(r["last_rollover"]); lr != nil {
+			entry.LastRollover = *lr
+		}
+		out[groupKey] = entry
+	}
+	return out, nil
+}
+
+// decodeHistory unmarshals the session-group history JSON array.
+func decodeHistory(historyJSON, groupKey string) ([]string, error) {
+	if historyJSON == "" {
+		return nil, nil
+	}
+	var history []string
+	if err := json.Unmarshal([]byte(historyJSON), &history); err != nil {
+		return nil, fmt.Errorf("decode history for %s: %w", groupKey, err)
+	}
+	return history, nil
+}

--- a/internal/infra/storage/d1_test.go
+++ b/internal/infra/storage/d1_test.go
@@ -1,0 +1,445 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	sdk "github.com/inference-gateway/sdk"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// newD1MockServer stands up an httptest.Server that speaks the D1 /query
+// envelope, backed by a real in-process SQLite database. Because the backing
+// store is genuine SQLite, round-trips exercise real SQL semantics (ORDER BY,
+// changes==0 not-found, the title predicate, JSON round-trips) rather than
+// hand-rolled fixtures.
+func newD1MockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "d1mock.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleD1Query(t, db, w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// handleD1Query executes one /query request against the backing SQLite DB and
+// renders the response in D1's envelope shape.
+func handleD1Query(t *testing.T, db *sql.DB, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+
+	var body d1RequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeD1Error(w, http.StatusBadRequest, "bad request body")
+		return
+	}
+
+	if isD1Mutation(body.SQL) {
+		res, err := db.ExecContext(r.Context(), body.SQL, body.Params...)
+		if err != nil {
+			writeD1Error(w, http.StatusOK, err.Error())
+			return
+		}
+		changes, _ := res.RowsAffected()
+		writeD1Result(w, nil, changes)
+		return
+	}
+
+	rows, err := db.QueryContext(r.Context(), body.SQL, body.Params...)
+	if err != nil {
+		writeD1Error(w, http.StatusOK, err.Error())
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	results, err := scanD1Rows(rows)
+	if err != nil {
+		writeD1Error(w, http.StatusOK, err.Error())
+		return
+	}
+	writeD1Result(w, results, 0)
+}
+
+func isD1Mutation(sqlText string) bool {
+	trimmed := strings.ToUpper(strings.TrimSpace(sqlText))
+	for _, p := range []string{"INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER"} {
+		if strings.HasPrefix(trimmed, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// scanD1Rows generically scans rows into JSON objects, converting []byte→string
+// and int64→float64 to mimic the types Cloudflare's JSON response carries
+// (TEXT→string, INTEGER→number).
+func scanD1Rows(rows *sql.Rows) ([]map[string]any, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	var out []map[string]any
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+
+		m := make(map[string]any, len(cols))
+		for i, c := range cols {
+			switch v := vals[i].(type) {
+			case []byte:
+				m[c] = string(v)
+			case int64:
+				m[c] = float64(v)
+			default:
+				m[c] = v
+			}
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+func writeD1Result(w http.ResponseWriter, results []map[string]any, changes int64) {
+	if results == nil {
+		results = []map[string]any{}
+	}
+	env := d1Envelope{
+		Success: true,
+		Result: []d1QueryResult{{
+			Results: results,
+			Success: true,
+			Meta:    d1Meta{Changes: changes},
+		}},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(env)
+}
+
+func writeD1Error(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(d1Envelope{
+		Success: false,
+		Errors:  []d1APIError{{Message: msg}},
+	})
+}
+
+func setupTestD1Storage(t *testing.T) *D1Storage {
+	srv := newD1MockServer(t)
+	storage, err := NewD1Storage(D1Config{
+		AccountID:  "test-acct",
+		DatabaseID: "test-db",
+		APIToken:   "test-token",
+		BaseURL:    srv.URL,
+	})
+	require.NoError(t, err)
+	return storage
+}
+
+func TestD1Storage_BasicOperations(t *testing.T) {
+	storage := setupTestD1Storage(t)
+	ctx := context.Background()
+
+	t.Run("Health Check", func(t *testing.T) {
+		assert.NoError(t, storage.Health(ctx))
+	})
+
+	t.Run("Save and Load Conversation", func(t *testing.T) {
+		conversationID := "test-conversation-1"
+		entries := createTestEntries()
+		metadata := createTestMetadata(conversationID)
+
+		require.NoError(t, storage.SaveConversation(ctx, conversationID, entries, metadata))
+
+		loadedEntries, loadedMetadata, err := storage.LoadConversation(ctx, conversationID)
+		require.NoError(t, err)
+
+		assert.Equal(t, metadata.ID, loadedMetadata.ID)
+		assert.Equal(t, metadata.Title, loadedMetadata.Title)
+		assert.Equal(t, len(entries), loadedMetadata.MessageCount)
+		assert.Equal(t, metadata.TokenStats, loadedMetadata.TokenStats)
+		assert.Equal(t, metadata.Tags, loadedMetadata.Tags)
+
+		assert.Len(t, loadedEntries, len(entries))
+		for i, entry := range entries {
+			assert.Equal(t, entry.Message.Content, loadedEntries[i].Message.Content)
+			assert.Equal(t, entry.Message.Role, loadedEntries[i].Message.Role)
+			assert.Equal(t, entry.Model, loadedEntries[i].Model)
+			assert.Equal(t, entry.Hidden, loadedEntries[i].Hidden)
+		}
+	})
+
+	t.Run("Update Conversation", func(t *testing.T) {
+		conversationID := "test-conversation-update"
+		entries := createTestEntries()
+		metadata := createTestMetadata(conversationID)
+
+		require.NoError(t, storage.SaveConversation(ctx, conversationID, entries, metadata))
+
+		newEntry := domain.ConversationEntry{
+			Message: sdk.Message{
+				Role:    sdk.Assistant,
+				Content: sdk.NewMessageContent("Updated response"),
+			},
+			Time:  time.Now(),
+			Model: "claude-4",
+		}
+		entries = append(entries, newEntry)
+
+		metadata.Title = "Updated Title"
+		metadata.UpdatedAt = time.Now()
+		metadata.MessageCount = len(entries)
+
+		require.NoError(t, storage.SaveConversation(ctx, conversationID, entries, metadata))
+
+		loadedEntries, loadedMetadata, err := storage.LoadConversation(ctx, conversationID)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Updated Title", loadedMetadata.Title)
+		assert.Len(t, loadedEntries, len(entries))
+		lastContent, _ := loadedEntries[len(loadedEntries)-1].Message.Content.AsMessageContent0()
+		assert.Equal(t, "Updated response", lastContent)
+	})
+}
+
+func TestD1Storage_ConversationManagement(t *testing.T) {
+	storage := setupTestD1Storage(t)
+	ctx := context.Background()
+
+	t.Run("List Conversations", func(t *testing.T) {
+		conversations := []string{"conv1", "conv2", "conv3"}
+
+		for i, id := range conversations {
+			entries := createTestEntries()
+			metadata := createTestMetadata(id)
+			metadata.Title = "Conversation " + string(rune('A'+i))
+			metadata.CreatedAt = time.Now().Add(time.Duration(i) * time.Hour)
+			metadata.UpdatedAt = metadata.CreatedAt
+
+			require.NoError(t, storage.SaveConversation(ctx, id, entries, metadata))
+		}
+
+		summaries, err := storage.ListConversations(ctx, 10, 0)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(summaries), 3)
+
+		for i := 1; i < len(summaries); i++ {
+			assert.True(t, summaries[i-1].UpdatedAt.After(summaries[i].UpdatedAt) ||
+				summaries[i-1].UpdatedAt.Equal(summaries[i].UpdatedAt))
+		}
+	})
+
+	t.Run("Delete Conversation", func(t *testing.T) {
+		conversationID := "test-conversation-delete"
+		entries := createTestEntries()
+		metadata := createTestMetadata(conversationID)
+
+		require.NoError(t, storage.SaveConversation(ctx, conversationID, entries, metadata))
+
+		_, _, err := storage.LoadConversation(ctx, conversationID)
+		require.NoError(t, err)
+
+		require.NoError(t, storage.DeleteConversation(ctx, conversationID))
+
+		_, _, err = storage.LoadConversation(ctx, conversationID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "conversation not found")
+	})
+
+	t.Run("Update Metadata", func(t *testing.T) {
+		conversationID := "test-conversation-metadata"
+		entries := createTestEntries()
+		metadata := createTestMetadata(conversationID)
+
+		require.NoError(t, storage.SaveConversation(ctx, conversationID, entries, metadata))
+
+		metadata.Title = "New Title"
+		metadata.Tags = []string{"updated", "test"}
+		metadata.UpdatedAt = time.Now()
+
+		require.NoError(t, storage.UpdateConversationMetadata(ctx, conversationID, metadata))
+
+		_, loadedMetadata, err := storage.LoadConversation(ctx, conversationID)
+		require.NoError(t, err)
+
+		assert.Equal(t, "New Title", loadedMetadata.Title)
+		assert.Equal(t, []string{"updated", "test"}, loadedMetadata.Tags)
+	})
+}
+
+func TestD1Storage_ErrorCases(t *testing.T) {
+	storage := setupTestD1Storage(t)
+	ctx := context.Background()
+
+	t.Run("Load Non-existent Conversation", func(t *testing.T) {
+		_, _, err := storage.LoadConversation(ctx, "non-existent")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "conversation not found")
+	})
+
+	t.Run("Delete Non-existent Conversation", func(t *testing.T) {
+		err := storage.DeleteConversation(ctx, "non-existent")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "conversation not found")
+	})
+}
+
+// TestD1Storage_ListConversationsNeedingTitles guards the issue's explicit
+// warning: the title-generation batch path must receive Model/Tags/RequestCount
+// (i.e. the full mapper, not the lean ListConversations one).
+func TestD1Storage_ListConversationsNeedingTitles(t *testing.T) {
+	storage := setupTestD1Storage(t)
+	ctx := context.Background()
+
+	for i := range 3 {
+		id := fmt.Sprintf("needs-title-%d", i)
+		entries := createTestEntries() // 4 entries → count >= 2
+		metadata := createTestMetadata(id)
+		metadata.TitleGenerated = false
+		metadata.UpdatedAt = time.Now().Add(time.Duration(i) * time.Hour)
+		require.NoError(t, storage.SaveConversation(ctx, id, entries, metadata))
+	}
+
+	summaries, err := storage.ListConversationsNeedingTitles(ctx, 10)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(summaries), 3)
+
+	for _, s := range summaries {
+		assert.Equal(t, "claude-4", s.Model, "Model must be carried for the title batch path")
+		assert.Equal(t, []string{"test", "demo"}, s.Tags, "Tags must be carried for the title batch path")
+		assert.Equal(t, s.MessageCount/2, s.TokenStats.RequestCount)
+		assert.False(t, s.TitleGenerated)
+	}
+}
+
+func TestD1Storage_SessionGroups(t *testing.T) {
+	s := setupTestD1Storage(t)
+	ctx := context.Background()
+
+	_, ok, err := s.GetSessionGroup(ctx, "missing")
+	require.NoError(t, err)
+	assert.False(t, ok, "missing key must report not-found")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	entry := SessionGroupEntry{
+		CurrentSessionID: "uuid-1",
+		History:          []string{"prev-a", "prev-b"},
+		LastRollover:     now,
+		UpdatedAt:        now,
+	}
+	require.NoError(t, s.PutSessionGroup(ctx, "channel-telegram-42", entry))
+
+	got, ok, err := s.GetSessionGroup(ctx, "channel-telegram-42")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "uuid-1", got.CurrentSessionID)
+	assert.Equal(t, []string{"prev-a", "prev-b"}, got.History)
+	assert.WithinDuration(t, now, got.UpdatedAt, time.Second)
+	assert.WithinDuration(t, now, got.LastRollover, time.Second)
+
+	require.NoError(t, s.PutSessionGroup(ctx, "channel-telegram-42", SessionGroupEntry{
+		CurrentSessionID: "uuid-2",
+		History:          []string{"prev-a", "prev-b", "uuid-1"},
+		UpdatedAt:        now,
+	}))
+
+	got, ok, err = s.GetSessionGroup(ctx, "channel-telegram-42")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "uuid-2", got.CurrentSessionID)
+	assert.Equal(t, []string{"prev-a", "prev-b", "uuid-1"}, got.History)
+	assert.True(t, got.LastRollover.IsZero(), "LastRollover must be cleared when UPSERT supplies zero value")
+
+	require.NoError(t, s.PutSessionGroup(ctx, "second", SessionGroupEntry{
+		CurrentSessionID: "uuid-3",
+		UpdatedAt:        now,
+	}))
+	all, err := s.ListSessionGroups(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, 2)
+	assert.Equal(t, "uuid-2", all["channel-telegram-42"].CurrentSessionID)
+	assert.Equal(t, "uuid-3", all["second"].CurrentSessionID)
+	assert.True(t, all["second"].LastRollover.IsZero())
+}
+
+// TestD1Storage_RequestShape asserts the driver hits the documented D1 endpoint
+// path and sends the bearer token.
+func TestD1Storage_RequestShape(t *testing.T) {
+	var gotPath, gotAuth, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		writeD1Result(w, []map[string]any{{"ok": float64(1)}}, 0)
+	}))
+	defer srv.Close()
+
+	storage, err := NewD1Storage(D1Config{
+		AccountID:  "acct123",
+		DatabaseID: "db456",
+		APIToken:   "tok789",
+		BaseURL:    srv.URL,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storage.Health(context.Background()))
+
+	assert.Equal(t, "/accounts/acct123/d1/database/db456/query", gotPath)
+	assert.Equal(t, "Bearer tok789", gotAuth)
+	assert.Equal(t, "application/json", gotContentType)
+}
+
+// TestD1Storage_Live exercises a real Cloudflare D1 database. It is skipped
+// unless INFER_TEST_D1_LIVE is set and the D1 credentials are provided.
+func TestD1Storage_Live(t *testing.T) {
+	if os.Getenv("INFER_TEST_D1_LIVE") == "" {
+		t.Skip("set INFER_TEST_D1_LIVE=1 and INFER_STORAGE_D1_* to run the live D1 test")
+	}
+
+	cfg := D1Config{
+		AccountID:  os.Getenv("INFER_STORAGE_D1_ACCOUNT_ID"),
+		DatabaseID: os.Getenv("INFER_STORAGE_D1_DATABASE_ID"),
+		APIToken:   os.Getenv("INFER_STORAGE_D1_API_TOKEN"),
+		BaseURL:    os.Getenv("INFER_STORAGE_D1_BASE_URL"),
+	}
+	require.NotEmpty(t, cfg.AccountID)
+	require.NotEmpty(t, cfg.DatabaseID)
+	require.NotEmpty(t, cfg.APIToken)
+
+	storage, err := NewD1Storage(cfg)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	id := "live-test-" + time.Now().UTC().Format("20060102150405")
+	require.NoError(t, storage.SaveConversation(ctx, id, createTestEntries(), createTestMetadata(id)))
+	t.Cleanup(func() { _ = storage.DeleteConversation(context.Background(), id) })
+
+	_, md, err := storage.LoadConversation(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, id, md.ID)
+	require.NoError(t, storage.Health(ctx))
+}

--- a/internal/infra/storage/factory.go
+++ b/internal/infra/storage/factory.go
@@ -52,6 +52,16 @@ func NewStorageFromConfig(cfg *config.Config) StorageConfig {
 				Database: cfg.Storage.Redis.DB,
 			},
 		}
+	case "d1":
+		return StorageConfig{
+			Type: "d1",
+			D1: D1Config{
+				AccountID:  cfg.Storage.D1.AccountID,
+				DatabaseID: cfg.Storage.D1.DatabaseID,
+				APIToken:   cfg.Storage.D1.APIToken,
+				BaseURL:    cfg.Storage.D1.BaseURL,
+			},
+		}
 	case "jsonl":
 		path := cfg.Storage.Jsonl.Path
 		if !filepath.IsAbs(path) {
@@ -86,6 +96,8 @@ func NewStorage(config StorageConfig) (ConversationStorage, error) {
 		return NewPostgresStorage(config.Postgres)
 	case "redis":
 		return NewRedisStorage(config.Redis)
+	case "d1":
+		return NewD1Storage(config.D1)
 	case "jsonl":
 		return NewJsonlStorage(config.Jsonl)
 	case "memory":

--- a/internal/infra/storage/interfaces.go
+++ b/internal/infra/storage/interfaces.go
@@ -110,6 +110,9 @@ type StorageConfig struct {
 
 	// JSONL specific configuration
 	Jsonl JsonlStorageConfig `json:"jsonl,omitempty" yaml:"jsonl,omitempty"`
+
+	// D1 specific configuration
+	D1 D1Config `json:"d1,omitempty" yaml:"d1,omitempty"`
 }
 
 // SQLiteConfig contains SQLite-specific configuration
@@ -140,4 +143,14 @@ type RedisConfig struct {
 // JsonlStorageConfig contains JSONL-specific configuration
 type JsonlStorageConfig struct {
 	Path string `json:"path" yaml:"path"`
+}
+
+// D1Config contains Cloudflare D1-specific configuration. D1 is SQLite exposed
+// over an HTTP query API, so the driver writes the same schema as SQLite but
+// over the network instead of a local file handle.
+type D1Config struct {
+	AccountID  string `json:"account_id" yaml:"account_id"`
+	DatabaseID string `json:"database_id" yaml:"database_id"`
+	APIToken   string `json:"api_token" yaml:"api_token"`
+	BaseURL    string `json:"base_url,omitempty" yaml:"base_url,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds a `d1` conversation storage backend that persists conversations **and** the channel session-group index to **Cloudflare D1** over its HTTP query API (`POST /accounts/{account}/d1/database/{database}/query`).

D1 is SQLite under the hood, so the driver mirrors the existing SQLite backend method-for-method and **reuses the SQLite migrations verbatim** - only the transport (HTTP instead of a local file handle) differs. This unblocks headless `infer` on ephemeral GitHub Actions runners: `sqlite`/`jsonl`/`memory` live on the runner's disk (wiped on recycle, unreadable externally) and `postgres`/`redis` speak wire protocols D1 doesn't, whereas D1 is external to the runner and the control plane can read it back via its native binding.

Closes #645

## What changed

| File | Change |
| --- | --- |
| `internal/infra/storage/d1.go` *(new)* | `D1Storage` implementing `ConversationStorage` + `SessionGroupStorage`; thin `do`/`exec`/`queryRows` HTTP layer over the D1 `/query` envelope; param encoder + decode helpers |
| `internal/infra/storage/d1_test.go` *(new)* | httptest mock **backed by a real in-process SQLite DB** so round-trips exercise genuine SQL (ordering, not-found, JSON round-trips); mirrors the SQLite tests + a `ListConversationsNeedingTitles` test, a request-shape/auth test, and a gated live test |
| `config/config.go`, `internal/infra/storage/interfaces.go`, `factory.go` | `StorageTypeD1`, `D1StorageConfig`/`D1Config`, defaults, and the two factory cases |
| `cmd/migrate.go` | report D1 as auto-migrated (its schema is created on connect) instead of erroring |
| `.infer/config.yaml` | regenerated `d1` block (`init --overwrite`; `agents.yaml` diff discarded per CLAUDE.md) |

## Configuration

```yaml
storage:
  enabled: true
  type: d1
  d1:
    account_id: "<cloudflare-account-id>"
    database_id: "<d1-database-id>"
    api_token: "<api-token-with-d1-edit>"   # inject via INFER_STORAGE_D1_API_TOKEN
    base_url: "https://api.cloudflare.com/client/v4"  # optional
```

Env overrides auto-derive: `INFER_STORAGE_D1_ACCOUNT_ID`, `_DATABASE_ID`, `_API_TOKEN`, `_BASE_URL`.

## Design notes

- **Schema parity**: the driver runs `migrations.GetSQLiteMigrations()` over HTTP, so `conversations` / `session_groups` stay byte-for-byte compatible with the SQLite backend - either side may initialise the database.
- **Timestamps**: stored as **UTC RFC3339** for stable lexical `ORDER BY updated_at DESC` across runners in any timezone and unambiguous external reads.
- **Two mappers preserved**: `ListConversations` stays lean while `ListConversationsNeedingTitles` carries `Model`/`Tags`/`TitleGenerated`/`TitleInvalidated`/`TitleGenerationTime` (the title-generation batch path needs them) - covered by a dedicated test.
- **Secrets**: `api_token` follows the existing plaintext-config + env-override convention (like the Postgres password) and is never logged.

## Testing

- `go build ./...` ✅
- `go test ./...` ✅ (exit 0, 0 failures)
- `task lint` ✅ (0 issues)
- D1 suite: 8 pass, live test skipped (runs against real D1 when `INFER_TEST_D1_LIVE` + `INFER_STORAGE_D1_*` are set)

## Cross-repo impact

Docs-only. No gateway/SDK/operator changes - the gateway already *reads* D1 via its native binding; this adds the CLI *write* path. A `[DOCS]` follow-up for `inference-gateway/docs` → `cli.md` (add Cloudflare D1 to the storage-backends sections + config keys/env vars) should accompany this PR - happy to file it.
