### PR TITLE
fix(chat): bind opt+backspace and ctrl+backspace to delete-word-backward

### DIFF
--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -215,7 +215,7 @@ func addTextEditingBindings(bindings map[string]KeyBindingEntry) {
 		Enabled:     &enabled,
 	}
 	bindings[ActionID(NamespaceTextEditing, "delete_word_backward")] = KeyBindingEntry{
-		Keys:        []string{"ctrl+w"},
+		Keys:        []string{"ctrl+w", "alt+backspace", "ctrl+backspace"},
 		Description: "delete word backward",
 		Category:    "text_editing",
 		Enabled:     &enabled,

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -429,6 +429,11 @@ bindings:
 `~/.infer/keybindings.yaml` → in-code defaults (when no file exists).
 Environment variables override whichever file was loaded.
 
+> **Note (macOS):** Word-wise delete in the chat input is bound to `ctrl+w`, `opt+backspace`
+> (`alt+backspace`), and `ctrl+backspace`. Some terminals only send `opt+backspace` as
+> `alt+backspace` when "Use Option as Meta key" is enabled (iTerm2: Profiles → Keys; Terminal.app:
+> Settings → Profiles → Keyboard → "Use Option as Meta key"). `ctrl+w` always works.
+
 **Available Commands:**
 
 ```bash

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -342,7 +342,7 @@ func (r *Registry) createTextEditingActions() []*KeyAction {
 		{
 			Namespace:   config.NamespaceTextEditing,
 			ID:          config.ActionID(config.NamespaceTextEditing, "delete_word_backward"),
-			Keys:        []string{"ctrl+w"},
+			Keys:        []string{"ctrl+w", "alt+backspace", "ctrl+backspace"},
 			Description: "delete word backward",
 			Category:    "text_editing",
 			Handler:     handleDeleteWordBackward,

--- a/internal/ui/keybinding/registry_test.go
+++ b/internal/ui/keybinding/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	services "github.com/inference-gateway/cli/internal/services"
 	keybinding "github.com/inference-gateway/cli/internal/ui/keybinding"
@@ -298,4 +299,36 @@ func TestActionConflictDetection(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected registration to succeed (key sharing is allowed), got error: %v", err)
 	}
+}
+
+func TestDeleteWordBackwardBindings(t *testing.T) {
+	wantID := config.ActionID(config.NamespaceTextEditing, "delete_word_backward")
+	wordDeleteKeys := []string{"ctrl+w", "alt+backspace", "ctrl+backspace"}
+
+	assertResolves := func(t *testing.T, registry *keybinding.Registry) {
+		t.Helper()
+		ctx := newTestContext(domain.ViewStateChat, "hello world")
+		for _, key := range wordDeleteKeys {
+			action := registry.Resolve(key, ctx)
+			if action == nil {
+				t.Fatalf("expected %q to resolve to an action", key)
+			}
+			if action.ID != wantID {
+				t.Errorf("expected %q to resolve to %q, got %q", key, wantID, action.ID)
+			}
+		}
+	}
+
+	t.Run("registry defaults", func(t *testing.T) {
+		assertResolves(t, keybinding.NewRegistry(nil))
+	})
+
+	t.Run("default config overrides", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Chat.Keybindings = config.KeybindingsConfig{
+			Enabled:  true,
+			Bindings: config.GetDefaultKeybindings(),
+		}
+		assertResolves(t, keybinding.NewRegistry(cfg))
+	})
 }


### PR DESCRIPTION
## Summary

In the chat TUI input, `opt+backspace` (macOS) / `alt+backspace` and `ctrl+backspace` no longer deleted the previous word — only `ctrl+w` did. This restores the readline/macOS convention.

Closes #689

## Root cause

The chat input is a custom `InputView` (introduced in the Charm UI v2 migration, #576), driven by the keybinding registry rather than a native bubbles `textarea`. The `delete_word_backward` action carried over only `ctrl+w`. An unbound `alt+backspace` flows `ProcessKey → handleSingleKey`, fails `registry.Resolve`, and falls through to `handleCharacterInput`, where `keys.CanInputHandle` returns `false` (not in `InputHandlerKeys`, no printable text) — so it is a no-op.

Verified in the Bubble Tea v2 / ultraviolet source that `keyMsg.String()` emits exactly `"alt+backspace"` (`Keystroke()` prepends `alt+`; `keyTypeString[KeyBackspace] = "backspace"`), so binding the key dispatches the existing `handleDeleteWordBackward` handler.

## Changes

- **`internal/ui/keybinding/actions.go`** — registry default for `delete_word_backward`: `ctrl+w` → `ctrl+w, alt+backspace, ctrl+backspace`.
- **`config/keybindings.go`** — the config default (`GetDefaultKeybindings`) kept in sync. This is the *effective* binding for normal sessions: `ApplyConfigOverrides` runs by default (`Chat.Keybindings.Enabled = true`) and **full-replaces** an action's keys, so both default sources must agree.
- **`internal/ui/keybinding/registry_test.go`** — `TestDeleteWordBackwardBindings` asserts both default paths (registry default and the config-override path that mirrors chat startup), guarding the two-source sync.
- **`docs/configuration-reference.md`** — macOS terminal note ("Use Option as Meta key").

`ctrl+backspace` is included for cross-platform parity (word-delete convention on Windows/Linux); no existing binding/conflict, harmless where a terminal doesn't emit it. No change to `InputHandlerKeys`/`CanInputHandle` is needed — the registry resolves and dispatches the key before that fallback.

## Testing

- `task build` ✓
- `task test` (full suite) ✓
- `task lint` (golangci-lint 0 issues + markdownlint) ✓

Manual: `./infer chat`, type `hello world foo`, press opt+backspace → `hello world ` (word deleted); `ctrl+w` still deletes a word.

## Note for users

Anyone with an existing `keybindings.yaml` from a prior `infer init` has `delete_word_backward` pinned to `ctrl+w` only; that file overrides the new default. They can pick up the new keys with `infer keybindings reset` (or by re-generating the file). Fresh installs and the in-code defaults get them immediately.
