### PR TITLE
fix(autocomplete): surface arguments for one-of/all-optional tool schemas

### DIFF
--- a/internal/ui/autocomplete/autocomplete.go
+++ b/internal/ui/autocomplete/autocomplete.go
@@ -3,6 +3,7 @@ package autocomplete
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -266,9 +267,13 @@ func (a *AutocompleteImpl) loadTools() {
 			continue
 		}
 
+		description := "Execute " + toolName + " tool directly"
+		if hints := a.generateParameterHints(toolDef); hints != "" {
+			description += " - args: " + hints
+		}
 		a.suggestions = append(a.suggestions, ShortcutOption{
 			Shortcut:    a.generateToolTemplate(toolDef),
-			Description: "Execute " + toolName + " tool directly",
+			Description: description,
 			Usage:       "",
 		})
 	}
@@ -276,18 +281,22 @@ func (a *AutocompleteImpl) loadTools() {
 
 // generateToolTemplate creates a complete tool template with required arguments
 func (a *AutocompleteImpl) generateToolTemplate(toolDef sdk.ChatCompletionTool) string {
-	template := "!!" + toolDef.Function.Name + "("
+	return "!!" + toolDef.Function.Name + "(" + a.generateToolArguments(toolDef) + ")"
+}
 
-	if toolDef.Function.Parameters != nil {
-		params := map[string]any(*toolDef.Function.Parameters)
-		requiredArgs := a.extractRequiredArguments(params)
-		if len(requiredArgs) > 0 {
-			template += strings.Join(requiredArgs, ", ")
-		}
+// generateToolArguments builds the comma-separated argument skeleton that goes
+// inside the parentheses. It prefers top-level "required" properties, then
+// falls back to all top-level properties so one-of / all-optional schemas
+// (like the Agent tool) still surface their meaningful arguments.
+func (a *AutocompleteImpl) generateToolArguments(toolDef sdk.ChatCompletionTool) string {
+	if toolDef.Function.Parameters == nil {
+		return ""
 	}
-
-	template += ")"
-	return template
+	params := map[string]any(*toolDef.Function.Parameters)
+	if requiredArgs := a.extractRequiredArguments(params); len(requiredArgs) > 0 {
+		return strings.Join(requiredArgs, ", ")
+	}
+	return strings.Join(a.extractAllProperties(params), ", ")
 }
 
 // extractRequiredArguments extracts required arguments from parameters
@@ -309,6 +318,79 @@ func (a *AutocompleteImpl) extractRequiredArguments(params map[string]any) []str
 	}
 
 	return requiredArgs
+}
+
+// extractAllProperties builds argument templates for every top-level property,
+// sorted by name for deterministic output. Used as the fallback when a schema
+// has no top-level "required" array (one-of / all-optional schemas like the
+// Agent tool), so the skeleton still shows the tool's meaningful arguments.
+// Returns nil when there are no properties.
+func (a *AutocompleteImpl) extractAllProperties(params map[string]any) []string {
+	properties, ok := params["properties"].(map[string]any)
+	if !ok || len(properties) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	args := make([]string, 0, len(names))
+	for _, name := range names {
+		args = append(args, a.generateArgumentTemplate(name, properties))
+	}
+	return args
+}
+
+// generateParameterHints builds a compact, sorted parameter list of the form
+// "name (type, required|optional)" from the tool's top-level schema, so the
+// dropdown description surfaces what to pass even when the schema has no
+// top-level "required". Returns "" when the tool has no parameters.
+func (a *AutocompleteImpl) generateParameterHints(toolDef sdk.ChatCompletionTool) string {
+	if toolDef.Function.Parameters == nil {
+		return ""
+	}
+	params := map[string]any(*toolDef.Function.Parameters)
+	properties, ok := params["properties"].(map[string]any)
+	if !ok || len(properties) == 0 {
+		return ""
+	}
+
+	required := make(map[string]bool)
+	switch reqRaw := params["required"].(type) {
+	case []any:
+		for _, r := range reqRaw {
+			if s, ok := r.(string); ok {
+				required[s] = true
+			}
+		}
+	case []string:
+		for _, s := range reqRaw {
+			required[s] = true
+		}
+	}
+
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		typ := "any"
+		if propDef, ok := properties[name].(map[string]any); ok {
+			if t, ok := propDef["type"].(string); ok && t != "" {
+				typ = t
+			}
+		}
+		qualifier := "optional"
+		if required[name] {
+			qualifier = "required"
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s, %s)", name, typ, qualifier))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // processAnySlice processes a slice of any type for required arguments
@@ -354,6 +436,10 @@ func (a *AutocompleteImpl) generateArgumentTemplate(paramName string, properties
 				return paramName + "=0.0"
 			case "boolean":
 				return paramName + "=false"
+			case "array":
+				return paramName + "=[]"
+			case "object":
+				return paramName + "={}"
 			default:
 				return paramName + "=\"\""
 			}

--- a/internal/ui/autocomplete/autocomplete_test.go
+++ b/internal/ui/autocomplete/autocomplete_test.go
@@ -600,9 +600,103 @@ func TestAutocomplete_SkillsMidText(t *testing.T) {
 	})
 }
 
