### PR TITLE
fix(agent): keep the internal completion check out of channel replies

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -492,8 +492,10 @@ func (s *AgentSession) execute(taskDescription string, files []string) error {
 		}
 
 		verifyMsg := ConversationMessage{
-			Role:      "user",
-			Content:   "Is there anything else that needs to be done to complete this task? If not, simply confirm the task is complete. If there is more work, please continue.",
+			Role: "user",
+			Content: `<system-reminder>
+This is an automated check, not a message from the user. If more work is needed to fully address the user's last request, continue now. If everything is already done, stop without replying - do NOT announce completion, summarize, or otherwise mention this check to the user.
+</system-reminder>`,
 			Timestamp: time.Now(),
 			Internal:  true,
 		}


### PR DESCRIPTION
## Summary

In remote/channel mode (e.g. Telegram), the agent kept sending **"The task is complete."** after answering, plus replies second-guessing whether a prior task existed.

Root cause: when the agent produces a turn with no tool calls, the loop injects an internal verification message asking it to *"confirm the task is complete."* That message's answer is a normal assistant turn, which the channel manager streams straight to the user.

## Fix

Reframe the verification message as a `<system-reminder>` (the marker the codebase already recognizes and hides). It now:
- states it is an automated check, **not** a message from the user;
- tells the agent to **stop without replying** when nothing is left to do;
- says not to announce completion or mention the check to the user.

Autonomous/CI runs keep their "continue if work remains" behavior - only the user-facing noise is removed.

Scope: `cmd/agent.go` only - no config, schema, or API changes.

## Verification

`go build ./...` · `cmd` + `config` tests pass · `golangci-lint` 0 issues · rebuilt the channels-manager image and confirmed the new reminder text is compiled in (old text gone).
