### PR TITLE
feat(tools): add AskUserQuestion clarifying-question form for plan mode

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -169,6 +169,8 @@ tools:
       multiplexer: tmux
       layout: vertical
       fallback: headless
+  ask_user_question:
+    enabled: true
   safety:
     require_approval: true
     approval_behaviour: prompt

--- a/.infer/prompts.yaml
+++ b/.infer/prompts.yaml
@@ -9,6 +9,7 @@ agent:
     CAPABILITIES IN PLAN MODE:
     - Read, Grep, and Tree tools for gathering information
     - TodoWrite for tracking planning progress
+    - AskUserQuestion tool to ask the user up to 4 multiple-choice clarifying questions as an interactive form
     - RequestPlanApproval tool to submit your plan for user approval (also persists the plan as a Markdown file under <configDir>/plans/)
     - Analyze code structure and dependencies
     - Break down complex tasks into concrete, executable steps
@@ -23,13 +24,14 @@ agent:
     PLANNING WORKFLOW:
     1. Use Read/Grep/Tree to understand the codebase thoroughly
     2. Analyze the user's request and identify ALL requirements
-    3. If you need clarification or more information, ASK the user in a regular assistant turn - do NOT call RequestPlanApproval yet
+    3. If a decision hinges on a discrete choice (approach, scope, format, naming, trade-off), call AskUserQuestion to ask 1-4 multiple-choice questions instead of guessing. For open-ended clarification, ASK the user in a regular assistant turn. Either way, do NOT call RequestPlanApproval yet.
     4. Iterate with the user until the plan is complete and unambiguous
     5. When the plan is final, call RequestPlanApproval with both a short title AND the Markdown plan body
 
     DECISION MAKING:
-    - Need more info? ASK questions instead of requesting approval
-    - Plan has gaps or uncertainties? ASK for clarification
+    - Need a discrete choice clarified? Call AskUserQuestion (1-4 questions, 2-4 options each) instead of guessing
+    - Need open-ended info? ASK questions in a normal turn instead of requesting approval
+    - Plan has gaps or uncertainties? Clarify first - do not request approval
     - Plan is complete and specific? Call RequestPlanApproval tool
 
     OUTPUT FORMAT - MARKDOWN PLAN:
@@ -344,6 +346,23 @@ tools:
       - plan: The full plan as Markdown using H2 sections in this order - ## Context, ## Files to Modify, ## Current Code, ## Changes, ## Performance Impact, ## Critical Files, ## Edge Cases, ## Verification. Omit any section that is not applicable.
 
       Only call this tool when the plan is final. If you need clarification, ask the user in a normal assistant turn first.
+  AskUserQuestion:
+    description: |-
+      Ask the user 1-4 multiple-choice clarifying questions as an interactive form (plan mode only).
+
+      Use this when the plan hinges on a discrete decision the user should make - format, scope, approach, naming, trade-off - instead of guessing or asking in prose. Call it BEFORE RequestPlanApproval; fold the answers into the plan, then submit the plan.
+
+      Each question has:
+      - header: a short chip/tag (<= 12 chars), e.g. "Scope", "Format"
+      - question: the full question text
+      - options: 2-4 choices, each with a concise label (returned as the answer) and a description of the trade-off
+      - multiSelect (optional): set true to let the user pick more than one option
+
+      The UI always adds an "Other" free-text choice, so you do not need an "Other" option yourself. The user answers with the keyboard and the selected labels (and any free text) are returned to you.
+
+      Notes:
+      - Ask only what you genuinely need - prefer one focused round of questions over many.
+      - If no interactive user is available (headless run), you will be told to proceed with stated assumptions instead.
   WebFetch:
     description: Fetch content from allowed URLs. Set download=true to save the file to disk automatically. Useful for downloading A2A task artifacts or other files.
   WebSearch:

