### PR TITLE
feat(claude-code): surface token usage and cost in headless mode

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -154,7 +154,16 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 		return fmt.Errorf("no models available from inference gateway")
 	}
 
-	selectedModel, err := selectModel(models, modelFlag, cfg.Agent.Model)
+	// Claude Code mode accepts bare Claude ids for back-compat; normalize them to
+	// the anthropic/-prefixed canonical form so they validate against the model
+	// list and resolve in the pricing table for session cost.
+	defaultModel := cfg.Agent.Model
+	if cfg.IsClaudeCodeMode() {
+		modelFlag = services.CanonicalClaudeModelID(modelFlag)
+		defaultModel = services.CanonicalClaudeModelID(defaultModel)
+	}
+
+	selectedModel, err := selectModel(models, modelFlag, defaultModel)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -154,9 +154,6 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 		return fmt.Errorf("no models available from inference gateway")
 	}
 
-	// Claude Code mode accepts bare Claude ids for back-compat; normalize them to
-	// the anthropic/-prefixed canonical form so they validate against the model
-	// list and resolve in the pricing table for session cost.
 	defaultModel := cfg.Agent.Model
 	if cfg.IsClaudeCodeMode() {
 		modelFlag = services.CanonicalClaudeModelID(modelFlag)

--- a/config/model_context.go
+++ b/config/model_context.go
@@ -18,6 +18,7 @@ const DefaultContextWindow = 8192
 // model families that aren't served are intentionally omitted to keep the list
 // small and the View output truthful.
 var ContextMatchers = []ModelMatcher{
+	{Patterns: []string{"fable"}, ContextWindow: 1000000},
 	{Patterns: []string{"claude-opus-4-7"}, ContextWindow: 1000000},
 	{Patterns: []string{"claude-opus-4", "claude-sonnet-4", "claude-haiku-4"}, ContextWindow: 200000},
 	{Patterns: []string{"claude"}, ContextWindow: 200000},

--- a/config/model_context.go
+++ b/config/model_context.go
@@ -19,7 +19,7 @@ const DefaultContextWindow = 8192
 // small and the View output truthful.
 var ContextMatchers = []ModelMatcher{
 	{Patterns: []string{"fable"}, ContextWindow: 1000000},
-	{Patterns: []string{"claude-opus-4-7"}, ContextWindow: 1000000},
+	{Patterns: []string{"claude-opus-4-7", "claude-opus-4-8"}, ContextWindow: 1000000},
 	{Patterns: []string{"claude-opus-4", "claude-sonnet-4", "claude-haiku-4"}, ContextWindow: 200000},
 	{Patterns: []string{"claude"}, ContextWindow: 200000},
 	{Patterns: []string{"gemini-3"}, ContextWindow: 1048576},

--- a/config/pricing.go
+++ b/config/pricing.go
@@ -44,6 +44,13 @@ func GetDefaultPricingConfig() PricingConfig {
 // Prices are based on publicly available pricing as of December 2024.
 // Users can override these in their config files.
 var DefaultModelPricing = map[string]ModelPricing{
+	"anthropic/claude-opus-4-8": {
+		Provider:             "anthropic",
+		Model:                "claude-opus-4-8",
+		InputPricePerMToken:  5.00,
+		OutputPricePerMToken: 25.00,
+		Currency:             "USD",
+	},
 	"anthropic/claude-opus-4-7": {
 		Provider:             "anthropic",
 		Model:                "claude-opus-4-7",

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -702,7 +702,8 @@ func (s *AgentServiceImpl) validateRequest(req *domain.AgentRequest) error {
 }
 
 // parseProvider parses provider and model name from model string
-// In Claude Code mode, models don't have a provider prefix, so we return "claude" as the provider
+// Claude Code mode uses anthropic/-prefixed ids (like gateway mode); the bare
+// fallback returns "claude" only for legacy un-prefixed inputs.
 func (s *AgentServiceImpl) parseProvider(model string) (string, string, error) {
 	if s.config != nil {
 		cfg := s.config.GetAgentConfig()

--- a/internal/infra/adapters/claude_code_client.go
+++ b/internal/infra/adapters/claude_code_client.go
@@ -73,12 +73,14 @@ func (c *ClaudeCodeClient) GenerateContent(
 		return nil, err
 	}
 
-	content, toolCallsMap, err := c.processEvents(eventChan)
+	content, toolCallsMap, usage, err := c.processEvents(eventChan)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.buildResponse(content, toolCallsMap), nil
+	response := c.buildResponse(content, toolCallsMap)
+	response.Usage = usage
+	return response, nil
 }
 
 // GenerateContentStream makes a streaming request to Claude Code CLI
@@ -138,6 +140,14 @@ func (c *ClaudeCodeClient) GenerateContentStream(
 func (c *ClaudeCodeClient) buildArgs(model string) []string {
 	permissionMode := c.getPermissionMode()
 	maxTurns := c.config.MaxTurns
+
+	// The claude CLI expects a bare model id; strip any provider prefix
+	// (e.g. "anthropic/claude-opus-4-5" -> "claude-opus-4-5") so Claude Code
+	// mode can share the anthropic/-prefixed ids used by gateway mode and the
+	// pricing table.
+	if idx := strings.LastIndex(model, "/"); idx != -1 {
+		model = model[idx+1:]
+	}
 
 	args := []string{
 		"--output-format", "stream-json",
@@ -284,6 +294,31 @@ func (c *ClaudeCodeClient) createDeltaEvent(delta map[string]any) sdk.SSEvent {
 	return sdk.SSEvent{Event: &eventType, Data: &responseBytes}
 }
 
+// createUsageEvent builds a usage-bearing chat.completion.chunk. It carries a
+// single empty-delta choice (a no-op for the sync content/tool accumulator, and
+// required by the chat TUI consumer which only reads Usage inside its choices
+// loop) plus the top-level usage object that both consumers read.
+func (c *ClaudeCodeClient) createUsageEvent(usage *sdk.CompletionUsage) sdk.SSEvent {
+	streamResponse := map[string]any{
+		"id":      "chatcmpl-" + fmt.Sprintf("%d", time.Now().UnixNano()),
+		"object":  "chat.completion.chunk",
+		"created": time.Now().Unix(),
+		"model":   "",
+		"choices": []map[string]any{
+			{"delta": map[string]any{}, "index": 0},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     usage.PromptTokens,
+			"completion_tokens": usage.CompletionTokens,
+			"total_tokens":      usage.TotalTokens,
+		},
+	}
+
+	responseBytes, _ := json.Marshal(streamResponse)
+	eventType := sdk.SSEventEvent("content_block_delta")
+	return sdk.SSEvent{Event: &eventType, Data: &responseBytes}
+}
+
 func (c *ClaudeCodeClient) transformMessage(msg ClaudeCodeMessage) []sdk.SSEvent {
 	var events []sdk.SSEvent
 
@@ -358,12 +393,19 @@ func (c *ClaudeCodeClient) transformMessage(msg ClaudeCodeMessage) []sdk.SSEvent
 		return events
 
 	case "result":
+		// The result message carries the invocation's cumulative usage. Emit it
+		// as an OpenAI-style usage chunk (always, even when Claude omits usage, so
+		// the downstream request counter still increments) ahead of message_stop.
+		usage := &ClaudeUsage{}
+		if msg.Usage != nil {
+			usage = msg.Usage
+		}
 		doneBytes := []byte("done")
-		eventType := sdk.SSEventEvent("message_stop")
-		return []sdk.SSEvent{{
-			Event: &eventType,
-			Data:  &doneBytes,
-		}}
+		stopType := sdk.SSEventEvent("message_stop")
+		return []sdk.SSEvent{
+			c.createUsageEvent(usage.toCompletionUsage()),
+			{Event: &stopType, Data: &doneBytes},
+		}
 
 	case "user":
 		var toolResultMsg ToolResultMessage
@@ -465,10 +507,32 @@ type ClaudeCodeMessage struct {
 	SessionID string          `json:"session_id,omitempty"`
 
 	// Result fields
-	TotalCostUSD float64 `json:"total_cost_usd,omitempty"`
-	IsError      bool    `json:"is_error,omitempty"`
-	DurationMS   int     `json:"duration_ms,omitempty"`
-	NumTurns     int     `json:"num_turns,omitempty"`
+	TotalCostUSD float64      `json:"total_cost_usd,omitempty"`
+	IsError      bool         `json:"is_error,omitempty"`
+	DurationMS   int          `json:"duration_ms,omitempty"`
+	NumTurns     int          `json:"num_turns,omitempty"`
+	Usage        *ClaudeUsage `json:"usage,omitempty"`
+}
+
+// ClaudeUsage is Anthropic's token breakdown as reported on the result message.
+type ClaudeUsage struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+}
+
+// toCompletionUsage maps Anthropic's token breakdown onto the SDK's
+// prompt/completion shape. The SDK usage type has no cache fields, so cache
+// tokens fold into prompt_tokens - matching how the gateway reports a single
+// prompt_tokens count for cached input.
+func (u *ClaudeUsage) toCompletionUsage() *sdk.CompletionUsage {
+	prompt := u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
+	return &sdk.CompletionUsage{
+		PromptTokens:     prompt,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      prompt + u.OutputTokens,
+	}
 }
 
 // filterEnv removes a specific environment variable from the env slice
@@ -485,18 +549,37 @@ func filterEnv(env []string, key string) []string {
 	return filtered
 }
 
-// processEvents processes SSE events and accumulates content and tool calls
-func (c *ClaudeCodeClient) processEvents(eventChan <-chan sdk.SSEvent) (string, map[string]*sdk.ChatCompletionMessageToolCall, error) {
+// processEvents processes SSE events and accumulates content, tool calls, and
+// the usage carried by the final usage chunk.
+func (c *ClaudeCodeClient) processEvents(eventChan <-chan sdk.SSEvent) (string, map[string]*sdk.ChatCompletionMessageToolCall, *sdk.CompletionUsage, error) {
 	var content strings.Builder
 	toolCallsMap := make(map[string]*sdk.ChatCompletionMessageToolCall)
+	var usage *sdk.CompletionUsage
 
 	for event := range eventChan {
+		if event.Data != nil {
+			if u := parseChunkUsage(*event.Data); u != nil {
+				usage = u
+			}
+		}
 		if err := c.handleEvent(event, &content, toolCallsMap); err != nil {
-			return "", nil, err
+			return "", nil, nil, err
 		}
 	}
 
-	return content.String(), toolCallsMap, nil
+	return content.String(), toolCallsMap, usage, nil
+}
+
+// parseChunkUsage extracts a top-level usage object from a chat.completion.chunk
+// payload, returning nil when the chunk carries no usage (content/tool deltas).
+func parseChunkUsage(data []byte) *sdk.CompletionUsage {
+	var chunk struct {
+		Usage *sdk.CompletionUsage `json:"usage"`
+	}
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return nil
+	}
+	return chunk.Usage
 }
 
 // handleEvent processes a single SSE event

--- a/internal/infra/adapters/claude_code_client.go
+++ b/internal/infra/adapters/claude_code_client.go
@@ -141,9 +141,6 @@ func (c *ClaudeCodeClient) buildArgs(model string) []string {
 	permissionMode := c.getPermissionMode()
 	maxTurns := c.config.MaxTurns
 
-	// The claude CLI expects a bare model id; strip any provider prefix
-	// (e.g. "anthropic/claude-opus-4-5" -> "claude-opus-4-5") so Claude Code
-	// mode can share the anthropic/-prefixed ids used by gateway mode and the
 	// pricing table.
 	if idx := strings.LastIndex(model, "/"); idx != -1 {
 		model = model[idx+1:]
@@ -393,9 +390,6 @@ func (c *ClaudeCodeClient) transformMessage(msg ClaudeCodeMessage) []sdk.SSEvent
 		return events
 
 	case "result":
-		// The result message carries the invocation's cumulative usage. Emit it
-		// as an OpenAI-style usage chunk (always, even when Claude omits usage, so
-		// the downstream request counter still increments) ahead of message_stop.
 		usage := &ClaudeUsage{}
 		if msg.Usage != nil {
 			usage = msg.Usage

--- a/internal/infra/adapters/claude_code_client.go
+++ b/internal/infra/adapters/claude_code_client.go
@@ -141,7 +141,6 @@ func (c *ClaudeCodeClient) buildArgs(model string) []string {
 	permissionMode := c.getPermissionMode()
 	maxTurns := c.config.MaxTurns
 
-	// pricing table.
 	if idx := strings.LastIndex(model, "/"); idx != -1 {
 		model = model[idx+1:]
 	}

--- a/internal/infra/adapters/claude_code_client_test.go
+++ b/internal/infra/adapters/claude_code_client_test.go
@@ -1,0 +1,153 @@
+package adapters
+
+import (
+	"encoding/json"
+	"testing"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+func TestClaudeUsageToCompletionUsage(t *testing.T) {
+	u := &ClaudeUsage{
+		InputTokens:              100,
+		OutputTokens:             20,
+		CacheCreationInputTokens: 30,
+		CacheReadInputTokens:     50,
+	}
+
+	got := u.toCompletionUsage()
+
+	// Cache tokens fold into prompt_tokens: 100 + 30 + 50 = 180.
+	if got.PromptTokens != 180 {
+		t.Errorf("PromptTokens = %d, want 180", got.PromptTokens)
+	}
+	if got.CompletionTokens != 20 {
+		t.Errorf("CompletionTokens = %d, want 20", got.CompletionTokens)
+	}
+	if got.TotalTokens != 200 {
+		t.Errorf("TotalTokens = %d, want 200", got.TotalTokens)
+	}
+}
+
+// chunkShape mirrors the JSON the adapter emits for a usage chunk.
+type chunkShape struct {
+	Choices []struct {
+		Delta map[string]any `json:"delta"`
+		Index int            `json:"index"`
+	} `json:"choices"`
+	Usage *sdk.CompletionUsage `json:"usage"`
+}
+
+func TestTransformMessageResultEmitsUsageChunk(t *testing.T) {
+	c := &ClaudeCodeClient{}
+
+	events := c.transformMessage(ClaudeCodeMessage{
+		Type:  "result",
+		Usage: &ClaudeUsage{InputTokens: 100, OutputTokens: 20, CacheCreationInputTokens: 30, CacheReadInputTokens: 50},
+	})
+
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2 (usage chunk + message_stop)", len(events))
+	}
+
+	if events[0].Data == nil {
+		t.Fatal("usage chunk has nil data")
+	}
+	var chunk chunkShape
+	if err := json.Unmarshal(*events[0].Data, &chunk); err != nil {
+		t.Fatalf("unmarshal usage chunk: %v", err)
+	}
+	if chunk.Usage == nil {
+		t.Fatal("usage chunk is missing the usage object")
+	}
+	if chunk.Usage.PromptTokens != 180 || chunk.Usage.CompletionTokens != 20 || chunk.Usage.TotalTokens != 200 {
+		t.Errorf("usage = %+v, want prompt=180 completion=20 total=200", chunk.Usage)
+	}
+	if len(chunk.Choices) != 1 || len(chunk.Choices[0].Delta) != 0 {
+		t.Errorf("want exactly one empty-delta choice, got %+v", chunk.Choices)
+	}
+
+	if events[1].Event == nil || string(*events[1].Event) != "message_stop" {
+		t.Errorf("second event = %v, want message_stop", events[1].Event)
+	}
+	if events[1].Data == nil || string(*events[1].Data) != "done" {
+		t.Errorf("second event data = %v, want done", events[1].Data)
+	}
+}
+
+func TestTransformMessageResultNilUsageEmitsZeroUsage(t *testing.T) {
+	c := &ClaudeCodeClient{}
+
+	// A result without a usage object must still emit a (zero) usage chunk so the
+	// downstream request counter increments and a session_stats line is produced.
+	events := c.transformMessage(ClaudeCodeMessage{Type: "result"})
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+
+	var chunk chunkShape
+	if err := json.Unmarshal(*events[0].Data, &chunk); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if chunk.Usage == nil {
+		t.Fatal("want a zero usage object, got nil")
+	}
+	if chunk.Usage.PromptTokens != 0 || chunk.Usage.CompletionTokens != 0 || chunk.Usage.TotalTokens != 0 {
+		t.Errorf("want zero usage, got %+v", chunk.Usage)
+	}
+}
+
+func TestProcessEventsCapturesUsage(t *testing.T) {
+	c := &ClaudeCodeClient{}
+
+	ch := make(chan sdk.SSEvent, 8)
+	for _, ev := range c.transformMessage(ClaudeCodeMessage{
+		Type:    "assistant",
+		Message: json.RawMessage(`{"role":"assistant","content":[{"type":"text","text":"hello"}]}`),
+	}) {
+		ch <- ev
+	}
+	for _, ev := range c.transformMessage(ClaudeCodeMessage{
+		Type:  "result",
+		Usage: &ClaudeUsage{InputTokens: 10, OutputTokens: 5},
+	}) {
+		ch <- ev
+	}
+	close(ch)
+
+	content, _, usage, err := c.processEvents(ch)
+	if err != nil {
+		t.Fatalf("processEvents: %v", err)
+	}
+	if content != "hello" {
+		t.Errorf("content = %q, want hello (empty-delta usage chunk must not corrupt content)", content)
+	}
+	if usage == nil {
+		t.Fatal("usage is nil")
+	}
+	if usage.PromptTokens != 10 || usage.CompletionTokens != 5 || usage.TotalTokens != 15 {
+		t.Errorf("usage = %+v, want prompt=10 completion=5 total=15", usage)
+	}
+}
+
+func TestBuildArgsStripsProviderPrefix(t *testing.T) {
+	c := &ClaudeCodeClient{config: &config.ClaudeCodeConfig{MaxTurns: 10}}
+
+	if got := modelArg(c.buildArgs("anthropic/claude-sonnet-4-5-20250929")); got != "claude-sonnet-4-5-20250929" {
+		t.Errorf("--model = %q, want bare claude-sonnet-4-5-20250929", got)
+	}
+	if got := modelArg(c.buildArgs("claude-opus-4-5")); got != "claude-opus-4-5" {
+		t.Errorf("--model = %q, want claude-opus-4-5 (bare passes through)", got)
+	}
+}
+
+func modelArg(args []string) string {
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}

--- a/internal/infra/adapters/claude_code_client_test.go
+++ b/internal/infra/adapters/claude_code_client_test.go
@@ -19,7 +19,6 @@ func TestClaudeUsageToCompletionUsage(t *testing.T) {
 
 	got := u.toCompletionUsage()
 
-	// Cache tokens fold into prompt_tokens: 100 + 30 + 50 = 180.
 	if got.PromptTokens != 180 {
 		t.Errorf("PromptTokens = %d, want 180", got.PromptTokens)
 	}
@@ -80,8 +79,6 @@ func TestTransformMessageResultEmitsUsageChunk(t *testing.T) {
 func TestTransformMessageResultNilUsageEmitsZeroUsage(t *testing.T) {
 	c := &ClaudeCodeClient{}
 
-	// A result without a usage object must still emit a (zero) usage chunk so the
-	// downstream request counter increments and a session_stats line is produced.
 	events := c.transformMessage(ClaudeCodeMessage{Type: "result"})
 	if len(events) != 2 {
 		t.Fatalf("got %d events, want 2", len(events))

--- a/internal/models/context_test.go
+++ b/internal/models/context_test.go
@@ -50,6 +50,8 @@ func TestClaudeContextWindow(t *testing.T) {
 		expected int
 	}{
 		{"anthropic/claude-opus-4-7", 1000000},
+		{"claude-fable-5", 1000000},
+		{"anthropic/claude-fable-5", 1000000},
 		{"anthropic/claude-sonnet-4-6", 200000},
 		{"anthropic/claude-opus-4-6", 200000},
 		{"anthropic/claude-opus-4-5-20251101", 200000},

--- a/internal/models/context_test.go
+++ b/internal/models/context_test.go
@@ -50,6 +50,7 @@ func TestClaudeContextWindow(t *testing.T) {
 		expected int
 	}{
 		{"anthropic/claude-opus-4-7", 1000000},
+		{"anthropic/claude-opus-4-8", 1000000},
 		{"claude-fable-5", 1000000},
 		{"anthropic/claude-fable-5", 1000000},
 		{"anthropic/claude-sonnet-4-6", 200000},

--- a/internal/services/model_claude_code.go
+++ b/internal/services/model_claude_code.go
@@ -28,6 +28,7 @@ func NewClaudeCodeModelService() domain.ModelService {
 // adapter strips the prefix before invoking the claude CLI.
 func (s *ClaudeCodeModelService) ListModels(ctx context.Context) ([]string, error) {
 	return []string{
+		"anthropic/claude-opus-4-8",
 		"anthropic/claude-opus-4-7",
 		"anthropic/claude-opus-4-6",
 		"anthropic/claude-opus-4-5-20251101",

--- a/internal/services/model_claude_code.go
+++ b/internal/services/model_claude_code.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
@@ -16,28 +17,43 @@ type ClaudeCodeModelService struct {
 // NewClaudeCodeModelService creates a new Claude Code model service
 func NewClaudeCodeModelService() domain.ModelService {
 	return &ClaudeCodeModelService{
-		currentModel: "claude-sonnet-4-5-20250929",
+		currentModel: "anthropic/claude-sonnet-4-5-20250929",
 	}
 }
 
-// ListModels returns a static list of Claude models available via subscription
+// ListModels returns a static list of Claude models available via subscription.
+// The ids are anthropic/-prefixed to stay consistent with gateway mode and the
+// pricing table (config.DefaultModelPricing); the set is curated to ids that the
+// pricing table prices, so session cost can be derived from token counts. The
+// adapter strips the prefix before invoking the claude CLI.
 func (s *ClaudeCodeModelService) ListModels(ctx context.Context) ([]string, error) {
 	return []string{
-		"claude-opus-4-5",
-		"claude-haiku-4-5-20251001",
-		"claude-sonnet-4-5-20250929",
-		"claude-opus-4-1-20250805",
-		"claude-opus-4-20250514",
-		"claude-sonnet-4-1-20250805",
-		"claude-3-7-sonnet-20250219",
-		"claude-3-5-haiku-20241022",
-		"claude-3-haiku-20240307",
+		"anthropic/claude-opus-4-7",
+		"anthropic/claude-opus-4-6",
+		"anthropic/claude-opus-4-5-20251101",
+		"anthropic/claude-opus-4-1-20250805",
+		"anthropic/claude-opus-4-20250514",
+		"anthropic/claude-sonnet-4-6",
+		"anthropic/claude-sonnet-4-5-20250929",
+		"anthropic/claude-sonnet-4-20250514",
+		"anthropic/claude-haiku-4-5-20251001",
 	}, nil
+}
+
+// CanonicalClaudeModelID normalizes a bare Claude id to its anthropic/-prefixed
+// form so callers may pass either "claude-..." (back-compat) or
+// "anthropic/claude-..." (canonical). Already-prefixed or non-Claude ids pass
+// through unchanged.
+func CanonicalClaudeModelID(modelID string) string {
+	if strings.HasPrefix(modelID, "claude-") {
+		return "anthropic/" + modelID
+	}
+	return modelID
 }
 
 // SelectModel selects a model to use
 func (s *ClaudeCodeModelService) SelectModel(modelID string) error {
-	s.currentModel = modelID
+	s.currentModel = CanonicalClaudeModelID(modelID)
 	return nil
 }
 
@@ -48,9 +64,10 @@ func (s *ClaudeCodeModelService) GetCurrentModel() string {
 
 // IsModelAvailable checks if a model is available
 func (s *ClaudeCodeModelService) IsModelAvailable(modelID string) bool {
+	target := CanonicalClaudeModelID(modelID)
 	models, _ := s.ListModels(context.Background())
 	for _, m := range models {
-		if m == modelID {
+		if m == target {
 			return true
 		}
 	}

--- a/internal/services/model_claude_code_test.go
+++ b/internal/services/model_claude_code_test.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+func TestClaudeCodeListModelsArePrefixed(t *testing.T) {
+	s := NewClaudeCodeModelService()
+	models, err := s.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("expected a non-empty model list")
+	}
+	for _, m := range models {
+		if !strings.HasPrefix(m, "anthropic/claude-") {
+			t.Errorf("model %q is not anthropic/-prefixed", m)
+		}
+	}
+}
+
+// TestClaudeCodeModelsArePriced enforces the curate-to-priced invariant: every
+// model offered in Claude Code mode must have a pricing entry so session cost can
+// be computed from token counts.
+func TestClaudeCodeModelsArePriced(t *testing.T) {
+	s := NewClaudeCodeModelService()
+	models, _ := s.ListModels(context.Background())
+	for _, m := range models {
+		if _, ok := config.DefaultModelPricing[m]; !ok {
+			t.Errorf("model %q has no pricing entry (curate-to-priced invariant)", m)
+		}
+	}
+}
+
+func TestClaudeCodeModelAvailabilityAcceptsBareAndPrefixed(t *testing.T) {
+	s := NewClaudeCodeModelService()
+
+	if !s.IsModelAvailable("anthropic/claude-sonnet-4-5-20250929") {
+		t.Error("prefixed id should be available")
+	}
+	if !s.IsModelAvailable("claude-sonnet-4-5-20250929") {
+		t.Error("bare id should be available (back-compat)")
+	}
+	if s.IsModelAvailable("claude-3-haiku-20240307") {
+		t.Error("dropped legacy model should not be available")
+	}
+	if err := s.ValidateModel("claude-opus-4-5-20251101"); err != nil {
+		t.Errorf("bare valid id should validate: %v", err)
+	}
+}
+
+func TestClaudeCodeSelectModelCanonicalizes(t *testing.T) {
+	s := NewClaudeCodeModelService()
+	if err := s.SelectModel("claude-opus-4-6"); err != nil {
+		t.Fatalf("SelectModel: %v", err)
+	}
+	if got := s.GetCurrentModel(); got != "anthropic/claude-opus-4-6" {
+		t.Errorf("GetCurrentModel = %q, want anthropic/claude-opus-4-6", got)
+	}
+}
+
+func TestCanonicalClaudeModelID(t *testing.T) {
+	cases := map[string]string{
+		"claude-opus-4-6":           "anthropic/claude-opus-4-6",
+		"anthropic/claude-opus-4-6": "anthropic/claude-opus-4-6",
+		"":                          "",
+		"deepseek/deepseek-v4":      "deepseek/deepseek-v4",
+	}
+	for in, want := range cases {
+		if got := CanonicalClaudeModelID(in); got != want {
+			t.Errorf("CanonicalClaudeModelID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/services/pricing_service_test.go
+++ b/internal/services/pricing_service_test.go
@@ -388,7 +388,6 @@ func TestPricingService_ClaudeCodeModelDefaults(t *testing.T) {
 	}
 	service := NewPricingService(cfg)
 
-	// Sonnet 4.5 is $3/$15 per MTok in the default table.
 	inputCost, outputCost, totalCost := service.CalculateCost("anthropic/claude-sonnet-4-5-20250929", 1_000_000, 1_000_000)
 	assert.InDelta(t, 3.00, inputCost, 0.01)
 	assert.InDelta(t, 15.00, outputCost, 0.01)

--- a/internal/services/pricing_service_test.go
+++ b/internal/services/pricing_service_test.go
@@ -377,3 +377,20 @@ func TestPricingService_CalculateCost(t *testing.T) {
 	assert.InDelta(t, expectedOutputCost, outputCost, 0.01)
 	assert.InDelta(t, expectedTotalCost, totalCost, 0.01)
 }
+
+// TestPricingService_ClaudeCodeModelDefaults verifies that the anthropic/-prefixed
+// Claude Code model ids resolve against the default pricing table, so headless
+// Claude Code sessions can price token usage from infer's own list.
+func TestPricingService_ClaudeCodeModelDefaults(t *testing.T) {
+	cfg := &config.PricingConfig{
+		Enabled:      true,
+		CustomPrices: map[string]config.CustomPricing{},
+	}
+	service := NewPricingService(cfg)
+
+	// Sonnet 4.5 is $3/$15 per MTok in the default table.
+	inputCost, outputCost, totalCost := service.CalculateCost("anthropic/claude-sonnet-4-5-20250929", 1_000_000, 1_000_000)
+	assert.InDelta(t, 3.00, inputCost, 0.01)
+	assert.InDelta(t, 15.00, outputCost, 0.01)
+	assert.InDelta(t, 18.00, totalCost, 0.01)
+}

--- a/internal/ui/components/model_selection_view.go
+++ b/internal/ui/components/model_selection_view.go
@@ -370,10 +370,14 @@ func (m *ModelSelectorImpl) isModelFree(model string) bool {
 	return inputPrice == 0.0 && outputPrice == 0.0
 }
 
-// isModelSubscription reports whether a model is gated behind a paid (flat-fee)
-// subscription rather than per-token billing.
-// Returns false if pricing is disabled or not configured.
+// isModelSubscription reports whether a model is accessed via a flat-fee
+// subscription rather than per-token billing. All models are subscription in
+// Claude Code mode; otherwise it follows the pricing table's RequiresPro flag.
 func (m *ModelSelectorImpl) isModelSubscription(model string) bool {
+	if m.config != nil && m.config.IsClaudeCodeMode() {
+		return true
+	}
+
 	if m.pricingService == nil || !m.pricingService.IsEnabled() {
 		return false
 	}

--- a/internal/ui/components/model_selection_view_test.go
+++ b/internal/ui/components/model_selection_view_test.go
@@ -3,6 +3,7 @@ package components
 import (
 	"testing"
 
+	config "github.com/inference-gateway/cli/config"
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,6 +59,29 @@ func TestModelSelector_FilterBuckets(t *testing.T) {
 	assert.ElementsMatch(t, []string{"free-model"}, filteredFor(ModelViewFree, models))
 	assert.ElementsMatch(t, []string{"paid-model"}, filteredFor(ModelViewPayAsYouGo, models))
 	assert.ElementsMatch(t, []string{"subscription-model"}, filteredFor(ModelViewSubscription, models))
+}
+
+// TestModelSelector_ClaudeCodeModeCategorizesAsSubscription verifies that in
+// Claude Code mode every offered model is bucketed under Subscription (not
+// Pay-as-you-go), regardless of the shared pricing table's per-token prices.
+func TestModelSelector_ClaudeCodeModeCategorizesAsSubscription(t *testing.T) {
+	pricing := &domainmocks.FakePricingService{}
+	pricing.IsEnabledReturns(true)
+	pricing.GetInputPriceReturns(5.0)
+	pricing.GetOutputPriceReturns(25.0)
+	pricing.RequiresProReturns(false)
+
+	cfg := &config.Config{ClaudeCode: config.ClaudeCodeConfig{Enabled: true}}
+	models := []string{"anthropic/claude-opus-4-8", "anthropic/claude-sonnet-4-6"}
+	m := NewModelSelector(models, nil, pricing, cfg, nil)
+
+	m.currentView = ModelViewSubscription
+	m.applyFilters()
+	assert.ElementsMatch(t, models, m.filteredModels)
+
+	m.currentView = ModelViewPayAsYouGo
+	m.applyFilters()
+	assert.Empty(t, m.filteredModels)
 }
 
 // TestModelSelector_SubscriptionModelExcludedFromFree is the core bug fix for


### PR DESCRIPTION
## Summary

In **Claude Code mode** the stream adapter dropped token usage, so headless `infer agent`
reported `0 in / 0 out / 0 total`, no `token_usage` on assistant lines, and no
`session_stats` line. This surfaces the real token counts and prices the session via
infer's own pricing list.

- **Tokens (real):** parse the `claude` stream-json `result` message's cumulative `usage`
  (`internal/infra/adapters/claude_code_client.go`) and attach it as `response.Usage`.
  Cache tokens fold into `prompt_tokens` (the SDK usage type has no cache tier). Once
  `Usage` is set, the existing `processSyncResponse` / `emitSessionStats` chain accumulates
  tokens, emits per-turn `token_usage`, and produces a `session_stats` line — no changes
  needed there.
- **Cost from infer's pricing list:** session cost is computed from the accumulated tokens
  via the existing `PricingService` — consistent with how the official Claude Code
  Action/SDK estimate cost from a bundled price table — rather than Claude's
  `total_cost_usd` (a client-side estimate; a subscription has no per-call billing).
- **Model-id consistency:** Claude Code model ids are now `anthropic/`-prefixed (canonical,
  matching gateway mode and the pricing table). Bare `claude-*` ids are still accepted and
  normalized (`CanonicalClaudeModelID`), and the adapter strips the prefix before invoking
  the `claude` CLI. The model list is curated to ids priced in `DefaultModelPricing`
  (a test enforces the invariant).
- **Fable 5 context window:** `claude-fable-5` was falling through to the generic
  `claude = 200K` matcher; corrected to **1M** per Anthropic's docs.

## Cross-repo impact

Unblocks run-metrics parity in **inference-gateway/infer-action#133** (its
`src/usage.ts::extractUsage` renders the CLI's `token_usage` / `session_stats` footer) with
**no action-side change** — its bare `claude-…` model id normalizes to `anthropic/…` and
prices correctly. A docs note for the new `anthropic/`-prefixed Claude Code ids belongs in
`inference-gateway/docs` (alongside #133's docs ticket).

## Test plan

- `task test` (full suite), `task lint` (0 issues), and `task build` all pass.
- New tests: adapter usage parse/emit + prefix stripping (`claude_code_client_test.go`),
  model-service prefix/curate/normalize + curate-to-priced invariant
  (`model_claude_code_test.go`), Claude pricing default resolution
  (`pricing_service_test.go`), Fable 5 = 1M (`context_test.go`).
- Manual e2e (assistant lines carry `token_usage`, `session_stats` shows non-zero cost)
  requires the `claude` CLI logged into a Max/Pro subscription.

## Notes

- The context-window change is scoped to **Fable 5 only**; `claude-opus-4-6` / `-4-8` and
  `claude-sonnet-4-6` remain 200K per the existing test, though Anthropic docs list them as
  1M GA — can bump in a follow-up.

Closes #649
