### PR TITLE
docs(skills): add charm v2 skills (bubbletea, lipgloss, bubbles)

### DIFF
--- a/.agents/skills/bubbles-v2/SKILL.md
+++ b/.agents/skills/bubbles-v2/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: bubbles-v2
+description: >
+  Use the Bubbles v2 component library for Bubble Tea v2 (charm.land/bubbles/v2):
+  viewport, textinput/textarea, spinner, progress, list, table, key, help. Use when
+  adding or reviewing prebuilt TUI components — scrollable viewports, text inputs,
+  spinners, progress bars, key bindings and help — with this stack. Each component is
+  a sub-model you embed and delegate to; v2 constructors and key handling differ from
+  v1, so lead with the contract and the v1->v2 table.
+license: Apache-2.0
+---
+
+# Bubbles v2
+
+Prebuilt components for Bubble Tea v2. Import `charm.land/bubbles/v2/<component>`;
+pinned to v2.1.0. Each component is itself a small Bubble Tea model that you embed in
+your own model and delegate to.
+
+## The component contract
+
+Every bubble has `New(...)`, an `Update(tea.Msg) (Model, tea.Cmd)` that returns its
+**concrete** type, and `View() string`. Embed it, delegate in `Update` (reassign the
+field and collect the cmd), and place its view:
+
+```go
+import (
+    tea "charm.land/bubbletea/v2"
+    "charm.land/bubbles/v2/spinner"
+    "charm.land/bubbles/v2/viewport"
+    "charm.land/lipgloss/v2"
+)
+
+type model struct {
+    vp viewport.Model
+    sp spinner.Model
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    var cmds []tea.Cmd
+    var cmd tea.Cmd
+
+    m.vp, cmd = m.vp.Update(msg) // reassign — dropping it loses state
+    cmds = append(cmds, cmd)
+    m.sp, cmd = m.sp.Update(msg)
+    cmds = append(cmds, cmd)
+
+    return m, tea.Batch(cmds...)
+}
+
+func (m model) View() tea.View {
+    // components return string; compose, then wrap ONCE at the root
+    body := lipgloss.JoinVertical(lipgloss.Left, m.sp.View(), m.vp.View())
+    return tea.NewView(body)
+}
+```
+
+That last step is the integration key: components produce **strings**; only the root
+model wraps the composed string in `tea.NewView` (see **bubbletea-v2**).
+
+## v2 vs the v1 you remember
+
+| Topic | v1 | v2 |
+| --- | --- | --- |
+| Import | `github.com/charmbracelet/bubbles/...` | `charm.land/bubbles/v2/...` |
+| Constructors | positional, e.g. `viewport.New(w, h)` | functional options: `viewport.New(viewport.WithWidth(w), ...)` |
+| Default keymap | `DefaultKeyMap` variable | `DefaultKeyMap()` function |
+| Sizing | public `Width`/`Height` fields | `SetWidth`/`SetHeight` methods |
+| Keys | `tea.KeyMsg` | `tea.KeyPressMsg`; `key.Matches` is generic over `fmt.Stringer` |
+| Styling | Lip Gloss v1 | Lip Gloss v2 (`Color()` func, `LightDark`) |
+
+## Components you'll reach for
+
+| Component | Purpose | Construct / must-know |
+| --- | --- | --- |
+| `viewport` | scrollable region | `New(WithWidth(w), WithHeight(h))`; `SetContent`, `SetWidth/SetHeight`, `DefaultKeyMap()` |
+| `textinput` | one-line input | `New()`; `Focus() tea.Cmd`, `Blur()`, `Value()`, `SetValue()` |
+| `textarea` | multi-line input | `New()`; `Focus()`, `Value()`, `SetWidth/SetHeight` |
+| `spinner` | activity indicator | `New(WithSpinner(spinner.Dot))`; start with its `Tick` |
+| `progress` | progress bar | `New(WithDefaultBlend())`; static `ViewAs` vs animated `SetPercent` |
+| `list` | filterable list | `New(items, delegate, width, height)` (positional) |
+| `table` | data grid | `New(WithColumns(...), WithRows(...))` |
+| `key` | key bindings | `NewBinding(WithKeys("q"), WithHelp("q","quit"))`; `key.Matches(msg, b)` |
+| `help` | keymap help line | `New()`; renders short/full help from your keymap |
+
+## Notes on the common ones
+
+**viewport** — size on resize, then set content:
+
+```go
+case tea.WindowSizeMsg:
+    m.vp.SetWidth(msg.Width)
+    m.vp.SetHeight(msg.Height - headerH)
+// elsewhere:
+m.vp.SetContent(body)
+```
+
+**spinner** — animation is a self-perpetuating command; kick it off in `Init` and let
+its `TickMsg` flow back through the component's `Update`:
+
+```go
+func (m model) Init() tea.Cmd { return m.sp.Tick }
+```
+
+**progress** — two modes. Static: `m.pr.ViewAs(0.4)` renders a bar at a percentage you
+own. Animated: `cmd := m.pr.SetPercent(0.4)`, then route `progress.FrameMsg` through
+`m.pr.Update`.
+
+**key + help** — define a keymap of `key.Binding`s, match with
+`key.Matches(msg, m.keys.Up)`, and let `help` render it (implement `ShortHelp` /
+`FullHelp` on your keymap).
+
+## Best practices & gotchas
+
+- Always reassign the component (`m.vp, cmd = m.vp.Update(msg)`) and `tea.Batch` the
+  cmds — dropping either loses state or stops animation.
+- Set component sizes from `tea.WindowSizeMsg`; account for borders/margins you wrap
+  around them.
+- Manage focus: exactly one input `Focus()`ed at a time; `Blur()` the rest. `Focus()`
+  returns a `tea.Cmd` — don't drop it.
+- Constructors take options now: `viewport.New(w, h)` won't compile; use `WithWidth`/
+  `WithHeight`. (`list.New` is the exception — still positional.)
+- `DefaultKeyMap` is a call now: `viewport.DefaultKeyMap()`.
+
+Pairs with **bubbletea-v2** (the runtime) and **lipgloss-v2** (styling components).
+Pinned to bubbles v2.1.0.

