### PR TITLE
docs(skills): add Go skills adapted from spf13/go-skills

### DIFF
--- a/.agents/skills/cobra-viper/SKILL.md
+++ b/.agents/skills/cobra-viper/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: cobra-viper
+description: >
+  Build and review Go CLI apps with Cobra and Viper (both used heavily here) -
+  command-first architecture, RunE error handling, PersistentPreRunE setup, flag
+  design, typed-struct config, the flag/env/file/default precedence hierarchy, and
+  in-memory command tests. Use when adding commands or flags, wiring Viper config
+  or env binding, or reviewing any cmd/ code. Distilled from spf13/go-skills (by
+  Cobra's and Viper's author) and adapted to this repo's config layering.
+license: Apache-2.0
+---
+
+# Go CLI Architecture: Cobra & Viper
+
+Treat the binary as a **router for commands**: Cobra owns flags, args, and
+routing; your business logic stays unaware of the CLI and stays testable. Viper is
+the single source of truth that merges defaults, config files, env vars, and flags
+into one typed config before the app runs.
+
+## Command-first architecture
+
+`cmd/` files do exactly three things: (1) define the command + help, (2) bind its
+flags/config, (3) call into a domain package, passing the parsed config and the
+command context. Your core packages must have **zero** imports of `cobra` or
+`viper`.
+
+```go
+package main
+
+import "github.com/you/app/cmd"
+
+func main() { cmd.Execute() } // main.go is this small
+```
+
+> **In this repo:** `cmd/` is the thin Cobra layer; all logic lives under
+> `internal/` behind a DI **service container** - commands fetch services via
+> container accessors, not by importing cobra/viper into business code. The
+> surviving rule is "`cmd/` holds no business logic," **not** "avoid `internal/`."
+
+## Cobra essentials
+
+**Use `RunE`, not `Run`** - return errors up the chain instead of `log.Fatal`
+(which skips defers). Pass `cmd.Context()` down so `Ctrl+C`/`SIGINT` cancels work.
+
+```go
+var serveCmd = &cobra.Command{
+    Use:   "serve",
+    Short: "Start the server",
+    RunE: func(cmd *cobra.Command, args []string) error {
+        if err := engine.Run(cmd.Context(), args); err != nil {
+            return fmt.Errorf("serve: %w", err)
+        }
+        return nil
+    },
+}
+```
+
+**Silence noise on runtime errors** so a network timeout doesn't dump usage text:
+
+```go
+rootCmd := &cobra.Command{
+    Use:           "myapp",
+    SilenceUsage:  true, // no help-dump on a runtime failure
+    SilenceErrors: true, // main.go prints the error itself
+}
+```
+
+**`PersistentPreRunE`** on root runs setup (logging, validation) after flags parse
+but before any subcommand. Cobra runs it for every subcommand; if a child defines
+its own, call the parent's explicitly - Cobra does not chain them.
+
+**Flags:** `PersistentFlags()` for cross-cutting options (config, verbosity,
+output); `Flags()` for command-local ones; `MarkFlagRequired` /
+`MarkFlagsMutuallyExclusive` for validation; always offer short flags for common
+options. Cobra generates shell completion (`myapp completion zsh|bash|fish`) for
+free; add `RegisterFlagCompletionFunc` for flag-value completion.
+
+## Viper: merge sources into a typed struct
+
+**Don't** scatter `viper.GetString("db.host")` through business logic - that
+couples your domain to Viper and spreads magic strings. Unmarshal once, at the
+routing layer, into a typed struct and pass it down.
+
+```go
+type Config struct {
+    Host string `mapstructure:"host"`
+    Port int    `mapstructure:"port"`
+}
+
+var cfg Config
+if err := viper.Unmarshal(&cfg); err != nil {
+    return fmt.Errorf("decoding config: %w", err)
+}
+```
+
+**Precedence** (highest to lowest): explicit `Set` -> flags (`BindPFlag`) -> env
+(`AutomaticEnv`) -> config file -> `SetDefault`. Each source is opt-in; bind env
+explicitly for containers, and map nested keys with a replacer:
+
+```go
+viper.SetEnvPrefix("myapp")
+viper.AutomaticEnv()
+viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_")) // serve.addr -> MYAPP_SERVE_ADDR
+```
+
+> **In this repo:** config is assembled in `cmd/root.go::initConfig`, layered
+> **defaults -> `~/.infer/config.yaml` -> `./.infer/config.yaml` -> flags ->
+> `INFER_*` env (env wins)**, and **split across files by concern**
+> (`config.yaml`, `prompts.yaml`, `channels.yaml`, `mcp.yaml`, ...). The prefix is
+> `INFER`, the replacer is `strings.NewReplacer(".", "_")`, and two list vars
+> (`INFER_A2A_AGENTS`, `INFER_TOOLS_BASH_ALLOW_APPEND`) are parsed with
+> `parseDelimitedList`. The typed target is the `Config` struct in
+> `config/config.go` - extend that; don't sprinkle `viper.Get*` through services.
+
+## Test commands in memory
+
+Cobra commands are structs - test them directly; never shell out to a compiled
+binary (`os/exec` is slow, brittle, and hides coverage).
+
+```go
+func TestServe(t *testing.T) {
+    viper.Reset() // Viper is a global singleton - reset between tests
+
+    buf := new(bytes.Buffer)
+    cmd := newServeCmd() // a factory beats a package var for isolation
+    cmd.SetOut(buf)
+    cmd.SetErr(buf)
+    cmd.SetArgs([]string{"--port", "9090"})
+
+    if err := cmd.Execute(); err != nil {
+        t.Fatalf("execute: %v", err)
+    }
+}
+```
+
+## Common mistakes
+
+- **Reading Viper too early** - values are empty until `cobra.OnInitialize`
+  callbacks run; don't read it in `init()` or `var` blocks.
+- **Forgetting `BindPFlag`** - flags aren't visible to Viper until bound.
+- **Missing `SetEnvKeyReplacer`** - `serve.addr` won't match `MYAPP_SERVE_ADDR`.
+- **Cobra/Viper in business logic** - pass a typed config struct down instead.
+- **Racing on global command/Viper state** in parallel tests - use factories +
+  `viper.Reset()`.
+- **Over-nesting subcommands** - two levels (`app cmd sub`) is usually the limit.
+
+---
+
+*Adapted from [spf13/go-skills](https://github.com/spf13/go-skills) (MIT, by Steve
+Francia - author of Cobra and Viper), reconciled with this repo's config layering
+and DI container. Pairs with **go** and **go-spec-reviewer**.*

