### PR TITLE
refactor(subagents): subagents inherit the parent chat's coding mode

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -85,6 +85,7 @@ type AgentSession struct {
 	fileService           domain.FileService
 	imageService          domain.ImageService
 	model                 string
+	agentMode             domain.AgentMode
 	conversation          []ConversationMessage
 	sessionID             string
 	maxTurns              int
@@ -102,6 +103,17 @@ type AgentSession struct {
 	totalCompletionTokens int
 	totalTokens           int
 	requestCount          int
+}
+
+// inheritedSubagentMode returns the coding mode a subagent should start in, read
+// from INFER_SUBAGENT_AGENT_MODE (set by the Agent tool when spawning from a
+// non-Standard parent). It defaults to Standard when unset or unrecognized, so
+// top-level `infer chat` / `infer agent` runs are unaffected.
+func inheritedSubagentMode() domain.AgentMode {
+	if m, ok := domain.ParseAgentMode(os.Getenv(domain.EnvSubagentAgentMode)); ok {
+		return m
+	}
+	return domain.AgentModeStandard
 }
 
 func RunAgentCommand(cfg *config.Config, modelFlag, taskDescription string, files []string, noSave bool, sessionID string, requireApproval, heartbeat, remote bool, resultFile string) (err error) {
@@ -174,7 +186,8 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 	stateManager := svc.GetStateManager()
 	pricingService := svc.GetPricingService()
 
-	stateManager.SetAgentMode(domain.AgentModeStandard)
+	agentMode := inheritedSubagentMode()
+	stateManager.SetAgentMode(agentMode)
 
 	saveEnabled := !noSave
 
@@ -185,6 +198,7 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 		fileService:      fileService,
 		imageService:     imageService,
 		model:            selectedModel,
+		agentMode:        agentMode,
 		sessionID:        newSessionID,
 		maxTurns:         cfg.Agent.MaxTurns,
 		conversation:     []ConversationMessage{},
@@ -687,19 +701,20 @@ func (s *AgentSession) processSyncResponse(response *domain.ChatSyncResponse, re
 	return nil
 }
 
-// executeToolCall runs a single tool. Headless always runs in standard mode (a
-// restricted allow-list); off-list/mutating actions are gated upstream by
-// approval_behaviour rather than by switching to the unrestricted auto mode. The
-// mode is carried on the context so the Bash tool resolves the right per-mode
-// allow-list. approved is set only after an explicit IPC approval, marking the
-// context so an off-list but user-approved command is allowed to run.
+// executeToolCall runs a single tool. Headless normally runs in standard mode (a
+// restricted allow-list) with off-list/mutating actions gated upstream by
+// approval_behaviour; when spawned by the Agent tool from a non-Standard parent
+// it inherits that mode (s.agentMode, from INFER_SUBAGENT_AGENT_MODE) instead.
+// The mode is carried on the context so the Bash tool resolves the right
+// per-mode allow-list. approved is set only after an explicit IPC approval,
+// marking the context so an off-list but user-approved command is allowed to run.
 func (s *AgentSession) executeToolCall(toolName, args string, approved bool) (*domain.ToolExecutionResult, error) {
 	var argsMap map[string]any
 	if err := json.Unmarshal([]byte(args), &argsMap); err != nil {
 		return nil, fmt.Errorf("failed to parse tool arguments: %w", err)
 	}
 
-	ctx := domain.WithModel(domain.WithAgentMode(domain.WithSessionID(context.Background(), s.sessionID), domain.AgentModeStandard), s.model)
+	ctx := domain.WithModel(domain.WithAgentMode(domain.WithSessionID(context.Background(), s.sessionID), s.agentMode), s.model)
 	if approved {
 		ctx = domain.WithToolApproved(ctx)
 	}
@@ -911,6 +926,13 @@ func (s *AgentSession) deliverApprovalRequiredTool(tc sdk.ChatCompletionMessageT
 
 // isToolApprovalRequired checks if a tool requires user approval based on config.
 func (s *AgentSession) isToolApprovalRequired(tc sdk.ChatCompletionMessageToolCall) bool {
+	// Auto-accept bypasses approval entirely, matching chat YOLO mode. A headless
+	// run only reaches this mode when spawned by the Agent tool from an
+	// auto-accept parent (via INFER_SUBAGENT_AGENT_MODE); top-level runs stay
+	// Standard and fall through to the per-mode gating below.
+	if s.agentMode == domain.AgentModeAutoAccept {
+		return false
+	}
 	if tc.Function.Name == "Bash" {
 		var args map[string]any
 		if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
@@ -920,11 +942,11 @@ func (s *AgentSession) isToolApprovalRequired(tc sdk.ChatCompletionMessageToolCa
 		if !ok {
 			return true
 		}
-		// Headless always runs in standard mode: an allowed command runs without
+		// An allowed command (per the session's mode allow-list) runs without
 		// approval; an off-list one needs approval and is then delivered per
 		// tools.safety.approval_behaviour (IPC when a broker is attached, else
 		// blocked) by deliverApprovalRequiredTool.
-		if s.config.IsBashCommandAllowed(command, "standard") {
+		if s.config.IsBashCommandAllowed(command, s.agentMode.AllowedlistKey()) {
 			return false
 		}
 	}

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -403,13 +403,13 @@ func TestExecuteToolCalls_BlocksWhenNoApprover(t *testing.T) {
 			mockToolService := &domainmocks.FakeToolService{}
 
 			cfg := &config.Config{Agent: config.AgentConfig{MaxConcurrentTools: 5}}
-			cfg.Tools.Safety.RequireApproval = true // Write needs approval
+			cfg.Tools.Safety.RequireApproval = true
 			cfg.Tools.Safety.ApprovalBehaviour = behaviour
 
 			session := &AgentSession{
 				toolService:     mockToolService,
 				config:          cfg,
-				requireApproval: false, // no IPC broker (CI/heartbeat)
+				requireApproval: false,
 			}
 
 			results := session.executeToolCalls([]sdk.ChatCompletionMessageToolCall{
@@ -434,6 +434,61 @@ func TestExecuteToolCalls_BlocksWhenNoApprover(t *testing.T) {
 	}
 }
 
+func TestInheritedSubagentMode(t *testing.T) {
+	t.Run("unset defaults to Standard", func(t *testing.T) {
+		t.Setenv("INFER_SUBAGENT_AGENT_MODE", "")
+		if got := inheritedSubagentMode(); got != domain.AgentModeStandard {
+			t.Fatalf("inheritedSubagentMode() = %v, want Standard", got)
+		}
+	})
+	t.Run("auto parses to AutoAccept", func(t *testing.T) {
+		t.Setenv("INFER_SUBAGENT_AGENT_MODE", "auto")
+		if got := inheritedSubagentMode(); got != domain.AgentModeAutoAccept {
+			t.Fatalf("inheritedSubagentMode() = %v, want AutoAccept", got)
+		}
+	})
+	t.Run("unrecognized falls back to Standard", func(t *testing.T) {
+		t.Setenv("INFER_SUBAGENT_AGENT_MODE", "bogus")
+		if got := inheritedSubagentMode(); got != domain.AgentModeStandard {
+			t.Fatalf("inheritedSubagentMode() = %v, want Standard", got)
+		}
+	})
+}
+
+// TestExecuteToolCalls_AutoAcceptBypassesApproval verifies that a headless
+// subagent inheriting Auto-Accept (via INFER_SUBAGENT_AGENT_MODE) runs an
+// approval-requiring tool without an approver attached - matching chat YOLO.
+// Contrast with TestExecuteToolCalls_BlocksWhenNoApprover, which blocks the
+// same call in the default Standard mode.
+func TestExecuteToolCalls_AutoAcceptBypassesApproval(t *testing.T) {
+	mockToolService := &domainmocks.FakeToolService{}
+	mockToolService.ExecuteToolReturns(&domain.ToolExecutionResult{ToolName: "Write", Success: true, Data: "ok"}, nil)
+
+	cfg := &config.Config{Agent: config.AgentConfig{MaxConcurrentTools: 5}}
+	cfg.Tools.Safety.RequireApproval = true
+	cfg.Tools.Safety.ApprovalBehaviour = config.ApprovalBehaviourBlock
+
+	session := &AgentSession{
+		toolService:     mockToolService,
+		config:          cfg,
+		agentMode:       domain.AgentModeAutoAccept,
+		requireApproval: false,
+	}
+
+	results := session.executeToolCalls([]sdk.ChatCompletionMessageToolCall{
+		{ID: "call_1", Function: sdk.ChatCompletionMessageToolCallFunction{
+			Name: "Write", Arguments: `{"file_path":"x","content":"y"}`,
+		}},
+	})
+
+	if mockToolService.ExecuteToolCallCount() != 1 {
+		t.Errorf("auto-accept must execute the tool, got %d calls", mockToolService.ExecuteToolCallCount())
+	}
+	if len(results) != 1 || results[0].ToolExecution == nil || !results[0].ToolExecution.Success {
+		t.Errorf("expected a successful execution result, got %+v", results)
+	}
+}
+
 // TestExecuteToolCalls_IPCApprovalExecutesWhenApproved verifies that with an IPC
 // broker attached (--require-approval) and the default prompt behaviour, an
 // approval-requiring tool is delivered over IPC and runs once the user approves.
@@ -451,7 +506,7 @@ func TestExecuteToolCalls_IPCApprovalExecutesWhenApproved(t *testing.T) {
 	session := &AgentSession{
 		toolService:     mockToolService,
 		config:          cfg,
-		requireApproval: true, // broker attached -> prompt resolves to IPC
+		requireApproval: true,
 		approvalCh:      approvalCh,
 	}
 
@@ -659,7 +714,7 @@ func TestEmitSessionStatsSuppressedWhenNoRequests(t *testing.T) {
 func TestEmitSessionStatsZeroCostWhenPricingDisabled(t *testing.T) {
 	session := &AgentSession{
 		model:                 "some/model",
-		pricingService:        fakePricing(0, 0, 0), // pricing disabled / zero cost
+		pricingService:        fakePricing(0, 0, 0),
 		config:                &config.Config{Pricing: config.PricingConfig{Currency: "USD"}},
 		totalPromptTokens:     10,
 		totalCompletionTokens: 5,

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -164,6 +164,10 @@ func StartChatSession(cfg *config.Config) error {
 	conversationOptimizer := services.GetConversationOptimizer()
 	sessionRolloverManager := services.GetSessionRolloverManager()
 
+	if mode := inheritedSubagentMode(); mode != domain.AgentModeStandard {
+		stateManager.SetAgentMode(mode)
+	}
+
 	var screenshotServer *screenshotsvc.ScreenshotServer
 
 	if cfg.ComputerUse.Enabled && cfg.ComputerUse.Screenshot.StreamingEnabled {

--- a/internal/agent/tools/agent.go
+++ b/internal/agent/tools/agent.go
@@ -36,6 +36,7 @@ type AgentTaskSpec struct {
 	Model        string
 	Files        []string
 	SystemPrompt string
+	ParentMode   domain.AgentMode
 }
 
 // AgentSubResult is the per-subagent outcome reported back to the LLM.
@@ -164,8 +165,10 @@ func (t *AgentTool) Execute(ctx context.Context, args map[string]any) (*domain.T
 
 	parentSession := domain.GetSessionID(ctx)
 	parentModel := domain.GetModel(ctx)
+	parentMode, _ := domain.AgentModeFromContext(ctx) // absent -> Standard (the zero value)
 	for i := range specs {
 		specs[i].Model = t.resolveModel(specs[i].Model, parentModel)
+		specs[i].ParentMode = parentMode
 	}
 
 	if wait {
@@ -365,6 +368,9 @@ func (t *AgentTool) buildChatPaneCommand(spec AgentTaskSpec) string {
 	if spec.SystemPrompt != "" {
 		parts = append(parts, subagentSystemPromptEnv+"="+shellQuote(spec.SystemPrompt))
 	}
+	if spec.ParentMode != domain.AgentModeStandard {
+		parts = append(parts, domain.EnvSubagentAgentMode+"="+shellQuote(spec.ParentMode.AllowedlistKey()))
+	}
 	if spec.Model != "" {
 		parts = append(parts, "INFER_AGENT_MODEL="+shellQuote(spec.Model))
 	}
@@ -378,6 +384,9 @@ func subagentExtraEnv(spec AgentTaskSpec) []string {
 	env := []string{fmt.Sprintf("%s=%d", subagentDepthEnv, currentSubagentDepth()+1)}
 	if spec.SystemPrompt != "" {
 		env = append(env, subagentSystemPromptEnv+"="+spec.SystemPrompt)
+	}
+	if spec.ParentMode != domain.AgentModeStandard {
+		env = append(env, domain.EnvSubagentAgentMode+"="+spec.ParentMode.AllowedlistKey())
 	}
 	return env
 }

--- a/internal/agent/tools/agent_test.go
+++ b/internal/agent/tools/agent_test.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
 	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
 	agentrunner "github.com/inference-gateway/cli/internal/services/agentrunner"
 	utils "github.com/inference-gateway/cli/internal/utils"
 )
@@ -152,5 +154,53 @@ func TestParseAgentTasks(t *testing.T) {
 
 	if _, err := parseAgentTasks(map[string]any{}); err == nil {
 		t.Fatalf("expected error for empty args")
+	}
+}
+
+func TestBuildChatPaneCommand_PropagatesParentMode(t *testing.T) {
+	tool := newTestAgentTool(t)
+
+	if got := tool.buildChatPaneCommand(AgentTaskSpec{ParentMode: domain.AgentModeAutoAccept}); !strings.Contains(got, "INFER_SUBAGENT_AGENT_MODE='auto'") {
+		t.Fatalf("AutoAccept parent must propagate auto mode; cmd = %q", got)
+	}
+	if got := tool.buildChatPaneCommand(AgentTaskSpec{ParentMode: domain.AgentModePlan}); !strings.Contains(got, "INFER_SUBAGENT_AGENT_MODE='plan'") {
+		t.Fatalf("Plan parent must propagate plan mode; cmd = %q", got)
+	}
+	if got := tool.buildChatPaneCommand(AgentTaskSpec{ParentMode: domain.AgentModeStandard}); strings.Contains(got, "INFER_SUBAGENT_AGENT_MODE") {
+		t.Fatalf("Standard parent must NOT emit the mode var; cmd = %q", got)
+	}
+}
+
+func TestSubagentExtraEnv_PropagatesParentMode(t *testing.T) {
+	t.Setenv("INFER_SUBAGENT_DEPTH", "")
+	if env := strings.Join(subagentExtraEnv(AgentTaskSpec{ParentMode: domain.AgentModeAutoAccept}), " "); !strings.Contains(env, "INFER_SUBAGENT_AGENT_MODE=auto") {
+		t.Fatalf("AutoAccept parent must add the mode var to headless env; got %q", env)
+	}
+	if env := strings.Join(subagentExtraEnv(AgentTaskSpec{ParentMode: domain.AgentModeStandard}), " "); strings.Contains(env, "INFER_SUBAGENT_AGENT_MODE") {
+		t.Fatalf("Standard parent must NOT add the mode var; got %q", env)
+	}
+}
+
+// TestAgentTool_InteractiveInheritsParentMode exercises the full Execute path:
+// the parent mode on the context must reach the tmux pane command.
+func TestAgentTool_InteractiveInheritsParentMode(t *testing.T) {
+	t.Setenv("INFER_SUBAGENT_DEPTH", "")
+	cfg := config.DefaultConfig()
+	cfg.Tools.Agent.Mode = "interactive"
+	cfg.Tools.Agent.Wait = true
+	tool := NewAgentTool(cfg, utils.NewSubagentTracker())
+	tool.interactiveAvailable = func() bool { return true }
+	var captured string
+	tool.launchPane = func(ctx context.Context, title, command string) (string, error) {
+		captured = command
+		return "", nil
+	}
+
+	ctx := domain.WithAgentMode(context.Background(), domain.AgentModeAutoAccept)
+	if _, err := tool.Execute(ctx, map[string]any{"description": "do x"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(captured, "INFER_SUBAGENT_AGENT_MODE='auto'") {
+		t.Fatalf("interactive subagent should inherit parent auto mode; cmd = %q", captured)
 	}
 }

--- a/internal/domain/agent_mode_test.go
+++ b/internal/domain/agent_mode_test.go
@@ -1,0 +1,24 @@
+package domain
+
+import "testing"
+
+func TestParseAgentMode_RoundTripsAllowedlistKey(t *testing.T) {
+	for _, m := range []AgentMode{AgentModeStandard, AgentModePlan, AgentModeAutoAccept} {
+		got, ok := ParseAgentMode(m.AllowedlistKey())
+		if !ok || got != m {
+			t.Fatalf("ParseAgentMode(%q) = (%v,%v), want (%v,true)", m.AllowedlistKey(), got, ok, m)
+		}
+	}
+}
+
+func TestParseAgentMode_CaseWhitespaceAndUnknown(t *testing.T) {
+	if got, ok := ParseAgentMode("  AUTO "); !ok || got != AgentModeAutoAccept {
+		t.Fatalf(`ParseAgentMode("  AUTO ") = (%v,%v), want (AutoAccept,true)`, got, ok)
+	}
+	if got, ok := ParseAgentMode("bogus"); ok || got != AgentModeStandard {
+		t.Fatalf(`ParseAgentMode("bogus") = (%v,%v), want (Standard,false)`, got, ok)
+	}
+	if got, ok := ParseAgentMode(""); ok || got != AgentModeStandard {
+		t.Fatalf(`ParseAgentMode("") = (%v,%v), want (Standard,false)`, got, ok)
+	}
+}

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -103,6 +103,23 @@ func (m AgentMode) AllowedlistKey() string {
 	}
 }
 
+// ParseAgentMode is the inverse of AllowedlistKey: it maps a mode key
+// ("standard"/"plan"/"auto") back to an AgentMode. Matching is case-insensitive
+// and tolerant of surrounding whitespace. ok is false for an empty or
+// unrecognized key, in which case callers should keep AgentModeStandard.
+func ParseAgentMode(s string) (AgentMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "standard":
+		return AgentModeStandard, true
+	case "plan":
+		return AgentModePlan, true
+	case "auto":
+		return AgentModeAutoAccept, true
+	default:
+		return AgentModeStandard, false
+	}
+}
+
 func (v ViewState) String() string {
 	switch v {
 	case ViewStateModelSelection:

--- a/internal/domain/subagent.go
+++ b/internal/domain/subagent.go
@@ -20,6 +20,13 @@ const (
 	SubagentModeInteractive = "interactive"
 )
 
+// EnvSubagentAgentMode names the environment variable the Agent tool sets to
+// carry the parent chat's coding mode (the AgentMode.AllowedlistKey form -
+// "standard"/"plan"/"auto") to a spawned subagent, so it starts in the same
+// mode as its parent. It is absent for top-level `infer chat`/`infer agent`
+// runs, which therefore stay Standard-by-default.
+const EnvSubagentAgentMode = "INFER_SUBAGENT_AGENT_MODE"
+
 // SubagentState tracks one in-flight local subagent (an `infer agent`
 // subprocess spawned by the Agent tool). It is the subagent analogue of
 // TaskPollingState: the SubagentPoller selects on ResultChan/ErrorChan to


### PR DESCRIPTION
## Summary

Subagents spawned by the `Agent` tool now start in the **same coding mode** (Standard / Plan / Auto-Accept) as the parent chat that spawned them, instead of always Standard. This applies to **both** surfaces — the interactive `infer chat` tmux pane and the headless `infer agent` subprocess fallback.

Motivation: if you're in Auto-Accept and delegate to a subagent, the subagent should also be in Auto-Accept rather than silently dropping back to Standard.

## How it works

- The mode travels via a single env var, `INFER_SUBAGENT_AGENT_MODE` (the `AllowedlistKey` form — `standard`/`plan`/`auto`), emitted by the Agent tool **only when the parent is non-Standard**.
- Shared pieces in `internal/domain`: `ParseAgentMode` (inverse of `AllowedlistKey`) and the `EnvSubagentAgentMode` constant.
- Both entry points read it at startup and set the mode on the session before any tools run: `cmd/chat.go::StartChatSession` (interactive) and `cmd/agent.go` (headless).
- Headless honours an inherited Auto-Accept by bypassing approval like chat YOLO — otherwise non-Bash mutating tools (Write/Edit) would still block and the subagent would be only "half" in auto mode.

## Security scoping

Top-level `infer agent` runs (CI, heartbeat, channels-manager, manual) **never** set the env var, so they stay **Standard-by-default** — unchanged. The relaxation is confined to subagents spawned from an Auto-Accept session. Since Plan mode filters the `Agent` tool out of the toolset, the only behaviour-changing case in practice is **Auto-Accept → Auto-Accept**.

## Test plan

- `go test ./...` green; `golangci-lint run` reports 0 issues.
- New tests cover: `ParseAgentMode` round-trip / case / unknown; both env-emission paths (`buildChatPaneCommand`, `subagentExtraEnv`); the full interactive `Execute` path; `inheritedSubagentMode`; and the headless Auto-Accept approval bypass (contrasted with the existing blocks-when-no-approver test, which still passes for Standard).

### Manual check
Inside tmux: set chat to Auto-Accept (shift+tab), spawn a subagent — the new pane's `infer chat` opens already showing `▸ AUTO` and runs without approval prompts.