--- a/.agents/skills/bubbletea-v2/SKILL.md
+++ b/.agents/skills/bubbletea-v2/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: bubbletea-v2
+description: >
+  Build and review Bubble Tea v2 terminal UIs in Go (charm.land/bubbletea/v2) —
+  The Elm Architecture: a tea.Model with Init/Update/View plus tea.Cmd/tea.Msg.
+  Use whenever writing or reviewing a TUI, a tea.Model, Update/View methods,
+  commands, key/mouse handling, or full-screen terminal apps with this stack,
+  even if "Bubble Tea" isn't named. v2's API differs sharply from v1 — lead with
+  the v1->v2 table so you don't write v1 code that won't compile.
+license: Apache-2.0
+---
+
+# Bubble Tea v2
+
+The Elm-Architecture TUI runtime. Import `charm.land/bubbletea/v2` (alias `tea`);
+pinned to v2.0.7. State lives in a `Model`; messages drive `Update`, which returns
+a new model and optional commands; `View` renders. The biggest risk here is v1
+muscle memory, so start with what changed.
+
+## v2 vs the v1 you remember
+
+| Topic | v1 | v2 |
+| --- | --- | --- |
+| Import | `github.com/charmbracelet/bubbletea` | `charm.land/bubbletea/v2` |
+| `View()` returns | `string` | **`tea.View`** (wrap via `tea.NewView(s)`) |
+| Full-screen / mouse | `WithAltScreen()` / `WithMouseCellMotion()` opts | **View fields** `v.AltScreen=true`, `v.MouseMode` (opts gone) |
+| Cursor / title / focus | imperative cmds | View fields: `v.Cursor`, `v.WindowTitle`, `v.ReportFocus` |
+| Keys | `tea.KeyMsg` struct (`msg.Type`, `msg.Runes`) | **`tea.KeyPressMsg`** / `KeyReleaseMsg`; match `msg.String()` |
+| Quit | `return m, tea.Quit` | same — `tea.Quit` is a `Cmd`, pass it, don't call it |
+
+## The Model interface (exact v2)
+
+```go
+type Model interface {
+    Init() tea.Cmd                       // initial command, or nil
+    Update(tea.Msg) (tea.Model, tea.Cmd) // handle a message → new model + command
+    View() tea.View                      // render — note: tea.View, NOT string
+}
+```
+
+## Minimal program
+
+```go
+package main
+
+import (
+    "fmt"
+
+    tea "charm.land/bubbletea/v2"
+)
+
+type model struct{ count int }
+
+func (m model) Init() tea.Cmd { return nil }
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.KeyPressMsg:
+        switch msg.String() {
+        case "q", "ctrl+c":
+            return m, tea.Quit // tea.Quit is a Cmd — pass it, never tea.Quit()
+        case "+":
+            m.count++
+        }
+    }
+    return m, nil
+}
+
+func (m model) View() tea.View {
+    return tea.NewView(fmt.Sprintf("count: %d  (+ add, q quit)\n", m.count))
+}
+
+func main() {
+    if _, err := tea.NewProgram(model{}).Run(); err != nil {
+        panic(err)
+    }
+}
+```
+
+## Control the terminal via the View (not program options)
+
+In v2 the `View` struct carries terminal state. Build it, set fields, return it:
+
+```go
+func (m model) View() tea.View {
+    v := tea.NewView(m.render())
+    v.AltScreen = true                    // full-screen (alternate buffer)
+    v.MouseMode = tea.MouseModeCellMotion // or MouseModeAllMotion / MouseModeNone
+    v.WindowTitle = "my app"
+    v.ReportFocus = true                  // deliver FocusMsg / BlurMsg
+    v.Cursor = tea.NewCursor(m.cx, m.cy)  // *tea.Cursor; nil hides it
+    return v
+}
+```
+
+`WithAltScreen`, `WithMouseCellMotion`, `WithMouseAllMotion`, `WithReportFocus` no
+longer exist. The real `tea.NewProgram` options are `WithContext`, `WithInput`,
+`WithOutput`, `WithFPS`, `WithFilter`, `WithColorProfile`, `WithWindowSize`,
+`WithEnvironment`, `WithoutSignalHandler`, `WithoutRenderer`, `WithoutCatchPanics`.
+
+## Commands & messages
+
+A `tea.Cmd` is `func() tea.Msg` — the only place to do I/O. Never mutate the model
+from a bare goroutine; return a command and handle its message in `Update`.
+
+```go
+type gotData struct {
+    body string
+    err  error
+}
+
+func fetch(url string) tea.Cmd {
+    return func() tea.Msg {
+        resp, err := http.Get(url)
+        if err != nil {
+            return gotData{err: err}
+        }
+        defer resp.Body.Close()
+        b, _ := io.ReadAll(resp.Body)
+        return gotData{body: string(b)}
+    }
+}
+```
+
+- `tea.Batch(c1, c2)` runs commands concurrently; `tea.Sequence(c1, c2)` in order.
+- `tea.Tick(d, fn)` / `tea.Every(d, fn)` are timers (`fn` returns a `tea.Msg`).
+- `tea.Quit` exits; `tea.Printf` / `tea.Println` print above the UI.
+- From outside the loop, push messages with `p.Send(msg)`.
+
+## Input
+
+- Keys: `case tea.KeyPressMsg:` then `switch msg.String()` (`"enter"`, `"ctrl+c"`,
+  `"a"`, `"shift+tab"`, …). `KeyReleaseMsg` only arrives with keyboard enhancements.
+- Resize: `case tea.WindowSizeMsg: m.w, m.h = msg.Width, msg.Height` — propagate to
+  child components.
+- Mouse: `tea.MouseClickMsg`, `MouseReleaseMsg`, `MouseMotionMsg`, `MouseWheelMsg`
+  (all satisfy `tea.MouseMsg`); sent only when `v.MouseMode != MouseModeNone`.
+- Focus/paste: `tea.FocusMsg` / `tea.BlurMsg` (needs `v.ReportFocus`), `tea.PasteMsg`.
+- Light/dark: return `tea.RequestBackgroundColor` from `Init`, handle
+  `tea.BackgroundColorMsg` (`msg.IsDark()`), rebuild styles — see **lipgloss-v2**.
+
+## Best practices
+
+- Keep `Update`/`View` pure and fast; offload I/O and sleeps to commands (a
+  `time.Sleep` in `Update` freezes the UI — use `tea.Tick`).
+- Compose: give each child its own model and have the parent delegate (route
+  messages down, join views) — see **bubbles-v2** for the embed-and-delegate pattern.
+- Value receivers are idiomatic; the runtime swaps in whatever model you return, so
+  always return the updated copy.
+- Cancel cleanly with `tea.NewProgram(m, tea.WithContext(ctx))`.
+
+## Gotchas
+
+- `View()` must return `tea.View` — wrap your string with `tea.NewView(...)`.
+- Return `tea.Quit` (a `Cmd`); calling `tea.Quit()` yields a `Msg` and is wrong here.
+- Never call another model's `Update` directly, and never touch the model from a
+  goroutine — return a command instead.
+- `tea.Batch` is unordered; use `tea.Sequence` when order matters.
+- Reaching for `tea.WithAltScreen()`? Gone — set `v.AltScreen = true` in the View.
+
+Pairs with **lipgloss-v2** (styling the strings in your View) and **bubbles-v2**
+(prebuilt components). Pinned to bubbletea v2.0.7 — verify against the installed
+module, not v1 memory.