--- a/config/config.go
+++ b/config/config.go
@@ -140,20 +140,21 @@ type ClipboardImageOptimizeConfig struct {
 
 // ToolsConfig contains tool execution settings
 type ToolsConfig struct {
-	Enabled   bool                `yaml:"enabled" mapstructure:"enabled"`
-	Sandbox   SandboxConfig       `yaml:"sandbox" mapstructure:"sandbox"`
-	Bash      BashToolConfig      `yaml:"bash" mapstructure:"bash"`
-	Read      ReadToolConfig      `yaml:"read" mapstructure:"read"`
-	Write     WriteToolConfig     `yaml:"write" mapstructure:"write"`
-	Edit      EditToolConfig      `yaml:"edit" mapstructure:"edit"`
-	Delete    DeleteToolConfig    `yaml:"delete" mapstructure:"delete"`
-	Grep      GrepToolConfig      `yaml:"grep" mapstructure:"grep"`
-	Tree      TreeToolConfig      `yaml:"tree" mapstructure:"tree"`
-	WebFetch  WebFetchToolConfig  `yaml:"web_fetch" mapstructure:"web_fetch"`
-	WebSearch WebSearchToolConfig `yaml:"web_search" mapstructure:"web_search"`
-	TodoWrite TodoWriteToolConfig `yaml:"todo_write" mapstructure:"todo_write"`
-	Schedule  ScheduleToolConfig  `yaml:"schedule" mapstructure:"schedule"`
-	Agent     AgentToolConfig     `yaml:"agent" mapstructure:"agent"`
+	Enabled         bool                      `yaml:"enabled" mapstructure:"enabled"`
+	Sandbox         SandboxConfig             `yaml:"sandbox" mapstructure:"sandbox"`
+	Bash            BashToolConfig            `yaml:"bash" mapstructure:"bash"`
+	Read            ReadToolConfig            `yaml:"read" mapstructure:"read"`
+	Write           WriteToolConfig           `yaml:"write" mapstructure:"write"`
+	Edit            EditToolConfig            `yaml:"edit" mapstructure:"edit"`
+	Delete          DeleteToolConfig          `yaml:"delete" mapstructure:"delete"`
+	Grep            GrepToolConfig            `yaml:"grep" mapstructure:"grep"`
+	Tree            TreeToolConfig            `yaml:"tree" mapstructure:"tree"`
+	WebFetch        WebFetchToolConfig        `yaml:"web_fetch" mapstructure:"web_fetch"`
+	WebSearch       WebSearchToolConfig       `yaml:"web_search" mapstructure:"web_search"`
+	TodoWrite       TodoWriteToolConfig       `yaml:"todo_write" mapstructure:"todo_write"`
+	Schedule        ScheduleToolConfig        `yaml:"schedule" mapstructure:"schedule"`
+	Agent           AgentToolConfig           `yaml:"agent" mapstructure:"agent"`
+	AskUserQuestion AskUserQuestionToolConfig `yaml:"ask_user_question" mapstructure:"ask_user_question"`
 
 	Safety SafetyConfig `yaml:"safety" mapstructure:"safety"`
 }
@@ -236,6 +237,12 @@ type WebSearchToolConfig struct {
 type TodoWriteToolConfig struct {
 	Enabled         bool  `yaml:"enabled" mapstructure:"enabled"`
 	RequireApproval *bool `yaml:"require_approval,omitempty" mapstructure:"require_approval,omitempty"`
+}
+
+// AskUserQuestionToolConfig contains AskUserQuestion-specific tool settings.
+// The tool is read-only and plan-mode only, so it carries no approval flag.
+type AskUserQuestionToolConfig struct {
+	Enabled bool `yaml:"enabled" mapstructure:"enabled"`
 }
 
 // ScheduleToolConfig contains schedule-specific tool settings.
@@ -784,6 +791,9 @@ func DefaultConfig() *Config { //nolint:funlen
 				StorageDir:      "",
 				MaxJobs:         100,
 			},
+			AskUserQuestion: AskUserQuestionToolConfig{
+				Enabled: true,
+			},
 			Agent: AgentToolConfig{
 				Enabled:         true,
 				RequireApproval: &[]bool{true}[0],
@@ -998,6 +1008,8 @@ func (c *Config) IsApprovalRequired(toolName string) bool { // nolint:gocyclo,cy
 			return *c.Tools.Agent.RequireApproval
 		}
 	case "RequestPlanApproval":
+		return false
+	case "AskUserQuestion":
 		return false
 	case "A2A_QueryAgent":
 		if c.A2A.Tools.QueryAgent.RequireApproval != nil {

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -85,6 +85,7 @@ func mergeToolDefaults(loaded, defaults *PromptsToolsConfig) {
 	mergeToolDescription(&loaded.Tree, &defaults.Tree)
 	mergeToolDescription(&loaded.TodoWrite, &defaults.TodoWrite)
 	mergeToolDescription(&loaded.RequestPlanApproval, &defaults.RequestPlanApproval)
+	mergeToolDescription(&loaded.AskUserQuestion, &defaults.AskUserQuestion)
 	mergeToolDescription(&loaded.WebFetch, &defaults.WebFetch)
 	mergeToolDescription(&loaded.WebSearch, &defaults.WebSearch)
 	mergeToolDescription(&loaded.Schedule, &defaults.Schedule)
@@ -191,6 +192,7 @@ type PromptsToolsConfig struct {
 	Tree                PromptsToolDescription `yaml:"Tree" mapstructure:"Tree"`
 	TodoWrite           PromptsToolDescription `yaml:"TodoWrite" mapstructure:"TodoWrite"`
 	RequestPlanApproval PromptsToolDescription `yaml:"RequestPlanApproval" mapstructure:"RequestPlanApproval"`
+	AskUserQuestion     PromptsToolDescription `yaml:"AskUserQuestion" mapstructure:"AskUserQuestion"`
 	WebFetch            PromptsToolDescription `yaml:"WebFetch" mapstructure:"WebFetch"`
 	WebSearch           PromptsToolDescription `yaml:"WebSearch" mapstructure:"WebSearch"`
 	Schedule            PromptsToolDescription `yaml:"Schedule" mapstructure:"Schedule"`
@@ -221,6 +223,7 @@ CRITICAL: Your plan MUST be actionable - if the user accepts it, you will be ask
 CAPABILITIES IN PLAN MODE:
 - Read, Grep, and Tree tools for gathering information
 - TodoWrite for tracking planning progress
+- AskUserQuestion tool to ask the user up to 4 multiple-choice clarifying questions as an interactive form
 - RequestPlanApproval tool to submit your plan for user approval (also persists the plan as a Markdown file under <configDir>/plans/)
 - Analyze code structure and dependencies
 - Break down complex tasks into concrete, executable steps
@@ -235,13 +238,14 @@ RESTRICTIONS IN PLAN MODE:
 PLANNING WORKFLOW:
 1. Use Read/Grep/Tree to understand the codebase thoroughly
 2. Analyze the user's request and identify ALL requirements
-3. If you need clarification or more information, ASK the user in a regular assistant turn - do NOT call RequestPlanApproval yet
+3. If a decision hinges on a discrete choice (approach, scope, format, naming, trade-off), call AskUserQuestion to ask 1-4 multiple-choice questions instead of guessing. For open-ended clarification, ASK the user in a regular assistant turn. Either way, do NOT call RequestPlanApproval yet.
 4. Iterate with the user until the plan is complete and unambiguous
 5. When the plan is final, call RequestPlanApproval with both a short title AND the Markdown plan body
 
 DECISION MAKING:
-- Need more info? ASK questions instead of requesting approval
-- Plan has gaps or uncertainties? ASK for clarification
+- Need a discrete choice clarified? Call AskUserQuestion (1-4 questions, 2-4 options each) instead of guessing
+- Need open-ended info? ASK questions in a normal turn instead of requesting approval
+- Plan has gaps or uncertainties? Clarify first - do not request approval
 - Plan is complete and specific? Call RequestPlanApproval tool
 
 OUTPUT FORMAT - MARKDOWN PLAN:
@@ -559,6 +563,23 @@ Required parameters:
 - plan: The full plan as Markdown using H2 sections in this order - ## Context, ## Files to Modify, ## Current Code, ## Changes, ## Performance Impact, ## Critical Files, ## Edge Cases, ## Verification. Omit any section that is not applicable.
 
 Only call this tool when the plan is final. If you need clarification, ask the user in a normal assistant turn first.`,
+		},
+		AskUserQuestion: PromptsToolDescription{
+			Description: `Ask the user 1-4 multiple-choice clarifying questions as an interactive form (plan mode only).
+
+Use this when the plan hinges on a discrete decision the user should make - format, scope, approach, naming, trade-off - instead of guessing or asking in prose. Call it BEFORE RequestPlanApproval; fold the answers into the plan, then submit the plan.
+
+Each question has:
+- header: a short chip/tag (<= 12 chars), e.g. "Scope", "Format"
+- question: the full question text
+- options: 2-4 choices, each with a concise label (returned as the answer) and a description of the trade-off
+- multiSelect (optional): set true to let the user pick more than one option
+
+The UI always adds an "Other" free-text choice, so you do not need an "Other" option yourself. The user answers with the keyboard and the selected labels (and any free text) are returned to you.
+
+Notes:
+- Ask only what you genuinely need - prefer one focused round of questions over many.
+- If no interactive user is available (headless run), you will be told to proceed with stated assumptions instead.`,
 		},
 		WebFetch: PromptsToolDescription{
 			Description: `Fetch content from allowed URLs. Set download=true to save the file to disk automatically. Useful for downloading A2A task artifacts or other files.`,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -93,6 +93,37 @@ func newEventPublisher(requestID string, chatEvents chan<- domain.ChatEvent) *ev
 	}
 }
 
+// chatQuestionBroker implements domain.UserQuestionBroker for the chat executor.
+// It publishes a UserQuestionRequestedEvent onto the per-request chatEvents
+// channel and blocks on the response channel, mirroring requestToolApproval.
+// The agent loop is only blocked in the tool's Execute goroutine; the TUI keeps
+// running and the answers arrive via the UI. When the user dismisses the form
+// the UI closes the channel (ok=false); session cancellation unblocks ctx.Done.
+type chatQuestionBroker struct {
+	publisher *eventPublisher
+}
+
+func (b *chatQuestionBroker) AskUserQuestions(ctx context.Context, questions []domain.UserQuestion) ([]domain.UserQuestionAnswer, bool, error) {
+	responseChan := make(chan []domain.UserQuestionAnswer, 1)
+
+	b.publisher.chatEvents <- domain.UserQuestionRequestedEvent{
+		RequestID:    b.publisher.requestID,
+		Timestamp:    time.Now(),
+		Questions:    questions,
+		ResponseChan: responseChan,
+	}
+
+	select {
+	case answers, open := <-responseChan:
+		if !open {
+			return nil, false, nil
+		}
+		return answers, true, nil
+	case <-ctx.Done():
+		return nil, false, ctx.Err()
+	}
+}
+
 // publishChatStart publishes a ChatStartEvent
 func (p *eventPublisher) publishChatStart() {
 	p.chatEvents <- domain.ChatStartEvent{
@@ -939,6 +970,13 @@ func (s *AgentServiceImpl) executeToolInternal(
 			}()
 		}
 		execCtx = domain.WithBashDetachChannel(execCtx, detachChan)
+	}
+
+	// AskUserQuestion blocks on an interactive form. Only hand it the broker
+	// when a chat UI/event loop is present (GetChatHandler is set only on the
+	// chat path); headless runs see a nil broker and degrade gracefully.
+	if tc.Function.Name == "AskUserQuestion" && domain.GetChatHandler(ctx) != nil {
+		execCtx = domain.WithUserQuestionBroker(execCtx, &chatQuestionBroker{publisher: eventPublisher})
 	}
 
 	resultChan := make(chan struct {

--- a/internal/agent/tools/ask_user_question.go
+++ b/internal/agent/tools/ask_user_question.go
@@ -11,6 +11,7 @@ import (
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	logger "github.com/inference-gateway/cli/internal/logger"
 )
 
 // Bounds for the AskUserQuestion schema. They are enforced in Validate (and
@@ -130,6 +131,7 @@ func (t *AskUserQuestionTool) Execute(ctx context.Context, args map[string]any) 
 
 	broker := domain.GetUserQuestionBroker(ctx)
 	if broker == nil {
+		logger.Debug("AskUserQuestion: no interactive broker in context - degrading", "questions", len(questions))
 		return t.result(args, start, map[string]any{
 			"available": false,
 			"message": "No interactive user is available to answer questions in this session " +
@@ -138,7 +140,9 @@ func (t *AskUserQuestionTool) Execute(ctx context.Context, args map[string]any) 
 		}), nil
 	}
 
+	logger.Debug("AskUserQuestion: presenting questions to user, blocking for answers", "questions", len(questions))
 	answers, ok, err := broker.AskUserQuestions(ctx, questions)
+	logger.Debug("AskUserQuestion: user responded", "ok", ok, "answers", len(answers), "err", err)
 	if err != nil {
 		return t.failure(args, start, fmt.Sprintf("question request cancelled: %v", err)), nil
 	}
@@ -250,9 +254,11 @@ func (t *AskUserQuestionTool) ShouldCollapseArg(key string) bool {
 	return key == "questions"
 }
 
-// ShouldAlwaysExpand determines if tool results should always be expanded in UI.
+// ShouldAlwaysExpand keeps the collected answers expanded in the conversation
+// by default - the Q&A is the whole point of the tool, so it shouldn't be
+// hidden behind a collapsed one-liner.
 func (t *AskUserQuestionTool) ShouldAlwaysExpand() bool {
-	return false
+	return true
 }
 
 // triState lets the format helpers distinguish "absent" from an explicit

--- a/internal/agent/tools/ask_user_question.go
+++ b/internal/agent/tools/ask_user_question.go
@@ -1,0 +1,414 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// Bounds for the AskUserQuestion schema. They are enforced in Validate (and
+// re-checked in Execute) so a malformed tool call fails fast with a clear
+// message instead of rendering a broken form.
+const (
+	minQuestions      = 1
+	maxQuestions      = 4
+	minOptions        = 2
+	maxOptions        = 4
+	maxQuestionHeader = 12
+)
+
+// AskUserQuestionTool presents the user with a small interactive form of 1-4
+// multiple-choice questions during plan mode and returns the chosen answers to
+// the agent so it can fold them into the plan before RequestPlanApproval.
+//
+// It is read-only (no approval gate) and only reaches the user when a chat TUI
+// is present: the brokering capability is injected into the execution context
+// only on the chat path. On headless/no-TTY runs the broker is absent and the
+// tool degrades gracefully instead of blocking.
+type AskUserQuestionTool struct {
+	config    *config.Config
+	enabled   bool
+	formatter domain.BaseFormatter
+}
+
+// NewAskUserQuestionTool creates a new AskUserQuestion tool.
+func NewAskUserQuestionTool(cfg *config.Config) *AskUserQuestionTool {
+	return &AskUserQuestionTool{
+		config:    cfg,
+		enabled:   true,
+		formatter: domain.NewBaseFormatter("AskUserQuestion"),
+	}
+}
+
+// Definition returns the tool definition for the LLM.
+func (t *AskUserQuestionTool) Definition() sdk.ChatCompletionTool {
+	description := t.config.Prompts.Tools.AskUserQuestion.Description
+
+	return sdk.ChatCompletionTool{
+		Type: sdk.Function,
+		Function: sdk.FunctionObject{
+			Name:        "AskUserQuestion",
+			Description: &description,
+			Parameters: &sdk.FunctionParameters{
+				"$schema":              "http://json-schema.org/draft-07/schema#",
+				"additionalProperties": false,
+				"type":                 "object",
+				"required":             []string{"questions"},
+				"properties": map[string]any{
+					"questions": map[string]any{
+						"type":        "array",
+						"minItems":    minQuestions,
+						"maxItems":    maxQuestions,
+						"description": "1-4 clarifying questions to ask the user.",
+						"items": map[string]any{
+							"type":                 "object",
+							"additionalProperties": false,
+							"required":             []string{"header", "question", "options"},
+							"properties": map[string]any{
+								"header": map[string]any{
+									"type":        "string",
+									"maxLength":   maxQuestionHeader,
+									"description": "Short label/chip shown as a tag (<= 12 chars).",
+								},
+								"question": map[string]any{
+									"type":        "string",
+									"description": "The full question text to display.",
+								},
+								"multiSelect": map[string]any{
+									"type":        "boolean",
+									"default":     false,
+									"description": "Allow selecting multiple options.",
+								},
+								"options": map[string]any{
+									"type":        "array",
+									"minItems":    minOptions,
+									"maxItems":    maxOptions,
+									"description": "2-4 selectable options. An 'Other' free-text choice is always added by the UI.",
+									"items": map[string]any{
+										"type":                 "object",
+										"additionalProperties": false,
+										"required":             []string{"label", "description"},
+										"properties": map[string]any{
+											"label": map[string]any{
+												"type":        "string",
+												"description": "Concise option value returned as the answer.",
+											},
+											"description": map[string]any{
+												"type":        "string",
+												"description": "What this option means / its trade-off.",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Execute presents the questions to the user and returns their answers. The
+// tool blocks (in its own goroutine) until the user submits, dismisses, or the
+// session is cancelled. When no interactive user is reachable it returns a
+// graceful result telling the model to proceed with assumptions.
+func (t *AskUserQuestionTool) Execute(ctx context.Context, args map[string]any) (*domain.ToolExecutionResult, error) {
+	start := time.Now()
+
+	questions, err := extractQuestions(args)
+	if err != nil {
+		return t.failure(args, start, err.Error()), nil
+	}
+
+	broker := domain.GetUserQuestionBroker(ctx)
+	if broker == nil {
+		return t.result(args, start, map[string]any{
+			"available": false,
+			"message": "No interactive user is available to answer questions in this session " +
+				"(headless/non-interactive run). Proceed using your best judgment and clearly " +
+				"state the assumptions you are making, or stop and report what you need from the user.",
+		}), nil
+	}
+
+	answers, ok, err := broker.AskUserQuestions(ctx, questions)
+	if err != nil {
+		return t.failure(args, start, fmt.Sprintf("question request cancelled: %v", err)), nil
+	}
+	if !ok {
+		return t.result(args, start, map[string]any{
+			"cancelled": true,
+			"message": "The user dismissed the questions without answering. Proceed with stated " +
+				"assumptions, or ask again only if essential.",
+		}), nil
+	}
+
+	return t.result(args, start, map[string]any{
+		"answers": answers,
+		"message": formatAnswersForLLM(answers),
+	}), nil
+}
+
+// Validate checks that the AskUserQuestion arguments satisfy the schema bounds.
+func (t *AskUserQuestionTool) Validate(args map[string]any) error {
+	_, err := extractQuestions(args)
+	return err
+}
+
+// IsEnabled returns whether the AskUserQuestion tool is enabled.
+func (t *AskUserQuestionTool) IsEnabled() bool {
+	return t.enabled
+}
+
+func (t *AskUserQuestionTool) result(args map[string]any, start time.Time, data map[string]any) *domain.ToolExecutionResult {
+	return &domain.ToolExecutionResult{
+		ToolName:  "AskUserQuestion",
+		Arguments: args,
+		Success:   true,
+		Duration:  time.Since(start),
+		Data:      data,
+	}
+}
+
+func (t *AskUserQuestionTool) failure(args map[string]any, start time.Time, msg string) *domain.ToolExecutionResult {
+	return &domain.ToolExecutionResult{
+		ToolName:  "AskUserQuestion",
+		Arguments: args,
+		Success:   false,
+		Duration:  time.Since(start),
+		Error:     msg,
+	}
+}
+
+// FormatResult formats tool execution results for different contexts.
+func (t *AskUserQuestionTool) FormatResult(result *domain.ToolExecutionResult, formatType domain.FormatterType) string {
+	switch formatType {
+	case domain.FormatterUI:
+		return t.FormatForUI(result)
+	case domain.FormatterLLM:
+		return t.FormatForLLM(result)
+	case domain.FormatterShort:
+		return t.FormatPreview(result)
+	default:
+		return t.FormatForUI(result)
+	}
+}
+
+// FormatPreview returns a short preview of the result for UI display.
+func (t *AskUserQuestionTool) FormatPreview(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return "Tool execution result unavailable"
+	}
+	if !result.Success {
+		return "AskUserQuestion failed"
+	}
+	switch {
+	case questionResultFlag(result, "available") == flagFalse:
+		return "No interactive user available"
+	case questionResultFlag(result, "cancelled") == flagTrue:
+		return "Questions dismissed"
+	default:
+		if n := answerCount(result); n > 0 {
+			return fmt.Sprintf("Collected %d answer(s)", n)
+		}
+		return "Questions answered"
+	}
+}
+
+// FormatForUI formats the result for UI display.
+func (t *AskUserQuestionTool) FormatForUI(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return "Tool execution result unavailable"
+	}
+	statusIcon := t.formatter.FormatStatusIcon(result.Success)
+	return fmt.Sprintf("AskUserQuestion(...)\n└─ %s %s", statusIcon, t.FormatPreview(result))
+}
+
+// FormatForLLM formats the result for LLM consumption.
+func (t *AskUserQuestionTool) FormatForLLM(result *domain.ToolExecutionResult) string {
+	if result == nil {
+		return "Tool execution result unavailable"
+	}
+	if !result.Success {
+		return fmt.Sprintf("Failed to ask the user: %s", result.Error)
+	}
+	if msg := questionResultMessage(result); msg != "" {
+		return msg
+	}
+	return "The user answered the questions."
+}
+
+// ShouldCollapseArg determines if an argument should be collapsed in display.
+func (t *AskUserQuestionTool) ShouldCollapseArg(key string) bool {
+	return key == "questions"
+}
+
+// ShouldAlwaysExpand determines if tool results should always be expanded in UI.
+func (t *AskUserQuestionTool) ShouldAlwaysExpand() bool {
+	return false
+}
+
+// triState lets the format helpers distinguish "absent" from an explicit
+// boolean stored in the result Data map.
+type triState int
+
+const (
+	flagAbsent triState = iota
+	flagTrue
+	flagFalse
+)
+
+func questionResultFlag(result *domain.ToolExecutionResult, key string) triState {
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		return flagAbsent
+	}
+	v, present := data[key].(bool)
+	if !present {
+		return flagAbsent
+	}
+	if v {
+		return flagTrue
+	}
+	return flagFalse
+}
+
+func questionResultMessage(result *domain.ToolExecutionResult) string {
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		return ""
+	}
+	msg, _ := data["message"].(string)
+	return msg
+}
+
+func answerCount(result *domain.ToolExecutionResult) int {
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		return 0
+	}
+	answers, _ := data["answers"].([]domain.UserQuestionAnswer)
+	return len(answers)
+}
+
+// extractQuestions parses and validates the `questions` argument into the
+// domain type. Shared by Validate and Execute so both apply identical rules.
+func extractQuestions(args map[string]any) ([]domain.UserQuestion, error) {
+	rawQuestions, ok := args["questions"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("questions parameter is required and must be an array")
+	}
+	if len(rawQuestions) < minQuestions || len(rawQuestions) > maxQuestions {
+		return nil, fmt.Errorf("questions must contain between %d and %d items, got %d", minQuestions, maxQuestions, len(rawQuestions))
+	}
+
+	questions := make([]domain.UserQuestion, 0, len(rawQuestions))
+	for i, raw := range rawQuestions {
+		q, err := extractQuestion(raw, i)
+		if err != nil {
+			return nil, err
+		}
+		questions = append(questions, q)
+	}
+	return questions, nil
+}
+
+func extractQuestion(raw any, idx int) (domain.UserQuestion, error) {
+	qMap, ok := raw.(map[string]any)
+	if !ok {
+		return domain.UserQuestion{}, fmt.Errorf("question %d must be an object", idx+1)
+	}
+
+	header, ok := qMap["header"].(string)
+	if !ok || strings.TrimSpace(header) == "" {
+		return domain.UserQuestion{}, fmt.Errorf("question %d: header is required and must be a non-empty string", idx+1)
+	}
+	if utf8.RuneCountInString(header) > maxQuestionHeader {
+		return domain.UserQuestion{}, fmt.Errorf("question %d: header must be at most %d characters", idx+1, maxQuestionHeader)
+	}
+
+	questionText, ok := qMap["question"].(string)
+	if !ok || strings.TrimSpace(questionText) == "" {
+		return domain.UserQuestion{}, fmt.Errorf("question %d: question text is required and must be a non-empty string", idx+1)
+	}
+
+	options, err := extractOptions(qMap["options"], idx)
+	if err != nil {
+		return domain.UserQuestion{}, err
+	}
+
+	multiSelect, _ := qMap["multiSelect"].(bool)
+
+	return domain.UserQuestion{
+		Header:      strings.TrimSpace(header),
+		Question:    strings.TrimSpace(questionText),
+		Options:     options,
+		MultiSelect: multiSelect,
+	}, nil
+}
+
+func extractOptions(raw any, qIdx int) ([]domain.UserQuestionOption, error) {
+	rawOptions, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("question %d: options is required and must be an array", qIdx+1)
+	}
+	if len(rawOptions) < minOptions || len(rawOptions) > maxOptions {
+		return nil, fmt.Errorf("question %d: options must contain between %d and %d items, got %d", qIdx+1, minOptions, maxOptions, len(rawOptions))
+	}
+
+	options := make([]domain.UserQuestionOption, 0, len(rawOptions))
+	for j, rawOpt := range rawOptions {
+		optMap, ok := rawOpt.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("question %d, option %d must be an object", qIdx+1, j+1)
+		}
+		label, ok := optMap["label"].(string)
+		if !ok || strings.TrimSpace(label) == "" {
+			return nil, fmt.Errorf("question %d, option %d: label is required and must be a non-empty string", qIdx+1, j+1)
+		}
+		description, _ := optMap["description"].(string)
+		options = append(options, domain.UserQuestionOption{
+			Label:       strings.TrimSpace(label),
+			Description: strings.TrimSpace(description),
+		})
+	}
+	return options, nil
+}
+
+// formatAnswersForLLM renders the collected answers as one line per question:
+//
+//	[Header] question -> label1, label2; Other: "free text"
+func formatAnswersForLLM(answers []domain.UserQuestionAnswer) string {
+	if len(answers) == 0 {
+		return "The user provided no answers."
+	}
+	var b strings.Builder
+	for i, a := range answers {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "[%s] %s -> %s", a.Header, a.Question, formatAnswerValue(a))
+	}
+	return b.String()
+}
+
+func formatAnswerValue(a domain.UserQuestionAnswer) string {
+	parts := make([]string, 0, 2)
+	if len(a.SelectedLabels) > 0 {
+		parts = append(parts, strings.Join(a.SelectedLabels, ", "))
+	}
+	if a.OtherText != "" {
+		parts = append(parts, fmt.Sprintf("Other: %q", a.OtherText))
+	}
+	if len(parts) == 0 {
+		return "(no selection)"
+	}
+	return strings.Join(parts, "; ")
+}

--- a/internal/agent/tools/ask_user_question_test.go
+++ b/internal/agent/tools/ask_user_question_test.go
@@ -1,0 +1,286 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+func newAskUserQuestionToolForTest() *AskUserQuestionTool {
+	cfg := &config.Config{
+		Prompts: *config.DefaultPromptsConfig(),
+	}
+	return NewAskUserQuestionTool(cfg)
+}
+
+// option builds a raw option map as it arrives from JSON unmarshalling.
+func option(label, desc string) map[string]any {
+	return map[string]any{"label": label, "description": desc}
+}
+
+// question builds a raw question map as it arrives from JSON unmarshalling.
+func question(header, text string, multi bool, opts ...map[string]any) map[string]any {
+	rawOpts := make([]any, 0, len(opts))
+	for _, o := range opts {
+		rawOpts = append(rawOpts, o)
+	}
+	return map[string]any{
+		"header":      header,
+		"question":    text,
+		"multiSelect": multi,
+		"options":     rawOpts,
+	}
+}
+
+func validQuestionArgs() map[string]any {
+	return map[string]any{
+		"questions": []any{
+			question("Format", "Which output format?", false,
+				option("JSON", "machine readable"),
+				option("YAML", "human readable"),
+			),
+		},
+	}
+}
+
+// stubBroker is an in-memory UserQuestionBroker for Execute tests.
+type stubBroker struct {
+	answers   []domain.UserQuestionAnswer
+	ok        bool
+	err       error
+	received  []domain.UserQuestion
+	callCount int
+}
+
+func (s *stubBroker) AskUserQuestions(_ context.Context, questions []domain.UserQuestion) ([]domain.UserQuestionAnswer, bool, error) {
+	s.callCount++
+	s.received = questions
+	return s.answers, s.ok, s.err
+}
+
+func TestAskUserQuestionTool_Definition(t *testing.T) {
+	tool := newAskUserQuestionToolForTest()
+	def := tool.Definition()
+
+	if def.Function.Name != "AskUserQuestion" {
+		t.Fatalf("expected name AskUserQuestion, got %q", def.Function.Name)
+	}
+	if def.Function.Description == nil || *def.Function.Description == "" {
+		t.Fatal("expected a non-empty description")
+	}
+
+	params := *def.Function.Parameters
+	required, ok := params["required"].([]string)
+	if !ok || len(required) != 1 || required[0] != "questions" {
+		t.Fatalf("expected required=[questions], got %v", params["required"])
+	}
+
+	props, _ := params["properties"].(map[string]any)
+	questions, _ := props["questions"].(map[string]any)
+	if questions["minItems"] != minQuestions || questions["maxItems"] != maxQuestions {
+		t.Fatalf("expected questions minItems=%d maxItems=%d, got %v/%v", minQuestions, maxQuestions, questions["minItems"], questions["maxItems"])
+	}
+}
+
+func TestAskUserQuestionTool_Validate(t *testing.T) {
+	tool := newAskUserQuestionToolForTest()
+
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr bool
+	}{
+		{
+			name:    "valid single-select",
+			args:    validQuestionArgs(),
+			wantErr: false,
+		},
+		{
+			name: "valid four questions multi-select",
+			args: map[string]any{"questions": []any{
+				question("A", "qa", true, option("1", "d"), option("2", "d"), option("3", "d"), option("4", "d")),
+				question("B", "qb", false, option("1", "d"), option("2", "d")),
+				question("C", "qc", false, option("1", "d"), option("2", "d")),
+				question("D", "qd", true, option("1", "d"), option("2", "d")),
+			}},
+			wantErr: false,
+		},
+		{
+			name:    "no questions key",
+			args:    map[string]any{},
+			wantErr: true,
+		},
+		{
+			name:    "empty questions",
+			args:    map[string]any{"questions": []any{}},
+			wantErr: true,
+		},
+		{
+			name: "too many questions",
+			args: map[string]any{"questions": []any{
+				question("A", "qa", false, option("1", "d"), option("2", "d")),
+				question("B", "qb", false, option("1", "d"), option("2", "d")),
+				question("C", "qc", false, option("1", "d"), option("2", "d")),
+				question("D", "qd", false, option("1", "d"), option("2", "d")),
+				question("E", "qe", false, option("1", "d"), option("2", "d")),
+			}},
+			wantErr: true,
+		},
+		{
+			name:    "header too long",
+			args:    map[string]any{"questions": []any{question("ThisHeaderIsWayTooLong", "q", false, option("1", "d"), option("2", "d"))}},
+			wantErr: true,
+		},
+		{
+			name:    "empty header",
+			args:    map[string]any{"questions": []any{question("", "q", false, option("1", "d"), option("2", "d"))}},
+			wantErr: true,
+		},
+		{
+			name:    "empty question text",
+			args:    map[string]any{"questions": []any{question("H", "", false, option("1", "d"), option("2", "d"))}},
+			wantErr: true,
+		},
+		{
+			name:    "too few options",
+			args:    map[string]any{"questions": []any{question("H", "q", false, option("1", "d"))}},
+			wantErr: true,
+		},
+		{
+			name:    "too many options",
+			args:    map[string]any{"questions": []any{question("H", "q", false, option("1", "d"), option("2", "d"), option("3", "d"), option("4", "d"), option("5", "d"))}},
+			wantErr: true,
+		},
+		{
+			name:    "empty option label",
+			args:    map[string]any{"questions": []any{question("H", "q", false, option("", "d"), option("2", "d"))}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tool.Validate(tt.args)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAskUserQuestionTool_Execute_HeadlessDegrade(t *testing.T) {
+	tool := newAskUserQuestionToolForTest()
+
+	// No broker in context -> degrade gracefully without blocking.
+	result, err := tool.Execute(context.Background(), validQuestionArgs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got error %q", result.Error)
+	}
+	data, _ := result.Data.(map[string]any)
+	if data["available"] != false {
+		t.Fatalf("expected available=false, got %v", data["available"])
+	}
+	if msg, _ := data["message"].(string); !strings.Contains(msg, "No interactive user") {
+		t.Fatalf("expected degrade message, got %q", msg)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_WithBroker(t *testing.T) {
+	tool := newAskUserQuestionToolForTest()
+
+	broker := &stubBroker{
+		ok: true,
+		answers: []domain.UserQuestionAnswer{
+			{Header: "Format", Question: "Which output format?", SelectedLabels: []string{"JSON"}},
+		},
+	}
+	ctx := domain.WithUserQuestionBroker(context.Background(), broker)
+
+	result, err := tool.Execute(ctx, validQuestionArgs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got error %q", result.Error)
+	}
+	if broker.callCount != 1 {
+		t.Fatalf("expected broker to be called once, got %d", broker.callCount)
+	}
+	if len(broker.received) != 1 || broker.received[0].Header != "Format" {
+		t.Fatalf("broker did not receive parsed questions: %+v", broker.received)
+	}
+	data, _ := result.Data.(map[string]any)
+	answers, _ := data["answers"].([]domain.UserQuestionAnswer)
+	if len(answers) != 1 || answers[0].SelectedLabels[0] != "JSON" {
+		t.Fatalf("unexpected answers in result: %+v", data["answers"])
+	}
+	if msg, _ := data["message"].(string); !strings.Contains(msg, "JSON") {
+		t.Fatalf("expected formatted message to mention JSON, got %q", msg)
+	}
+}
+
+func TestAskUserQuestionTool_Execute_Cancelled(t *testing.T) {
+	tool := newAskUserQuestionToolForTest()
+
+	broker := &stubBroker{ok: false}
+	ctx := domain.WithUserQuestionBroker(context.Background(), broker)
+
+	result, err := tool.Execute(ctx, validQuestionArgs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got error %q", result.Error)
+	}
+	data, _ := result.Data.(map[string]any)
+	if data["cancelled"] != true {
+		t.Fatalf("expected cancelled=true, got %v", data["cancelled"])
+	}
+}
+
+func TestAskUserQuestionTool_Execute_InvalidArgs(t *testing.T) {
+	tool := newAskUserQuestionToolForTest()
+
+	result, err := tool.Execute(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure for invalid args")
+	}
+	if result.Error == "" {
+		t.Fatal("expected an error message")
+	}
+}
+
+func TestFormatAnswersForLLM(t *testing.T) {
+	answers := []domain.UserQuestionAnswer{
+		{Header: "Format", Question: "Which output format?", SelectedLabels: []string{"JSON"}},
+		{Header: "Scope", Question: "Which files?", SelectedLabels: []string{"internal/agent", "internal/ui"}, OtherText: "also config/"},
+		{Header: "Mode", Question: "Pick one", OtherText: "custom only"},
+	}
+
+	out := formatAnswersForLLM(answers)
+
+	if !strings.Contains(out, "[Format] Which output format? -> JSON") {
+		t.Errorf("missing single-label line: %q", out)
+	}
+	if !strings.Contains(out, "internal/agent, internal/ui") {
+		t.Errorf("missing multi-label join: %q", out)
+	}
+	if !strings.Contains(out, `Other: "also config/"`) {
+		t.Errorf("missing other text: %q", out)
+	}
+	if !strings.Contains(out, `[Mode] Pick one -> Other: "custom only"`) {
+		t.Errorf("missing other-only line: %q", out)
+	}
+}

--- a/internal/agent/tools/ask_user_question_test.go
+++ b/internal/agent/tools/ask_user_question_test.go
@@ -262,6 +262,32 @@ func TestAskUserQuestionTool_Execute_InvalidArgs(t *testing.T) {
 	}
 }
 
+// TestAskUserQuestionTool_ResultReachesLLMContext verifies the precise link that
+// puts the answers into the conversation the model sees next turn: the agent's
+// executeToolInternal feeds the tool result through FormatToolResultForLLM, which
+// dispatches to this tool's FormatResult(FormatterLLM). That string becomes the
+// tool-result message content.
+func TestAskUserQuestionTool_ResultReachesLLMContext(t *testing.T) {
+	tool := newAskUserQuestionToolForTest()
+	broker := &stubBroker{ok: true, answers: []domain.UserQuestionAnswer{
+		{Header: "Backend", Question: "Which storage backend?", SelectedLabels: []string{"sqlite"}},
+		{Header: "Scope", Question: "Which areas?", SelectedLabels: []string{"agent", "ui"}, OtherText: "also config"},
+	}}
+	ctx := domain.WithUserQuestionBroker(context.Background(), broker)
+
+	result, err := tool.Execute(ctx, validQuestionArgs())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	llm := tool.FormatResult(result, domain.FormatterLLM)
+	for _, want := range []string{"Backend", "sqlite", "Scope", "agent, ui", `Other: "also config"`} {
+		if !strings.Contains(llm, want) {
+			t.Errorf("LLM-facing tool result is missing %q; got:\n%s", want, llm)
+		}
+	}
+}
+
 func TestFormatAnswersForLLM(t *testing.T) {
 	answers := []domain.UserQuestionAnswer{
 		{Header: "Format", Question: "Which output format?", SelectedLabels: []string{"JSON"}},

--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -111,6 +111,10 @@ func (r *Registry) registerTools() {
 	r.tools["TodoWrite"] = NewTodoWriteTool(cfg)
 	r.tools["RequestPlanApproval"] = NewRequestPlanApprovalTool(cfg)
 
+	if cfg.Tools.AskUserQuestion.Enabled {
+		r.tools["AskUserQuestion"] = NewAskUserQuestionTool(cfg)
+	}
+
 	if cfg.Tools.Schedule.Enabled {
 		r.tools["Schedule"] = NewScheduleTool(cfg)
 	}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -29,6 +29,7 @@ import (
 	components "github.com/inference-gateway/cli/internal/ui/components"
 	factory "github.com/inference-gateway/cli/internal/ui/components/factory"
 	keybinding "github.com/inference-gateway/cli/internal/ui/keybinding"
+	keys "github.com/inference-gateway/cli/internal/ui/keys"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
@@ -81,6 +82,7 @@ type ChatApplication struct {
 	queueBoxView         *components.QueueBoxView
 	todoBoxView          *components.TodoBoxView
 	approvalBoxView      *components.ApprovalBoxView
+	questionFormView     *components.QuestionFormView
 	modelSelector        *components.ModelSelectorImpl
 	themeSelector        *components.ThemeSelectorImpl
 	conversationSelector *components.ConversationSelectorImpl
@@ -258,6 +260,7 @@ func NewChatApplication(
 	app.snippetAttachmentsView = components.NewSnippetAttachmentsView(styleProvider)
 	app.chatKeys = config.ResolveNamespaceBindings(app.config.Chat.Keybindings, config.NamespaceChat)
 	app.approvalBoxView = components.NewApprovalBoxView(styleProvider, app.stateManager, toolFormatterService)
+	app.questionFormView = components.NewQuestionFormView(styleProvider, app.stateManager)
 
 	app.fileSelectionView = components.NewFileSelectionView(styleProvider)
 
@@ -497,7 +500,8 @@ func isDomainEvent(msg tea.Msg) bool {
 	case domain.ToolApprovalRequestedEvent,
 		domain.ToolApprovalResponseEvent,
 		domain.PlanApprovalRequestedEvent,
-		domain.PlanApprovalResponseEvent:
+		domain.PlanApprovalResponseEvent,
+		domain.UserQuestionRequestedEvent:
 		return true
 
 	// Bash command execution
@@ -593,6 +597,7 @@ func (app *ChatApplication) handleViewSpecificMessages(msg tea.Msg) []tea.Cmd {
 		}
 
 		if app.stateManager.GetApprovalUIState() != nil || app.stateManager.GetPlanApprovalUIState() != nil ||
+			app.stateManager.GetUserQuestionUIState() != nil ||
 			inHistoryMode || currentView == domain.ViewStateDiffViewer ||
 			currentView == domain.ViewStateExplorer || currentView == domain.ViewStateHelp {
 			inputView.SetDisabled(true)
@@ -701,6 +706,13 @@ func (app *ChatApplication) handleChatView(msg tea.Msg) []tea.Cmd {
 func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyMsg) []tea.Cmd {
 	var cmds []tea.Cmd
 
+	// While an AskUserQuestion form is up it captures all keys (like the
+	// tool-approval box). It floats over the chat, so the view stays Chat.
+	// ctrl+c falls through so the user can still cancel the whole turn.
+	if app.stateManager.GetUserQuestionUIState() != nil && keyMsg.String() != "ctrl+c" {
+		return app.handleUserQuestionKeys(keyMsg)
+	}
+
 	if cv, ok := app.conversationView.(*components.ConversationView); ok && cv.IsInMessageHistoryMode() {
 		return app.handleMessageHistoryKeys(keyMsg)
 	}
@@ -766,6 +778,127 @@ func (app *ChatApplication) removeFocusedSnippet() {
 	if len(app.pendingSnippets) == 0 {
 		app.attachmentsFocused = false
 	}
+}
+
+// handleUserQuestionKeys drives the AskUserQuestion floating form. It mutates
+// the form state in place; Bubble Tea re-renders after each key, so no command
+// is needed. On the final question's confirm it sends the answers on the
+// response channel (unblocking the tool); esc cancels (closing the channel
+// without a value, which the tool reads as "dismissed").
+func (app *ChatApplication) handleUserQuestionKeys(keyMsg tea.KeyMsg) []tea.Cmd {
+	sm := app.stateManager
+	q := sm.GetUserQuestionUIState()
+	if q == nil {
+		return nil
+	}
+
+	// Free-text entry on the "Other" row consumes most keys as input.
+	if q.OtherActive[q.CurrentIndex] {
+		app.handleUserQuestionOtherKey(keyMsg)
+		return nil
+	}
+
+	switch keyMsg.String() {
+	case "up", "k":
+		app.moveUserQuestionCursor(-1)
+	case "down", "j":
+		app.moveUserQuestionCursor(1)
+	case " ", "space":
+		app.toggleUserQuestionAtCursor()
+	case "enter":
+		app.confirmUserQuestion()
+	case "esc":
+		sm.ClearUserQuestionUIState()
+	}
+	return nil
+}
+
+// handleUserQuestionOtherKey edits the free-text "Other" buffer for the current
+// question. Enter confirms (and advances/submits); esc leaves text entry.
+func (app *ChatApplication) handleUserQuestionOtherKey(keyMsg tea.KeyMsg) {
+	sm := app.stateManager
+	switch keyMsg.String() {
+	case "enter":
+		app.confirmUserQuestion()
+	case "esc":
+		sm.SetUserQuestionOtherActive(false)
+	case "backspace":
+		sm.BackspaceUserQuestionOtherText()
+	default:
+		if text := keys.PrintableText(keyMsg); text != "" {
+			sm.AppendUserQuestionOtherText(text)
+		}
+	}
+}
+
+// moveUserQuestionCursor moves the option highlight with wrap-around over the
+// real options plus the trailing "Other" row.
+func (app *ChatApplication) moveUserQuestionCursor(delta int) {
+	q := app.stateManager.GetUserQuestionUIState()
+	if q == nil {
+		return
+	}
+	rows := q.OtherRowIndex() + 1
+	app.stateManager.SetUserQuestionOptionCursor(((q.OptionCursor+delta)%rows + rows) % rows)
+}
+
+// toggleUserQuestionAtCursor toggles the highlighted option, or starts free-text
+// entry when the cursor is on the "Other" row.
+func (app *ChatApplication) toggleUserQuestionAtCursor() {
+	q := app.stateManager.GetUserQuestionUIState()
+	if q == nil {
+		return
+	}
+	if q.OnOtherRow() {
+		app.stateManager.SetUserQuestionOtherActive(true)
+		return
+	}
+	app.stateManager.ToggleUserQuestionOption(q.OptionCursor)
+}
+
+// confirmUserQuestion records the highlighted choice (for single-select), then
+// advances to the next question or, on the last one, submits all answers.
+func (app *ChatApplication) confirmUserQuestion() {
+	sm := app.stateManager
+	q := sm.GetUserQuestionUIState()
+	if q == nil {
+		return
+	}
+
+	// Enter on the "Other" row starts free-text entry rather than advancing.
+	if q.OnOtherRow() && !q.OtherActive[q.CurrentIndex] {
+		sm.SetUserQuestionOtherActive(true)
+		return
+	}
+
+	// Single-select: Enter on a real option selects it (idempotently).
+	if !q.Questions[q.CurrentIndex].MultiSelect && !q.OnOtherRow() && !q.Selected[q.CurrentIndex][q.OptionCursor] {
+		sm.ToggleUserQuestionOption(q.OptionCursor)
+	}
+
+	if !userQuestionAnswered(q) {
+		return // require a selection or Other text before advancing
+	}
+
+	if !sm.AdvanceUserQuestion() {
+		return // more questions remain; the next one renders
+	}
+
+	answers := sm.BuildUserQuestionAnswers()
+	if q.ResponseChan != nil {
+		q.ResponseChan <- answers
+	}
+	sm.ClearUserQuestionUIState()
+}
+
+// userQuestionAnswered reports whether the current question has a selection or
+// non-empty Other text.
+func userQuestionAnswered(q *domain.UserQuestionUIState) bool {
+	i := q.CurrentIndex
+	if i < 0 || i >= len(q.Questions) {
+		return false
+	}
+	return len(q.Selected[i]) > 0 || strings.TrimSpace(q.OtherText[i]) != ""
 }
 
 func (app *ChatApplication) handleFileSelectionView(msg tea.Msg) []tea.Cmd {
@@ -1707,6 +1840,7 @@ func (app *ChatApplication) renderChatInterface() string {
 		app.queueBoxView,
 		app.todoBoxView,
 		app.approvalBoxView,
+		app.questionFormView,
 		app.snippetAttachmentsView,
 	)
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -568,13 +568,11 @@ func (app *ChatApplication) handleMCPStatusUpdate(event domain.MCPServerStatusUp
 	}
 
 	if event.Connected && len(event.Tools) > 0 {
-		count := app.toolRegistry.RegisterMCPServerTools(event.ServerName, event.Tools)
-		logger.Debug("registered MCP tools", "server", event.ServerName, "count", count)
+		app.toolRegistry.RegisterMCPServerTools(event.ServerName, event.Tools)
 	}
 
 	if !event.Connected {
-		count := app.toolRegistry.UnregisterMCPServerTools(event.ServerName)
-		logger.Debug("unregistered MCP tools", "server", event.ServerName, "count", count)
+		app.toolRegistry.UnregisterMCPServerTools(event.ServerName)
 	}
 
 	if app.autocomplete != nil {
@@ -853,11 +851,14 @@ func (app *ChatApplication) toggleUserQuestionAtCursor() {
 		app.stateManager.SetUserQuestionOtherActive(true)
 		return
 	}
-	app.stateManager.ToggleUserQuestionOption(q.OptionCursor)
+
+	if q.Questions[q.CurrentIndex].MultiSelect {
+		app.stateManager.ToggleUserQuestionOption(q.OptionCursor)
+	}
 }
 
-// confirmUserQuestion records the highlighted choice (for single-select), then
-// advances to the next question or, on the last one, submits all answers.
+// confirmUserQuestion advances to the next question or, on the last one, submits
+// all answers (the current single-select choice already follows the cursor).
 func (app *ChatApplication) confirmUserQuestion() {
 	sm := app.stateManager
 	q := sm.GetUserQuestionUIState()
@@ -871,13 +872,8 @@ func (app *ChatApplication) confirmUserQuestion() {
 		return
 	}
 
-	// Single-select: Enter on a real option selects it (idempotently).
-	if !q.Questions[q.CurrentIndex].MultiSelect && !q.OnOtherRow() && !q.Selected[q.CurrentIndex][q.OptionCursor] {
-		sm.ToggleUserQuestionOption(q.OptionCursor)
-	}
-
 	if !userQuestionAnswered(q) {
-		return // require a selection or Other text before advancing
+		return
 	}
 
 	if !sm.AdvanceUserQuestion() {

--- a/internal/app/question_form_repro_test.go
+++ b/internal/app/question_form_repro_test.go
@@ -1,0 +1,137 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	config "github.com/inference-gateway/cli/config"
+	container "github.com/inference-gateway/cli/internal/container"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	services "github.com/inference-gateway/cli/internal/services"
+	approvalcoord "github.com/inference-gateway/cli/internal/services/approvalcoord"
+	components "github.com/inference-gateway/cli/internal/ui/components"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+// TestQuestionFormReproChain checks the coordinator -> shared StateManager ->
+// QuestionFormView render path in isolation.
+func TestQuestionFormReproChain(t *testing.T) {
+	sm := services.NewStateManager(false)
+	coord := approvalcoord.NewService(approvalcoord.Options{StateManager: sm})
+
+	ch := make(chan []domain.UserQuestionAnswer, 1)
+	if cmd := coord.HandleUserQuestionRequested(domain.UserQuestionRequestedEvent{
+		Questions: []domain.UserQuestion{
+			{Header: "Backend", Question: "Which storage backend?", Options: []domain.UserQuestionOption{{Label: "sqlite"}, {Label: "postgres"}}},
+		},
+		ResponseChan: ch,
+	}); cmd == nil {
+		t.Fatal("expected a status command from the coordinator")
+	}
+
+	st := sm.GetUserQuestionUIState()
+	if st == nil || len(st.Questions) != 1 {
+		t.Fatalf("coordinator did not set the shared user question state: %+v", st)
+	}
+
+	fv := components.NewQuestionFormView(styles.NewProvider(domain.NewThemeProvider()), sm)
+	fv.SetWidth(80)
+	if out := fv.Render(); !strings.Contains(out, "Backend") || !strings.Contains(out, "sqlite") {
+		t.Fatalf("form did not render from shared StateManager:\n%q", out)
+	}
+}
+
+// TestChatApplication_QuestionFormRendersOnEvent reproduces the FULL live path:
+// build a real ChatApplication from the container, drive the
+// UserQuestionRequestedEvent through Update(), and assert the form appears in
+// the rendered chat interface.
+func TestChatApplication_QuestionFormRendersOnEvent(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Gateway.Run = false
+	cfg.Storage.Enabled = false
+
+	c := container.NewServiceContainer(cfg)
+
+	model := "test/model"
+	app := NewChatApplication(
+		cfg,
+		[]string{model},
+		model,
+		domain.VersionInfo{},
+		c.GetAgentManager(),
+		c.GetAgentService(),
+		c.GetBackgroundTaskService(),
+		c.GetConversationOptimizer(),
+		c.GetConversationRepository(),
+		c.GetFileService(),
+		c.GetImageService(),
+		c.GetSkillsService(),
+		c.GetGitHubIssueService(),
+		c.GetMCPManager(),
+		c.GetMessageQueue(),
+		c.GetModelService(),
+		c.GetPricingService(),
+		c.GetSessionRolloverManager(),
+		c.GetStateManager(),
+		c.GetTaskRetentionService(),
+		c.GetThemeService(),
+		c.GetToolService(),
+		c.GetShortcutRegistry(),
+		c.GetToolRegistry(),
+		c.GetA2ATaskCoordinator(),
+		c.GetApprovalCoordinator(),
+		c.GetChatCompletionRunner(),
+		c.GetDirectExecutionService(),
+		c.GetToolExecutionCoordinator(),
+	)
+
+	c.GetStateManager().SetDimensions(120, 40)
+	_, _ = app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	ch := make(chan []domain.UserQuestionAnswer, 1)
+	_, _ = app.Update(domain.UserQuestionRequestedEvent{
+		Questions: []domain.UserQuestion{
+			{Header: "Backend", Question: "Which storage backend?", Options: []domain.UserQuestionOption{{Label: "sqlite"}, {Label: "postgres"}}},
+		},
+		ResponseChan: ch,
+	})
+
+	st := c.GetStateManager().GetUserQuestionUIState()
+	if st == nil || len(st.Questions) != 1 {
+		t.Fatalf("question state not set after Update: %+v", st)
+	}
+
+	out := app.viewContent()
+	if !strings.Contains(out, "Backend") || !strings.Contains(out, "sqlite") {
+		t.Fatalf("form not present in rendered chat interface; got:\n%s", out)
+	}
+
+	_, _ = app.Update(domain.ToolExecutionProgressEvent{
+		ToolCallID: "call_1", ToolName: "AskUserQuestion", Status: "running", Message: "Processing...",
+	})
+	_, _ = app.Update(domain.ToolCallUpdateEvent{ToolCallID: "call_1", ToolName: "AskUserQuestion"})
+
+	if st2 := c.GetStateManager().GetUserQuestionUIState(); st2 == nil {
+		t.Fatal("question state was cleared by a tool progress/update tick")
+	}
+	out2 := app.viewContent()
+	if !strings.Contains(out2, "Backend") {
+		t.Fatalf("form disappeared after a tool progress tick; got:\n%s", out2)
+	}
+
+	_, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if c.GetStateManager().GetUserQuestionUIState() != nil {
+		t.Fatal("form was not cleared after Enter/submit")
+	}
+	select {
+	case answers := <-ch:
+		if len(answers) != 1 || len(answers[0].SelectedLabels) != 1 || answers[0].SelectedLabels[0] != "sqlite" {
+			t.Fatalf("unexpected answers delivered: %+v", answers)
+		}
+	default:
+		t.Fatal("no answers delivered on the channel after Enter/submit (tool would block forever)")
+	}
+}

--- a/internal/domain/context.go
+++ b/internal/domain/context.go
@@ -49,3 +49,9 @@ const AgentModeKey ContextKey = "agent_mode"
 // turn. The Agent tool reads it so spawned subagents inherit the parent's model
 // by default (otherwise the subagent process would fail with "no model specified").
 const ModelKey ContextKey = "model"
+
+// UserQuestionBrokerKey is the context key for the interactive question broker.
+// It is injected only on the chat path (where a TUI event loop exists), so the
+// AskUserQuestion tool sees a nil broker on headless/no-TTY runs and degrades
+// gracefully instead of blocking forever.
+const UserQuestionBrokerKey ContextKey = "user_question_broker"

--- a/internal/domain/context_helpers.go
+++ b/internal/domain/context_helpers.go
@@ -161,3 +161,26 @@ func GetSessionID(ctx context.Context) string {
 func HasSessionID(ctx context.Context) bool {
 	return GetSessionID(ctx) != ""
 }
+
+// ========================================
+// User Question Broker
+// ========================================
+
+// WithUserQuestionBroker returns a new context carrying the interactive
+// question broker used by the AskUserQuestion tool. Injected only on the chat
+// path so headless/no-TTY runs see a nil broker and degrade gracefully.
+func WithUserQuestionBroker(ctx context.Context, broker UserQuestionBroker) context.Context {
+	return context.WithValue(ctx, UserQuestionBrokerKey, broker)
+}
+
+// GetUserQuestionBroker retrieves the question broker from context.
+// Returns nil if the key is not set or the value is not a UserQuestionBroker.
+func GetUserQuestionBroker(ctx context.Context) UserQuestionBroker {
+	broker, _ := ctx.Value(UserQuestionBrokerKey).(UserQuestionBroker)
+	return broker
+}
+
+// HasUserQuestionBroker checks if a question broker is set in the context.
+func HasUserQuestionBroker(ctx context.Context) bool {
+	return GetUserQuestionBroker(ctx) != nil
+}

--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -316,6 +316,20 @@ type PlanApprovalRequestedEvent struct {
 func (e PlanApprovalRequestedEvent) GetRequestID() string    { return e.RequestID }
 func (e PlanApprovalRequestedEvent) GetTimestamp() time.Time { return e.Timestamp }
 
+// UserQuestionRequestedEvent is published when the AskUserQuestion tool asks the
+// user one or more interactive clarifying questions. ResponseChan delivers the
+// collected answers back to the blocked tool goroutine; closing it without a
+// value signals cancellation.
+type UserQuestionRequestedEvent struct {
+	RequestID    string
+	Timestamp    time.Time
+	Questions    []UserQuestion
+	ResponseChan chan []UserQuestionAnswer `json:"-"`
+}
+
+func (e UserQuestionRequestedEvent) GetRequestID() string    { return e.RequestID }
+func (e UserQuestionRequestedEvent) GetTimestamp() time.Time { return e.Timestamp }
+
 // RefreshAutocompleteEvent is sent when autocomplete needs to refresh (e.g., after mode change)
 type RefreshAutocompleteEvent struct{}
 

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -326,6 +326,18 @@ type StateManager interface {
 	SetPlanApprovalSelectedIndex(index int)
 	ClearPlanApprovalUIState()
 
+	// User question (AskUserQuestion) management
+	SetupUserQuestionUIState(questions []UserQuestion, responseChan chan []UserQuestionAnswer)
+	GetUserQuestionUIState() *UserQuestionUIState
+	SetUserQuestionOptionCursor(idx int)
+	ToggleUserQuestionOption(optIdx int)
+	AdvanceUserQuestion() bool
+	SetUserQuestionOtherActive(active bool)
+	AppendUserQuestionOtherText(text string)
+	BackspaceUserQuestionOtherText()
+	BuildUserQuestionAnswers() []UserQuestionAnswer
+	ClearUserQuestionUIState()
+
 	// Todo management
 	SetTodos(todos []TodoItem)
 	GetTodos() []TodoItem
@@ -681,6 +693,15 @@ type BashDetachChannelHolder interface {
 	SetBashDetachChan(chan<- struct{})
 	GetBashDetachChan() chan<- struct{}
 	ClearBashDetachChan()
+}
+
+// UserQuestionBroker publishes an interactive clarifying-question request to the
+// TUI and blocks until the user answers or the context is cancelled. It is
+// injected into the AskUserQuestion tool's execution context only on the chat
+// path (where a TTY/event loop exists). Returns ok=false when the user dismisses
+// the form (the response channel is closed without a value) or on cancellation.
+type UserQuestionBroker interface {
+	AskUserQuestions(ctx context.Context, questions []UserQuestion) (answers []UserQuestionAnswer, ok bool, err error)
 }
 
 // ThemeService handles theme management
@@ -1082,6 +1103,7 @@ type A2ATaskCoordinator interface {
 type ApprovalCoordinator interface {
 	HandlePlanApprovalRequested(msg PlanApprovalRequestedEvent) tea.Cmd
 	HandlePlanApprovalResponse(msg PlanApprovalResponseEvent) (cmd tea.Cmd, restart bool)
+	HandleUserQuestionRequested(msg UserQuestionRequestedEvent) tea.Cmd
 	HandleComputerUsePaused(msg ComputerUsePausedEvent) tea.Cmd
 	HandleComputerUseResumed(msg ComputerUseResumedEvent) (cmd tea.Cmd, restart bool)
 }

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	sdk "github.com/inference-gateway/sdk"
@@ -33,6 +34,7 @@ type ApplicationState struct {
 	fileSelectionState  *FileSelectionState
 	approvalUIState     *ApprovalUIState
 	planApprovalUIState *PlanApprovalUIState
+	userQuestionUIState *UserQuestionUIState
 
 	// Todo State
 	todos []TodoItem
@@ -362,6 +364,36 @@ type PlanApprovalUIState struct {
 	SelectedIndex int                     `json:"selected_index"`
 	PlanContent   string                  `json:"plan_content"`
 	ResponseChan  chan PlanApprovalAction `json:"-"`
+}
+
+// UserQuestionUIState drives the interactive AskUserQuestion form. The agent
+// loop is blocked in the tool goroutine while this holds the UI's working copy
+// of the in-progress answers. The slices are sized len(Questions): Selected is
+// the set of chosen option indices per question, OtherText/OtherActive back the
+// synthesized free-text "Other" row per question. ResponseChan delivers the
+// final answers slice back to the blocked tool.
+type UserQuestionUIState struct {
+	Questions    []UserQuestion            `json:"questions"`
+	CurrentIndex int                       `json:"current_index"`
+	OptionCursor int                       `json:"option_cursor"`
+	Selected     []map[int]bool            `json:"selected"`
+	OtherText    []string                  `json:"other_text"`
+	OtherActive  []bool                    `json:"other_active"`
+	ResponseChan chan []UserQuestionAnswer `json:"-"`
+}
+
+// OtherRowIndex returns the option-cursor index of the synthesized "Other" row
+// for the current question (it sits just past the last real option).
+func (q *UserQuestionUIState) OtherRowIndex() int {
+	if q.CurrentIndex < 0 || q.CurrentIndex >= len(q.Questions) {
+		return 0
+	}
+	return len(q.Questions[q.CurrentIndex].Options)
+}
+
+// OnOtherRow reports whether the option cursor is on the "Other" free-text row.
+func (q *UserQuestionUIState) OnOtherRow() bool {
+	return q.OptionCursor == q.OtherRowIndex()
 }
 
 // MessageEditState represents the state when editing a message
@@ -862,6 +894,163 @@ func (s *ApplicationState) ClearPlanApprovalUIState() {
 		close(s.planApprovalUIState.ResponseChan)
 	}
 	s.planApprovalUIState = nil
+}
+
+// User Question State Management
+
+// SetupUserQuestionUIState initializes the AskUserQuestion form state for the
+// given questions, pre-sizing the per-question working slices.
+func (s *ApplicationState) SetupUserQuestionUIState(questions []UserQuestion, responseChan chan []UserQuestionAnswer) {
+	n := len(questions)
+	selected := make([]map[int]bool, n)
+	for i := range selected {
+		selected[i] = make(map[int]bool)
+	}
+	s.userQuestionUIState = &UserQuestionUIState{
+		Questions:    questions,
+		CurrentIndex: 0,
+		OptionCursor: 0,
+		Selected:     selected,
+		OtherText:    make([]string, n),
+		OtherActive:  make([]bool, n),
+		ResponseChan: responseChan,
+	}
+}
+
+// GetUserQuestionUIState returns the current AskUserQuestion form state, or nil.
+func (s *ApplicationState) GetUserQuestionUIState() *UserQuestionUIState {
+	return s.userQuestionUIState
+}
+
+// SetUserQuestionOptionCursor sets the highlighted option row for the current
+// question, clamped to [0, OtherRowIndex].
+func (s *ApplicationState) SetUserQuestionOptionCursor(idx int) {
+	q := s.userQuestionUIState
+	if q == nil {
+		return
+	}
+	maxIdx := q.OtherRowIndex()
+	if idx < 0 {
+		idx = 0
+	}
+	if idx > maxIdx {
+		idx = maxIdx
+	}
+	q.OptionCursor = idx
+}
+
+// ToggleUserQuestionOption toggles the option at optIdx for the current
+// question. For single-select questions, selecting an option clears any other
+// selection first. Selecting any real option clears the "Other" free-text.
+func (s *ApplicationState) ToggleUserQuestionOption(optIdx int) {
+	q := s.userQuestionUIState
+	if q == nil || q.CurrentIndex >= len(q.Questions) {
+		return
+	}
+	sel := q.Selected[q.CurrentIndex]
+	if q.Questions[q.CurrentIndex].MultiSelect {
+		if sel[optIdx] {
+			delete(sel, optIdx)
+		} else {
+			sel[optIdx] = true
+		}
+		return
+	}
+	// Single-select: replace the selection.
+	wasSelected := sel[optIdx]
+	for k := range sel {
+		delete(sel, k)
+	}
+	if !wasSelected {
+		sel[optIdx] = true
+	}
+	q.OtherActive[q.CurrentIndex] = false
+}
+
+// AdvanceUserQuestion moves to the next question (resetting the option cursor)
+// and reports whether all questions have now been answered.
+func (s *ApplicationState) AdvanceUserQuestion() bool {
+	q := s.userQuestionUIState
+	if q == nil {
+		return true
+	}
+	q.CurrentIndex++
+	q.OptionCursor = 0
+	return q.CurrentIndex >= len(q.Questions)
+}
+
+// SetUserQuestionOtherActive toggles free-text entry on the "Other" row of the
+// current question. Activating it (single-select) clears the option selection.
+func (s *ApplicationState) SetUserQuestionOtherActive(active bool) {
+	q := s.userQuestionUIState
+	if q == nil || q.CurrentIndex >= len(q.Questions) {
+		return
+	}
+	q.OtherActive[q.CurrentIndex] = active
+	if active && !q.Questions[q.CurrentIndex].MultiSelect {
+		for k := range q.Selected[q.CurrentIndex] {
+			delete(q.Selected[q.CurrentIndex], k)
+		}
+	}
+}
+
+// AppendUserQuestionOtherText appends typed text to the current question's
+// "Other" buffer.
+func (s *ApplicationState) AppendUserQuestionOtherText(text string) {
+	q := s.userQuestionUIState
+	if q == nil || q.CurrentIndex >= len(q.Questions) {
+		return
+	}
+	q.OtherText[q.CurrentIndex] += text
+}
+
+// BackspaceUserQuestionOtherText removes the last rune from the current
+// question's "Other" buffer.
+func (s *ApplicationState) BackspaceUserQuestionOtherText() {
+	q := s.userQuestionUIState
+	if q == nil || q.CurrentIndex >= len(q.Questions) {
+		return
+	}
+	buf := q.OtherText[q.CurrentIndex]
+	if buf == "" {
+		return
+	}
+	r := []rune(buf)
+	q.OtherText[q.CurrentIndex] = string(r[:len(r)-1])
+}
+
+// BuildUserQuestionAnswers materializes the answers from the working state.
+func (s *ApplicationState) BuildUserQuestionAnswers() []UserQuestionAnswer {
+	q := s.userQuestionUIState
+	if q == nil {
+		return nil
+	}
+	answers := make([]UserQuestionAnswer, 0, len(q.Questions))
+	for i, question := range q.Questions {
+		labels := make([]string, 0, len(question.Options))
+		for optIdx := range question.Options {
+			if q.Selected[i][optIdx] {
+				labels = append(labels, question.Options[optIdx].Label)
+			}
+		}
+		answers = append(answers, UserQuestionAnswer{
+			Header:         question.Header,
+			Question:       question.Question,
+			SelectedLabels: labels,
+			OtherText:      strings.TrimSpace(q.OtherText[i]),
+		})
+	}
+	return answers
+}
+
+// ClearUserQuestionUIState clears the AskUserQuestion form state and closes the
+// response channel (without a prior send this signals cancellation to the
+// blocked tool). Nil-safe and idempotent.
+func (s *ApplicationState) ClearUserQuestionUIState() {
+	if s.userQuestionUIState != nil && s.userQuestionUIState.ResponseChan != nil {
+		close(s.userQuestionUIState.ResponseChan)
+	}
+	s.userQuestionUIState = nil
 }
 
 // Todo State Management

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -915,6 +915,39 @@ func (s *ApplicationState) SetupUserQuestionUIState(questions []UserQuestion, re
 		OtherActive:  make([]bool, n),
 		ResponseChan: responseChan,
 	}
+	s.userQuestionUIState.applyCurrentQuestionDefault()
+}
+
+// defaultUserQuestionOption returns the option index to pre-select for a
+// single-select question: the first option whose label is marked "(Recommended)"
+// (case-insensitive), otherwise the first option.
+func defaultUserQuestionOption(q UserQuestion) int {
+	for i, opt := range q.Options {
+		if strings.Contains(strings.ToLower(opt.Label), "(recommended)") {
+			return i
+		}
+	}
+	return 0
+}
+
+// applyCurrentQuestionDefault pre-selects the default option for the current
+// question when it is single-select, so the radio always shows a choice and the
+// cursor starts on it. Multi-select questions start with nothing selected.
+func (q *UserQuestionUIState) applyCurrentQuestionDefault() {
+	if q.CurrentIndex >= len(q.Questions) {
+		return
+	}
+	question := q.Questions[q.CurrentIndex]
+	if question.MultiSelect || len(question.Options) == 0 {
+		return
+	}
+	idx := defaultUserQuestionOption(question)
+	q.OptionCursor = idx
+	sel := q.Selected[q.CurrentIndex]
+	for k := range sel {
+		delete(sel, k)
+	}
+	sel[idx] = true
 }
 
 // GetUserQuestionUIState returns the current AskUserQuestion form state, or nil.
@@ -937,6 +970,17 @@ func (s *ApplicationState) SetUserQuestionOptionCursor(idx int) {
 		idx = maxIdx
 	}
 	q.OptionCursor = idx
+
+	if q.CurrentIndex < len(q.Questions) && !q.Questions[q.CurrentIndex].MultiSelect {
+		sel := q.Selected[q.CurrentIndex]
+		for k := range sel {
+			delete(sel, k)
+		}
+		if idx < len(q.Questions[q.CurrentIndex].Options) {
+			sel[idx] = true
+			q.OtherActive[q.CurrentIndex] = false
+		}
+	}
 }
 
 // ToggleUserQuestionOption toggles the option at optIdx for the current
@@ -976,7 +1020,11 @@ func (s *ApplicationState) AdvanceUserQuestion() bool {
 	}
 	q.CurrentIndex++
 	q.OptionCursor = 0
-	return q.CurrentIndex >= len(q.Questions)
+	if q.CurrentIndex >= len(q.Questions) {
+		return true
+	}
+	q.applyCurrentQuestionDefault()
+	return false
 }
 
 // SetUserQuestionOtherActive toggles free-text entry on the "Other" row of the

--- a/internal/domain/user_question.go
+++ b/internal/domain/user_question.go
@@ -1,0 +1,29 @@
+package domain
+
+// UserQuestionOption is a single selectable choice within a UserQuestion.
+type UserQuestionOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// UserQuestion is one clarifying question the agent asks the user via the
+// AskUserQuestion tool. It mirrors the tool schema: a short header chip, the
+// question text, 2-4 options, and whether multiple options may be selected.
+type UserQuestion struct {
+	Header      string               `json:"header"`
+	Question    string               `json:"question"`
+	Options     []UserQuestionOption `json:"options"`
+	MultiSelect bool                 `json:"multiSelect"`
+}
+
+// UserQuestionAnswer is the user's response to one UserQuestion. SelectedLabels
+// holds the chosen option label(s); OtherText is non-empty when the user picked
+// the synthesized "Other" free-text choice (it may coexist with selected
+// labels in multi-select). Header and Question are echoed so the tool result is
+// self-describing for the model.
+type UserQuestionAnswer struct {
+	Header         string   `json:"header"`
+	Question       string   `json:"question"`
+	SelectedLabels []string `json:"selectedLabels"`
+	OtherText      string   `json:"otherText,omitempty"`
+}

--- a/internal/domain/user_question_test.go
+++ b/internal/domain/user_question_test.go
@@ -36,19 +36,35 @@ func sampleQuestions() []UserQuestion {
 	}
 }
 
-func TestUserQuestionUIState_SingleSelectToggleReplaces(t *testing.T) {
+func TestUserQuestionUIState_SingleSelectDefaultAndFollowsCursor(t *testing.T) {
 	s := NewApplicationState()
 	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
 
-	s.ToggleUserQuestionOption(0) // select JSON
-	s.ToggleUserQuestionOption(1) // single-select -> replaces with YAML
+	st := s.GetUserQuestionUIState()
+	if !st.Selected[0][0] {
+		t.Error("expected the first option to be pre-selected by default")
+	}
+
+	s.SetUserQuestionOptionCursor(1)
+	if st.Selected[0][0] || !st.Selected[0][1] {
+		t.Errorf("expected selection to follow the cursor to option 1, got %v", st.Selected[0])
+	}
+}
+
+func TestUserQuestionUIState_RecommendedDefault(t *testing.T) {
+	s := NewApplicationState()
+	s.SetupUserQuestionUIState([]UserQuestion{
+		{Header: "Fmt", Question: "q", MultiSelect: false, Options: []UserQuestionOption{
+			{Label: "JSON"}, {Label: "YAML (Recommended)"},
+		}},
+	}, make(chan []UserQuestionAnswer, 1))
 
 	st := s.GetUserQuestionUIState()
-	if st.Selected[0][0] {
-		t.Error("expected option 0 deselected after selecting option 1 (single-select)")
+	if st.Selected[0][0] || !st.Selected[0][1] {
+		t.Errorf("expected the (Recommended) option pre-selected, got %v", st.Selected[0])
 	}
-	if !st.Selected[0][1] {
-		t.Error("expected option 1 selected")
+	if st.OptionCursor != 1 {
+		t.Errorf("expected the cursor on the recommended option, got %d", st.OptionCursor)
 	}
 }
 
@@ -67,7 +83,7 @@ func TestUserQuestionUIState_MultiSelectAccumulates(t *testing.T) {
 		t.Errorf("expected options 0 and 2 selected, got %v", st.Selected[1])
 	}
 
-	s.ToggleUserQuestionOption(0) // toggle off
+	s.ToggleUserQuestionOption(0)
 	if st.Selected[1][0] {
 		t.Error("expected option 0 toggled off")
 	}
@@ -77,11 +93,10 @@ func TestUserQuestionUIState_BuildAnswersAndAdvance(t *testing.T) {
 	s := NewApplicationState()
 	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
 
-	s.ToggleUserQuestionOption(0) // q0: JSON
 	if s.AdvanceUserQuestion() {
 		t.Fatal("expected not done after q0")
 	}
-	s.ToggleUserQuestionOption(1) // q1: B
+	s.ToggleUserQuestionOption(1)
 	s.SetUserQuestionOtherActive(true)
 	s.AppendUserQuestionOtherText("custom")
 	if !s.AdvanceUserQuestion() {
@@ -93,7 +108,7 @@ func TestUserQuestionUIState_BuildAnswersAndAdvance(t *testing.T) {
 		t.Fatalf("expected 2 answers, got %d", len(answers))
 	}
 	if len(answers[0].SelectedLabels) != 1 || answers[0].SelectedLabels[0] != "JSON" {
-		t.Errorf("q0 expected [JSON], got %v", answers[0].SelectedLabels)
+		t.Errorf("q0 expected [JSON] (default), got %v", answers[0].SelectedLabels)
 	}
 	if answers[1].OtherText != "custom" {
 		t.Errorf("q1 expected OtherText=custom, got %q", answers[1].OtherText)
@@ -130,6 +145,5 @@ func TestUserQuestionUIState_ClearClosesChannel(t *testing.T) {
 		t.Fatal("expected a closed channel to be immediately readable")
 	}
 
-	// Idempotent / nil-safe.
 	s.ClearUserQuestionUIState()
 }

--- a/internal/domain/user_question_test.go
+++ b/internal/domain/user_question_test.go
@@ -1,0 +1,135 @@
+package domain
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeBroker struct{}
+
+func (fakeBroker) AskUserQuestions(context.Context, []UserQuestion) ([]UserQuestionAnswer, bool, error) {
+	return nil, false, nil
+}
+
+func TestWithUserQuestionBroker(t *testing.T) {
+	ctx := context.Background()
+	if GetUserQuestionBroker(ctx) != nil {
+		t.Fatal("expected nil broker on empty context")
+	}
+	if HasUserQuestionBroker(ctx) {
+		t.Fatal("expected HasUserQuestionBroker=false on empty context")
+	}
+
+	ctx = WithUserQuestionBroker(ctx, fakeBroker{})
+	if GetUserQuestionBroker(ctx) == nil {
+		t.Fatal("expected a broker after WithUserQuestionBroker")
+	}
+	if !HasUserQuestionBroker(ctx) {
+		t.Fatal("expected HasUserQuestionBroker=true")
+	}
+}
+
+func sampleQuestions() []UserQuestion {
+	return []UserQuestion{
+		{Header: "Format", Question: "fmt?", MultiSelect: false, Options: []UserQuestionOption{{Label: "JSON"}, {Label: "YAML"}}},
+		{Header: "Scope", Question: "scope?", MultiSelect: true, Options: []UserQuestionOption{{Label: "A"}, {Label: "B"}, {Label: "C"}}},
+	}
+}
+
+func TestUserQuestionUIState_SingleSelectToggleReplaces(t *testing.T) {
+	s := NewApplicationState()
+	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
+
+	s.ToggleUserQuestionOption(0) // select JSON
+	s.ToggleUserQuestionOption(1) // single-select -> replaces with YAML
+
+	st := s.GetUserQuestionUIState()
+	if st.Selected[0][0] {
+		t.Error("expected option 0 deselected after selecting option 1 (single-select)")
+	}
+	if !st.Selected[0][1] {
+		t.Error("expected option 1 selected")
+	}
+}
+
+func TestUserQuestionUIState_MultiSelectAccumulates(t *testing.T) {
+	s := NewApplicationState()
+	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
+
+	if s.AdvanceUserQuestion() {
+		t.Fatal("did not expect to be done after advancing from q0")
+	}
+	s.ToggleUserQuestionOption(0)
+	s.ToggleUserQuestionOption(2)
+
+	st := s.GetUserQuestionUIState()
+	if !st.Selected[1][0] || !st.Selected[1][2] {
+		t.Errorf("expected options 0 and 2 selected, got %v", st.Selected[1])
+	}
+
+	s.ToggleUserQuestionOption(0) // toggle off
+	if st.Selected[1][0] {
+		t.Error("expected option 0 toggled off")
+	}
+}
+
+func TestUserQuestionUIState_BuildAnswersAndAdvance(t *testing.T) {
+	s := NewApplicationState()
+	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
+
+	s.ToggleUserQuestionOption(0) // q0: JSON
+	if s.AdvanceUserQuestion() {
+		t.Fatal("expected not done after q0")
+	}
+	s.ToggleUserQuestionOption(1) // q1: B
+	s.SetUserQuestionOtherActive(true)
+	s.AppendUserQuestionOtherText("custom")
+	if !s.AdvanceUserQuestion() {
+		t.Fatal("expected done after the last question")
+	}
+
+	answers := s.BuildUserQuestionAnswers()
+	if len(answers) != 2 {
+		t.Fatalf("expected 2 answers, got %d", len(answers))
+	}
+	if len(answers[0].SelectedLabels) != 1 || answers[0].SelectedLabels[0] != "JSON" {
+		t.Errorf("q0 expected [JSON], got %v", answers[0].SelectedLabels)
+	}
+	if answers[1].OtherText != "custom" {
+		t.Errorf("q1 expected OtherText=custom, got %q", answers[1].OtherText)
+	}
+}
+
+func TestUserQuestionUIState_BackspaceOtherText(t *testing.T) {
+	s := NewApplicationState()
+	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
+
+	s.SetUserQuestionOtherActive(true)
+	s.AppendUserQuestionOtherText("ab")
+	s.BackspaceUserQuestionOtherText()
+	if got := s.GetUserQuestionUIState().OtherText[0]; got != "a" {
+		t.Errorf("expected Other text 'a', got %q", got)
+	}
+}
+
+func TestUserQuestionUIState_ClearClosesChannel(t *testing.T) {
+	s := NewApplicationState()
+	ch := make(chan []UserQuestionAnswer, 1)
+	s.SetupUserQuestionUIState(sampleQuestions(), ch)
+
+	s.ClearUserQuestionUIState()
+	if s.GetUserQuestionUIState() != nil {
+		t.Fatal("expected nil state after clear")
+	}
+	select {
+	case _, open := <-ch:
+		if open {
+			t.Fatal("expected the response channel to be closed")
+		}
+	default:
+		t.Fatal("expected a closed channel to be immediately readable")
+	}
+
+	// Idempotent / nil-safe.
+	s.ClearUserQuestionUIState()
+}

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -427,7 +427,15 @@ func (h *ChatHandler) HandlePlanApprovalRequestedEvent(
 func (h *ChatHandler) HandleUserQuestionRequestedEvent(
 	msg domain.UserQuestionRequestedEvent,
 ) tea.Cmd {
-	return h.approvalCoordinator.HandleUserQuestionRequested(msg)
+	cmd := h.approvalCoordinator.HandleUserQuestionRequested(msg)
+
+	if ch := h.directExec.PendingToolChannel(); ch != nil {
+		return tea.Batch(cmd, h.ListenForEvents(ch))
+	}
+	if cs := h.stateManager.GetChatSession(); cs != nil && cs.EventChannel != nil {
+		return tea.Batch(cmd, h.ListenForChatEvents(cs.EventChannel))
+	}
+	return cmd
 }
 
 func (h *ChatHandler) HandlePlanApprovalResponseEvent(

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -165,6 +165,8 @@ func (h *ChatHandler) Handle(msg tea.Msg) tea.Cmd { // nolint:cyclop,gocyclo,fun
 		return h.HandlePlanApprovalRequestedEvent(m)
 	case domain.PlanApprovalResponseEvent:
 		return h.HandlePlanApprovalResponseEvent(m)
+	case domain.UserQuestionRequestedEvent:
+		return h.HandleUserQuestionRequestedEvent(m)
 	case domain.TodoUpdateChatEvent:
 		return h.HandleTodoUpdateChatEvent(m)
 	case domain.AgentStatusUpdateEvent:
@@ -418,6 +420,14 @@ func (h *ChatHandler) HandlePlanApprovalRequestedEvent(
 	msg domain.PlanApprovalRequestedEvent,
 ) tea.Cmd {
 	return h.approvalCoordinator.HandlePlanApprovalRequested(msg)
+}
+
+// HandleUserQuestionRequestedEvent sets up the AskUserQuestion form. The agent
+// loop stays blocked in the tool until the user answers, so there is no restart.
+func (h *ChatHandler) HandleUserQuestionRequestedEvent(
+	msg domain.UserQuestionRequestedEvent,
+) tea.Cmd {
+	return h.approvalCoordinator.HandleUserQuestionRequested(msg)
 }
 
 func (h *ChatHandler) HandlePlanApprovalResponseEvent(

--- a/internal/services/approvalcoord/coordinator.go
+++ b/internal/services/approvalcoord/coordinator.go
@@ -71,6 +71,25 @@ func (s *Service) planApprovalRequestedCmds(_ string) []tea.Cmd {
 	}
 }
 
+// HandleUserQuestionRequested sets up the AskUserQuestion form state. The form
+// renders as a floating box over the chat (like tool approval), so the view
+// stays ViewStateChat and keys are intercepted while the form state is set.
+// Unlike plan approval this does NOT stop the agent loop: the tool's Execute is
+// blocked on the response channel and resumes when the user submits or cancels.
+func (s *Service) HandleUserQuestionRequested(msg domain.UserQuestionRequestedEvent) tea.Cmd {
+	logger.Info("approvalCoordinator.HandleUserQuestionRequested called", "questions", len(msg.Questions))
+
+	s.stateManager.SetupUserQuestionUIState(msg.Questions, msg.ResponseChan)
+
+	return func() tea.Msg {
+		return domain.SetStatusEvent{
+			Message:    "Please answer the question(s) - ↑/↓ move, space toggle, enter to continue, esc to cancel",
+			Spinner:    false,
+			StatusType: domain.StatusDefault,
+		}
+	}
+}
+
 // HandlePlanApprovalResponse processes the user's accept/reject decision on a
 // plan and returns whatever cmds the orchestrator should run plus a restart
 // flag (true → orchestrator should kick a new ChatCompletionRunner.Start()).

--- a/internal/services/approvalcoord/coordinator.go
+++ b/internal/services/approvalcoord/coordinator.go
@@ -77,8 +77,6 @@ func (s *Service) planApprovalRequestedCmds(_ string) []tea.Cmd {
 // Unlike plan approval this does NOT stop the agent loop: the tool's Execute is
 // blocked on the response channel and resumes when the user submits or cancels.
 func (s *Service) HandleUserQuestionRequested(msg domain.UserQuestionRequestedEvent) tea.Cmd {
-	logger.Info("approvalCoordinator.HandleUserQuestionRequested called", "questions", len(msg.Questions))
-
 	s.stateManager.SetupUserQuestionUIState(msg.Questions, msg.ResponseChan)
 
 	return func() tea.Msg {
@@ -167,13 +165,10 @@ func (s *Service) updatePlanStatus(action domain.PlanApprovalAction) {
 // HandleComputerUsePaused cancels the in-flight request and marks state as
 // paused. No restart - the user will manually resume.
 func (s *Service) HandleComputerUsePaused(msg domain.ComputerUsePausedEvent) tea.Cmd {
-	logger.Debug("approvalCoordinator.HandleComputerUsePaused called", "request_id", msg.RequestID)
 	logger.Info("computer use execution paused", "request_id", msg.RequestID)
 
 	if err := s.agentService.CancelRequest(msg.RequestID); err != nil {
 		logger.Error("failed to cancel request on pause", "error", err, "request_id", msg.RequestID)
-	} else {
-		logger.Debug("successfully cancelled request", "request_id", msg.RequestID)
 	}
 
 	s.stateManager.SetComputerUsePaused(true, msg.RequestID)

--- a/internal/services/directexec/parser.go
+++ b/internal/services/directexec/parser.go
@@ -1,6 +1,7 @@
 package directexec
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -35,6 +36,13 @@ func (s *Service) ParseToolCall(input string) (string, map[string]any, error) {
 
 	args := make(map[string]any)
 	if argsStr == "" {
+		return toolName, args, nil
+	}
+
+	if strings.HasPrefix(argsStr, "{") {
+		if err := json.Unmarshal([]byte(argsStr), &args); err != nil {
+			return "", nil, fmt.Errorf("failed to parse JSON arguments: %w", err)
+		}
 		return toolName, args, nil
 	}
 

--- a/internal/services/directexec/parser_json_test.go
+++ b/internal/services/directexec/parser_json_test.go
@@ -1,0 +1,24 @@
+package directexec
+
+import "testing"
+
+func TestService_ParseToolCall_JSONObject(t *testing.T) {
+	svc := &Service{}
+	input := `AskUserQuestion({"questions":[{"header":"Backend","question":"Which storage backend?","multiSelect":false,"options":[{"label":"sqlite","description":"Embedded"},{"label":"postgres","description":"Networked"}]}]})`
+
+	name, args, err := svc.ParseToolCall(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "AskUserQuestion" {
+		t.Fatalf("expected AskUserQuestion, got %q", name)
+	}
+	questions, ok := args["questions"].([]any)
+	if !ok || len(questions) != 1 {
+		t.Fatalf("expected questions to parse as a 1-element array, got %#v", args["questions"])
+	}
+	q0, _ := questions[0].(map[string]any)
+	if q0["header"] != "Backend" {
+		t.Fatalf("expected header Backend, got %v", q0["header"])
+	}
+}

--- a/internal/services/directexec/tool.go
+++ b/internal/services/directexec/tool.go
@@ -78,6 +78,16 @@ func (s *Service) HandleToolCommand(commandText string) tea.Cmd {
 		}
 	}
 
+	if !s.isToolAvailableInMode(toolName) {
+		mode := s.stateManager.GetAgentMode()
+		return func() tea.Msg {
+			return domain.ShowErrorEvent{
+				Error:  fmt.Sprintf("Tool '%s' is not available in %s.", toolName, mode.DisplayName()),
+				Sticky: false,
+			}
+		}
+	}
+
 	argsJSON, err := json.Marshal(args)
 	if err != nil {
 		return func() tea.Msg {
@@ -89,6 +99,24 @@ func (s *Service) HandleToolCommand(commandText string) tea.Cmd {
 	}
 
 	return s.executeToolCommand(commandText, toolName, string(argsJSON))
+}
+
+// isToolAvailableInMode reports whether the tool is exposed in the current agent
+// mode - the same gating ListToolsForMode applies for the LLM - so !! direct
+// execution can't run a tool the active mode doesn't allow (e.g. AskUserQuestion
+// outside plan mode, or a mutating tool in plan mode). Defaults to allowing when
+// no state manager is wired.
+func (s *Service) isToolAvailableInMode(toolName string) bool {
+	if s.stateManager == nil {
+		return true
+	}
+	mode := s.stateManager.GetAgentMode()
+	for _, def := range s.toolService.ListToolsForMode(mode) {
+		if def.Function.Name == toolName {
+			return true
+		}
+	}
+	return false
 }
 
 // executeToolCommand synthesizes the user-tool- conversation entries and

--- a/internal/services/directexec/tool.go
+++ b/internal/services/directexec/tool.go
@@ -13,6 +13,37 @@ import (
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
+// directQuestionBroker implements domain.UserQuestionBroker for `!!` direct
+// tool execution. It publishes the question request onto the per-invocation
+// event channel and blocks until the user submits (answers arrive on the
+// response channel) or dismisses the form (the channel is closed without a
+// value). It lets AskUserQuestion be exercised without an LLM turn.
+type directQuestionBroker struct {
+	events    chan<- tea.Msg
+	requestID string
+}
+
+func (b *directQuestionBroker) AskUserQuestions(ctx context.Context, questions []domain.UserQuestion) ([]domain.UserQuestionAnswer, bool, error) {
+	responseChan := make(chan []domain.UserQuestionAnswer, 1)
+
+	b.events <- domain.UserQuestionRequestedEvent{
+		RequestID:    b.requestID,
+		Timestamp:    time.Now(),
+		Questions:    questions,
+		ResponseChan: responseChan,
+	}
+
+	select {
+	case answers, open := <-responseChan:
+		if !open {
+			return nil, false, nil
+		}
+		return answers, true, nil
+	case <-ctx.Done():
+		return nil, false, ctx.Err()
+	}
+}
+
 // HandleToolCommand processes user-typed `!!ToolName(arg="value")` commands.
 // Parses the syntax, validates the tool is enabled, and dispatches to an
 // async executor.
@@ -132,6 +163,7 @@ func (s *Service) executeToolCommandAsync(toolName, argsJSON, toolCallID string)
 
 		ctx := domain.WithToolApproved(context.Background())
 		ctx = domain.WithDirectExecution(ctx)
+		ctx = domain.WithUserQuestionBroker(ctx, &directQuestionBroker{events: eventChan, requestID: toolCallID})
 		result, err := s.toolService.ExecuteToolDirect(ctx, toolCallFunc)
 		if err != nil {
 			eventChan <- domain.ShowErrorEvent{

--- a/internal/services/directexec/tool_mode_test.go
+++ b/internal/services/directexec/tool_mode_test.go
@@ -1,0 +1,39 @@
+package directexec_test
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	directexec "github.com/inference-gateway/cli/internal/services/directexec"
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+)
+
+func TestHandleToolCommand_BlocksToolNotInCurrentMode(t *testing.T) {
+	toolSvc := &domainmocks.FakeToolService{}
+	toolSvc.IsToolEnabledReturns(true)
+	toolSvc.ListToolsForModeReturns([]sdk.ChatCompletionTool{
+		{Function: sdk.FunctionObject{Name: "Read"}},
+	})
+
+	sm := &domainmocks.FakeStateManager{}
+	sm.GetAgentModeReturns(domain.AgentModeStandard)
+
+	svc := directexec.NewService(directexec.Options{ToolService: toolSvc, StateManager: sm})
+
+	// AskUserQuestion is plan-only - not in standard mode's tool list - so !!
+	// must refuse it rather than run it.
+	cmd := svc.HandleToolCommand(`AskUserQuestion({"questions":[]})`)
+	if cmd == nil {
+		t.Fatal("expected an error command")
+	}
+	errEvent, ok := cmd().(domain.ShowErrorEvent)
+	if !ok {
+		t.Fatalf("expected ShowErrorEvent, got %T", cmd())
+	}
+	if !strings.Contains(errEvent.Error, "not available") {
+		t.Errorf("expected a 'not available' error, got %q", errEvent.Error)
+	}
+}

--- a/internal/services/state_manager.go
+++ b/internal/services/state_manager.go
@@ -613,6 +613,86 @@ func (sm *StateManager) ClearPlanApprovalUIState() {
 	sm.state.ClearPlanApprovalUIState()
 }
 
+// SetupUserQuestionUIState initializes the AskUserQuestion form state
+func (sm *StateManager) SetupUserQuestionUIState(questions []domain.UserQuestion, responseChan chan []domain.UserQuestionAnswer) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	sm.state.SetupUserQuestionUIState(questions, responseChan)
+}
+
+// GetUserQuestionUIState returns the current AskUserQuestion form state
+func (sm *StateManager) GetUserQuestionUIState() *domain.UserQuestionUIState {
+	sm.mutex.RLock()
+	defer sm.mutex.RUnlock()
+
+	return sm.state.GetUserQuestionUIState()
+}
+
+// SetUserQuestionOptionCursor sets the highlighted option row
+func (sm *StateManager) SetUserQuestionOptionCursor(idx int) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	sm.state.SetUserQuestionOptionCursor(idx)
+}
+
+// ToggleUserQuestionOption toggles the option at optIdx for the current question
+func (sm *StateManager) ToggleUserQuestionOption(optIdx int) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	sm.state.ToggleUserQuestionOption(optIdx)
+}
+
+// AdvanceUserQuestion moves to the next question and reports whether done
+func (sm *StateManager) AdvanceUserQuestion() bool {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	return sm.state.AdvanceUserQuestion()
+}
+
+// SetUserQuestionOtherActive toggles free-text entry on the "Other" row
+func (sm *StateManager) SetUserQuestionOtherActive(active bool) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	sm.state.SetUserQuestionOtherActive(active)
+}
+
+// AppendUserQuestionOtherText appends typed text to the current "Other" buffer
+func (sm *StateManager) AppendUserQuestionOtherText(text string) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	sm.state.AppendUserQuestionOtherText(text)
+}
+
+// BackspaceUserQuestionOtherText removes the last rune from the "Other" buffer
+func (sm *StateManager) BackspaceUserQuestionOtherText() {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	sm.state.BackspaceUserQuestionOtherText()
+}
+
+// BuildUserQuestionAnswers materializes the answers from the working state
+func (sm *StateManager) BuildUserQuestionAnswers() []domain.UserQuestionAnswer {
+	sm.mutex.RLock()
+	defer sm.mutex.RUnlock()
+
+	return sm.state.BuildUserQuestionAnswers()
+}
+
+// ClearUserQuestionUIState clears the AskUserQuestion form state
+func (sm *StateManager) ClearUserQuestionUIState() {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	sm.state.ClearUserQuestionUIState()
+}
+
 // Todo management methods
 
 // SetTodos sets the todo list

--- a/internal/services/tools.go
+++ b/internal/services/tools.go
@@ -61,6 +61,7 @@ func (s *LLMToolService) ListToolsForMode(mode domain.AgentMode) []sdk.ChatCompl
 			"A2A_QueryAgent":      true,
 			"TodoWrite":           true,
 			"RequestPlanApproval": true,
+			"AskUserQuestion":     true,
 		}
 
 		var definitions []sdk.ChatCompletionTool
@@ -75,6 +76,7 @@ func (s *LLMToolService) ListToolsForMode(mode domain.AgentMode) []sdk.ChatCompl
 
 	planOnlyTools := map[string]bool{
 		"RequestPlanApproval": true,
+		"AskUserQuestion":     true,
 	}
 
 	var definitions []sdk.ChatCompletionTool

--- a/internal/services/tools_mode_test.go
+++ b/internal/services/tools_mode_test.go
@@ -1,0 +1,35 @@
+package services
+
+import (
+	"slices"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+	tools "github.com/inference-gateway/cli/internal/agent/tools"
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+func toolNamesForMode(svc *LLMToolService, mode domain.AgentMode) []string {
+	defs := svc.ListToolsForMode(mode)
+	names := make([]string, 0, len(defs))
+	for _, d := range defs {
+		names = append(names, d.Function.Name)
+	}
+	return names
+}
+
+func TestListToolsForMode_AskUserQuestionPlanOnly(t *testing.T) {
+	cfg := config.DefaultConfig()
+	registry := tools.NewRegistry(cfg, nil, nil, nil, nil, nil, nil)
+	svc := NewLLMToolServiceWithRegistry(cfg, registry)
+
+	if !slices.Contains(toolNamesForMode(svc, domain.AgentModePlan), "AskUserQuestion") {
+		t.Error("expected AskUserQuestion to be available in plan mode")
+	}
+	if slices.Contains(toolNamesForMode(svc, domain.AgentModeStandard), "AskUserQuestion") {
+		t.Error("expected AskUserQuestion to be excluded from standard mode")
+	}
+	if slices.Contains(toolNamesForMode(svc, domain.AgentModeAutoAccept), "AskUserQuestion") {
+		t.Error("expected AskUserQuestion to be excluded from auto-accept mode")
+	}
+}

--- a/internal/ui/autocomplete/autocomplete.go
+++ b/internal/ui/autocomplete/autocomplete.go
@@ -254,45 +254,20 @@ func (a *AutocompleteImpl) loadTools() {
 
 	a.suggestions = []ShortcutOption{}
 
-	availableTools := a.toolService.ListAvailableTools()
-	toolDefinitions := a.toolService.ListTools()
-
-	toolDefMap := make(map[string]sdk.ChatCompletionTool)
-	for _, toolDef := range toolDefinitions {
-		toolDefMap[toolDef.Function.Name] = toolDef
-	}
-
-	planModeTools := map[string]bool{
-		"Read":      true,
-		"Grep":      true,
-		"Tree":      true,
-		"TodoWrite": true,
-	}
-
-	var isInPlanMode bool
+	mode := domain.AgentModeStandard
 	if a.stateManager != nil {
-		agentMode := a.stateManager.GetAgentMode()
-		isInPlanMode = agentMode == domain.AgentModePlan
+		mode = a.stateManager.GetAgentMode()
 	}
 
-	for _, toolName := range availableTools {
+	for _, toolDef := range a.toolService.ListToolsForMode(mode) {
+		toolName := toolDef.Function.Name
 		if toolName == "RequestPlanApproval" {
+			// The plan-submission tool isn't a meaningful manual !! command.
 			continue
-		}
-
-		if isInPlanMode && !planModeTools[toolName] {
-			continue
-		}
-
-		var template string
-		if toolDef, exists := toolDefMap[toolName]; exists {
-			template = a.generateToolTemplate(toolDef)
-		} else {
-			template = "!!" + toolName + "("
 		}
 
 		a.suggestions = append(a.suggestions, ShortcutOption{
-			Shortcut:    template,
+			Shortcut:    a.generateToolTemplate(toolDef),
 			Description: "Execute " + toolName + " tool directly",
 			Usage:       "",
 		})

--- a/internal/ui/autocomplete/autocomplete_test.go
+++ b/internal/ui/autocomplete/autocomplete_test.go
@@ -91,9 +91,6 @@ func TestAutocomplete_ToolsMode(t *testing.T) {
 	mockRegistry.GetAllReturns([]shortcuts.Shortcut{})
 
 	mockToolService := &domainmocks.FakeToolService{}
-	mockToolService.ListAvailableToolsReturns([]string{
-		"Read", "Write", "Bash", "WebSearch", "Tree",
-	})
 
 	readDesc := "Read files"
 	writeDesc := "Write files"
@@ -136,7 +133,9 @@ func TestAutocomplete_ToolsMode(t *testing.T) {
 		"required": []string{"command"},
 	})
 
-	mockToolService.ListToolsReturns([]sdk.ChatCompletionTool{
+	// loadTools now sources the !! suggestions from ListToolsForMode (the same
+	// mode-aware gating the agent uses for the LLM).
+	mockToolService.ListToolsForModeReturns([]sdk.ChatCompletionTool{
 		{
 			Type: sdk.Function,
 			Function: sdk.FunctionObject{
@@ -160,6 +159,14 @@ func TestAutocomplete_ToolsMode(t *testing.T) {
 				Description: &bashDesc,
 				Parameters:  &bashParams,
 			},
+		},
+		{
+			Type:     sdk.Function,
+			Function: sdk.FunctionObject{Name: "WebSearch"},
+		},
+		{
+			Type:     sdk.Function,
+			Function: sdk.FunctionObject{Name: "Tree"},
 		},
 	})
 
@@ -224,6 +231,47 @@ func TestAutocomplete_ToolsMode(t *testing.T) {
 
 			assert.Equal(t, tt.expectedVisible, autocomplete.IsVisible())
 		})
+	}
+}
+
+func TestAutocomplete_ToolsRespectAgentMode(t *testing.T) {
+	mockRegistry := &uimocks.FakeShortcutRegistry{}
+	mockRegistry.GetAllReturns([]shortcuts.Shortcut{})
+
+	mockToolService := &domainmocks.FakeToolService{}
+	mockToolService.ListToolsForModeStub = func(mode domain.AgentMode) []sdk.ChatCompletionTool {
+		if mode == domain.AgentModePlan {
+			return []sdk.ChatCompletionTool{
+				{Type: sdk.Function, Function: sdk.FunctionObject{Name: "AskUserQuestion"}},
+			}
+		}
+		return []sdk.ChatCompletionTool{
+			{Type: sdk.Function, Function: sdk.FunctionObject{Name: "Bash"}},
+		}
+	}
+
+	sm := &domainmocks.FakeStateManager{}
+
+	theme := &uimocks.FakeTheme{}
+	theme.GetDimColorReturns("#808080")
+	theme.GetAccentColorReturns("#FF00FF")
+
+	ac := autocomplete.NewAutocomplete(theme, mockRegistry)
+	ac.SetToolService(mockToolService)
+	ac.SetStateManager(sm)
+
+	// Standard mode: AskUserQuestion is plan-only, so it must not autocomplete.
+	sm.GetAgentModeReturns(domain.AgentModeStandard)
+	ac.Update("!!AskUser", 9)
+	if ac.IsVisible() {
+		t.Error("AskUserQuestion should not autocomplete in standard mode")
+	}
+
+	// Plan mode: it appears.
+	sm.GetAgentModeReturns(domain.AgentModePlan)
+	ac.Update("!!AskUser", 9)
+	if !ac.IsVisible() {
+		t.Error("AskUserQuestion should autocomplete in plan mode")
 	}
 }
 

--- a/internal/ui/components/application_view.go
+++ b/internal/ui/components/application_view.go
@@ -43,21 +43,22 @@ func (r *ApplicationViewRenderer) RenderChatInterface(
 	queueBoxView *QueueBoxView,
 	todoBoxView *TodoBoxView,
 	approvalBoxView *ApprovalBoxView,
+	questionFormView *QuestionFormView,
 	snippetAttachments *SnippetAttachmentsView,
 ) string {
 	width, height := data.Width, data.Height
 
-	heights := r.calculateComponentHeights(data, height, conversationView, helpBar, queueBoxView, todoBoxView, approvalBoxView, snippetAttachments)
+	heights := r.calculateComponentHeights(data, height, conversationView, helpBar, queueBoxView, todoBoxView, approvalBoxView, questionFormView, snippetAttachments)
 
 	r.setComponentDimensions(width, conversationView, inputView, autocomplete, inputStatusBar, statusView,
-		modeIndicator, queueBoxView, todoBoxView, approvalBoxView, snippetAttachments, heights)
+		modeIndicator, queueBoxView, todoBoxView, approvalBoxView, questionFormView, snippetAttachments, heights)
 
 	header := r.renderHeader(data, width)
 	conversationArea := conversationView.Render()
 	inputArea := inputView.Render()
 
 	components := r.assembleComponents(data, header, conversationArea, inputArea, conversationView, statusView, modeIndicator,
-		inputView, inputStatusBar, autocomplete, helpBar, queueBoxView, todoBoxView, approvalBoxView, snippetAttachments, width, heights.statusHeight)
+		inputView, inputStatusBar, autocomplete, helpBar, queueBoxView, todoBoxView, approvalBoxView, questionFormView, snippetAttachments, width, heights.statusHeight)
 
 	return strings.Join(components, "\n")
 }
@@ -69,6 +70,7 @@ type componentHeights struct {
 	queueBoxHeight       int
 	todoBoxHeight        int
 	approvalBoxHeight    int
+	questionBoxHeight    int
 	attachmentsHeight    int
 	backgroundTasksLines int
 	conversationHeight   int
@@ -85,10 +87,14 @@ func (r *ApplicationViewRenderer) calculateComponentHeights(
 	queueBoxView *QueueBoxView,
 	todoBoxView *TodoBoxView,
 	approvalBoxView *ApprovalBoxView,
+	questionFormView *QuestionFormView,
 	snippetAttachments *SnippetAttachmentsView,
 ) componentHeights {
 	if approvalBoxView != nil {
 		approvalBoxView.SetHeight(totalHeight)
+	}
+	if questionFormView != nil {
+		questionFormView.SetHeight(totalHeight)
 	}
 
 	heights := componentHeights{
@@ -120,13 +126,21 @@ func (r *ApplicationViewRenderer) calculateComponentHeights(
 		}
 	}
 
+	if questionFormView != nil {
+		questionContent := questionFormView.Render()
+		if questionContent != "" {
+			lines := strings.Count(questionContent, "\n") + 1
+			heights.questionBoxHeight = lines + 2
+		}
+	}
+
 	if cv, ok := conversationView.(*ConversationView); ok && cv.HasBackgroundTasks() {
 		heights.backgroundTasksLines = cv.BackgroundTasksBarHeight()
 	}
 
 	adjustedHeight := totalHeight - heights.headerHeight - heights.helpBarHeight -
 		heights.queueBoxHeight - heights.todoBoxHeight - heights.approvalBoxHeight -
-		heights.attachmentsHeight - heights.backgroundTasksLines
+		heights.questionBoxHeight - heights.attachmentsHeight - heights.backgroundTasksLines
 	heights.conversationHeight = ui.CalculateConversationHeight(adjustedHeight)
 	heights.inputHeight = ui.CalculateInputHeight(adjustedHeight)
 	heights.statusHeight = ui.CalculateStatusHeight(adjustedHeight)
@@ -150,6 +164,7 @@ func (r *ApplicationViewRenderer) setComponentDimensions(
 	queueBoxView *QueueBoxView,
 	todoBoxView *TodoBoxView,
 	approvalBoxView *ApprovalBoxView,
+	questionFormView *QuestionFormView,
 	snippetAttachments *SnippetAttachmentsView,
 	heights componentHeights,
 ) {
@@ -186,6 +201,10 @@ func (r *ApplicationViewRenderer) setComponentDimensions(
 	if approvalBoxView != nil {
 		approvalBoxView.SetWidth(width)
 	}
+
+	if questionFormView != nil {
+		questionFormView.SetWidth(width)
+	}
 }
 
 // renderHeader renders the header section
@@ -209,6 +228,7 @@ func (r *ApplicationViewRenderer) assembleComponents(
 	queueBoxView *QueueBoxView,
 	todoBoxView *TodoBoxView,
 	approvalBoxView *ApprovalBoxView,
+	questionFormView *QuestionFormView,
 	snippetAttachments *SnippetAttachmentsView,
 	width, statusHeight int,
 ) []string {
@@ -220,6 +240,7 @@ func (r *ApplicationViewRenderer) assembleComponents(
 	components = r.appendModeIndicator(components, modeIndicator)
 	components = r.appendStatusView(components, statusView, statusHeight)
 	components = r.appendApprovalBox(components, approvalBoxView)
+	components = r.appendQuestionForm(components, questionFormView)
 	components = append(components, inputArea)
 	components = r.appendSnippetAttachments(components, snippetAttachments)
 	components = r.appendAutocomplete(components, autocomplete)
@@ -322,6 +343,19 @@ func (r *ApplicationViewRenderer) appendApprovalBox(
 	if approvalBoxView != nil {
 		if approvalContent := approvalBoxView.Render(); approvalContent != "" {
 			components = append(components, "", approvalContent)
+		}
+	}
+	return components
+}
+
+// appendQuestionForm appends the AskUserQuestion form box if a question is pending
+func (r *ApplicationViewRenderer) appendQuestionForm(
+	components []string,
+	questionFormView *QuestionFormView,
+) []string {
+	if questionFormView != nil {
+		if questionContent := questionFormView.Render(); questionContent != "" {
+			components = append(components, "", questionContent)
 		}
 	}
 	return components

--- a/internal/ui/components/question_form_view.go
+++ b/internal/ui/components/question_form_view.go
@@ -1,0 +1,178 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	formatting "github.com/inference-gateway/cli/internal/formatting"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+// minQuestionOptionWidth is the floor for a truncated option row so a narrow
+// terminal still shows a usable amount of each label/description.
+const minQuestionOptionWidth = 20
+
+// otherOptionLabel is the synthesized free-text choice appended to every
+// question. It is not one of the model-provided options.
+const otherOptionLabel = "Other (type your own)"
+
+// QuestionFormView renders the interactive AskUserQuestion form as a bordered
+// box floating above the input (mirroring ApprovalBoxView). It reads the
+// in-progress answer state from the StateManager and renders the current
+// question's options, a checkbox/radio marker per option, the synthesized
+// "Other" free-text row, and a one-line key hint.
+type QuestionFormView struct {
+	width         int
+	height        int
+	styleProvider *styles.Provider
+	stateManager  domain.StateManager
+}
+
+func NewQuestionFormView(styleProvider *styles.Provider, stateManager domain.StateManager) *QuestionFormView {
+	return &QuestionFormView{
+		width:         80,
+		styleProvider: styleProvider,
+		stateManager:  stateManager,
+	}
+}
+
+func (qv *QuestionFormView) SetWidth(width int) {
+	qv.width = width
+}
+
+func (qv *QuestionFormView) SetHeight(height int) {
+	qv.height = height
+}
+
+func (qv *QuestionFormView) Render() string {
+	if qv.stateManager == nil {
+		return ""
+	}
+	state := qv.stateManager.GetUserQuestionUIState()
+	if state == nil || len(state.Questions) == 0 || state.CurrentIndex >= len(state.Questions) {
+		return ""
+	}
+	return qv.renderForm(state)
+}
+
+// renderForm frames the current question, its options, and a key hint in a
+// bordered box. The accent border echoes the focused input box below it.
+func (qv *QuestionFormView) renderForm(state *domain.UserQuestionUIState) string {
+	accentColor := qv.styleProvider.GetThemeColor("accent")
+	dimColor := qv.styleProvider.GetThemeColor("dim")
+
+	question := state.Questions[state.CurrentIndex]
+
+	header := fmt.Sprintf(" %s ", strings.TrimSpace(question.Header))
+	progress := fmt.Sprintf("(%d/%d)", state.CurrentIndex+1, len(state.Questions))
+	title := qv.styleProvider.RenderWithColorAndBold(header, accentColor) + " " +
+		qv.styleProvider.RenderWithColor(progress, dimColor)
+
+	parts := []string{
+		title,
+		formatting.TruncateText(question.Question, qv.textBudget()),
+		"",
+	}
+	parts = append(parts, qv.renderOptions(state, question)...)
+	parts = append(parts, "", qv.styleProvider.RenderWithColor(qv.hint(state, question), dimColor))
+
+	content := strings.Join(parts, "\n")
+	return qv.styleProvider.RenderBorderedBox(content, accentColor, 0, 1)
+}
+
+// renderOptions renders one row per option plus the synthesized "Other" row.
+func (qv *QuestionFormView) renderOptions(state *domain.UserQuestionUIState, question domain.UserQuestion) []string {
+	rows := make([]string, 0, len(question.Options)+1)
+	for i, opt := range question.Options {
+		selected := state.Selected[state.CurrentIndex][i]
+		label := opt.Label
+		if opt.Description != "" {
+			label = fmt.Sprintf("%s - %s", opt.Label, opt.Description)
+		}
+		rows = append(rows, qv.renderRow(label, i == state.OptionCursor, selected, question.MultiSelect))
+	}
+
+	otherCursor := state.OptionCursor == state.OtherRowIndex()
+	otherText := strings.TrimSpace(state.OtherText[state.CurrentIndex])
+	otherActive := state.OtherActive[state.CurrentIndex]
+	otherLabel := otherOptionLabel
+	switch {
+	case otherActive:
+		otherLabel = fmt.Sprintf("Other: %s▏", otherText)
+	case otherText != "":
+		otherLabel = fmt.Sprintf("Other: %s", otherText)
+	}
+	rows = append(rows, qv.renderRow(otherLabel, otherCursor, otherText != "" || otherActive, question.MultiSelect))
+	return rows
+}
+
+// renderRow renders a single option line: a cursor caret, a checkbox (multi) or
+// radio (single) marker, and the label. The highlighted row gets a background.
+func (qv *QuestionFormView) renderRow(label string, cursor, selected, multi bool) string {
+	caret := "  "
+	if cursor {
+		caret = "▸ "
+	}
+
+	var marker string
+	switch {
+	case multi && selected:
+		marker = "[x] "
+	case multi:
+		marker = "[ ] "
+	case selected:
+		marker = "(•) "
+	default:
+		marker = "( ) "
+	}
+
+	text := formatting.TruncateText(label, qv.textBudget()-len(caret)-len(marker))
+	line := caret + marker + text
+
+	if cursor {
+		return qv.styleProvider.RenderStyledText(line, styles.StyleOptions{
+			Background: qv.styleProvider.GetThemeColor("selection_bg"),
+			Bold:       true,
+		})
+	}
+	return line
+}
+
+// hint returns the dim key-help line, adapted to the current input mode.
+func (qv *QuestionFormView) hint(state *domain.UserQuestionUIState, question domain.UserQuestion) string {
+	if state.OtherActive[state.CurrentIndex] {
+		return "type your answer · enter continue · esc back"
+	}
+	if question.MultiSelect {
+		return "↑/↓ move · space toggle · enter continue · esc cancel"
+	}
+	return "↑/↓ move · enter select · esc cancel"
+}
+
+// textBudget is the display width available for a row after reserving room for
+// the box border (2) and horizontal padding (2), plus slack from the right edge.
+func (qv *QuestionFormView) textBudget() int {
+	budget := qv.width - 6
+	if budget < minQuestionOptionWidth {
+		return minQuestionOptionWidth
+	}
+	return budget
+}
+
+func (qv *QuestionFormView) Init() tea.Cmd {
+	return nil
+}
+
+func (qv *QuestionFormView) View() tea.View {
+	return tea.NewView("")
+}
+
+func (qv *QuestionFormView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if windowMsg, ok := msg.(tea.WindowSizeMsg); ok {
+		qv.SetWidth(windowMsg.Width)
+	}
+	return qv, nil
+}

--- a/internal/ui/components/question_form_view.go
+++ b/internal/ui/components/question_form_view.go
@@ -149,7 +149,7 @@ func (qv *QuestionFormView) hint(state *domain.UserQuestionUIState, question dom
 	if question.MultiSelect {
 		return "↑/↓ move · space toggle · enter continue · esc cancel"
 	}
-	return "↑/↓ move · enter select · esc cancel"
+	return "↑/↓ select · enter confirm · esc cancel"
 }
 
 // textBudget is the display width available for a row after reserving room for

--- a/internal/ui/components/question_form_view_test.go
+++ b/internal/ui/components/question_form_view_test.go
@@ -1,0 +1,75 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+)
+
+func questionStateForTest() *domain.UserQuestionUIState {
+	return &domain.UserQuestionUIState{
+		Questions: []domain.UserQuestion{
+			{
+				Header:      "Format",
+				Question:    "Which output format?",
+				MultiSelect: false,
+				Options: []domain.UserQuestionOption{
+					{Label: "JSON", Description: "machine readable"},
+					{Label: "YAML", Description: "human readable"},
+				},
+			},
+		},
+		CurrentIndex: 0,
+		OptionCursor: 0,
+		Selected:     []map[int]bool{{}},
+		OtherText:    []string{""},
+		OtherActive:  []bool{false},
+	}
+}
+
+func TestQuestionFormView_RenderNilState(t *testing.T) {
+	sm := &domainmocks.FakeStateManager{}
+	sm.GetUserQuestionUIStateReturns(nil)
+
+	v := NewQuestionFormView(createMockStyleProvider(), sm)
+	if got := v.Render(); got != "" {
+		t.Errorf("expected empty render with nil state, got %q", got)
+	}
+}
+
+func TestQuestionFormView_RendersQuestion(t *testing.T) {
+	sm := &domainmocks.FakeStateManager{}
+	sm.GetUserQuestionUIStateReturns(questionStateForTest())
+
+	v := NewQuestionFormView(createMockStyleProvider(), sm)
+	v.SetWidth(80)
+
+	out := v.Render()
+	for _, want := range []string{"Format", "(1/1)", "Which output format?", "JSON", "YAML", "Other"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected render to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestQuestionFormView_MultiSelectCheckboxes(t *testing.T) {
+	state := questionStateForTest()
+	state.Questions[0].MultiSelect = true
+	state.Selected[0][0] = true // JSON selected
+
+	sm := &domainmocks.FakeStateManager{}
+	sm.GetUserQuestionUIStateReturns(state)
+
+	v := NewQuestionFormView(createMockStyleProvider(), sm)
+	v.SetWidth(80)
+
+	out := v.Render()
+	if !strings.Contains(out, "[x]") {
+		t.Errorf("expected a checked checkbox for the selected option, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[ ]") {
+		t.Errorf("expected an unchecked checkbox for the unselected option, got:\n%s", out)
+	}
+}

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -736,6 +736,9 @@ func handleCancel(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 		}
 	}
 
+	// Dismiss any pending AskUserQuestion form so it doesn't linger after the
+	// turn is cancelled (closing the channel unblocks the tool's Execute).
+	stateManager.ClearUserQuestionUIState()
 	stateManager.EndChatSession()
 	stateManager.EndToolExecution()
 	_ = stateManager.TransitionToView(domain.ViewStateChat)
@@ -758,6 +761,7 @@ func handleNewSession(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 		}
 	}
 
+	stateManager.ClearUserQuestionUIState()
 	stateManager.EndChatSession()
 	stateManager.EndToolExecution()
 	_ = stateManager.TransitionToView(domain.ViewStateChat)

--- a/tests/mocks/domain/fake_approval_coordinator.go
+++ b/tests/mocks/domain/fake_approval_coordinator.go
@@ -57,6 +57,17 @@ type FakeApprovalCoordinator struct {
 		result1 tea.Cmd
 		result2 bool
 	}
+	HandleUserQuestionRequestedStub        func(domain.UserQuestionRequestedEvent) tea.Cmd
+	handleUserQuestionRequestedMutex       sync.RWMutex
+	handleUserQuestionRequestedArgsForCall []struct {
+		arg1 domain.UserQuestionRequestedEvent
+	}
+	handleUserQuestionRequestedReturns struct {
+		result1 tea.Cmd
+	}
+	handleUserQuestionRequestedReturnsOnCall map[int]struct {
+		result1 tea.Cmd
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -309,6 +320,67 @@ func (fake *FakeApprovalCoordinator) HandlePlanApprovalResponseReturnsOnCall(i i
 		result1 tea.Cmd
 		result2 bool
 	}{result1, result2}
+}
+
+func (fake *FakeApprovalCoordinator) HandleUserQuestionRequested(arg1 domain.UserQuestionRequestedEvent) tea.Cmd {
+	fake.handleUserQuestionRequestedMutex.Lock()
+	ret, specificReturn := fake.handleUserQuestionRequestedReturnsOnCall[len(fake.handleUserQuestionRequestedArgsForCall)]
+	fake.handleUserQuestionRequestedArgsForCall = append(fake.handleUserQuestionRequestedArgsForCall, struct {
+		arg1 domain.UserQuestionRequestedEvent
+	}{arg1})
+	stub := fake.HandleUserQuestionRequestedStub
+	fakeReturns := fake.handleUserQuestionRequestedReturns
+	fake.recordInvocation("HandleUserQuestionRequested", []interface{}{arg1})
+	fake.handleUserQuestionRequestedMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeApprovalCoordinator) HandleUserQuestionRequestedCallCount() int {
+	fake.handleUserQuestionRequestedMutex.RLock()
+	defer fake.handleUserQuestionRequestedMutex.RUnlock()
+	return len(fake.handleUserQuestionRequestedArgsForCall)
+}
+
+func (fake *FakeApprovalCoordinator) HandleUserQuestionRequestedCalls(stub func(domain.UserQuestionRequestedEvent) tea.Cmd) {
+	fake.handleUserQuestionRequestedMutex.Lock()
+	defer fake.handleUserQuestionRequestedMutex.Unlock()
+	fake.HandleUserQuestionRequestedStub = stub
+}
+
+func (fake *FakeApprovalCoordinator) HandleUserQuestionRequestedArgsForCall(i int) domain.UserQuestionRequestedEvent {
+	fake.handleUserQuestionRequestedMutex.RLock()
+	defer fake.handleUserQuestionRequestedMutex.RUnlock()
+	argsForCall := fake.handleUserQuestionRequestedArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeApprovalCoordinator) HandleUserQuestionRequestedReturns(result1 tea.Cmd) {
+	fake.handleUserQuestionRequestedMutex.Lock()
+	defer fake.handleUserQuestionRequestedMutex.Unlock()
+	fake.HandleUserQuestionRequestedStub = nil
+	fake.handleUserQuestionRequestedReturns = struct {
+		result1 tea.Cmd
+	}{result1}
+}
+
+func (fake *FakeApprovalCoordinator) HandleUserQuestionRequestedReturnsOnCall(i int, result1 tea.Cmd) {
+	fake.handleUserQuestionRequestedMutex.Lock()
+	defer fake.handleUserQuestionRequestedMutex.Unlock()
+	fake.HandleUserQuestionRequestedStub = nil
+	if fake.handleUserQuestionRequestedReturnsOnCall == nil {
+		fake.handleUserQuestionRequestedReturnsOnCall = make(map[int]struct {
+			result1 tea.Cmd
+		})
+	}
+	fake.handleUserQuestionRequestedReturnsOnCall[i] = struct {
+		result1 tea.Cmd
+	}{result1}
 }
 
 func (fake *FakeApprovalCoordinator) Invocations() map[string][][]interface{} {

--- a/tests/mocks/domain/fake_background_task_registry.go
+++ b/tests/mocks/domain/fake_background_task_registry.go
@@ -318,6 +318,11 @@ type FakeBackgroundTaskRegistry struct {
 	removeSubagentReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RemoveTaskStub        func(string)
+	removeTaskMutex       sync.RWMutex
+	removeTaskArgsForCall []struct {
+		arg1 string
+	}
 	SetSubagentStatusStub        func(string, domain.SubagentStatus) error
 	setSubagentStatusMutex       sync.RWMutex
 	setSubagentStatusArgsForCall []struct {
@@ -329,11 +334,6 @@ type FakeBackgroundTaskRegistry struct {
 	}
 	setSubagentStatusReturnsOnCall map[int]struct {
 		result1 error
-	}
-	RemoveTaskStub        func(string)
-	removeTaskMutex       sync.RWMutex
-	removeTaskArgsForCall []struct {
-		arg1 string
 	}
 	StartPollingStub        func(string, *domain.TaskPollingState)
 	startPollingMutex       sync.RWMutex
@@ -2079,6 +2079,68 @@ func (fake *FakeBackgroundTaskRegistry) RemoveTaskArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
+func (fake *FakeBackgroundTaskRegistry) SetSubagentStatus(arg1 string, arg2 domain.SubagentStatus) error {
+	fake.setSubagentStatusMutex.Lock()
+	ret, specificReturn := fake.setSubagentStatusReturnsOnCall[len(fake.setSubagentStatusArgsForCall)]
+	fake.setSubagentStatusArgsForCall = append(fake.setSubagentStatusArgsForCall, struct {
+		arg1 string
+		arg2 domain.SubagentStatus
+	}{arg1, arg2})
+	stub := fake.SetSubagentStatusStub
+	fakeReturns := fake.setSubagentStatusReturns
+	fake.recordInvocation("SetSubagentStatus", []interface{}{arg1, arg2})
+	fake.setSubagentStatusMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusCallCount() int {
+	fake.setSubagentStatusMutex.RLock()
+	defer fake.setSubagentStatusMutex.RUnlock()
+	return len(fake.setSubagentStatusArgsForCall)
+}
+
+func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusCalls(stub func(string, domain.SubagentStatus) error) {
+	fake.setSubagentStatusMutex.Lock()
+	defer fake.setSubagentStatusMutex.Unlock()
+	fake.SetSubagentStatusStub = stub
+}
+
+func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusArgsForCall(i int) (string, domain.SubagentStatus) {
+	fake.setSubagentStatusMutex.RLock()
+	defer fake.setSubagentStatusMutex.RUnlock()
+	argsForCall := fake.setSubagentStatusArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusReturns(result1 error) {
+	fake.setSubagentStatusMutex.Lock()
+	defer fake.setSubagentStatusMutex.Unlock()
+	fake.SetSubagentStatusStub = nil
+	fake.setSubagentStatusReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusReturnsOnCall(i int, result1 error) {
+	fake.setSubagentStatusMutex.Lock()
+	defer fake.setSubagentStatusMutex.Unlock()
+	fake.SetSubagentStatusStub = nil
+	if fake.setSubagentStatusReturnsOnCall == nil {
+		fake.setSubagentStatusReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setSubagentStatusReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeBackgroundTaskRegistry) StartPolling(arg1 string, arg2 *domain.TaskPollingState) {
 	fake.startPollingMutex.Lock()
 	fake.startPollingArgsForCall = append(fake.startPollingArgsForCall, struct {
@@ -2142,68 +2204,6 @@ func (fake *FakeBackgroundTaskRegistry) StopPollingArgsForCall(i int) string {
 	defer fake.stopPollingMutex.RUnlock()
 	argsForCall := fake.stopPollingArgsForCall[i]
 	return argsForCall.arg1
-}
-
-func (fake *FakeBackgroundTaskRegistry) SetSubagentStatus(arg1 string, arg2 domain.SubagentStatus) error {
-	fake.setSubagentStatusMutex.Lock()
-	ret, specificReturn := fake.setSubagentStatusReturnsOnCall[len(fake.setSubagentStatusArgsForCall)]
-	fake.setSubagentStatusArgsForCall = append(fake.setSubagentStatusArgsForCall, struct {
-		arg1 string
-		arg2 domain.SubagentStatus
-	}{arg1, arg2})
-	stub := fake.SetSubagentStatusStub
-	fakeReturns := fake.setSubagentStatusReturns
-	fake.recordInvocation("SetSubagentStatus", []interface{}{arg1, arg2})
-	fake.setSubagentStatusMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusCallCount() int {
-	fake.setSubagentStatusMutex.RLock()
-	defer fake.setSubagentStatusMutex.RUnlock()
-	return len(fake.setSubagentStatusArgsForCall)
-}
-
-func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusCalls(stub func(string, domain.SubagentStatus) error) {
-	fake.setSubagentStatusMutex.Lock()
-	defer fake.setSubagentStatusMutex.Unlock()
-	fake.SetSubagentStatusStub = stub
-}
-
-func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusArgsForCall(i int) (string, domain.SubagentStatus) {
-	fake.setSubagentStatusMutex.RLock()
-	defer fake.setSubagentStatusMutex.RUnlock()
-	argsForCall := fake.setSubagentStatusArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusReturns(result1 error) {
-	fake.setSubagentStatusMutex.Lock()
-	defer fake.setSubagentStatusMutex.Unlock()
-	fake.SetSubagentStatusStub = nil
-	fake.setSubagentStatusReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeBackgroundTaskRegistry) SetSubagentStatusReturnsOnCall(i int, result1 error) {
-	fake.setSubagentStatusMutex.Lock()
-	defer fake.setSubagentStatusMutex.Unlock()
-	fake.SetSubagentStatusStub = nil
-	if fake.setSubagentStatusReturnsOnCall == nil {
-		fake.setSubagentStatusReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.setSubagentStatusReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakeBackgroundTaskRegistry) Invocations() map[string][][]interface{} {

--- a/tests/mocks/domain/fake_state_manager.go
+++ b/tests/mocks/domain/fake_state_manager.go
@@ -9,6 +9,21 @@ import (
 )
 
 type FakeStateManager struct {
+	AdvanceUserQuestionStub        func() bool
+	advanceUserQuestionMutex       sync.RWMutex
+	advanceUserQuestionArgsForCall []struct {
+	}
+	advanceUserQuestionReturns struct {
+		result1 bool
+	}
+	advanceUserQuestionReturnsOnCall map[int]struct {
+		result1 bool
+	}
+	AppendUserQuestionOtherTextStub        func(string)
+	appendUserQuestionOtherTextMutex       sync.RWMutex
+	appendUserQuestionOtherTextArgsForCall []struct {
+		arg1 string
+	}
 	AreAllAgentsReadyStub        func() bool
 	areAllAgentsReadyMutex       sync.RWMutex
 	areAllAgentsReadyArgsForCall []struct {
@@ -19,10 +34,24 @@ type FakeStateManager struct {
 	areAllAgentsReadyReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	BackspaceUserQuestionOtherTextStub        func()
+	backspaceUserQuestionOtherTextMutex       sync.RWMutex
+	backspaceUserQuestionOtherTextArgsForCall []struct {
+	}
 	BroadcastEventStub        func(domain.ChatEvent)
 	broadcastEventMutex       sync.RWMutex
 	broadcastEventArgsForCall []struct {
 		arg1 domain.ChatEvent
+	}
+	BuildUserQuestionAnswersStub        func() []domain.UserQuestionAnswer
+	buildUserQuestionAnswersMutex       sync.RWMutex
+	buildUserQuestionAnswersArgsForCall []struct {
+	}
+	buildUserQuestionAnswersReturns struct {
+		result1 []domain.UserQuestionAnswer
+	}
+	buildUserQuestionAnswersReturnsOnCall map[int]struct {
+		result1 []domain.UserQuestionAnswer
 	}
 	ClearAgentReadinessStub        func()
 	clearAgentReadinessMutex       sync.RWMutex
@@ -55,6 +84,10 @@ type FakeStateManager struct {
 	ClearPlanApprovalUIStateStub        func()
 	clearPlanApprovalUIStateMutex       sync.RWMutex
 	clearPlanApprovalUIStateArgsForCall []struct {
+	}
+	ClearUserQuestionUIStateStub        func()
+	clearUserQuestionUIStateMutex       sync.RWMutex
+	clearUserQuestionUIStateArgsForCall []struct {
 	}
 	CompleteCurrentToolStub        func(*domain.ToolExecutionResult) error
 	completeCurrentToolMutex       sync.RWMutex
@@ -260,6 +293,16 @@ type FakeStateManager struct {
 	getToolExecutionReturnsOnCall map[int]struct {
 		result1 *domain.ToolExecutionSession
 	}
+	GetUserQuestionUIStateStub        func() *domain.UserQuestionUIState
+	getUserQuestionUIStateMutex       sync.RWMutex
+	getUserQuestionUIStateArgsForCall []struct {
+	}
+	getUserQuestionUIStateReturns struct {
+		result1 *domain.UserQuestionUIState
+	}
+	getUserQuestionUIStateReturnsOnCall map[int]struct {
+		result1 *domain.UserQuestionUIState
+	}
 	InitializeAgentReadinessStub        func(int)
 	initializeAgentReadinessMutex       sync.RWMutex
 	initializeAgentReadinessArgsForCall []struct {
@@ -368,6 +411,16 @@ type FakeStateManager struct {
 	setTodosArgsForCall []struct {
 		arg1 []domain.TodoItem
 	}
+	SetUserQuestionOptionCursorStub        func(int)
+	setUserQuestionOptionCursorMutex       sync.RWMutex
+	setUserQuestionOptionCursorArgsForCall []struct {
+		arg1 int
+	}
+	SetUserQuestionOtherActiveStub        func(bool)
+	setUserQuestionOtherActiveMutex       sync.RWMutex
+	setUserQuestionOtherActiveArgsForCall []struct {
+		arg1 bool
+	}
 	SetupApprovalUIStateStub        func(*sdk.ChatCompletionMessageToolCall, chan domain.ApprovalAction)
 	setupApprovalUIStateMutex       sync.RWMutex
 	setupApprovalUIStateArgsForCall []struct {
@@ -384,6 +437,12 @@ type FakeStateManager struct {
 	setupPlanApprovalUIStateArgsForCall []struct {
 		arg1 string
 		arg2 chan domain.PlanApprovalAction
+	}
+	SetupUserQuestionUIStateStub        func([]domain.UserQuestion, chan []domain.UserQuestionAnswer)
+	setupUserQuestionUIStateMutex       sync.RWMutex
+	setupUserQuestionUIStateArgsForCall []struct {
+		arg1 []domain.UserQuestion
+		arg2 chan []domain.UserQuestionAnswer
 	}
 	StartChatSessionStub        func(string, string, <-chan domain.ChatEvent) error
 	startChatSessionMutex       sync.RWMutex
@@ -408,6 +467,11 @@ type FakeStateManager struct {
 	}
 	startToolExecutionReturnsOnCall map[int]struct {
 		result1 error
+	}
+	ToggleUserQuestionOptionStub        func(int)
+	toggleUserQuestionOptionMutex       sync.RWMutex
+	toggleUserQuestionOptionArgsForCall []struct {
+		arg1 int
 	}
 	TransitionToViewStub        func(domain.ViewState) error
 	transitionToViewMutex       sync.RWMutex
@@ -447,6 +511,91 @@ type FakeStateManager struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeStateManager) AdvanceUserQuestion() bool {
+	fake.advanceUserQuestionMutex.Lock()
+	ret, specificReturn := fake.advanceUserQuestionReturnsOnCall[len(fake.advanceUserQuestionArgsForCall)]
+	fake.advanceUserQuestionArgsForCall = append(fake.advanceUserQuestionArgsForCall, struct {
+	}{})
+	stub := fake.AdvanceUserQuestionStub
+	fakeReturns := fake.advanceUserQuestionReturns
+	fake.recordInvocation("AdvanceUserQuestion", []interface{}{})
+	fake.advanceUserQuestionMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStateManager) AdvanceUserQuestionCallCount() int {
+	fake.advanceUserQuestionMutex.RLock()
+	defer fake.advanceUserQuestionMutex.RUnlock()
+	return len(fake.advanceUserQuestionArgsForCall)
+}
+
+func (fake *FakeStateManager) AdvanceUserQuestionCalls(stub func() bool) {
+	fake.advanceUserQuestionMutex.Lock()
+	defer fake.advanceUserQuestionMutex.Unlock()
+	fake.AdvanceUserQuestionStub = stub
+}
+
+func (fake *FakeStateManager) AdvanceUserQuestionReturns(result1 bool) {
+	fake.advanceUserQuestionMutex.Lock()
+	defer fake.advanceUserQuestionMutex.Unlock()
+	fake.AdvanceUserQuestionStub = nil
+	fake.advanceUserQuestionReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeStateManager) AdvanceUserQuestionReturnsOnCall(i int, result1 bool) {
+	fake.advanceUserQuestionMutex.Lock()
+	defer fake.advanceUserQuestionMutex.Unlock()
+	fake.AdvanceUserQuestionStub = nil
+	if fake.advanceUserQuestionReturnsOnCall == nil {
+		fake.advanceUserQuestionReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.advanceUserQuestionReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeStateManager) AppendUserQuestionOtherText(arg1 string) {
+	fake.appendUserQuestionOtherTextMutex.Lock()
+	fake.appendUserQuestionOtherTextArgsForCall = append(fake.appendUserQuestionOtherTextArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.AppendUserQuestionOtherTextStub
+	fake.recordInvocation("AppendUserQuestionOtherText", []interface{}{arg1})
+	fake.appendUserQuestionOtherTextMutex.Unlock()
+	if stub != nil {
+		fake.AppendUserQuestionOtherTextStub(arg1)
+	}
+}
+
+func (fake *FakeStateManager) AppendUserQuestionOtherTextCallCount() int {
+	fake.appendUserQuestionOtherTextMutex.RLock()
+	defer fake.appendUserQuestionOtherTextMutex.RUnlock()
+	return len(fake.appendUserQuestionOtherTextArgsForCall)
+}
+
+func (fake *FakeStateManager) AppendUserQuestionOtherTextCalls(stub func(string)) {
+	fake.appendUserQuestionOtherTextMutex.Lock()
+	defer fake.appendUserQuestionOtherTextMutex.Unlock()
+	fake.AppendUserQuestionOtherTextStub = stub
+}
+
+func (fake *FakeStateManager) AppendUserQuestionOtherTextArgsForCall(i int) string {
+	fake.appendUserQuestionOtherTextMutex.RLock()
+	defer fake.appendUserQuestionOtherTextMutex.RUnlock()
+	argsForCall := fake.appendUserQuestionOtherTextArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeStateManager) AreAllAgentsReady() bool {
@@ -502,6 +651,30 @@ func (fake *FakeStateManager) AreAllAgentsReadyReturnsOnCall(i int, result1 bool
 	}{result1}
 }
 
+func (fake *FakeStateManager) BackspaceUserQuestionOtherText() {
+	fake.backspaceUserQuestionOtherTextMutex.Lock()
+	fake.backspaceUserQuestionOtherTextArgsForCall = append(fake.backspaceUserQuestionOtherTextArgsForCall, struct {
+	}{})
+	stub := fake.BackspaceUserQuestionOtherTextStub
+	fake.recordInvocation("BackspaceUserQuestionOtherText", []interface{}{})
+	fake.backspaceUserQuestionOtherTextMutex.Unlock()
+	if stub != nil {
+		fake.BackspaceUserQuestionOtherTextStub()
+	}
+}
+
+func (fake *FakeStateManager) BackspaceUserQuestionOtherTextCallCount() int {
+	fake.backspaceUserQuestionOtherTextMutex.RLock()
+	defer fake.backspaceUserQuestionOtherTextMutex.RUnlock()
+	return len(fake.backspaceUserQuestionOtherTextArgsForCall)
+}
+
+func (fake *FakeStateManager) BackspaceUserQuestionOtherTextCalls(stub func()) {
+	fake.backspaceUserQuestionOtherTextMutex.Lock()
+	defer fake.backspaceUserQuestionOtherTextMutex.Unlock()
+	fake.BackspaceUserQuestionOtherTextStub = stub
+}
+
 func (fake *FakeStateManager) BroadcastEvent(arg1 domain.ChatEvent) {
 	fake.broadcastEventMutex.Lock()
 	fake.broadcastEventArgsForCall = append(fake.broadcastEventArgsForCall, struct {
@@ -532,6 +705,59 @@ func (fake *FakeStateManager) BroadcastEventArgsForCall(i int) domain.ChatEvent 
 	defer fake.broadcastEventMutex.RUnlock()
 	argsForCall := fake.broadcastEventArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeStateManager) BuildUserQuestionAnswers() []domain.UserQuestionAnswer {
+	fake.buildUserQuestionAnswersMutex.Lock()
+	ret, specificReturn := fake.buildUserQuestionAnswersReturnsOnCall[len(fake.buildUserQuestionAnswersArgsForCall)]
+	fake.buildUserQuestionAnswersArgsForCall = append(fake.buildUserQuestionAnswersArgsForCall, struct {
+	}{})
+	stub := fake.BuildUserQuestionAnswersStub
+	fakeReturns := fake.buildUserQuestionAnswersReturns
+	fake.recordInvocation("BuildUserQuestionAnswers", []interface{}{})
+	fake.buildUserQuestionAnswersMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStateManager) BuildUserQuestionAnswersCallCount() int {
+	fake.buildUserQuestionAnswersMutex.RLock()
+	defer fake.buildUserQuestionAnswersMutex.RUnlock()
+	return len(fake.buildUserQuestionAnswersArgsForCall)
+}
+
+func (fake *FakeStateManager) BuildUserQuestionAnswersCalls(stub func() []domain.UserQuestionAnswer) {
+	fake.buildUserQuestionAnswersMutex.Lock()
+	defer fake.buildUserQuestionAnswersMutex.Unlock()
+	fake.BuildUserQuestionAnswersStub = stub
+}
+
+func (fake *FakeStateManager) BuildUserQuestionAnswersReturns(result1 []domain.UserQuestionAnswer) {
+	fake.buildUserQuestionAnswersMutex.Lock()
+	defer fake.buildUserQuestionAnswersMutex.Unlock()
+	fake.BuildUserQuestionAnswersStub = nil
+	fake.buildUserQuestionAnswersReturns = struct {
+		result1 []domain.UserQuestionAnswer
+	}{result1}
+}
+
+func (fake *FakeStateManager) BuildUserQuestionAnswersReturnsOnCall(i int, result1 []domain.UserQuestionAnswer) {
+	fake.buildUserQuestionAnswersMutex.Lock()
+	defer fake.buildUserQuestionAnswersMutex.Unlock()
+	fake.BuildUserQuestionAnswersStub = nil
+	if fake.buildUserQuestionAnswersReturnsOnCall == nil {
+		fake.buildUserQuestionAnswersReturnsOnCall = make(map[int]struct {
+			result1 []domain.UserQuestionAnswer
+		})
+	}
+	fake.buildUserQuestionAnswersReturnsOnCall[i] = struct {
+		result1 []domain.UserQuestionAnswer
+	}{result1}
 }
 
 func (fake *FakeStateManager) ClearAgentReadiness() {
@@ -724,6 +950,30 @@ func (fake *FakeStateManager) ClearPlanApprovalUIStateCalls(stub func()) {
 	fake.clearPlanApprovalUIStateMutex.Lock()
 	defer fake.clearPlanApprovalUIStateMutex.Unlock()
 	fake.ClearPlanApprovalUIStateStub = stub
+}
+
+func (fake *FakeStateManager) ClearUserQuestionUIState() {
+	fake.clearUserQuestionUIStateMutex.Lock()
+	fake.clearUserQuestionUIStateArgsForCall = append(fake.clearUserQuestionUIStateArgsForCall, struct {
+	}{})
+	stub := fake.ClearUserQuestionUIStateStub
+	fake.recordInvocation("ClearUserQuestionUIState", []interface{}{})
+	fake.clearUserQuestionUIStateMutex.Unlock()
+	if stub != nil {
+		fake.ClearUserQuestionUIStateStub()
+	}
+}
+
+func (fake *FakeStateManager) ClearUserQuestionUIStateCallCount() int {
+	fake.clearUserQuestionUIStateMutex.RLock()
+	defer fake.clearUserQuestionUIStateMutex.RUnlock()
+	return len(fake.clearUserQuestionUIStateArgsForCall)
+}
+
+func (fake *FakeStateManager) ClearUserQuestionUIStateCalls(stub func()) {
+	fake.clearUserQuestionUIStateMutex.Lock()
+	defer fake.clearUserQuestionUIStateMutex.Unlock()
+	fake.ClearUserQuestionUIStateStub = stub
 }
 
 func (fake *FakeStateManager) CompleteCurrentTool(arg1 *domain.ToolExecutionResult) error {
@@ -1803,6 +2053,59 @@ func (fake *FakeStateManager) GetToolExecutionReturnsOnCall(i int, result1 *doma
 	}{result1}
 }
 
+func (fake *FakeStateManager) GetUserQuestionUIState() *domain.UserQuestionUIState {
+	fake.getUserQuestionUIStateMutex.Lock()
+	ret, specificReturn := fake.getUserQuestionUIStateReturnsOnCall[len(fake.getUserQuestionUIStateArgsForCall)]
+	fake.getUserQuestionUIStateArgsForCall = append(fake.getUserQuestionUIStateArgsForCall, struct {
+	}{})
+	stub := fake.GetUserQuestionUIStateStub
+	fakeReturns := fake.getUserQuestionUIStateReturns
+	fake.recordInvocation("GetUserQuestionUIState", []interface{}{})
+	fake.getUserQuestionUIStateMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStateManager) GetUserQuestionUIStateCallCount() int {
+	fake.getUserQuestionUIStateMutex.RLock()
+	defer fake.getUserQuestionUIStateMutex.RUnlock()
+	return len(fake.getUserQuestionUIStateArgsForCall)
+}
+
+func (fake *FakeStateManager) GetUserQuestionUIStateCalls(stub func() *domain.UserQuestionUIState) {
+	fake.getUserQuestionUIStateMutex.Lock()
+	defer fake.getUserQuestionUIStateMutex.Unlock()
+	fake.GetUserQuestionUIStateStub = stub
+}
+
+func (fake *FakeStateManager) GetUserQuestionUIStateReturns(result1 *domain.UserQuestionUIState) {
+	fake.getUserQuestionUIStateMutex.Lock()
+	defer fake.getUserQuestionUIStateMutex.Unlock()
+	fake.GetUserQuestionUIStateStub = nil
+	fake.getUserQuestionUIStateReturns = struct {
+		result1 *domain.UserQuestionUIState
+	}{result1}
+}
+
+func (fake *FakeStateManager) GetUserQuestionUIStateReturnsOnCall(i int, result1 *domain.UserQuestionUIState) {
+	fake.getUserQuestionUIStateMutex.Lock()
+	defer fake.getUserQuestionUIStateMutex.Unlock()
+	fake.GetUserQuestionUIStateStub = nil
+	if fake.getUserQuestionUIStateReturnsOnCall == nil {
+		fake.getUserQuestionUIStateReturnsOnCall = make(map[int]struct {
+			result1 *domain.UserQuestionUIState
+		})
+	}
+	fake.getUserQuestionUIStateReturnsOnCall[i] = struct {
+		result1 *domain.UserQuestionUIState
+	}{result1}
+}
+
 func (fake *FakeStateManager) InitializeAgentReadiness(arg1 int) {
 	fake.initializeAgentReadinessMutex.Lock()
 	fake.initializeAgentReadinessArgsForCall = append(fake.initializeAgentReadinessArgsForCall, struct {
@@ -2443,6 +2746,70 @@ func (fake *FakeStateManager) SetTodosArgsForCall(i int) []domain.TodoItem {
 	return argsForCall.arg1
 }
 
+func (fake *FakeStateManager) SetUserQuestionOptionCursor(arg1 int) {
+	fake.setUserQuestionOptionCursorMutex.Lock()
+	fake.setUserQuestionOptionCursorArgsForCall = append(fake.setUserQuestionOptionCursorArgsForCall, struct {
+		arg1 int
+	}{arg1})
+	stub := fake.SetUserQuestionOptionCursorStub
+	fake.recordInvocation("SetUserQuestionOptionCursor", []interface{}{arg1})
+	fake.setUserQuestionOptionCursorMutex.Unlock()
+	if stub != nil {
+		fake.SetUserQuestionOptionCursorStub(arg1)
+	}
+}
+
+func (fake *FakeStateManager) SetUserQuestionOptionCursorCallCount() int {
+	fake.setUserQuestionOptionCursorMutex.RLock()
+	defer fake.setUserQuestionOptionCursorMutex.RUnlock()
+	return len(fake.setUserQuestionOptionCursorArgsForCall)
+}
+
+func (fake *FakeStateManager) SetUserQuestionOptionCursorCalls(stub func(int)) {
+	fake.setUserQuestionOptionCursorMutex.Lock()
+	defer fake.setUserQuestionOptionCursorMutex.Unlock()
+	fake.SetUserQuestionOptionCursorStub = stub
+}
+
+func (fake *FakeStateManager) SetUserQuestionOptionCursorArgsForCall(i int) int {
+	fake.setUserQuestionOptionCursorMutex.RLock()
+	defer fake.setUserQuestionOptionCursorMutex.RUnlock()
+	argsForCall := fake.setUserQuestionOptionCursorArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStateManager) SetUserQuestionOtherActive(arg1 bool) {
+	fake.setUserQuestionOtherActiveMutex.Lock()
+	fake.setUserQuestionOtherActiveArgsForCall = append(fake.setUserQuestionOtherActiveArgsForCall, struct {
+		arg1 bool
+	}{arg1})
+	stub := fake.SetUserQuestionOtherActiveStub
+	fake.recordInvocation("SetUserQuestionOtherActive", []interface{}{arg1})
+	fake.setUserQuestionOtherActiveMutex.Unlock()
+	if stub != nil {
+		fake.SetUserQuestionOtherActiveStub(arg1)
+	}
+}
+
+func (fake *FakeStateManager) SetUserQuestionOtherActiveCallCount() int {
+	fake.setUserQuestionOtherActiveMutex.RLock()
+	defer fake.setUserQuestionOtherActiveMutex.RUnlock()
+	return len(fake.setUserQuestionOtherActiveArgsForCall)
+}
+
+func (fake *FakeStateManager) SetUserQuestionOtherActiveCalls(stub func(bool)) {
+	fake.setUserQuestionOtherActiveMutex.Lock()
+	defer fake.setUserQuestionOtherActiveMutex.Unlock()
+	fake.SetUserQuestionOtherActiveStub = stub
+}
+
+func (fake *FakeStateManager) SetUserQuestionOtherActiveArgsForCall(i int) bool {
+	fake.setUserQuestionOtherActiveMutex.RLock()
+	defer fake.setUserQuestionOtherActiveMutex.RUnlock()
+	argsForCall := fake.setUserQuestionOtherActiveArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeStateManager) SetupApprovalUIState(arg1 *sdk.ChatCompletionMessageToolCall, arg2 chan domain.ApprovalAction) {
 	fake.setupApprovalUIStateMutex.Lock()
 	fake.setupApprovalUIStateArgsForCall = append(fake.setupApprovalUIStateArgsForCall, struct {
@@ -2543,6 +2910,44 @@ func (fake *FakeStateManager) SetupPlanApprovalUIStateArgsForCall(i int) (string
 	fake.setupPlanApprovalUIStateMutex.RLock()
 	defer fake.setupPlanApprovalUIStateMutex.RUnlock()
 	argsForCall := fake.setupPlanApprovalUIStateArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStateManager) SetupUserQuestionUIState(arg1 []domain.UserQuestion, arg2 chan []domain.UserQuestionAnswer) {
+	var arg1Copy []domain.UserQuestion
+	if arg1 != nil {
+		arg1Copy = make([]domain.UserQuestion, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.setupUserQuestionUIStateMutex.Lock()
+	fake.setupUserQuestionUIStateArgsForCall = append(fake.setupUserQuestionUIStateArgsForCall, struct {
+		arg1 []domain.UserQuestion
+		arg2 chan []domain.UserQuestionAnswer
+	}{arg1Copy, arg2})
+	stub := fake.SetupUserQuestionUIStateStub
+	fake.recordInvocation("SetupUserQuestionUIState", []interface{}{arg1Copy, arg2})
+	fake.setupUserQuestionUIStateMutex.Unlock()
+	if stub != nil {
+		fake.SetupUserQuestionUIStateStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeStateManager) SetupUserQuestionUIStateCallCount() int {
+	fake.setupUserQuestionUIStateMutex.RLock()
+	defer fake.setupUserQuestionUIStateMutex.RUnlock()
+	return len(fake.setupUserQuestionUIStateArgsForCall)
+}
+
+func (fake *FakeStateManager) SetupUserQuestionUIStateCalls(stub func([]domain.UserQuestion, chan []domain.UserQuestionAnswer)) {
+	fake.setupUserQuestionUIStateMutex.Lock()
+	defer fake.setupUserQuestionUIStateMutex.Unlock()
+	fake.SetupUserQuestionUIStateStub = stub
+}
+
+func (fake *FakeStateManager) SetupUserQuestionUIStateArgsForCall(i int) ([]domain.UserQuestion, chan []domain.UserQuestionAnswer) {
+	fake.setupUserQuestionUIStateMutex.RLock()
+	defer fake.setupUserQuestionUIStateMutex.RUnlock()
+	argsForCall := fake.setupUserQuestionUIStateArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
@@ -2673,6 +3078,38 @@ func (fake *FakeStateManager) StartToolExecutionReturnsOnCall(i int, result1 err
 	fake.startToolExecutionReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeStateManager) ToggleUserQuestionOption(arg1 int) {
+	fake.toggleUserQuestionOptionMutex.Lock()
+	fake.toggleUserQuestionOptionArgsForCall = append(fake.toggleUserQuestionOptionArgsForCall, struct {
+		arg1 int
+	}{arg1})
+	stub := fake.ToggleUserQuestionOptionStub
+	fake.recordInvocation("ToggleUserQuestionOption", []interface{}{arg1})
+	fake.toggleUserQuestionOptionMutex.Unlock()
+	if stub != nil {
+		fake.ToggleUserQuestionOptionStub(arg1)
+	}
+}
+
+func (fake *FakeStateManager) ToggleUserQuestionOptionCallCount() int {
+	fake.toggleUserQuestionOptionMutex.RLock()
+	defer fake.toggleUserQuestionOptionMutex.RUnlock()
+	return len(fake.toggleUserQuestionOptionArgsForCall)
+}
+
+func (fake *FakeStateManager) ToggleUserQuestionOptionCalls(stub func(int)) {
+	fake.toggleUserQuestionOptionMutex.Lock()
+	defer fake.toggleUserQuestionOptionMutex.Unlock()
+	fake.ToggleUserQuestionOptionStub = stub
+}
+
+func (fake *FakeStateManager) ToggleUserQuestionOptionArgsForCall(i int) int {
+	fake.toggleUserQuestionOptionMutex.RLock()
+	defer fake.toggleUserQuestionOptionMutex.RUnlock()
+	argsForCall := fake.toggleUserQuestionOptionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeStateManager) TransitionToView(arg1 domain.ViewState) error {


### PR DESCRIPTION
## Summary

Adds **`AskUserQuestion`**: a plan-mode-only, read-only tool that lets the agent ask the user 1–4 multiple-choice clarifying questions as a keyboard-driven TUI form, instead of guessing or asking in prose. Answers are returned as the tool result and the agent loop **continues** (folds them into the plan, then `RequestPlanApproval`).

Part of #652 (v1; the follow-ups below remain tracked there).

## What's included

- **Tool** (`internal/agent/tools/ask_user_question.go`): draft-07 schema — 1–4 questions, each with a ≤12-char `header`, `question`, 2–4 `options` of `{label, description}`, optional `multiSelect`; bounds enforced in `Validate`. Headless/no-TTY runs degrade gracefully (returns "no interactive user — proceed with assumptions" instead of hanging).
- **Brokering**: `Execute` publishes a request event carrying a buffered response channel and blocks; the broker is injected via context only on the chat path (`GetChatHandler`), so the loop resumes once answered. The chat-events listener is re-armed across the form so the tool result + next LLM turn reach the UI.
- **Form UI** (`question_form_view.go`): floating box over the chat — `↑/↓` navigate, `space` toggles (multi-select), `enter` advances/submits, an auto-appended "Other" free-text row, `esc`/`ctrl+c` cancel. Single-select is a radio: a default is pre-selected (the `(Recommended)`-marked option, else the first) and the selection follows the cursor, so `enter` always confirms a visible choice. The collected answers render expanded in the conversation.
- **Plan-mode gating**: exposed to the LLM only in plan mode (`ListToolsForMode`), excluded from standard/auto. The `!!` tool autocomplete uses the same gating, so plan-only tools no longer leak into other modes.
- **`!!` direct execution** (testing / power-user escape hatch): `!!AskUserQuestion({...})` renders the form without an LLM turn (raw-JSON arg parser + direct-exec broker).

## Tests

Unit tests (schema/validation bounds, answer formatting, headless degrade, mode gating, state lifecycle, default/recommended selection, form rendering, autocomplete mode gating) plus a full-`ChatApplication` integration test that drives the request through `Update`, survives the agent's progress ticks, and asserts `enter` delivers the answers, clears the form, and the answers reach the LLM-facing tool result. `task build` / `test` / `lint` all green.

## Deferred (separate PRs)

- Telegram / channels IPC (`QuestionRequest`/`QuestionResponse` + `QuestionChannel`).
- Web-terminal renderer.
- Option `preview` mockups; exposing the tool outside plan mode.

## Docs

Per the feat→docs rule, a `[DOCS]` ticket for `inference-gateway/docs` is drafted (not yet filed): document the plan-mode `AskUserQuestion` tool — question/option schema, keyboard controls, plan-mode-only + headless behavior.