### PR TITLE
test: relax TestSessionID_Age_Recent upper bound to tolerate slow CI

### DIFF
--- a/internal/domain/session_test.go
+++ b/internal/domain/session_test.go
@@ -143,9 +143,6 @@ func TestSessionID_Age_Recent(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	age := id.Age()
 
-	// Upper bound is deliberately generous (not 1s) so the assertion tolerates
-	// slow or -race CI runners while still catching a genuinely wrong Age()
-	// (e.g. a bad epoch that would yield hours).
 	if age < 10*time.Millisecond || age > time.Minute {
 		t.Errorf("SessionID.Age() = %v, expected to be recent (>=10ms, <1m)", age)
 	}

--- a/internal/domain/session_test.go
+++ b/internal/domain/session_test.go
@@ -143,8 +143,11 @@ func TestSessionID_Age_Recent(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	age := id.Age()
 
-	if age < 10*time.Millisecond || age > 1*time.Second {
-		t.Errorf("SessionID.Age() = %v, expected to be between 10ms and 1s", age)
+	// Upper bound is deliberately generous (not 1s) so the assertion tolerates
+	// slow or -race CI runners while still catching a genuinely wrong Age()
+	// (e.g. a bad epoch that would yield hours).
+	if age < 10*time.Millisecond || age > time.Minute {
+		t.Errorf("SessionID.Age() = %v, expected to be recent (>=10ms, <1m)", age)
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestSessionID_Age_Recent` generates a session ID, sleeps 10ms, then asserts `SessionID.Age()` is **between 10ms and 1s**. On loaded `-race` CI runners more than 1s can elapse before `Age()` is read - it was observed at **1.008s**, tripping the upper bound and failing the `test` job (surfaced on an unrelated PR, #671).

## Fix

Widen the upper bound from `1s` to `1m`. It still catches a genuinely wrong `Age()` (e.g. a bad epoch that would yield hours) while removing the timing flake. The lower bound (10ms) is unchanged.

Test-only change; no production code touched.