--- a/.agents/skills/lipgloss-v2/SKILL.md
+++ b/.agents/skills/lipgloss-v2/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: lipgloss-v2
+description: >
+  Style and lay out terminal output in Go with Lip Gloss v2 (charm.land/lipgloss/v2)
+  — styles, colors, borders, layout joins, and tables. Use when writing or reviewing
+  terminal styling: foreground/background colors, padding/border/width, JoinHorizontal/
+  JoinVertical, Place, or lipgloss/v2/table, usually alongside Bubble Tea v2. v2's
+  color and renderer model changed sharply from v1 — lead with the v1->v2 table so you
+  don't reach for AdaptiveColor or a global renderer that no longer exist.
+license: Apache-2.0
+---
+
+# Lip Gloss v2
+
+Declarative terminal styling and layout. Import `charm.land/lipgloss/v2` (alias
+`lipgloss`); pinned to v2.0.4. Styles are immutable values you build once and reuse.
+The sharp break from v1 is the color/renderer model, so start there.
+
+## v2 vs the v1 you remember
+
+| Topic | v1 | v2 |
+| --- | --- | --- |
+| Import | `github.com/charmbracelet/lipgloss` | `charm.land/lipgloss/v2` |
+| Color | `lipgloss.Color` is a string type | `lipgloss.Color(s)` is a **func** → `image/color.Color` |
+| Renderer | global default renderer, `SetColorProfile` | none — styles are pure values; downsampling at print / Bubble Tea |
+| Adaptive | `lipgloss.AdaptiveColor{Light,Dark}` | gone from root → `lipgloss.LightDark(isDark)(l,d)` or `compat.AdaptiveColor` |
+| Dark-bg detect | `HasDarkBackground()` (no args) | `HasDarkBackground(in, out)` or Bubble Tea `BackgroundColorMsg` |
+| Print | `fmt.Println(s.Render(...))` | `lipgloss.Println(...)` so color degrades to the terminal |
+
+## Styles
+
+Immutable — each setter returns a copy. Build once at package/model scope, reuse:
+
+```go
+var title = lipgloss.NewStyle().
+    Bold(true).
+    Foreground(lipgloss.Color("#7D56F4")).
+    Background(lipgloss.Color("236")).
+    Padding(0, 1).
+    Border(lipgloss.RoundedBorder()).
+    BorderForeground(lipgloss.Color("63")).
+    Width(40)
+
+out := title.Render("Hello")
+```
+
+Common setters: `Bold/Italic/Faint/Underline/Reverse`, `Foreground/Background`,
+`Padding/Margin` (1–4 ints, CSS order), `Width/Height/MaxWidth`,
+`Align/AlignHorizontal/AlignVertical`, `Border/BorderForeground`, `Inline`. Compose
+shared rules with `.Inherit(base)`.
+
+## Color
+
+`lipgloss.Color(s)` accepts ANSI (`"9"`), 256 (`"201"`), or truecolor (`"#04B575"`)
+and returns a standard `color.Color`:
+
+```go
+fg := lipgloss.Color("#04B575")
+```
+
+Adaptive light/dark — `AdaptiveColor` is gone from the root package. Choose by
+background instead:
+
+```go
+dark := lipgloss.HasDarkBackground(os.Stdin, os.Stdout) // standalone programs
+ld := lipgloss.LightDark(dark)
+fg := ld(lipgloss.Color("#333"), lipgloss.Color("#eee")) // ld(light, dark)
+```
+
+Inside Bubble Tea v2 don't query stdio yourself: return `tea.RequestBackgroundColor`
+from `Init`, handle `tea.BackgroundColorMsg` (`msg.IsDark()`), and rebuild styles via
+`LightDark`. For a quick v1 port, `compat.AdaptiveColor{Light, Dark}` still works
+(reads stdio globally, like v1). Color-profile degradation is automatic when you
+print via `lipgloss.Println`/`Print`/`Sprint` (standalone) or render inside Bubble
+Tea; for explicit control use `lipgloss.Complete(profile)`.
+
+## Layout
+
+```go
+row := lipgloss.JoinHorizontal(lipgloss.Top, left, right)    // align on cross axis
+col := lipgloss.JoinVertical(lipgloss.Center, head, body)
+banner := lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, box)
+```
+
+Measure rendered strings with `lipgloss.Width` / `Height` / `Size` — they ignore ANSI
+escapes and count wide runes correctly. **Never size styled text with `len(s)`.**
+
+## Borders
+
+`NormalBorder()`, `RoundedBorder()`, `ThickBorder()`, `DoubleBorder()`,
+`HiddenBorder()` (for spacing), or a custom `lipgloss.Border{...}`. Control sides and
+color with `BorderTop(true)`, `BorderForeground(c)`, `BorderTopForeground(c)`.
+
+## Tables (`charm.land/lipgloss/v2/table`)
+
+```go
+import "charm.land/lipgloss/v2/table"
+
+t := table.New().
+    Headers("NAME", "LANG").
+    Row("Bubble Tea", "Go").
+    Row("Lip Gloss", "Go").
+    Border(lipgloss.RoundedBorder()).
+    StyleFunc(func(row, col int) lipgloss.Style {
+        if row == table.HeaderRow { // HeaderRow == -1
+            return header
+        }
+        return cell
+    })
+
+fmt.Println(t) // *table.Table is a Stringer
+```
+
+## Best practices & gotchas
+
+- Define styles once; building a `NewStyle()` chain inside `View()` every frame is
+  wasteful.
+- Size with `lipgloss.Width`, not `len` — ANSI codes and wide glyphs make byte length
+  wrong.
+- Standalone output: print with `lipgloss.Println` so truecolor degrades on limited
+  terminals. Inside Bubble Tea, just return the styled string from your View.
+- Don't look for `AdaptiveColor`, `SetColorProfile`, or a `Renderer` — use
+  `LightDark`, explicit `Complete`, or the `compat` package.
+
+Pairs with **bubbletea-v2** (the View you style) and **bubbles-v2** (components you
+theme). Pinned to lipgloss v2.0.4.


