### PR TITLE
feat(channels): retain inbound voice/audio recordings with bounded cleanup

### DIFF
--- a/.infer/config.yaml
+++ b/.infer/config.yaml
@@ -38,6 +38,8 @@ speech_to_text:
   silence_timeout: 2
   ffmpeg_path: ""
   input_device: ""
+  retain_recordings: 0
+  recordings_dir: ""
 client:
   timeout: 200
   retry:

--- a/cmd/channels.go
+++ b/cmd/channels.go
@@ -202,17 +202,34 @@ func startHeartbeat(ctx context.Context, cfg *config.Config) (*heartbeat.Service
 	return svc, nil
 }
 
+// buildVoiceRetention returns a retainer for inbound voice/audio files when
+// speech_to_text.retain_recordings > 0, or nil to disable retention.
+func buildVoiceRetention(cfg config.SpeechToTextConfig) *channels.VoiceRetention {
+	if cfg.RetainRecordings <= 0 {
+		return nil
+	}
+	dir, err := cfg.ResolveRecordingsDir()
+	if err != nil {
+		logger.Warn("voice recording retention disabled", "error", err)
+		return nil
+	}
+	logger.Info("retaining inbound voice recordings", "dir", dir, "keep", cfg.RetainRecordings)
+	return &channels.VoiceRetention{Dir: dir, Keep: cfg.RetainRecordings}
+}
+
 // registerChannels registers enabled channel implementations with the manager
 func registerChannels(cm *services.ChannelManagerService, cfg *config.Config) error {
 	registered := 0
 
 	if cfg.Channels.Telegram.Enabled {
 		var transcriber channels.VoiceTranscriber
+		var retention *channels.VoiceRetention
 		if cfg.SpeechToText.Enabled {
 			transcriber = stt.NewFileTranscriber(cfg.SpeechToText)
+			retention = buildVoiceRetention(cfg.SpeechToText)
 			logger.Info("speech-to-text enabled for inbound voice messages", "model", cfg.SpeechToText.Model)
 		}
-		telegramCh := channels.NewTelegramChannel(cfg.Channels.Telegram, transcriber)
+		telegramCh := channels.NewTelegramChannel(cfg.Channels.Telegram, transcriber, retention)
 		cm.Register(telegramCh)
 		registered++
 		logger.Info("registered channel", "channel", "telegram")

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,21 @@ type SpeechToTextConfig struct {
 	SilenceTimeout      int    `yaml:"silence_timeout" mapstructure:"silence_timeout"`             // stop /voice after N s of silence (0 = record full cap)
 	FFmpegPath          string `yaml:"ffmpeg_path" mapstructure:"ffmpeg_path"`                     // "" -> resolve ffmpeg on PATH
 	InputDevice         string `yaml:"input_device" mapstructure:"input_device"`                   // "" -> platform default mic
+	RetainRecordings    int    `yaml:"retain_recordings" mapstructure:"retain_recordings"`         // keep last N inbound voice/audio files (0 = keep none)
+	RecordingsDir       string `yaml:"recordings_dir" mapstructure:"recordings_dir"`               // "" -> ~/.infer/voice
+}
+
+// ResolveRecordingsDir returns the directory where retained inbound voice/audio
+// recordings are stored, defaulting to ~/.infer/voice when RecordingsDir is unset.
+func (c SpeechToTextConfig) ResolveRecordingsDir() (string, error) {
+	if strings.TrimSpace(c.RecordingsDir) != "" {
+		return c.RecordingsDir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ConfigDirName, "voice"), nil
 }
 
 // ClientConfig contains HTTP client settings
@@ -679,6 +694,8 @@ func DefaultConfig() *Config { //nolint:funlen
 			SilenceTimeout:      2,
 			FFmpegPath:          "",
 			InputDevice:         "",
+			RetainRecordings:    0,
+			RecordingsDir:       "",
 		},
 		Client: ClientConfig{
 			Timeout: 200,
@@ -1056,6 +1073,13 @@ func (c *Config) Validate() error {
 			"invalid tools.safety.approval_behaviour %q: must be one of %q, %q, or %q",
 			c.Tools.Safety.ApprovalBehaviour,
 			ApprovalBehaviourPrompt, ApprovalBehaviourIPC, ApprovalBehaviourBlock,
+		)
+	}
+
+	if c.SpeechToText.RetainRecordings < 0 {
+		return fmt.Errorf(
+			"invalid speech_to_text.retain_recordings %d: must be >= 0",
+			c.SpeechToText.RetainRecordings,
 		)
 	}
 	return nil

--- a/config/recordings_test.go
+++ b/config/recordings_test.go
@@ -1,0 +1,55 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+func TestResolveRecordingsDir(t *testing.T) {
+	t.Run("explicit dir returned as-is", func(t *testing.T) {
+		cfg := config.SpeechToTextConfig{RecordingsDir: "/tmp/custom-voice"}
+		got, err := cfg.ResolveRecordingsDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "/tmp/custom-voice" {
+			t.Errorf("got %q, want /tmp/custom-voice", got)
+		}
+	})
+
+	t.Run("empty dir defaults to ~/.infer/voice", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skip("no home dir")
+		}
+		got, err := config.SpeechToTextConfig{}.ResolveRecordingsDir()
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(home, config.ConfigDirName, "voice")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestValidateRetainRecordings(t *testing.T) {
+	t.Run("negative is rejected", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.SpeechToText.RetainRecordings = -1
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for negative retain_recordings")
+		}
+	})
+
+	t.Run("non-negative is accepted", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.SpeechToText.RetainRecordings = 10
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/docs/speech-to-text.md
+++ b/docs/speech-to-text.md
@@ -38,10 +38,12 @@ speech_to_text:
   auto_download: true    # download the model on first use if missing
   max_recording_seconds: 30  # /voice hard recording cap
   silence_timeout: 2     # stop /voice this many seconds after you go quiet (0 = record full cap)
+  retain_recordings: 0   # keep the last N inbound Telegram voice/audio files (0 = keep none)
   # Optional overrides:
   binary_path: ""        # explicit whisper-cli/whisper-cpp path; empty = resolve on PATH
   ffmpeg_path: ""        # explicit ffmpeg path; empty = resolve on PATH
   models_dir: ""         # where models are cached; empty = ~/.infer/models/whisper
+  recordings_dir: ""     # where retained recordings live; empty = ~/.infer/voice
   input_device: ""       # microphone device; empty = platform default
   timeout: 120           # transcription timeout (seconds)
 ```
@@ -84,6 +86,11 @@ When `speech_to_text.enabled` is set and you run `infer channels-manager`, voice
 Telegram bot are downloaded, decoded with `ffmpeg`, transcribed, and forwarded to the agent as text.
 When speech-to-text is disabled, voice messages are ignored (as before). See
 [Channels](channels.md) for channel setup.
+
+By default the downloaded audio is transcribed and then deleted. To keep the original files, set
+`retain_recordings` to the number of recent recordings to keep (e.g. `10`). Retained files are written
+to `recordings_dir` (default `~/.infer/voice/`) with their original extension, and the oldest are
+pruned automatically once the cap is exceeded. `retain_recordings: 0` (the default) keeps nothing.
 
 ## Troubleshooting
 

--- a/examples/telegram-channel/README.md
+++ b/examples/telegram-channel/README.md
@@ -127,6 +127,37 @@ You (Telegram) --> Telegram Bot API --> infer channels-manager (listener)
 5. The agent processes it (may use tools, call LLM)
 6. The response is parsed from stdout and sent back through Telegram
 
+## Voice Messages (Optional)
+
+The bot can transcribe inbound Telegram **voice notes** to text locally with
+[Whisper](../../docs/speech-to-text.md), so you can talk to the agent from your phone instead of
+typing. Transcription runs fully offline once the model is downloaded - no cloud STT, no API keys.
+
+**Prerequisite:** speech-to-text shells out to `ffmpeg` (to decode OGG/Opus) and a
+`whisper-cli`/`whisper-cpp` binary. The published `ghcr.io/inference-gateway/cli:latest` image does
+**not** bundle these, so enable voice in one of two ways:
+
+- **Run on a host** that has them installed (`brew install ffmpeg whisper-cpp`, or `apt install
+  ffmpeg` plus a whisper.cpp build) - see [Running Without Docker](#running-without-docker).
+- **Build a custom image** that adds `ffmpeg` and a whisper binary on top of the base image.
+
+Then enable it via environment variables (in `.env` or the compose `environment:` block):
+
+```bash
+INFER_SPEECH_TO_TEXT_ENABLED=true
+INFER_SPEECH_TO_TEXT_MODEL=tiny            # tiny | base | small | medium | large-v3-turbo
+INFER_SPEECH_TO_TEXT_AUTO_DOWNLOAD=true    # fetch the GGML model on first use
+INFER_SPEECH_TO_TEXT_RETAIN_RECORDINGS=10  # keep the last 10 voice files (0 = keep none, the default)
+```
+
+Send a voice note to your bot; it is downloaded, transcribed, and answered as if you had typed it.
+
+With `retain_recordings` greater than `0`, the original audio is also kept under `recordings_dir`
+(default `~/.infer/voice`), and the oldest files are pruned once the cap is exceeded. In this compose
+setup that path resolves to `/home/infer/.infer/voice`, which already persists to `./tmp/.infer/voice`
+on your host via the existing volume mount. Override the location with
+`INFER_SPEECH_TO_TEXT_RECORDINGS_DIR` if you want.
+
 ## Running Without Docker
 
 ```bash

--- a/internal/services/channels/telegram.go
+++ b/internal/services/channels/telegram.go
@@ -37,12 +37,14 @@ type TelegramChannel struct {
 	cfg         config.TelegramChannelConfig
 	bot         *bot.Bot
 	transcriber VoiceTranscriber
+	retention   *VoiceRetention
 }
 
 // NewTelegramChannel creates a new Telegram channel. transcriber may be nil, in
-// which case inbound voice messages are ignored.
-func NewTelegramChannel(cfg config.TelegramChannelConfig, transcriber VoiceTranscriber) *TelegramChannel {
-	return &TelegramChannel{cfg: cfg, transcriber: transcriber}
+// which case inbound voice messages are ignored. retention may be nil to disable
+// local persistence of inbound voice/audio files.
+func NewTelegramChannel(cfg config.TelegramChannelConfig, transcriber VoiceTranscriber, retention *VoiceRetention) *TelegramChannel {
+	return &TelegramChannel{cfg: cfg, transcriber: transcriber, retention: retention}
 }
 
 // Name returns the channel identifier
@@ -275,12 +277,18 @@ func (t *TelegramChannel) applyVoiceTranscription(ctx context.Context, b *bot.Bo
 	return true
 }
 
-// transcribeVoice downloads the referenced Telegram file to a temp path and
-// transcribes it via the configured transcriber.
+// transcribeVoice downloads the referenced Telegram file, optionally retains a
+// copy of the original audio, and transcribes it via the configured transcriber.
 func (t *TelegramChannel) transcribeVoice(ctx context.Context, b *bot.Bot, fileID string) (string, error) {
 	data, filePath, err := fetchTelegramFile(ctx, b, t.cfg.BotToken, fileID)
 	if err != nil {
 		return "", err
+	}
+
+	if t.retention != nil {
+		if _, err := t.retention.save(filePath, data); err != nil {
+			logger.Warn("failed to retain inbound voice recording", "error", err)
+		}
 	}
 
 	tmp, err := os.CreateTemp("", "infer-tg-voice-*"+filepath.Ext(filePath))

--- a/internal/services/channels/telegram_test.go
+++ b/internal/services/channels/telegram_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestTelegramChannel_Name(t *testing.T) {
-	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil)
+	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil, nil)
 	if ch.Name() != "telegram" {
 		t.Errorf("expected 'telegram', got %q", ch.Name())
 	}
@@ -24,7 +24,7 @@ func TestTelegramChannel_Name(t *testing.T) {
 func TestTelegramChannel_StartRequiresToken(t *testing.T) {
 	ch := NewTelegramChannel(config.TelegramChannelConfig{
 		BotToken: "",
-	}, nil)
+	}, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -193,7 +193,7 @@ func TestProcessUpdate_AudioMessage(t *testing.T) {
 }
 
 func TestApplyVoiceTranscription_DisabledDropsMessage(t *testing.T) {
-	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil)
+	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil, nil)
 	msg := &domain.InboundMessage{Content: "[Voice message]"}
 	if ch.applyVoiceTranscription(context.Background(), nil, msg, "voice123") {
 		t.Error("expected applyVoiceTranscription to return false when transcriber is nil")
@@ -313,7 +313,7 @@ func TestDownloadTelegramPhoto(t *testing.T) {
 }
 
 func TestTelegramChannel_SendRequiresBot(t *testing.T) {
-	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil)
+	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil, nil)
 
 	err := ch.Send(context.Background(), domain.OutboundMessage{
 		RecipientID: "123",
@@ -326,7 +326,7 @@ func TestTelegramChannel_SendRequiresBot(t *testing.T) {
 }
 
 func TestTelegramChannel_Stop(t *testing.T) {
-	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil)
+	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil, nil)
 	err := ch.Stop()
 	if err != nil {
 		t.Errorf("expected nil error, got %v", err)
@@ -334,7 +334,7 @@ func TestTelegramChannel_Stop(t *testing.T) {
 }
 
 func TestTelegramChannel_SendApprovalRequiresBot(t *testing.T) {
-	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil)
+	ch := NewTelegramChannel(config.TelegramChannelConfig{}, nil, nil)
 
 	err := ch.SendApproval(context.Background(), "123", &domain.ApprovalRequest{
 		Type:       "approval_request",

--- a/internal/services/channels/voice_retention.go
+++ b/internal/services/channels/voice_retention.go
@@ -1,0 +1,105 @@
+package channels
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	logger "github.com/inference-gateway/cli/internal/logger"
+)
+
+// recordingFilePrefix tags retained recordings so pruning only ever touches
+// files this package wrote, never anything else a user drops in the directory.
+const recordingFilePrefix = "infer-voice-"
+
+// VoiceRetention persists a bounded number of inbound voice/audio recordings to
+// a local directory, pruning the oldest once the count exceeds Keep. A nil
+// *VoiceRetention or a Keep <= 0 disables retention (the default behavior).
+//
+// save serializes on mu because the channel manager may process voice messages
+// concurrently and they all share one directory.
+type VoiceRetention struct {
+	Dir  string
+	Keep int
+	mu   sync.Mutex
+}
+
+// save writes data to the retention directory using the extension implied by
+// hintPath (the Telegram file path), then prunes the oldest recordings beyond
+// Keep. It is best-effort: callers log and continue on error. Returns the path
+// written, or "" when retention is disabled.
+func (r *VoiceRetention) save(hintPath string, data []byte) (string, error) {
+	if r == nil || r.Keep <= 0 {
+		return "", nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := os.MkdirAll(r.Dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating recordings dir: %w", err)
+	}
+
+	f, err := os.CreateTemp(r.Dir, recordingFilePrefix+"*"+filepath.Ext(hintPath))
+	if err != nil {
+		return "", fmt.Errorf("creating recording file: %w", err)
+	}
+	name := f.Name()
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(name)
+		return "", fmt.Errorf("writing recording: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("closing recording: %w", err)
+	}
+
+	pruneRecordings(r.Dir, r.Keep)
+	return name, nil
+}
+
+// pruneRecordings removes the oldest retained recordings in dir once their count
+// exceeds keep. A keep <= 0 is a no-op. Mirrors pruneSessionImages in the
+// channel manager.
+func pruneRecordings(dir string, keep int) {
+	if keep <= 0 {
+		return
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	var files []os.DirEntry
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), recordingFilePrefix) {
+			files = append(files, e)
+		}
+	}
+
+	if len(files) <= keep {
+		return
+	}
+
+	slices.SortFunc(files, func(a, b os.DirEntry) int {
+		fa, _ := a.Info()
+		fb, _ := b.Info()
+		if fa == nil || fb == nil {
+			return 0
+		}
+		return fa.ModTime().Compare(fb.ModTime())
+	})
+
+	for _, e := range files[:len(files)-keep] {
+		path := filepath.Join(dir, e.Name())
+		if err := os.Remove(path); err != nil {
+			logger.Warn("failed to prune voice recording", "path", path, "error", err)
+			continue
+		}
+		logger.Info("pruned old voice recording", "path", path)
+	}
+}

--- a/internal/services/channels/voice_retention_test.go
+++ b/internal/services/channels/voice_retention_test.go
@@ -1,0 +1,148 @@
+package channels
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestVoiceRetentionSaveWritesFile(t *testing.T) {
+	dir := t.TempDir()
+	r := &VoiceRetention{Dir: dir, Keep: 3}
+
+	name, err := r.save("voice/file_42.oga", []byte("audio-bytes"))
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if name == "" {
+		t.Fatal("expected a path, got empty string")
+	}
+	if got := filepath.Dir(name); got != dir {
+		t.Errorf("file written to %q, want dir %q", got, dir)
+	}
+	if ext := filepath.Ext(name); ext != ".oga" {
+		t.Errorf("extension = %q, want .oga", ext)
+	}
+	if base := filepath.Base(name); !strings.HasPrefix(base, recordingFilePrefix) {
+		t.Errorf("file %q missing prefix %q", base, recordingFilePrefix)
+	}
+	data, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(data) != "audio-bytes" {
+		t.Errorf("content = %q, want audio-bytes", data)
+	}
+}
+
+func TestVoiceRetentionSaveDisabled(t *testing.T) {
+	dir := t.TempDir()
+	r := &VoiceRetention{Dir: dir, Keep: 0}
+
+	name, err := r.save("x.oga", []byte("x"))
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if name != "" {
+		t.Errorf("expected no file path with Keep=0, got %q", name)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected nothing written with Keep=0, got %d entries", len(entries))
+	}
+}
+
+func TestVoiceRetentionSaveNilReceiver(t *testing.T) {
+	var r *VoiceRetention
+	name, err := r.save("x.oga", []byte("x"))
+	if err != nil {
+		t.Fatalf("save on nil receiver: %v", err)
+	}
+	if name != "" {
+		t.Errorf("expected empty path on nil receiver, got %q", name)
+	}
+}
+
+func TestVoiceRetentionSaveEnforcesCap(t *testing.T) {
+	dir := t.TempDir()
+	r := &VoiceRetention{Dir: dir, Keep: 2}
+
+	for i := range 4 {
+		if _, err := r.save("x.oga", []byte{byte(i)}); err != nil {
+			t.Fatalf("save %d: %v", i, err)
+		}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected cap of 2 retained files, got %d", len(entries))
+	}
+}
+
+func TestPruneRecordingsKeepsNewest(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Now().Add(-time.Hour)
+
+	// names[i] gets mod time base+i*minute, so names[4] is the newest.
+	var names []string
+	for i := range 5 {
+		name := filepath.Join(dir, fmt.Sprintf("%s%d.oga", recordingFilePrefix, i))
+		if err := os.WriteFile(name, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		mod := base.Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(name, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, name)
+	}
+
+	// A non-recording file must never be pruned.
+	other := filepath.Join(dir, "keep-me.txt")
+	if err := os.WriteFile(other, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pruneRecordings(dir, 2)
+
+	for i, name := range names {
+		_, statErr := os.Stat(name)
+		removed := os.IsNotExist(statErr)
+		wantRemoved := i < 3 // oldest three pruned, newest two kept
+		if removed != wantRemoved {
+			t.Errorf("file %d: removed=%v, want removed=%v (stat err=%v)", i, removed, wantRemoved, statErr)
+		}
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("non-recording file should be kept: %v", err)
+	}
+}
+
+func TestPruneRecordingsNoOpUnderCap(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 2 {
+		name := filepath.Join(dir, fmt.Sprintf("%s%d.oga", recordingFilePrefix, i))
+		if err := os.WriteFile(name, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pruneRecordings(dir, 5)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected all 2 files kept under cap, got %d", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

Inbound Telegram voice/audio messages were transcribed to text and the original audio deleted
immediately. This adds **opt-in** local retention: keep the last N original recordings under a
configurable directory, pruning the oldest once the cap is exceeded.

Default is **off** (`retain_recordings: 0` = prior behavior), so nothing changes unless you opt in.

## Changes

- `internal/services/channels/voice_retention.go` (new) - `VoiceRetention` writes the original audio
  and prunes oldest-beyond-cap (mirrors `pruneSessionImages`); mutex-guarded for the concurrent
  channel worker pool.
- `internal/services/channels/telegram.go` - retains the downloaded bytes before transcription
  (best-effort), so files are kept even when transcription fails or yields no text.
- `config/config.go` - new `retain_recordings` + `recordings_dir` fields, defaults,
  `ResolveRecordingsDir()` (default `~/.infer/voice`), and a `Validate()` guard (`>= 0`).
- `cmd/channels.go` - builds the retainer only when speech-to-text is enabled and the cap is > 0.
- Docs: `docs/speech-to-text.md` + an optional "Voice Messages" section in
  `examples/telegram-channel/README.md`.
- Tests: `voice_retention_test.go`, `config/recordings_test.go`, updated `telegram_test.go`.

## Acceptance criteria (#668)

- [x] Retained under a configurable directory (default `~/.infer/voice/`)
- [x] Bounded by a configurable cap (`retain_recordings`; 0 = keep none)
- [x] Oldest pruned automatically once the cap is exceeded
- [x] Seeded by `infer init` + documented in `docs/speech-to-text.md`
- [x] Unit-tested (retention + pruning)

## Verification

`task fmt` (clean) - `task test` (passes) - `task lint` (0 issues) -
`go test -race ./internal/services/channels/...` (passes).

Closes #668