-// TestAutocomplete_TabCompletesWithoutSubmitting locks in that Tab only
-// completes a suggestion (with a trailing space) and never auto-submits, even
-// for a no-arg shortcut. The user submits with a deliberate Enter afterwards.
+// TestAutocomplete_ToolsAllOptionalSchema covers the regression in issue #690:
+// a tool whose useful arguments are not top-level "required" (a one-of /
+// all-optional schema like the Agent tool) must still surface its arguments in
+// the !! skeleton and the dropdown description, rather than showing a bare
+// "Tool()" with a generic "Execute <tool> tool directly" line.
+func TestAutocomplete_ToolsAllOptionalSchema(t *testing.T) {
+	mockRegistry := &uimocks.FakeShortcutRegistry{}
+	mockRegistry.GetAllReturns([]shortcuts.Shortcut{})
+
+	mockToolService := &domainmocks.FakeToolService{}
+
+	agentDesc := "Spawn local subagents in parallel"
+
+	// Agent-shaped schema: top-level properties with NO top-level "required"
+	// array (a one-of between `tasks` and `description`). The only "required"
+	// is nested under tasks.items, which the !! template builder must not rely
+	// on. Includes an array-typed property to exercise the new array handling.
+	agentParams := sdk.FunctionParameters(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"tasks": map[string]any{
+				"type":        "array",
+				"description": "Subagent tasks to run in parallel",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"description": map[string]any{"type": "string"},
+					},
+					"required": []string{"description"},
+				},
+			},
+			"description": map[string]any{
+				"type":        "string",
+				"description": "Shorthand for a single subagent task",
+			},
+			"system_prompt": map[string]any{
+				"type":        "string",
+				"description": "Optional system prompt for the single-task form",
+			},
+			"type": map[string]any{
+				"type":        "string",
+				"enum":        []string{"ReadOnly", "ReadWrite"},
+				"description": "Capability for the single-task form",
+			},
+		},
+	})
+
+	mockToolService.ListToolsForModeReturns([]sdk.ChatCompletionTool{
+		{
+			Type: sdk.Function,
+			Function: sdk.FunctionObject{
+				Name:        "Agent",
+				Description: &agentDesc,
+				Parameters:  &agentParams,
+			},
+		},
+	})
+
+	theme := &uimocks.FakeTheme{}
+	theme.GetDimColorReturns("#808080")
+	theme.GetAccentColorReturns("#FF00FF")
+
+	ac := autocomplete.NewAutocomplete(theme, mockRegistry)
+	ac.SetToolService(mockToolService)
+	// Use a wide terminal so the description column is wide enough for the full
+	// parameter hint list (it is truncated to descWidth during rendering).
+	ac.SetWidth(240)
+
+	t.Run("skeleton includes all top-level properties with type-appropriate defaults", func(t *testing.T) {
+		ac.Update("!!Age", 5)
+		assert.True(t, ac.IsVisible(), "!!Age should match the Agent tool")
+		// Properties are surfaced in sorted order; array -> [], string -> "".
+		assert.Equal(t, `!!Agent(description="", system_prompt="", tasks=[], type="")`,
+			ac.GetSelectedShortcut(),
+			"all-optional schema must fill the skeleton with its top-level properties, not empty parens")
+	})
+
+	t.Run("dropdown description lists the parameters with type and required/optional", func(t *testing.T) {
+		ac.Update("!!Age", 5)
+		assert.True(t, ac.IsVisible())
+		rendered := ac.Render()
+		assert.Contains(t, rendered, "args:",
+			"description should be enriched with a parameter list")
+		assert.Contains(t, rendered, "description (string, optional)")
+		assert.Contains(t, rendered, "system_prompt (string, optional)")
+		assert.Contains(t, rendered, "tasks (array, optional)")
+		assert.Contains(t, rendered, "type (string, optional)")
+	})
+
+	t.Run("empty !! prefix still shows the enriched Agent suggestion", func(t *testing.T) {
+		ac.Update("!!", 2)
+		assert.True(t, ac.IsVisible())
+		assert.Equal(t, `!!Agent(description="", system_prompt="", tasks=[], type="")`,
+			ac.GetSelectedShortcut())
+	})
+}
+
 func TestAutocomplete_TabCompletesWithoutSubmitting(t *testing.T) {
 	noArgShortcut := &shortcutsmocks.FakeShortcut{}
 	noArgShortcut.GetNameReturns("clear")

--- a/internal/ui/autocomplete/autocomplete_test.go
+++ b/internal/ui/autocomplete/autocomplete_test.go
@@ -613,10 +613,6 @@ func TestAutocomplete_ToolsAllOptionalSchema(t *testing.T) {
 
 	agentDesc := "Spawn local subagents in parallel"
 
-	// Agent-shaped schema: top-level properties with NO top-level "required"
-	// array (a one-of between `tasks` and `description`). The only "required"
-	// is nested under tasks.items, which the !! template builder must not rely
-	// on. Includes an array-typed property to exercise the new array handling.
 	agentParams := sdk.FunctionParameters(map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -664,14 +660,11 @@ func TestAutocomplete_ToolsAllOptionalSchema(t *testing.T) {
 
 	ac := autocomplete.NewAutocomplete(theme, mockRegistry)
 	ac.SetToolService(mockToolService)
-	// Use a wide terminal so the description column is wide enough for the full
-	// parameter hint list (it is truncated to descWidth during rendering).
 	ac.SetWidth(240)
 
 	t.Run("skeleton includes all top-level properties with type-appropriate defaults", func(t *testing.T) {
 		ac.Update("!!Age", 5)
 		assert.True(t, ac.IsVisible(), "!!Age should match the Agent tool")
-		// Properties are surfaced in sorted order; array -> [], string -> "".
 		assert.Equal(t, `!!Agent(description="", system_prompt="", tasks=[], type="")`,
 			ac.GetSelectedShortcut(),
 			"all-optional schema must fill the skeleton with its top-level properties, not empty parens")


### PR DESCRIPTION
## Summary

Fixes #690.

The `!!` direct-tool autocomplete only filled the skeleton with top-level `required` properties, so tools with no top-level `required` array (like the `Agent` tool - a one-of between `tasks` and `description`) showed a bare `Agent()` with no indication of what to pass. The same gap affected any tool whose useful arguments are not top-level `required` (one-of or all-optional schemas).

## Root cause

`generateToolTemplate` (`internal/ui/autocomplete/autocomplete.go`) filled the parentheses with **only** the tool's top-level `required` properties via `extractRequiredArguments`. The `Agent` tool's schema (`internal/agent/tools/agent.go`) has no top-level `required` array - its only `required` is nested under `tasks.items` - so `extractRequiredArguments` returned nothing and the template was `!!Agent()`. The suggestion's `Description` was the generic "Execute <tool> tool directly" and its `Usage` was empty, so no parameter names/types/descriptions were surfaced anywhere.

## Changes

- **`generateToolArguments`** (new, extracted from `generateToolTemplate` to keep nesting under the `nestif` limit) - prefers top-level `required` properties, then **falls back to all top-level properties** so one-of / all-optional schemas still surface their meaningful arguments.
- **`extractAllProperties`** (new) - builds argument templates for every top-level property, `slices.Sort`-ed by name for deterministic output. Returns nil when there are no properties (so parameter-less tools like `WebSearch`/`Tree` keep `!!WebSearch(` unchanged).
- **`generateArgumentTemplate`** - added `array` -> `=[]` and `object` -> `={}` cases (previously both fell through to `=""`).
- **`generateParameterHints`** (new) - builds a compact `name (type, required|optional)` list from the schema's top-level properties and `required` array, sorted by name. Used to enrich the dropdown description.
- **`loadTools`** - appends ` - args: <hints>` to the dropdown `Description` when the tool has parameters.

## Before / after

**Agent tool** (`!! Age`):

| | Before | After |
| --- | --- | --- |
| Skeleton | `Agent()` | `Agent(description="", system_prompt="", tasks=[], type="")` |
| Description | Execute Agent tool directly | Execute Agent tool directly - args: description (string, optional), system_prompt (string, optional), tasks (array, optional), type (string, optional) |

Tools with top-level `required` (`Read`/`Write`/`Bash`) and parameter-less tools (`WebSearch`/`Tree`) are unchanged.

## Test coverage

`TestAutocomplete_ToolsAllOptionalSchema` registers an Agent-shaped schema (one-of, all-optional top-level properties, with an array property and a nested `required` under `tasks.items`) and asserts:
- The skeleton includes all top-level properties with type-appropriate defaults (`=[]` for array, `=""` for string), in sorted order.
- The dropdown description lists each parameter with its type and `optional` qualifier.
- Filtering on `!!Age` and the empty `!!` prefix both work.

## Verification

- [x] `task test` - all packages pass
- [x] `task lint` - 0 issues
- [x] `task fmt` - clean
- [x] pre-commit hooks passed (fmt, lint, trailing whitespace, EOF)

no docs ticket: internal-only TUI autocomplete fix

Fixed by GLM-5.2