### PR TITLE
fix(agent): report failed bash exit code + stderr to the model

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -909,7 +909,13 @@ func (s *AgentSession) formatToolResult(result *domain.ToolExecutionResult) stri
 	}
 
 	if !result.Success {
-		return fmt.Sprintf("Tool execution failed: %s", result.Error)
+		detail := result.Error
+		if detail == "" && result.Data != nil {
+			if b, err := json.Marshal(result.Data); err == nil {
+				detail = string(b)
+			}
+		}
+		return fmt.Sprintf("Tool execution failed: %s", detail)
 	}
 
 	resultBytes, err := json.Marshal(result)

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -226,6 +226,33 @@ func TestBuildSDKMessages(t *testing.T) {
 	}
 }
 
+func TestFormatToolResult_FailedWithEmptyErrorSurfacesData(t *testing.T) {
+	session := &AgentSession{}
+
+	result := &domain.ToolExecutionResult{
+		ToolName: "Bash",
+		Success:  false,
+		Data: &domain.BashToolResult{
+			Command:  "gh search code foo --path bar",
+			Output:   "unknown flag: --path",
+			Error:    "exit status 1",
+			ExitCode: 1,
+		},
+	}
+
+	out := session.formatToolResult(result)
+
+	if !strings.HasPrefix(out, "Tool execution failed:") {
+		t.Fatalf("expected the failure prefix, got %q", out)
+	}
+	if strings.TrimSpace(strings.TrimPrefix(out, "Tool execution failed:")) == "" {
+		t.Fatal("expected a non-empty failure body, got a bare envelope")
+	}
+	if !strings.Contains(out, "unknown flag: --path") {
+		t.Errorf("expected the body to surface the command output, got %q", out)
+	}
+}
+
 func TestExecuteToolCallsParallel(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -122,6 +122,12 @@ func (t *BashTool) Execute(ctx context.Context, args map[string]any) (*domain.To
 
 	if err != nil {
 		result.Error = err.Error()
+	} else if !success {
+		detail := strings.TrimSpace(bashResult.Output)
+		if detail == "" {
+			detail = bashResult.Error
+		}
+		result.Error = fmt.Sprintf("exit status %d: %s", bashResult.ExitCode, detail)
 	}
 
 	return result, nil

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -201,6 +201,41 @@ func TestBashTool_Execute(t *testing.T) {
 	}
 }
 
+func TestBashTool_Execute_NonZeroExitSurfacesError(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Bash: config.BashToolConfig{
+				Enabled: true,
+				Mode: config.BashModesConfig{
+					All: config.BashModeAllowConfig{Allow: []string{"ls( .*)?"}},
+				},
+			},
+		},
+	}
+
+	tool := NewBashTool(cfg, nil)
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"command": "ls /no/such/path/xyz-12345",
+	})
+	if err != nil {
+		t.Fatalf("Execute() returned a Go error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected Success=false for a non-zero exit")
+	}
+	if result.Error == "" {
+		t.Fatal("expected a non-empty result.Error so the model sees why the command failed")
+	}
+	if !strings.Contains(result.Error, "exit status") {
+		t.Errorf("expected result.Error to include the exit status, got %q", result.Error)
+	}
+	if !strings.Contains(result.Error, "No such") {
+		t.Errorf("expected result.Error to include the command's stderr, got %q", result.Error)
+	}
+}
+
 func TestBashTool_GitPushValidation(t *testing.T) {
 	cfg := &config.Config{
 		Tools: config.ToolsConfig{


### PR DESCRIPTION
## Problem

A headless `infer agent` run with a weak model could go "in circles" — repeating the **same** failing tool call until it exhausted `max-turns` (an ~8-minute spin). It surfaced via an `inference-gateway/os` dispatch on `ollama_cloud/deepseek-v4-flash`: the agent ran `gh search code … --path bar` (`--path` is an invalid `gh search code` flag → `exit 1`, stderr `unknown flag: --path`) and got back a **bare** `Tool execution failed:` with no body, so it had no idea *why* and retried the identical command ~112 times.

## Root cause

A bash command that **runs but exits non-zero** returns a *nil* Go error from `BashTool.Execute`, stashing the detail (exit code, stderr) in `result.Data` while leaving the top-level `result.Error` empty (it's set only when the Go error is non-nil). The headless formatter `formatToolResult` (`cmd/agent.go`) reported only `result.Error` on failure → an empty envelope the model can't act on. The success path already JSON-marshals the whole result, so successful calls were unaffected.

This is not `infer-action` and not a v0.123.0 regression — a pre-existing CLI defect that a weak model exposed (a stronger model, or one that happens to hit a *sandbox/validation* failure, gets a populated message and recovers).

## Fix

- `internal/agent/tools/bash.go` — `Execute` promotes the exit code + output into `result.Error` when a command runs but exits non-zero.
- `cmd/agent.go` — `formatToolResult` falls back to `result.Data` when a failed result still has an empty `Error` (safety net for any tool with the same shape).

## Testing

- New: `TestBashTool_Execute_NonZeroExitSurfacesError`, `TestFormatToolResult_FailedWithEmptyErrorSurfacesData`.
- `task build`, `go test ./internal/agent/tools/... ./cmd/...`, `golangci-lint` — all green.
- E2E: the agent stream now shows `Tool execution failed: exit status 1: ls: …: No such file or directory`, and the run stops gracefully instead of spinning.

## Cross-repo impact

After this releases, the new CLI version should propagate downstream: bump `inputs.version.default` in `inference-gateway/infer-action`, then bump infer-action in `inference-gateway/os`.