--- a/.agents/skills/go-spec-reviewer/SKILL.md
+++ b/.agents/skills/go-spec-reviewer/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: go-spec-reviewer
+description: >
+  Review a Go design spec before implementation begins - dispatch a subagent that
+  checks a design doc for completeness, consistency, and idiomatic Go (simplicity,
+  small consumer-defined interfaces, explicit wrapped errors, context propagation)
+  plus Cobra/Viper conventions where applicable. Use when a user has a Go spec to
+  review, asks "is this spec ready?", or is about to implement from a written
+  design. Distilled from spf13/go-skills and adapted to this repo's conventions.
+license: Apache-2.0
+---
+
+# Go Spec Reviewer
+
+Dispatch a subagent to verify a Go **design spec is complete, consistent, and
+idiomatic before implementation begins** - the cheapest place to catch a flawed
+design. The reviewer channels Rob Pike, the stdlib authors, and spf13: reject
+needless abstraction, demand explicit error handling and context propagation,
+expect the simplest design that works. It complements plan mode with a focused
+spec gate.
+
+## When to use
+
+- A spec or design doc to review, or the question "is this spec ready?"
+- About to implement from a written spec
+- A technical review of a planned feature before any code is written
+
+## How to dispatch
+
+Spawn a `general-purpose` subagent (the **Agent** tool) pointed at the spec file,
+with the prompt below. It returns **Status / Issues / Recommendations** - it does
+not edit code.
+
+```text
+You are a Go spec reviewer. Verify this spec is complete and ready for
+implementation, through the lens of idiomatic Go.
+
+Think like Rob Pike: is it simple, doing one thing well?
+Think like the stdlib authors: small interfaces, defined at the point of use?
+Think like spf13: if it's a CLI, does it follow Cobra/Viper conventions?
+
+Spec to review: <SPEC_FILE_PATH>
+
+Step 1 - Codebase context. Before reviewing, explore the repo for conventions and
+conflicts: list packages under internal/ and cmd/; for a Cobra CLI, scan cmd/ for
+package-level flag vars (all cmd files share one package -> name collisions); check
+cmd/root.go for command registration; note existing types/interfaces the spec
+should reuse rather than reinvent.
+
+Step 2 - Go philosophy:
+| Concern     | Look for |
+| ----------- | -------- |
+| Simplicity  | layers/abstractions with one implementation; over-engineering |
+| Interfaces  | consumer-defined? small (1-3 methods)? real polymorphism? |
+| Errors      | returned explicitly, wrapped with %w, never silently swallowed? |
+| Context     | ctx threaded through I/O and long calls? timeouts set? |
+| Concurrency | goroutines with clear ownership and a stop condition? races? |
+| Packages    | one clear purpose each? new package justified vs extending one? |
+| Naming      | short, no stutter (pkg.PkgThing)? |
+| YAGNI       | driven by stated requirements, not speculative futures? |
+
+Step 3 - Cobra/Viper (skip if not a CLI):
+| Concern      | Look for |
+| ------------ | -------- |
+| Flag naming  | package-level flag vars unique across cmd/ (one shared package) |
+| Registration | new subcommands added in cmd/root.go via AddCommand? |
+| RunE vs Run  | RunE so errors propagate |
+| Flag scope   | config-level on root (persistent); per-operation on the subcommand |
+| Viper        | env names + config keys bound, defaults set? |
+
+Step 4 - Completeness:
+| Category     | Look for |
+| ------------ | -------- |
+| Completeness | TODO/TBD/placeholders, missing error paths |
+| Consistency  | contradictions, types named differently across sections |
+| Clarity      | ambiguity that would make two implementors build different things |
+| Scope        | one focused implementation, not several subsystems |
+| Security     | user input sanitized before shell/path/external use? |
+
+Calibration: only flag issues that would cause real implementation problems - a
+missing error path, a flag collision that won't compile, an abstraction that adds
+complexity without enabling anything. Skip wording and formatting nits. Respect
+THIS repo's established conventions (the internal/ domain-infra-services split, the
+DI container, counterfeiter-generated mocks, the per-mode bash allow-list,
+pluggable storage backends) - judge idiomaticity within them; do not flag the
+chosen architecture itself as a defect. Approve unless gaps would lead to a flawed
+or incomplete implementation.
+
+Output:
+## Go Spec Review
+Status: Approved | Issues Found
+Issues (if any):
+- [Section X]: [specific issue] - [why it matters for implementation]
+Recommendations (advisory, non-blocking):
+- [correctness / idiomaticity / clarity suggestions]
+```
+
+---
+
+*Adapted from [spf13/go-skills](https://github.com/spf13/go-skills) (MIT, by Steve
+Francia) for this repo's local subagent tooling and conventions. Pairs with **go**
+and **cobra-viper**.*