### PR DESCRIPTION
Part of #657.

Adds three **v2-pinned** Charm skills under `.agents/skills/`, distilled from charmbracelet's own docs/examples (not our code) for the stack the project actually uses via the `charm.land/<lib>/v2` import path.

| Skill | Library | Covers |
| --- | --- | --- |
| `bubbletea-v2` | `charm.land/bubbletea/v2` v2.0.7 | The Elm Architecture (`Model`/`Init`/`Update`/`View`), the `tea.View` struct, commands & messages, input, program options |
| `lipgloss-v2` | `charm.land/lipgloss/v2` v2.0.4 | Styles, the `Color()`/`LightDark` color model, layout joins, borders, tables |
| `bubbles-v2` | `charm.land/bubbles/v2` v2.1.0 | The embed-and-delegate contract + component cheat-table (viewport, textinput, spinner, progress, key, help) |

Each **leads with a "v2 vs the v1 you remember" correction table** — the highest-value part, since agents default to v1 idioms that don't compile on this stack. Every signature was **verified against the installed module cache**, which caught real traps:

- `View()` returns **`tea.View`** (not `string`); wrap with `tea.NewView(s)`
- full-screen / mouse are **View fields** (`v.AltScreen`, `v.MouseMode`) — the `WithAltScreen()` / `WithMouseCellMotion()` options were removed
- keys are **`tea.KeyPressMsg`** (`KeyMsg` is now an interface)
- `lipgloss.Color()` is a **func → `image/color.Color`**; `AdaptiveColor` gone → `LightDark()`
- bubbles use **functional-options** constructors; `key.Matches` is generic
- `tea.Quit` is a `Cmd` you pass, not call

Per #657's "core trio, not too many", glamour/huh/fang (2/1/1 files) were intentionally left out. Docs-only; markdownlint clean.

## Acceptance criteria (#657)
- [x] Skills directory under `.agents/skills/*`
- [x] A skill for the charm Bubble Tea framework (+ lipgloss & bubbles)
- [x] Skills added from the curated set (go-concurrency in #663 + these 3 = 4)
- [ ] Tested locally with agents
- [ ] Default system prompt adjusted (if applicable)
- [ ] Follow-ups created for any broken/partial skills

Leaving the issue open for local testing and any follow-ups.