--- a/.agents/skills/go/SKILL.md
+++ b/.agents/skills/go/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: go
+description: >
+  Idiomatic Go - package and interface design, error wrapping, table-driven
+  tests, generics, the modern standard library (slices/maps/cmp/errors.Join),
+  current syntax, and logging discipline. Use when writing, reviewing, or
+  refactoring any Go code, especially code drifting toward Java/Spring shapes
+  (deep layer trees, generic repositories, heavy frameworks) - even if the user
+  never says "idiomatic". Distilled from spf13/go-skills and adapted to this repo.
+license: Apache-2.0
+---
+
+# Idiomatic Go
+
+Write Go that is **boring in the best way** - direct, predictable, obvious on the
+first read. *Clear is better than clever.* The common failure mode (and the LLM
+default) is importing Java/Spring habits - deep layer trees, generic
+repositories, heavy frameworks, manual worker pools - into a language built for
+flat, simple, discoverable APIs. When in doubt, delete the abstraction.
+
+## Core principles
+
+**Clear is better than clever.** If a function's control flow takes three reads to
+follow, rewrite it. Keep the happy path un-indented: handle errors and edge cases
+first and `return`.
+
+```go
+func GetUser(id string) (*User, error) {
+    user, err := db.FindUser(id)
+    if err != nil {
+        return nil, fmt.Errorf("finding user %s: %w", id, err)
+    }
+    return user, nil // happy path stays at the left margin
+}
+```
+
+**Make the zero value useful.** Design types so the zero value works without a
+constructor - `sync.Mutex` and `bytes.Buffer` are the gold standard.
+
+```go
+type Counter struct {
+    mu    sync.Mutex // usable at the zero value - no New() needed
+    count int
+}
+
+func (c *Counter) Inc() { c.mu.Lock(); c.count++; c.mu.Unlock() }
+```
+
+## Packages: flat, named for what they do
+
+Start flat; add a package only when a domain earns a namespace. Name packages by
+**what they do** (`auth`, `billing`, `jobs`), never by what *layer* they are
+(`service`, `repository`, `controller`) - layer-named packages breed circular
+imports and interface bloat and add zero clarity in Go. No `utils/`, `helpers/`,
+or `common/` junk drawers; they signal unclear ownership. Packages don't import
+each other sideways - cycles mean wrong boundaries; the composition root wires them.
+
+> **In this repo:** code lives under `internal/` in a deliberate **domain** (pure
+> interfaces) / **infra** (adapters) / **services** (business logic) split, wired
+> by a DI container (`internal/container/container.go`). That *is* this project's
+> structure - follow it; don't "flatten `internal/`." spf13's transferable rules
+> still hold: name by purpose, no junk-drawer packages, wire at the composition
+> root (here, the container).
+
+## Interfaces: discovered, not designed
+
+Write concrete types first. Introduce an interface only when a consumer genuinely
+needs to swap implementations, and define it **in the consuming package**, kept
+small (`io.Reader`, not `*os.File`). **Accept interfaces, return structs** -
+callers get the narrow dependency they need without type-asserting to reach real
+fields.
+
+```go
+// the consumer declares exactly what it needs; the concrete store needn't know
+type UserFetcher interface {
+    GetUser(id string) (*User, error)
+}
+
+type Processor struct{ fetcher UserFetcher }
+```
+
+> **In this repo:** domain contracts are centralized in
+> `internal/domain/interfaces.go` so counterfeiter can generate fakes from one
+> place - that's the established seam. Still prefer small interfaces; just declare
+> new ones there when they need a generated mock.
+
+## Errors are values
+
+Check them explicitly; they aren't exceptions. Wrap with `%w` to add context while
+preserving the chain for `errors.Is` / `errors.As`. Combine siblings with
+`errors.Join` (Go 1.20) - no `multierr` needed.
+
+```go
+data, err := os.ReadFile(path)
+if err != nil {
+    return fmt.Errorf("loading config %s: %w", path, err)
+}
+```
+
+## Functional options for complex construction
+
+When a type has many optional settings, avoid telescoping constructors:
+
+```go
+type Option func(*Server)
+
+func WithTimeout(d time.Duration) Option { return func(s *Server) { s.timeout = d } }
+
+func NewServer(addr string, opts ...Option) *Server {
+    s := &Server{addr: addr, timeout: 30 * time.Second} // sane defaults
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+```
+
+## Testing is just Go
+
+Go testing is just Go programming - reach for the stdlib `testing` package, not a
+BDD framework.
+
+- **Table-driven tests** with `t.Run` subtests are the standard.
+- Call **`t.Helper()`** in assertion helpers so failures point at the case, not
+  the helper.
+- Prefer simple **fakes/stubs** for stand-ins - implicit interfaces make them
+  cheap to hand-write.
+- Put fixtures in **`testdata/`** (the tool ignores it); diff large output against
+  **golden files**.
+- Compare structs with **`github.com/google/go-cmp/cmp`**, not `reflect.DeepEqual`.
+- Abstract the filesystem with **`afero`** and inject `afero.NewMemMapFs()` in tests.
+
+```go
+func TestParse(t *testing.T) {
+    tests := []struct {
+        name    string
+        in      string
+        wantErr bool
+    }{
+        {"valid", "port=8080", false},
+        {"bad", "port=abc", true},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            _, err := Parse(tt.in)
+            if (err != nil) != tt.wantErr {
+                t.Fatalf("Parse(%q) err = %v, wantErr %v", tt.in, err, tt.wantErr)
+            }
+        })
+    }
+}
+```
+
+> **In this repo:** fakes for domain interfaces are **counterfeiter-generated**
+> under `tests/mocks/`, not hand-written. Regenerate with `task mocks:generate`
+> (pre-commit runs it when `internal/domain/interfaces.go` changes); for a *new*
+> domain interface, add a `counterfeiter` line under `mocks:generate` in
+> `Taskfile.yml`. Use the generated fakes - don't hand-roll rivals. Table tests,
+> `testdata`, and `go-cmp` still apply.
+
+## Use current Go, not 2018 Go
+
+This repo targets **Go 1.26** - reach for the modern stdlib before any third-party
+helper or hand-rolled loop:
+
+| Instead of | Use |
+| --- | --- |
+| `sort.Slice(s, ...)` | `slices.Sort(s)`, `slices.SortFunc`, `slices.Contains/Index` |
+| manual key/value loops | `maps.Keys/Values/Clone/Copy/Equal` |
+| `if x == 0 { x = def }` | `cmp.Or(x, def)`; `min`/`max` built-ins |
+| ad-hoc multi-error joins | `errors.Join(err1, err2)` |
+| `atomic.AddInt64(&n, 1)` | typed `atomic.Int64`/`Bool`/`Pointer[T]` (`n.Add(1)`) |
+| gorilla/mux for basic routing | `net/http`: `mux.HandleFunc("GET /u/{id}", ...)` + `r.PathValue("id")` |
+| `for i := 0; i < n; i++` | `for i := range n` |
+| `interface{}` | `any` |
+| `// +build` tags | `//go:build` |
+
+To keep a request's values but drop its cancellation for work that outlives it,
+use `context.WithoutCancel(ctx)` (Go 1.21).
+
+## Generics eliminate duplication, not model hierarchies
+
+Use a generic when the **same algorithm** runs over **many concrete types**.
+
+```go
+func Map[S, T any](s []S, f func(S) T) []T {
+    out := make([]T, len(s))
+    for i, v := range s {
+        out[i] = f(v)
+    }
+    return out
+}
+```
+
+Do **not** write generic "repositories", services, or base types - that's Java in
+Go syntax. Use `comparable` for map keys/equality and `cmp.Ordered` for `<`/`>`.
+Start concrete; generify only once the same logic repeats across 3+ types.
+
+## Logging discipline
+
+```go
+logger.Debug("cache miss", "key", key)      // high-volume internal state
+logger.Info("server started", "addr", addr) // lifecycle events
+logger.Warn("retrying", "attempt", n)        // recoverable problems
+logger.Error("request failed", "err", err)   // needs attention
+```
+
+- **Inject** the logger as a dependency; no package-level logger beyond `main`.
+- **Never log *and* return** the same error - log once at the boundary, return it
+  up the stack everywhere else.
+
+> **In this repo:** logging is **`go.uber.org/zap`** (`*zap.Logger`, from the
+> container's `Logger()`), not `slog`. The discipline above is identical.
+
+## Concurrency, briefly
+
+- **Share memory by communicating** - pass data over a channel instead of guarding
+  it with a mutex where you can. Channels orchestrate; mutexes serialize.
+- **Bound concurrency** with a buffered-channel semaphore, not a static worker pool
+  (Go's scheduler is cheap):
+
+```go
+func FetchAll(ctx context.Context, urls []string, max int) error {
+    sem := make(chan struct{}, max)
+    g, ctx := errgroup.WithContext(ctx)
+    for _, u := range urls {
+        sem <- struct{}{} // blocks at the limit
+        g.Go(func() error {
+            defer func() { <-sem }()
+            return fetch(ctx, u)
+        })
+    }
+    return g.Wait()
+}
+```
+
+- **Never start a goroutine without knowing how it stops** - every `go func()`
+  needs a `ctx`/closed-channel exit, or it leaks.
+
+For channel patterns in depth - done-channel, fan-out/fan-in, pipeline, or-done,
+context propagation, worker semaphore - see the **go-concurrency** skill, and
+verify with `go test -race`.
+
+## Debugging: the Go toolchain is not the bug
+
+`go build`/`test`/`run` are deterministic and the build cache is keyed by source -
+**don't** suspect them or reach for `go clean -cache`. When an error survives your
+edit, it's almost always one of these, in order:
+
+1. The edit didn't fix the actual logic.
+2. It was in the wrong file, function, or package.
+3. A second call site has the same bug, unfixed.
+4. The error comes from a different code path than you edited.
+
+Re-read the (accurate) error, confirm the file is actually compiled
+(`go list -f '{{.GoFiles}}' .`), and add a `t.Log`/print at the exact site.
+
+---
+
+*Adapted from [spf13/go-skills](https://github.com/spf13/go-skills) (MIT, by Steve
+Francia), trimmed and reconciled with this repo's conventions. Pairs with
+**go-concurrency**, **cobra-viper**, and **go-spec-reviewer**.*


### PR DESCRIPTION
Part of #657.

Adds three Go reference skills under `.agents/skills/`, distilled from [spf13/go-skills](https://github.com/spf13/go-skills) ("Idiomatic Go: The Pragmatic Playbook", by Steve Francia - author of Cobra/Viper/Hugo) and adapted to this repo's conventions.

## Skills

| Skill | What it covers |
| --- | --- |
| `go` | Idiomatic Go: zero-value / return-early, interfaces (accept interfaces, return structs), `%w` error wrapping, functional options, table-driven tests + go-cmp + afero, generics, modern stdlib (slices/maps/cmp/errors.Join, typed atomics, range-over-int), logging discipline, "the toolchain is not the bug" debugging |
| `cobra-viper` | Command-first CLI architecture: RunE, SilenceUsage, PersistentPreRunE, flag design, typed-struct Unmarshal, flag/env/file/default precedence, in-memory command tests |
| `go-spec-reviewer` | A general-purpose subagent dispatch template that reviews a Go design spec (philosophy / Cobra-Viper / completeness checklists) before implementation begins |

## Adapted to this repo, not parroted

spf13's playbook is deliberately opinionated and clashes with parts of this codebase. Each clashing stance is kept as the general idiom but annotated with a visible `> In this repo:` callout, so the skill won't tell an agent to fight the architecture:

- **"delete the `internal/` junk drawer"** -> keep name-by-purpose / no junk-drawer packages / wire-at-the-composition-root, but point at the real `internal/` domain/infra/services split + `internal/container/container.go`.
- **"fakes over generated mocks"** -> keep small consumer-defined interfaces, but point at counterfeiter (`tests/mocks/`, `task mocks:generate`, `Taskfile.yml`).
- **slog / single `~/.myapp.yaml`** -> note this repo uses `go.uber.org/zap` and the layered `INFER_*` config in `cmd/root.go::initConfig`.

All three are `license: Apache-2.0` with an "Adapted from spf13/go-skills (MIT)" attribution line, and cross-link each other plus the existing `go-concurrency` skill.

## Verification

- `flox activate -- markdownlint` clean on all three.
- Pre-commit `Format code` + `Lint` passed.
- Punctuation kept ASCII (hyphens, `...`) to match main's convention.
