### PR TITLE
refactor(tui): single event-loop ingress - one notifier, no self-rescheduling pollers

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -231,10 +231,13 @@ func StartChatSession(cfg *config.Config) error {
 
 	program := tea.NewProgram(application)
 
+	notifier := programNotifier{program: program}
+	services.SetUINotifier(notifier)
+
 	if floatingWindowMgr != nil {
 		eventBridge := stateManager.GetEventBridge()
 		if eventBridge != nil {
-			go forwardControlEventsToBubbleTea(program, eventBridge)
+			go forwardControlEventsToBubbleTea(notifier, eventBridge)
 		}
 	}
 
@@ -418,9 +421,18 @@ func startScreenshotServer(config *config.Config, imageService domain.ImageServi
 	return screenshotServer
 }
 
-// forwardControlEventsToBubbleTea forwards control events from EventBridge to BubbleTea program
-// This ensures control events (pause/resume) reach ChatHandler even when chat session is closed
-func forwardControlEventsToBubbleTea(program *tea.Program, eventBridge domain.EventBridge) {
+// programNotifier is the single domain.UINotifier backed by a real Bubble Tea
+// program: the one and only place (*tea.Program).Send is ever called, so every
+// background→TUI push funnels through this ingress. Set on the container via
+// SetUINotifier before program.Run.
+type programNotifier struct{ program *tea.Program }
+
+func (p programNotifier) Notify(event any) { p.program.Send(event) }
+
+// forwardControlEventsToBubbleTea forwards control events from EventBridge to the
+// Bubble Tea loop through the single UI notifier. This ensures control events
+// (pause/resume) reach ChatHandler even when the chat session is closed.
+func forwardControlEventsToBubbleTea(notifier domain.UINotifier, eventBridge domain.EventBridge) {
 	logger.Debug("starting control event forwarder")
 	subscription := eventBridge.Subscribe()
 
@@ -428,11 +440,11 @@ func forwardControlEventsToBubbleTea(program *tea.Program, eventBridge domain.Ev
 		switch e := event.(type) {
 		case domain.ComputerUsePausedEvent:
 			logger.Debug("forwarding ComputerUsePausedEvent to BubbleTea", "request_id", e.RequestID)
-			program.Send(e)
+			notifier.Notify(e)
 
 		case domain.ComputerUseResumedEvent:
 			logger.Debug("forwarding ComputerUseResumedEvent to BubbleTea", "request_id", e.RequestID)
-			program.Send(e)
+			notifier.Notify(e)
 
 		default:
 		}

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -231,7 +231,6 @@ func StartChatSession(cfg *config.Config) error {
 	)
 
 	program := tea.NewProgram(application)
-
 	notifier := programNotifier{program: program}
 	services.SetUINotifier(notifier)
 
@@ -428,6 +427,13 @@ func startScreenshotServer(config *config.Config, imageService domain.ImageServi
 // SetUINotifier before program.Run.
 type programNotifier struct{ program *tea.Program }
 
+// Notify MUST only ever be called from a background goroutine, never from the
+// Update loop. (*tea.Program).Send is unbuffered - it blocks until the loop
+// consumes the message - so a synchronous Notify from inside Update would deadlock
+// the loop against itself. That failure is also invisible: the slow-update warn
+// runs in a deferred call, and a deadlocked Update never returns to fire it. Every
+// producer captures this notifier at construction and calls it from its own
+// goroutine; keep it that way.
 func (p programNotifier) Notify(event any) { p.program.Send(event) }
 
 // forwardControlEventsToBubbleTea forwards control events from EventBridge to the

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -205,6 +205,7 @@ func StartChatSession(cfg *config.Config) error {
 		agentManager,
 		agentService,
 		backgroundTaskService,
+		services.GetBackgroundTaskRegistry(),
 		conversationOptimizer,
 		conversationRepo,
 		fileService,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -198,11 +198,12 @@ func initConfig() {
 	stdout := v.GetBool("logging.stdout")
 
 	if logDir == "" {
-		configFile := v.ConfigFileUsed()
-		if configFile != "" {
-			configDir := filepath.Dir(configFile)
-			logDir = filepath.Join(configDir, "logs")
-		}
+		// App logs are project-local: write to ./.infer/logs (relative to the
+		// working dir), the same place the gateway logs to. Previously this derived
+		// the dir from v.ConfigFileUsed(), which returns the home ~/.infer/config.yaml
+		// when both a home and project config exist, sending app logs to
+		// ~/.infer/logs while the gateway logged to ./.infer/logs.
+		logDir = config.DefaultLogsPath
 	}
 
 	logger.Init(logger.Config{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -198,11 +198,6 @@ func initConfig() {
 	stdout := v.GetBool("logging.stdout")
 
 	if logDir == "" {
-		// App logs are project-local: write to ./.infer/logs (relative to the
-		// working dir), the same place the gateway logs to. Previously this derived
-		// the dir from v.ConfigFileUsed(), which returns the home ~/.infer/config.yaml
-		// when both a home and project config exist, sending app logs to
-		// ~/.infer/logs while the gateway logged to ./.infer/logs.
 		logDir = config.DefaultLogsPath
 	}
 

--- a/internal/agent/tools/a2a_job_test.go
+++ b/internal/agent/tools/a2a_job_test.go
@@ -29,7 +29,7 @@ func TestA2AJob_PollsRemoteTaskToCompletion(t *testing.T) {
 
 	tracker := utils.NewA2ATaskTracker()
 	queue := &mocks.FakeMessageQueue{}
-	sup := jobs.NewSupervisor(queue, &mocks.FakeConversationRepository{})
+	sup := jobs.NewSupervisor(queue, &mocks.FakeConversationRepository{}, nil)
 	defer sup.Stop()
 
 	completed := adk.Task{ID: "t1", Status: adk.TaskStatus{State: adk.TaskStateCompleted}}

--- a/internal/agent/tools/registry_test.go
+++ b/internal/agent/tools/registry_test.go
@@ -550,7 +550,7 @@ type blockingMCPManager struct {
 
 func (m *blockingMCPManager) GetClients() []domain.MCPClient {
 	close(m.getClientsCalled)
-	select {} // block forever
+	select {}
 }
 func (m *blockingMCPManager) GetClient(string) domain.MCPClient  { return nil }
 func (m *blockingMCPManager) GetTotalServers() int               { return 0 }
@@ -559,9 +559,7 @@ func (m *blockingMCPManager) ClearToolCount(string)              {}
 func (m *blockingMCPManager) StartServers(context.Context) error { return nil }
 func (m *blockingMCPManager) StopServers(context.Context) error  { return nil }
 func (m *blockingMCPManager) Close() error                       { return nil }
-func (m *blockingMCPManager) StartMonitoring(context.Context) <-chan domain.MCPServerStatusUpdateEvent {
-	return nil
-}
+func (m *blockingMCPManager) StartMonitoring(context.Context)    {}
 
 // TestRegistry_NewRegistry_DoesNotBlockOnMCP is a regression test for
 // issue #523: NewRegistry must not synchronously call DiscoverTools (or any

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -527,6 +527,7 @@ func isDomainEvent(msg tea.Msg) bool {
 		domain.TodoUpdateChatEvent,
 		domain.AgentStatusUpdateEvent,
 		domain.DrainQueueEvent,
+		domain.DrainQueueRetryEvent,
 		domain.NavigateBackInTimeEvent,
 		domain.MessageHistoryRestoreEvent,
 		domain.ComputerUsePausedEvent,

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -59,6 +59,7 @@ type ChatApplication struct {
 	mcpManager             domain.MCPManager
 	taskRetentionService   domain.TaskRetentionService
 	backgroundTaskService  domain.BackgroundTaskService
+	backgroundTaskRegistry domain.BackgroundTaskRegistry
 
 	// Chat orchestration services
 	a2aTaskCoordinator       domain.A2ATaskCoordinator
@@ -139,6 +140,7 @@ func NewChatApplication(
 	agentManager domain.AgentManager,
 	agentService domain.AgentService,
 	backgroundTaskService domain.BackgroundTaskService,
+	backgroundTaskRegistry domain.BackgroundTaskRegistry,
 	conversationOptimizer domain.ConversationOptimizer,
 	conversationRepo domain.ConversationRepository,
 	fileService domain.FileService,
@@ -186,6 +188,7 @@ func NewChatApplication(
 		mcpManager:               mcpManager,
 		taskRetentionService:     taskRetentionService,
 		backgroundTaskService:    backgroundTaskService,
+		backgroundTaskRegistry:   backgroundTaskRegistry,
 		a2aTaskCoordinator:       a2aTaskCoordinator,
 		approvalCoordinator:      approvalCoordinator,
 		chatCompletionRunner:     chatCompletionRunner,
@@ -249,8 +252,8 @@ func NewChatApplication(
 		isb.SetTokenEstimator(services.NewTokenizerService(services.DefaultTokenizerConfig()))
 		isb.SetBackgroundShellService(app.toolRegistry.GetBackgroundShellService())
 		isb.SetBackgroundTaskService(app.backgroundTaskService)
-		if reg, ok := app.toolRegistry.GetA2ATaskTracker().(domain.BackgroundTaskRegistry); ok {
-			isb.SetBackgroundTaskRegistry(reg)
+		if app.backgroundTaskRegistry != nil {
+			isb.SetBackgroundTaskRegistry(app.backgroundTaskRegistry)
 		}
 	}
 
@@ -1346,20 +1349,14 @@ func (app *ChatApplication) handleA2ATaskManagementView(msg tea.Msg) []tea.Cmd {
 	var cmds []tea.Cmd
 
 	if app.taskManager == nil {
-		if !app.config.A2A.Enabled {
-			cmds = append(cmds, func() tea.Msg {
-				return domain.ShowErrorEvent{
-					Error:  "Task management requires A2A to be enabled in configuration.",
-					Sticky: true,
-				}
-			})
-			return cmds
-		}
-
+		// The task view shows all background work - shells, subagents, and A2A
+		// tasks - so it is no longer gated on A2A. Shell/subagent rows come from the
+		// unified BackgroundTaskRegistry's supervisor snapshot; A2A rows from the
+		// poller/retention service. Either source may simply be empty.
 		styleProvider := styles.NewProvider(app.themeService)
 		app.taskManager = components.NewTaskManager(app.themeService, styleProvider, app.taskRetentionService, app.backgroundTaskService)
-		if reg, ok := app.toolRegistry.GetA2ATaskTracker().(domain.BackgroundTaskRegistry); ok {
-			app.taskManager.SetBackgroundTaskRegistry(reg)
+		if app.backgroundTaskRegistry != nil {
+			app.taskManager.SetBackgroundTaskRegistry(app.backgroundTaskRegistry)
 		}
 		if cmd := app.taskManager.Init(); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -1509,7 +1506,7 @@ func (app *ChatApplication) renderConversationSelection() string {
 
 func (app *ChatApplication) renderA2ATaskManagement() string {
 	if app.taskManager == nil {
-		return "Task management requires A2A to be enabled in configuration."
+		return "Loading tasks…"
 	}
 
 	width, height := app.stateManager.GetDimensions()

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -400,19 +400,6 @@ func (app *ChatApplication) Init() tea.Cmd {
 		cmds = append(cmds, cmd)
 	}
 
-	if readiness := app.stateManager.GetAgentReadiness(); readiness != nil && readiness.TotalAgents > 0 {
-		cmds = append(cmds, tea.Tick(500*time.Millisecond, func(time.Time) tea.Msg {
-			return domain.AgentStatusUpdateEvent{}
-		}))
-	}
-
-	// Queue-drain ticker: starts a fresh agent turn whenever the agent is idle
-	// and the shared queue has content (background-job notes / messages typed
-	// while busy). Self-reschedules in HandleDrainQueueTickEvent.
-	cmds = append(cmds, tea.Tick(constants.DrainQueueTickInterval, func(time.Time) tea.Msg {
-		return domain.DrainQueueTickEvent{}
-	}))
-
 	if app.mcpManager != nil {
 		app.inputStatusBar.UpdateMCPStatus(&domain.MCPServerStatus{
 			TotalServers:     app.mcpManager.GetTotalServers(),
@@ -420,38 +407,22 @@ func (app *ChatApplication) Init() tea.Cmd {
 			TotalTools:       0,
 		})
 
-		ctx := context.Background()
-		statusChan := app.mcpManager.StartMonitoring(ctx)
-		cmds = append(cmds, waitForMCPStatusUpdate(statusChan))
+		app.mcpManager.StartMonitoring(context.Background())
 	}
 
 	return tea.Batch(cmds...)
 }
 
-// waitForMCPStatusUpdate waits for a status update from the MCP manager channel
-// The channel is captured in the closure and passed along with each event
-func waitForMCPStatusUpdate(statusChan <-chan domain.MCPServerStatusUpdateEvent) tea.Cmd {
-	return func() tea.Msg {
-		event, ok := <-statusChan
-		if !ok {
-			return nil
-		}
-
-		return mcpStatusUpdateWithChannel{
-			event:   event,
-			channel: statusChan,
-		}
-	}
-}
-
-// mcpStatusUpdateWithChannel wraps the event with the channel for continuation
-type mcpStatusUpdateWithChannel struct {
-	event   domain.MCPServerStatusUpdateEvent
-	channel <-chan domain.MCPServerStatusUpdateEvent
-}
-
-// Update handles all application messages using the state management system
+// Update handles all application messages using the state management system. It
+// is the single ingress for every message - background producers push through the
+// UI notifier (program.Send), so this is the one place to measure handler
+// duration: a slow handler in the single-threaded loop is a visible UI freeze.
 func (app *ChatApplication) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	start := time.Now()
+	defer logSlowUpdate(start, msg)
+
+	viewBefore := app.stateManager.GetCurrentView()
+
 	var cmds []tea.Cmd
 
 	if cmd := app.handleAppEvents(msg); cmd != nil {
@@ -468,14 +439,28 @@ func (app *ChatApplication) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	cmds = append(cmds, app.updateUIComponentsForUIMessages(msg)...)
 
-	if mcpStatusUpdate, ok := msg.(mcpStatusUpdateWithChannel); ok {
-		if cmd := app.handleMCPStatusUpdate(mcpStatusUpdate.event); cmd != nil {
+	if event, ok := msg.(domain.MCPServerStatusUpdateEvent); ok {
+		if cmd := app.handleMCPStatusUpdate(event); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
-		cmds = append(cmds, waitForMCPStatusUpdate(mcpStatusUpdate.channel))
+	}
+
+	if viewBefore != domain.ViewStateChat &&
+		app.stateManager.GetCurrentView() == domain.ViewStateChat &&
+		!app.messageQueue.IsEmpty() {
+		cmds = append(cmds, func() tea.Msg { return domain.DrainQueueEvent{} })
 	}
 
 	return app, tea.Batch(cmds...)
+}
+
+// logSlowUpdate warns when a single Update dispatch took longer than
+// SlowUpdateThreshold. The Update loop is single-threaded, so a slow handler is a
+// visible UI freeze - the one ingress is the one place worth measuring.
+func logSlowUpdate(start time.Time, msg tea.Msg) {
+	if d := time.Since(start); d > constants.SlowUpdateThreshold {
+		logger.Warn("slow update", "event", fmt.Sprintf("%T", msg), "ms", d.Milliseconds())
+	}
 }
 
 // isDomainEvent checks if an event should be handled by ChatHandler (positive filtering).
@@ -538,7 +523,7 @@ func isDomainEvent(msg tea.Msg) bool {
 		domain.ToolCancelledEvent,
 		domain.TodoUpdateChatEvent,
 		domain.AgentStatusUpdateEvent,
-		domain.DrainQueueTickEvent,
+		domain.DrainQueueEvent,
 		domain.NavigateBackInTimeEvent,
 		domain.MessageHistoryRestoreEvent,
 		domain.ComputerUsePausedEvent,

--- a/internal/app/question_form_repro_test.go
+++ b/internal/app/question_form_repro_test.go
@@ -63,6 +63,7 @@ func TestChatApplication_QuestionFormRendersOnEvent(t *testing.T) {
 		c.GetAgentManager(),
 		c.GetAgentService(),
 		c.GetBackgroundTaskService(),
+		c.GetBackgroundTaskRegistry(),
 		c.GetConversationOptimizer(),
 		c.GetConversationRepository(),
 		c.GetFileService(),

--- a/internal/app/slow_update_test.go
+++ b/internal/app/slow_update_test.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	zap "go.uber.org/zap"
+	zapcore "go.uber.org/zap/zapcore"
+	observer "go.uber.org/zap/zaptest/observer"
+
+	constants "github.com/inference-gateway/cli/internal/constants"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	logger "github.com/inference-gateway/cli/internal/logger"
+)
+
+// logSlowUpdate is the single-ingress instrumentation: a handler slower than
+// SlowUpdateThreshold warns once, tagged with the event type; a fast handler is
+// silent.
+func TestLogSlowUpdate(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	prev := logger.GetGlobalLogger()
+	logger.SetGlobalLogger(zap.New(core))
+	defer logger.SetGlobalLogger(prev)
+
+	logSlowUpdate(time.Now().Add(-2*constants.SlowUpdateThreshold), domain.DrainQueueEvent{})
+	logSlowUpdate(time.Now(), domain.DrainQueueEvent{})
+
+	warns := logs.FilterMessage("slow update").All()
+	if len(warns) != 1 {
+		t.Fatalf("expected exactly 1 'slow update' warning, got %d", len(warns))
+	}
+	if ev := warns[0].ContextMap()["event"]; ev != "domain.DrainQueueEvent" {
+		t.Errorf("event field = %v, want domain.DrainQueueEvent", ev)
+	}
+}

--- a/internal/constants/timing.go
+++ b/internal/constants/timing.go
@@ -9,6 +9,7 @@ const (
 	AgentIterationDelay       = 20 * time.Millisecond  // Delay between agent iterations
 	AgentToolExecutionDelay   = 20 * time.Millisecond  // Delay during tool execution
 	AgentStatusTickerInterval = 200 * time.Millisecond // Status update ticker interval
+	DrainQueueRetryInterval   = 300 * time.Millisecond // Re-check interval while queued work waits behind a busy agent
 
 	// UI component timing for smooth transitions
 	ToolCallUpdateThrottle    = 50 * time.Millisecond  // Minimum time between tool call updates

--- a/internal/constants/timing.go
+++ b/internal/constants/timing.go
@@ -9,7 +9,6 @@ const (
 	AgentIterationDelay       = 20 * time.Millisecond  // Delay between agent iterations
 	AgentToolExecutionDelay   = 20 * time.Millisecond  // Delay during tool execution
 	AgentStatusTickerInterval = 200 * time.Millisecond // Status update ticker interval
-	DrainQueueTickInterval    = 500 * time.Millisecond // Chat queue-drain ticker: start a turn when idle + queue non-empty
 
 	// UI component timing for smooth transitions
 	ToolCallUpdateThrottle    = 50 * time.Millisecond  // Minimum time between tool call updates
@@ -29,4 +28,12 @@ const (
 	ToolUpdateThrottle    = 50 * time.Millisecond
 	SpinnerUpdateInterval = 200 * time.Millisecond
 	StatusRefreshInterval = 500 * time.Millisecond
+)
+
+// ObservabilityTiming contains thresholds for the single-ingress instrumentation:
+// the Bubble Tea Update loop is single-threaded, so a slow handler is a UI freeze,
+// and a background job that overruns is worth a one-time warning.
+const (
+	SlowUpdateThreshold     = 100 * time.Millisecond
+	JobRunningLongThreshold = 5 * time.Minute
 )

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	zap "go.uber.org/zap"
@@ -109,30 +109,32 @@ type ServiceContainer struct {
 	uiNotifier               *uiNotifierHolder
 }
 
-// uiNotifierHolder is a thread-safe, swappable domain.UINotifier. It is the one
-// synchronized primitive for the notifier: producers capture it once at
-// construction (never reassigning it), so they never lock, while SetUINotifier
-// swaps the inner notifier exactly once at startup (before program.Run). The
-// RWMutex exists only to keep the late swap race-free under the detector.
+// uiNotifierHolder is a swap-once, read-many domain.UINotifier. Producers capture
+// the *uiNotifierHolder once at construction (never reassigning it) and call Notify
+// from their own goroutines; SetUINotifier stores the real program-backed notifier
+// exactly once at startup (before program.Run). atomic.Pointer keeps the read
+// lock-free and the late swap race-free without a mutex. The stored pointer is
+// never nil (newUINotifierHolder seeds a NoopUINotifier), so Notify is always safe.
 type uiNotifierHolder struct {
-	mu    sync.RWMutex
-	inner domain.UINotifier
+	inner atomic.Pointer[domain.UINotifier]
+}
+
+func newUINotifierHolder() *uiNotifierHolder {
+	h := &uiNotifierHolder{}
+	var noop domain.UINotifier = domain.NoopUINotifier{}
+	h.inner.Store(&noop)
+	return h
 }
 
 func (h *uiNotifierHolder) Notify(event any) {
-	h.mu.RLock()
-	n := h.inner
-	h.mu.RUnlock()
-	n.Notify(event)
+	(*h.inner.Load()).Notify(event)
 }
 
 func (h *uiNotifierHolder) set(n domain.UINotifier) {
 	if n == nil {
 		n = domain.NoopUINotifier{}
 	}
-	h.mu.Lock()
-	h.inner = n
-	h.mu.Unlock()
+	h.inner.Store(&n)
 }
 
 // NewServiceContainer creates a new service container with all dependencies
@@ -154,7 +156,7 @@ func NewServiceContainer(cfg *config.Config) *ServiceContainer {
 		config:           cfg,
 		containerRuntime: containerRuntime,
 		log:              log,
-		uiNotifier:       &uiNotifierHolder{inner: domain.NoopUINotifier{}},
+		uiNotifier:       newUINotifierHolder(),
 	}
 
 	cfg.SetConfigDir(config.ResolveConfigDir())

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	zap "go.uber.org/zap"
@@ -105,6 +106,33 @@ type ServiceContainer struct {
 	chatCompletionRunner     *chatcompletion.Runner
 	directExecutionService   domain.DirectExecutionService
 	toolExecutionCoordinator domain.ToolExecutionCoordinator
+	uiNotifier               *uiNotifierHolder
+}
+
+// uiNotifierHolder is a thread-safe, swappable domain.UINotifier. It is the one
+// synchronized primitive for the notifier: producers capture it once at
+// construction (never reassigning it), so they never lock, while SetUINotifier
+// swaps the inner notifier exactly once at startup (before program.Run). The
+// RWMutex exists only to keep the late swap race-free under the detector.
+type uiNotifierHolder struct {
+	mu    sync.RWMutex
+	inner domain.UINotifier
+}
+
+func (h *uiNotifierHolder) Notify(event any) {
+	h.mu.RLock()
+	n := h.inner
+	h.mu.RUnlock()
+	n.Notify(event)
+}
+
+func (h *uiNotifierHolder) set(n domain.UINotifier) {
+	if n == nil {
+		n = domain.NoopUINotifier{}
+	}
+	h.mu.Lock()
+	h.inner = n
+	h.mu.Unlock()
 }
 
 // NewServiceContainer creates a new service container with all dependencies
@@ -126,6 +154,7 @@ func NewServiceContainer(cfg *config.Config) *ServiceContainer {
 		config:           cfg,
 		containerRuntime: containerRuntime,
 		log:              log,
+		uiNotifier:       &uiNotifierHolder{inner: domain.NoopUINotifier{}},
 	}
 
 	cfg.SetConfigDir(config.ResolveConfigDir())
@@ -143,6 +172,15 @@ func NewServiceContainer(cfg *config.Config) *ServiceContainer {
 	container.initializeExtensibility()
 
 	return container
+}
+
+// SetUINotifier swaps in the real (program-backed) UI notifier. cmd/chat.go calls
+// it once, after tea.NewProgram and before program.Run, so every background
+// producer that captured the holder at construction begins pushing into the live
+// Bubble Tea loop. Safe to call from any goroutine; before it runs, producers
+// push to the no-op default.
+func (c *ServiceContainer) SetUINotifier(n domain.UINotifier) {
+	c.uiNotifier.set(n)
 }
 
 // initializeGatewayManager creates the gateway manager (but does not start it)
@@ -183,6 +221,13 @@ func (c *ServiceContainer) initializeAgentManager() {
 
 	c.agentManager.SetStatusCallback(func(agentName string, state domain.AgentState, message string, url string, image string) {
 		c.stateManager.UpdateAgentStatus(agentName, state, message, url, image)
+		c.uiNotifier.Notify(domain.AgentStatusUpdateEvent{
+			AgentName: agentName,
+			State:     state,
+			Message:   message,
+			URL:       url,
+			Image:     image,
+		})
 	})
 
 	ctx := context.Background()
@@ -197,7 +242,7 @@ func (c *ServiceContainer) initializeMCPManager() {
 		return
 	}
 
-	c.mcpManager = services.NewMCPManager(c.sessionID, &c.config.MCP, c.containerRuntime)
+	c.mcpManager = services.NewMCPManager(c.sessionID, &c.config.MCP, c.containerRuntime, c.uiNotifier)
 
 	hasServersToStart := c.hasAutoStartMCPServers()
 	if !hasServersToStart {
@@ -750,7 +795,7 @@ func (c *ServiceContainer) ensureBackgroundTaskRegistry() {
 	if c.backgroundTaskRegistry != nil {
 		return
 	}
-	c.jobSupervisor = jobs.NewSupervisor(c.messageQueue, c.conversationRepo)
+	c.jobSupervisor = jobs.NewSupervisor(c.messageQueue, c.conversationRepo, c.uiNotifier)
 	c.jobSupervisor.SetRetentionCount(domain.JobKindShell, c.config.Tools.Bash.BackgroundShells.CompletedRetention)
 	c.jobSupervisor.SetRetentionCount(domain.JobKindSubagent, c.config.Tools.Agent.CompletedRetention)
 	c.jobSupervisor.SetRetentionCount(domain.JobKindA2A, c.config.A2A.Task.CompletedTaskRetention)

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -862,8 +862,10 @@ type MCPManager interface {
 	// GetTotalServers returns the total number of configured MCP servers
 	GetTotalServers() int
 
-	// StartMonitoring begins background health monitoring and returns a channel for status updates
-	StartMonitoring(ctx context.Context) <-chan MCPServerStatusUpdateEvent
+	// StartMonitoring begins background health monitoring, pushing every
+	// MCPServerStatusUpdateEvent through the UI notifier injected at
+	// construction. Idempotent; the initial status is emitted asynchronously.
+	StartMonitoring(ctx context.Context)
 
 	// UpdateToolCount updates the tool count for a specific server
 	UpdateToolCount(serverName string, count int)

--- a/internal/domain/ui_events.go
+++ b/internal/domain/ui_events.go
@@ -214,14 +214,21 @@ type BashCommandCompletedEvent struct {
 	ErrorMessage  string
 }
 
-// DrainQueueTickEvent is a periodic tick (scheduled in the chat UI's Init and
-// self-rescheduled by its handler) that asks the orchestrator to start a fresh
-// agent turn whenever the agent is idle and the shared message queue has content
-// (background-job completion notes or user messages typed while busy). It is the
-// single, reliable mechanism that delivers queued work to the agent - replacing
-// the fragile supervisor "wake" - while keeping the agent state machine intact
-// (each turn still runs Idle -> CheckingQueue -> ... -> Completing -> Idle).
-type DrainQueueTickEvent struct{}
+// DrainQueueEvent asks the orchestrator to start a fresh agent turn when the
+// agent is idle on the chat view and the shared message queue has content
+// (background-job completion notes or user messages typed while busy). Unlike the
+// old queue-drain tick it is not a clock: it is pushed exactly once per real
+// trigger (a background job landing work, a turn completing with a non-empty
+// queue, or re-entering the chat view), and HandleDrainQueueEvent is a pure gate
+// that starts a turn (Idle -> CheckingQueue -> ... -> Completing -> Idle) or
+// returns nil. There is no self-reschedule.
+type DrainQueueEvent struct{}
+
+// BackgroundTasksChangedEvent signals that a background job's status changed
+// (submitted, signalled, completed, or failed). The supervisor pushes it so the
+// /tasks view and the inline conversation rows refresh on real change instead of
+// polling at render time.
+type BackgroundTasksChangedEvent struct{}
 
 // Agent Readiness Events
 

--- a/internal/domain/ui_events.go
+++ b/internal/domain/ui_events.go
@@ -224,6 +224,16 @@ type BashCommandCompletedEvent struct {
 // returns nil. There is no self-reschedule.
 type DrainQueueEvent struct{}
 
+// DrainQueueRetryEvent is the bounded retry behind DrainQueueEvent, and is NOT a
+// clock. A DrainQueueEvent can land while the agent is momentarily busy (e.g. a
+// background job finishes in the same instant the turn is still completing); the
+// gate drops it, so without a retry the queue would strand. HandleDrainQueueEvent
+// arms a single DrainQueueRetryEvent in that case, and the drainRetryArmed guard
+// keeps it to exactly one outstanding timer no matter how many DrainQueueEvents
+// arrived. When it fires, HandleDrainQueueRetryEvent re-runs the gate, which
+// re-arms only while work is still stranded and stops the moment the queue drains.
+type DrainQueueRetryEvent struct{}
+
 // BackgroundTasksChangedEvent signals that a background job's status changed
 // (submitted, signalled, completed, or failed). The supervisor pushes it so the
 // /tasks view and the inline conversation rows refresh on real change instead of

--- a/internal/domain/ui_notifier.go
+++ b/internal/domain/ui_notifier.go
@@ -1,0 +1,30 @@
+package domain
+
+// UINotifier delivers a background-originated event to the single Bubble Tea
+// Update loop. It is the one ingress every background producer uses to push work
+// or status changes into the UI, replacing the per-source self-rescheduling
+// pollers. The only production implementation wraps (*tea.Program).Send and lives
+// in cmd/chat.go; keeping this interface tea-free lets services depend on it
+// without importing bubbletea. The event is an `any` (tea.Msg is itself `any`).
+type UINotifier interface {
+	Notify(event any)
+}
+
+// NoopUINotifier is the useful zero value: producers can always call Notify even
+// before the program exists or after shutdown, with no nil checks. The container
+// defaults to it until cmd/chat.go swaps in the real (program-backed) notifier.
+type NoopUINotifier struct{}
+
+// Notify discards the event.
+func (NoopUINotifier) Notify(any) {}
+
+// NotifierFunc adapts a plain function to UINotifier. Tests use it to record the
+// events a producer pushes without a generated mock.
+type NotifierFunc func(event any)
+
+// Notify forwards to the wrapped function when non-nil.
+func (f NotifierFunc) Notify(event any) {
+	if f != nil {
+		f(event)
+	}
+}

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -39,6 +39,7 @@ type ChatHandler struct {
 	shortcutHandler        *ChatShortcutHandler
 	skillsService          domain.SkillsService
 	githubIssueService     domain.GitHubIssueService
+	drainRetryArmed        bool
 }
 
 func NewChatHandler(
@@ -174,6 +175,8 @@ func (h *ChatHandler) Handle(msg tea.Msg) tea.Cmd { // nolint:cyclop,gocyclo,fun
 		return h.HandleAgentStatusUpdateEvent(m)
 	case domain.DrainQueueEvent:
 		return h.HandleDrainQueueEvent(m)
+	case domain.DrainQueueRetryEvent:
+		return h.HandleDrainQueueRetryEvent(m)
 	case domain.NavigateBackInTimeEvent:
 		return nil
 	case domain.MessageHistoryRestoreEvent:
@@ -483,36 +486,57 @@ func (h *ChatHandler) HandleAgentStatusUpdateEvent(_ domain.AgentStatusUpdateEve
 // the chat view is active and the agent is idle, it marks the session pending and
 // starts a turn whose CheckingQueue state drains the queue.
 //
-// It re-arms a single low-frequency retry, but ONLY while there is genuinely
-// stranded work on the chat view (a non-empty queue). A background job can finish
-// at the exact instant the agent is still finishing its own turn; the supervisor's
-// one-shot DrainQueueEvent would then be gate-dropped and, without a retry, the
-// queue would be stranded forever (the old always-on ticker's repetition was the
-// de-facto retry). Arming the retry only while the queue is non-empty restores
-// that robustness without an idle clock: it stops the moment the queue drains, so
-// it never fires when idle on chat or off-chat (no /model flicker regression).
+// When work is stranded (chat view, non-empty queue) it also arms a single bounded
+// retry. A background job can finish at the exact instant the agent is still
+// finishing its own turn; the supervisor's one-shot DrainQueueEvent would then be
+// gate-dropped and, without a retry, the queue would be stranded forever (the old
+// always-on ticker's repetition was the de-facto retry). armDrainRetry restores
+// that robustness without an idle clock AND without multiplying timers: the
+// drainRetryArmed guard keeps exactly one retry chain no matter how many
+// DrainQueueEvents arrive, and the chain stops the moment the queue drains (so it
+// never fires when idle on chat or off-chat - no /model flicker regression).
 //
 // SetChatPending() marks the session busy synchronously (StartChatSession only
-// runs later inside the async Cmd), so the batched retry sees "busy" and cannot
+// runs later inside the async Cmd), so the retry sees "busy" and cannot
 // double-start. The Bubble Tea Update loop is single-threaded, so this
 // check-then-mark is race-free.
 func (h *ChatHandler) HandleDrainQueueEvent(_ domain.DrainQueueEvent) tea.Cmd {
-	// Nothing stranded, or off the chat view (the chat re-entry edge re-pushes a
-	// DrainQueueEvent on return) - no work and no retry.
 	if h.messageQueue.IsEmpty() || h.stateManager.GetCurrentView() != domain.ViewStateChat {
 		return nil
 	}
 
-	retry := tea.Tick(constants.DrainQueueRetryInterval, func(time.Time) tea.Msg {
-		return domain.DrainQueueEvent{}
-	})
-
 	if h.stateManager.IsAgentBusy() {
-		return retry
+		return h.armDrainRetry()
 	}
 
 	h.stateManager.SetChatPending()
-	return tea.Batch(h.startChatCompletion(), retry)
+	return tea.Batch(h.startChatCompletion(), h.armDrainRetry())
+}
+
+// armDrainRetry arms ONE bounded retry, collapsing the N-pushes-per-busy-turn case
+// to a single timer. It returns nil when a retry is already outstanding, so a burst
+// of DrainQueueEvents (one per background job landing in the same busy turn) can
+// never spawn parallel retry chains. Race-free: the flag is only ever touched on
+// the single-threaded Update loop.
+func (h *ChatHandler) armDrainRetry() tea.Cmd {
+	if h.drainRetryArmed {
+		return nil
+	}
+	h.drainRetryArmed = true
+	return tea.Tick(constants.DrainQueueRetryInterval, func(time.Time) tea.Msg {
+		return domain.DrainQueueRetryEvent{}
+	})
+}
+
+// HandleDrainQueueRetryEvent fires when the bounded retry tick elapses. It clears
+// the armed flag (this timer is spent) and re-runs the drain gate, which re-arms a
+// single fresh timer iff work is still stranded. A dedicated event type - rather
+// than re-emitting DrainQueueEvent - is what lets the guard distinguish "the retry
+// fired" from "a fresh external push", so exactly one retry chain stays alive
+// regardless of how many DrainQueueEvents were pushed.
+func (h *ChatHandler) HandleDrainQueueRetryEvent(_ domain.DrainQueueRetryEvent) tea.Cmd {
+	h.drainRetryArmed = false
+	return h.HandleDrainQueueEvent(domain.DrainQueueEvent{})
 }
 
 // HandleComputerUsePausedEvent handles computer use pause events

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -1,12 +1,9 @@
 package handlers
 
 import (
-	"time"
-
 	tea "charm.land/bubbletea/v2"
 
 	config "github.com/inference-gateway/cli/config"
-	constants "github.com/inference-gateway/cli/internal/constants"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	logger "github.com/inference-gateway/cli/internal/logger"
 	services "github.com/inference-gateway/cli/internal/services"
@@ -172,8 +169,8 @@ func (h *ChatHandler) Handle(msg tea.Msg) tea.Cmd { // nolint:cyclop,gocyclo,fun
 		return h.HandleTodoUpdateChatEvent(m)
 	case domain.AgentStatusUpdateEvent:
 		return h.HandleAgentStatusUpdateEvent(m)
-	case domain.DrainQueueTickEvent:
-		return h.HandleDrainQueueTickEvent(m)
+	case domain.DrainQueueEvent:
+		return h.HandleDrainQueueEvent(m)
 	case domain.NavigateBackInTimeEvent:
 		return nil
 	case domain.MessageHistoryRestoreEvent:
@@ -246,7 +243,26 @@ func (h *ChatHandler) HandleChatCompleteEvent(
 	if msg.Cancelled {
 		h.toolCoordinator.SetActiveToolCallID("")
 	}
+	if h.shouldDrainAfterComplete(msg) {
+		return tea.Batch(cmd, drainQueueCmd())
+	}
 	return cmd
+}
+
+// shouldDrainAfterComplete reports whether a completed turn should trigger a queue
+// drain. A terminal turn - cancelled, or a final answer with no tool calls - is
+// the moment queued work should drain (a message typed while busy, or a
+// background-job note that landed mid-turn). A turn with tool calls is not
+// terminal (results feed back in), so it does not drain.
+func (h *ChatHandler) shouldDrainAfterComplete(msg domain.ChatCompleteEvent) bool {
+	terminal := msg.Cancelled || len(msg.ToolCalls) == 0
+	return terminal && !h.messageQueue.IsEmpty()
+}
+
+// drainQueueCmd emits a single DrainQueueEvent on the next loop tick. The gate
+// (HandleDrainQueueEvent) starts a fresh turn only if the agent is idle.
+func drainQueueCmd() tea.Cmd {
+	return func() tea.Msg { return domain.DrainQueueEvent{} }
 }
 
 func (h *ChatHandler) HandleChatErrorEvent(
@@ -451,50 +467,35 @@ func (h *ChatHandler) HandlePlanApprovalResponseEvent(
 	return tea.Batch(cmd, h.startChatCompletion())
 }
 
-// HandleAgentStatusUpdateEvent handles agent status updates
-func (h *ChatHandler) HandleAgentStatusUpdateEvent(msg domain.AgentStatusUpdateEvent) tea.Cmd {
-	// The StateManager was already updated in the callback before this event was sent
-	// Just receiving this event triggers a UI refresh, which updates the agent indicator
-
-	// Check if all agents are ready - if so, stop polling
-	if readiness := h.stateManager.GetAgentReadiness(); readiness != nil {
-		if readiness.ReadyAgents >= readiness.TotalAgents {
-			// All agents ready, stop polling
-			return nil
-		}
-	}
-
-	// Keep polling for status updates
-	return func() tea.Msg {
-		time.Sleep(500 * time.Millisecond)
-		return domain.AgentStatusUpdateEvent{}
-	}
+// HandleAgentStatusUpdateEvent refreshes the agent indicator. The StateManager
+// was already updated by the container's status callback before this event was
+// pushed, so simply receiving it re-renders the indicator. There is no polling:
+// the callback pushes a fresh event on every real status change and stops when
+// the agents stop changing.
+func (h *ChatHandler) HandleAgentStatusUpdateEvent(_ domain.AgentStatusUpdateEvent) tea.Cmd {
+	return nil
 }
 
-// HandleDrainQueueTickEvent is the queue-drain ticker. Every tick, if the agent
-// is idle (not busy) and the shared message queue has content - a background-job
-// completion note or a user message typed while busy - it starts a fresh agent
-// turn through the normal entry point (startChatCompletion). The new turn's
-// CheckingQueue state drains the queue into the conversation and the agent
-// responds, so queued work is delivered reliably without the supervisor "wake".
-// It always reschedules itself so the loop is self-perpetuating.
+// HandleDrainQueueEvent is the pure gate for draining queued work. When the chat
+// view is active, the agent is idle, and the shared queue has content (a
+// background-job note or a message typed while busy), it marks the session
+// pending and starts a fresh turn whose CheckingQueue state drains the queue.
+// Every other case returns nil: there is no self-reschedule (the old ticker is
+// gone). The event is re-pushed by its real triggers - the supervisor on enqueue,
+// turn completion (HandleChatCompleteEvent), and re-entering the chat view.
 //
-// SetChatPending() is called synchronously before startChatCompletion because
-// the session is not marked busy until StartChatSession runs inside the async
-// Cmd; without it, the next tick could double-start a completion. The Bubble Tea
-// Update loop is single-threaded, so this check-then-mark is race-free.
-func (h *ChatHandler) HandleDrainQueueTickEvent(_ domain.DrainQueueTickEvent) tea.Cmd {
-	reschedule := tea.Tick(constants.DrainQueueTickInterval, func(time.Time) tea.Msg {
-		return domain.DrainQueueTickEvent{}
-	})
-
+// SetChatPending() is called synchronously before startChatCompletion because the
+// session is not marked busy until StartChatSession runs inside the async Cmd;
+// without it, a second DrainQueueEvent could double-start a completion. The Bubble
+// Tea Update loop is single-threaded, so this check-then-mark is race-free.
+func (h *ChatHandler) HandleDrainQueueEvent(_ domain.DrainQueueEvent) tea.Cmd {
 	if h.stateManager.GetCurrentView() != domain.ViewStateChat ||
 		h.stateManager.IsAgentBusy() || h.messageQueue.IsEmpty() {
-		return reschedule
+		return nil
 	}
 
 	h.stateManager.SetChatPending()
-	return tea.Batch(h.startChatCompletion(), reschedule)
+	return h.startChatCompletion()
 }
 
 // HandleComputerUsePausedEvent handles computer use pause events

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -1,9 +1,12 @@
 package handlers
 
 import (
+	"time"
+
 	tea "charm.land/bubbletea/v2"
 
 	config "github.com/inference-gateway/cli/config"
+	constants "github.com/inference-gateway/cli/internal/constants"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	logger "github.com/inference-gateway/cli/internal/logger"
 	services "github.com/inference-gateway/cli/internal/services"
@@ -476,26 +479,40 @@ func (h *ChatHandler) HandleAgentStatusUpdateEvent(_ domain.AgentStatusUpdateEve
 	return nil
 }
 
-// HandleDrainQueueEvent is the pure gate for draining queued work. When the chat
-// view is active, the agent is idle, and the shared queue has content (a
-// background-job note or a message typed while busy), it marks the session
-// pending and starts a fresh turn whose CheckingQueue state drains the queue.
-// Every other case returns nil: there is no self-reschedule (the old ticker is
-// gone). The event is re-pushed by its real triggers - the supervisor on enqueue,
-// turn completion (HandleChatCompleteEvent), and re-entering the chat view.
+// HandleDrainQueueEvent gates draining queued work into a fresh agent turn. When
+// the chat view is active and the agent is idle, it marks the session pending and
+// starts a turn whose CheckingQueue state drains the queue.
 //
-// SetChatPending() is called synchronously before startChatCompletion because the
-// session is not marked busy until StartChatSession runs inside the async Cmd;
-// without it, a second DrainQueueEvent could double-start a completion. The Bubble
-// Tea Update loop is single-threaded, so this check-then-mark is race-free.
+// It re-arms a single low-frequency retry, but ONLY while there is genuinely
+// stranded work on the chat view (a non-empty queue). A background job can finish
+// at the exact instant the agent is still finishing its own turn; the supervisor's
+// one-shot DrainQueueEvent would then be gate-dropped and, without a retry, the
+// queue would be stranded forever (the old always-on ticker's repetition was the
+// de-facto retry). Arming the retry only while the queue is non-empty restores
+// that robustness without an idle clock: it stops the moment the queue drains, so
+// it never fires when idle on chat or off-chat (no /model flicker regression).
+//
+// SetChatPending() marks the session busy synchronously (StartChatSession only
+// runs later inside the async Cmd), so the batched retry sees "busy" and cannot
+// double-start. The Bubble Tea Update loop is single-threaded, so this
+// check-then-mark is race-free.
 func (h *ChatHandler) HandleDrainQueueEvent(_ domain.DrainQueueEvent) tea.Cmd {
-	if h.stateManager.GetCurrentView() != domain.ViewStateChat ||
-		h.stateManager.IsAgentBusy() || h.messageQueue.IsEmpty() {
+	// Nothing stranded, or off the chat view (the chat re-entry edge re-pushes a
+	// DrainQueueEvent on return) - no work and no retry.
+	if h.messageQueue.IsEmpty() || h.stateManager.GetCurrentView() != domain.ViewStateChat {
 		return nil
 	}
 
+	retry := tea.Tick(constants.DrainQueueRetryInterval, func(time.Time) tea.Msg {
+		return domain.DrainQueueEvent{}
+	})
+
+	if h.stateManager.IsAgentBusy() {
+		return retry
+	}
+
 	h.stateManager.SetChatPending()
-	return h.startChatCompletion()
+	return tea.Batch(h.startChatCompletion(), retry)
 }
 
 // HandleComputerUsePausedEvent handles computer use pause events

--- a/internal/handlers/chat_handler_drain_test.go
+++ b/internal/handlers/chat_handler_drain_test.go
@@ -13,23 +13,28 @@ import (
 // TestHandleDrainQueueEvent guards the drain gate. It starts a fresh agent turn -
 // marking the session pending to close the double-start window - ONLY when the
 // chat view is active, the agent is idle, and the queue has content. When the
-// agent is busy with work still queued it returns a single retry Cmd (so a
-// transient gate-block can't strand the queue) WITHOUT starting a turn. When there
-// is nothing stranded (empty queue) or the user is off-chat it returns nil, so the
-// retry never fires when idle - no resurrected idle ticker.
+// agent is busy with work still queued it arms a single retry Cmd (so a transient
+// gate-block can't strand the queue) WITHOUT starting a turn. When there is nothing
+// stranded (empty queue) or the user is off-chat it returns nil, so the retry never
+// fires when idle - no resurrected idle ticker. initialArmed exercises the dedup
+// guard: a second push while a retry is already outstanding arms no second timer.
 func TestHandleDrainQueueEvent(t *testing.T) {
 	tests := []struct {
-		name       string
-		view       domain.ViewState
-		busy       bool
-		queueEmpty bool
-		wantStart  bool
-		wantCmd    bool
+		name         string
+		view         domain.ViewState
+		busy         bool
+		queueEmpty   bool
+		initialArmed bool
+		wantStart    bool
+		wantCmd      bool
+		wantArmed    bool
 	}{
-		{"idle + queued + chat -> start a turn (and retry)", domain.ViewStateChat, false, false, true, true},
-		{"busy + queued + chat -> retry only, no start", domain.ViewStateChat, true, false, false, true},
-		{"empty queue + chat -> nil (no idle ticker)", domain.ViewStateChat, false, true, false, false},
-		{"non-chat view + queued -> nil", domain.ViewStateModelSelection, false, false, false, false},
+		{"idle + queued + chat -> start a turn (and arm retry)", domain.ViewStateChat, false, false, false, true, true, true},
+		{"busy + queued + chat -> arm retry only, no start", domain.ViewStateChat, true, false, false, false, true, true},
+		{"busy + queued + chat, retry already armed -> dedup (nil, no 2nd timer)", domain.ViewStateChat, true, false, true, false, false, true},
+		{"idle + queued + chat, retry already armed -> start, no 2nd timer", domain.ViewStateChat, false, false, true, true, true, true},
+		{"empty queue + chat -> nil (no idle ticker)", domain.ViewStateChat, false, true, false, false, false, false},
+		{"non-chat view + queued -> nil", domain.ViewStateModelSelection, false, false, false, false, false, false},
 	}
 
 	for _, tt := range tests {
@@ -50,6 +55,7 @@ func TestHandleDrainQueueEvent(t *testing.T) {
 				completionRunner: runner,
 				directExec:       &mocks.FakeDirectExecutionService{},
 			}
+			h.drainRetryArmed = tt.initialArmed
 
 			cmd := h.HandleDrainQueueEvent(domain.DrainQueueEvent{})
 
@@ -59,6 +65,9 @@ func TestHandleDrainQueueEvent(t *testing.T) {
 			if started := runner.StartCallCount() > 0; started != tt.wantStart {
 				t.Fatalf("startChatCompletion called=%v, want %v", started, tt.wantStart)
 			}
+			if h.drainRetryArmed != tt.wantArmed {
+				t.Fatalf("drainRetryArmed = %v, want %v", h.drainRetryArmed, tt.wantArmed)
+			}
 
 			wantPending := 0
 			if tt.wantStart {
@@ -66,6 +75,59 @@ func TestHandleDrainQueueEvent(t *testing.T) {
 			}
 			if got := sm.SetChatPendingCallCount(); got != wantPending {
 				t.Fatalf("SetChatPending called %d times, want %d (must guard the double-start window)", got, wantPending)
+			}
+		})
+	}
+}
+
+// TestHandleDrainQueueRetryEvent pins the bounded-retry chain: when the retry tick
+// fires it disarms (this timer is spent) then re-runs the gate, re-arming exactly
+// one fresh timer while work is still stranded and stopping the moment the queue
+// drains. This is what keeps a burst of pushes to a single retry chain.
+func TestHandleDrainQueueRetryEvent(t *testing.T) {
+	tests := []struct {
+		name       string
+		busy       bool
+		queueEmpty bool
+		wantStart  bool
+		wantCmd    bool
+		wantArmed  bool
+	}{
+		{"still busy + queued -> re-arm one timer", true, false, false, true, true},
+		{"queue drained -> stop (nil, disarmed)", false, true, false, false, false},
+		{"idle + queued -> start + re-arm", false, false, true, true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := &mocks.FakeStateManager{}
+			sm.GetCurrentViewReturns(domain.ViewStateChat)
+			sm.IsAgentBusyReturns(tt.busy)
+
+			queue := &mocks.FakeMessageQueue{}
+			queue.IsEmptyReturns(tt.queueEmpty)
+
+			runner := &mocks.FakeChatCompletionRunner{}
+			runner.StartReturns(func() tea.Msg { return nil })
+
+			h := &ChatHandler{
+				stateManager:     sm,
+				messageQueue:     queue,
+				completionRunner: runner,
+				directExec:       &mocks.FakeDirectExecutionService{},
+			}
+			h.drainRetryArmed = true
+
+			cmd := h.HandleDrainQueueRetryEvent(domain.DrainQueueRetryEvent{})
+
+			if (cmd != nil) != tt.wantCmd {
+				t.Fatalf("returned a Cmd = %v, want %v", cmd != nil, tt.wantCmd)
+			}
+			if started := runner.StartCallCount() > 0; started != tt.wantStart {
+				t.Fatalf("startChatCompletion called=%v, want %v", started, tt.wantStart)
+			}
+			if h.drainRetryArmed != tt.wantArmed {
+				t.Fatalf("drainRetryArmed = %v, want %v (exactly one chain)", h.drainRetryArmed, tt.wantArmed)
 			}
 		})
 	}

--- a/internal/handlers/chat_handler_drain_test.go
+++ b/internal/handlers/chat_handler_drain_test.go
@@ -10,11 +10,13 @@ import (
 	mocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
-// TestHandleDrainQueueEvent is the regression guard for the pure, gate-only queue
-// drain. It must start a fresh agent turn - and mark the session pending to close
-// the double-start window - ONLY when the chat view is active, the agent is idle,
-// and the queue has content. In every other case it must return nil: there is no
-// self-reschedule, so the deleted ticker can never creep back in.
+// TestHandleDrainQueueEvent guards the drain gate. It starts a fresh agent turn -
+// marking the session pending to close the double-start window - ONLY when the
+// chat view is active, the agent is idle, and the queue has content. When the
+// agent is busy with work still queued it returns a single retry Cmd (so a
+// transient gate-block can't strand the queue) WITHOUT starting a turn. When there
+// is nothing stranded (empty queue) or the user is off-chat it returns nil, so the
+// retry never fires when idle - no resurrected idle ticker.
 func TestHandleDrainQueueEvent(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -22,11 +24,12 @@ func TestHandleDrainQueueEvent(t *testing.T) {
 		busy       bool
 		queueEmpty bool
 		wantStart  bool
+		wantCmd    bool
 	}{
-		{"idle + queued + chat -> start a turn", domain.ViewStateChat, false, false, true},
-		{"agent busy -> nil", domain.ViewStateChat, true, false, false},
-		{"empty queue -> nil", domain.ViewStateChat, false, true, false},
-		{"non-chat view -> nil", domain.ViewStateModelSelection, false, false, false},
+		{"idle + queued + chat -> start a turn (and retry)", domain.ViewStateChat, false, false, true, true},
+		{"busy + queued + chat -> retry only, no start", domain.ViewStateChat, true, false, false, true},
+		{"empty queue + chat -> nil (no idle ticker)", domain.ViewStateChat, false, true, false, false},
+		{"non-chat view + queued -> nil", domain.ViewStateModelSelection, false, false, false, false},
 	}
 
 	for _, tt := range tests {
@@ -50,14 +53,9 @@ func TestHandleDrainQueueEvent(t *testing.T) {
 
 			cmd := h.HandleDrainQueueEvent(domain.DrainQueueEvent{})
 
-			if tt.wantStart {
-				if cmd == nil {
-					t.Fatal("expected a start Cmd when chat + idle + queued")
-				}
-			} else if cmd != nil {
-				t.Fatal("gate-only handler must return nil in every no-op branch (no reschedule ticker)")
+			if (cmd != nil) != tt.wantCmd {
+				t.Fatalf("returned a Cmd = %v, want %v", cmd != nil, tt.wantCmd)
 			}
-
 			if started := runner.StartCallCount() > 0; started != tt.wantStart {
 				t.Fatalf("startChatCompletion called=%v, want %v", started, tt.wantStart)
 			}

--- a/internal/handlers/chat_handler_drain_test.go
+++ b/internal/handlers/chat_handler_drain_test.go
@@ -3,16 +3,19 @@ package handlers
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+	sdk "github.com/inference-gateway/sdk"
+
 	domain "github.com/inference-gateway/cli/internal/domain"
 	mocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
-// TestHandleDrainQueueTickEvent is the regression guard for the queue-drain
-// ticker (the reliable replacement for the supervisor "wake"). It must start a
-// fresh agent turn - and mark the session pending to close the double-start
-// window - ONLY when the chat view is active, the agent is idle, and the queue
-// has content. In every other case it just reschedules itself.
-func TestHandleDrainQueueTickEvent(t *testing.T) {
+// TestHandleDrainQueueEvent is the regression guard for the pure, gate-only queue
+// drain. It must start a fresh agent turn - and mark the session pending to close
+// the double-start window - ONLY when the chat view is active, the agent is idle,
+// and the queue has content. In every other case it must return nil: there is no
+// self-reschedule, so the deleted ticker can never creep back in.
+func TestHandleDrainQueueEvent(t *testing.T) {
 	tests := []struct {
 		name       string
 		view       domain.ViewState
@@ -21,9 +24,9 @@ func TestHandleDrainQueueTickEvent(t *testing.T) {
 		wantStart  bool
 	}{
 		{"idle + queued + chat -> start a turn", domain.ViewStateChat, false, false, true},
-		{"agent busy -> reschedule only", domain.ViewStateChat, true, false, false},
-		{"empty queue -> reschedule only", domain.ViewStateChat, false, true, false},
-		{"non-chat view -> reschedule only", domain.ViewStateModelSelection, false, false, false},
+		{"agent busy -> nil", domain.ViewStateChat, true, false, false},
+		{"empty queue -> nil", domain.ViewStateChat, false, true, false},
+		{"non-chat view -> nil", domain.ViewStateModelSelection, false, false, false},
 	}
 
 	for _, tt := range tests {
@@ -36,6 +39,7 @@ func TestHandleDrainQueueTickEvent(t *testing.T) {
 			queue.IsEmptyReturns(tt.queueEmpty)
 
 			runner := &mocks.FakeChatCompletionRunner{}
+			runner.StartReturns(func() tea.Msg { return nil })
 
 			h := &ChatHandler{
 				stateManager:     sm,
@@ -44,9 +48,14 @@ func TestHandleDrainQueueTickEvent(t *testing.T) {
 				directExec:       &mocks.FakeDirectExecutionService{},
 			}
 
-			cmd := h.HandleDrainQueueTickEvent(domain.DrainQueueTickEvent{})
-			if cmd == nil {
-				t.Fatal("handler must always return a reschedule Cmd so the ticker keeps running")
+			cmd := h.HandleDrainQueueEvent(domain.DrainQueueEvent{})
+
+			if tt.wantStart {
+				if cmd == nil {
+					t.Fatal("expected a start Cmd when chat + idle + queued")
+				}
+			} else if cmd != nil {
+				t.Fatal("gate-only handler must return nil in every no-op branch (no reschedule ticker)")
 			}
 
 			if started := runner.StartCallCount() > 0; started != tt.wantStart {
@@ -59,6 +68,39 @@ func TestHandleDrainQueueTickEvent(t *testing.T) {
 			}
 			if got := sm.SetChatPendingCallCount(); got != wantPending {
 				t.Fatalf("SetChatPending called %d times, want %d (must guard the double-start window)", got, wantPending)
+			}
+		})
+	}
+}
+
+// TestShouldDrainAfterComplete pins the emit decision for HandleChatCompleteEvent:
+// a terminal turn (cancelled, or a final answer with no tool calls) drains only
+// when the queue is non-empty; a turn that still has tool calls never drains.
+func TestShouldDrainAfterComplete(t *testing.T) {
+	toolCall := []sdk.ChatCompletionMessageToolCall{{}}
+	tests := []struct {
+		name       string
+		cancelled  bool
+		toolCalls  []sdk.ChatCompletionMessageToolCall
+		queueEmpty bool
+		want       bool
+	}{
+		{"final answer + queued -> drain", false, nil, false, true},
+		{"cancelled + queued -> drain", true, toolCall, false, true},
+		{"final answer + empty queue -> no drain", false, nil, true, false},
+		{"has tool calls (not terminal) + queued -> no drain", false, toolCall, false, false},
+		{"has tool calls + empty queue -> no drain", false, toolCall, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			queue := &mocks.FakeMessageQueue{}
+			queue.IsEmptyReturns(tt.queueEmpty)
+			h := &ChatHandler{messageQueue: queue}
+
+			msg := domain.ChatCompleteEvent{Cancelled: tt.cancelled, ToolCalls: tt.toolCalls}
+			if got := h.shouldDrainAfterComplete(msg); got != tt.want {
+				t.Errorf("shouldDrainAfterComplete = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -73,6 +73,17 @@ func GetGlobalLogger() *zap.Logger {
 	return globalLogger
 }
 
+// SetGlobalLogger swaps the global logger (and its sugared form). It is primarily
+// a test seam: tests build a logger over an observed core to assert what was
+// logged. Passing nil is a no-op.
+func SetGlobalLogger(l *zap.Logger) {
+	if l == nil {
+		return
+	}
+	globalLogger = l
+	sugar = l.Sugar()
+}
+
 // Debug logs a debug message
 func Debug(msg string, args ...any) {
 	if sugar != nil {

--- a/internal/services/background_task_registry_test.go
+++ b/internal/services/background_task_registry_test.go
@@ -10,7 +10,7 @@ import (
 // newTestRegistry builds a registry with a real (idle) supervisor for the
 // per-kind tracker tests below.
 func newTestRegistry(maxShells int) domain.BackgroundTaskRegistry {
-	return NewBackgroundTaskRegistry(maxShells, jobs.NewSupervisor(nil, nil))
+	return NewBackgroundTaskRegistry(maxShells, jobs.NewSupervisor(nil, nil, nil))
 }
 
 // TestHasPending_ExcludesInteractiveSubagents guards the fix for #678: a running

--- a/internal/services/chatcompletion/runner.go
+++ b/internal/services/chatcompletion/runner.go
@@ -182,6 +182,7 @@ func (r *Runner) HandleChatComplete(msg domain.ChatCompleteEvent) tea.Cmd {
 		r.stateManager.EndToolExecution()
 	} else if len(msg.ToolCalls) == 0 {
 		_ = r.stateManager.UpdateChatStatus(domain.ChatStatusCompleted)
+		r.stateManager.EndToolExecution()
 	}
 
 	cmds := []tea.Cmd{

--- a/internal/services/chatcompletion/runner_test.go
+++ b/internal/services/chatcompletion/runner_test.go
@@ -281,6 +281,9 @@ func TestRunner_HandleChatComplete(t *testing.T) {
 		if status := state.UpdateChatStatusArgsForCall(0); status != domain.ChatStatusCompleted {
 			t.Errorf("expected ChatStatusCompleted, got %v", status)
 		}
+		if state.EndToolExecutionCallCount() != 1 {
+			t.Errorf("expected EndToolExecution once on terminal completion, got %d", state.EndToolExecutionCallCount())
+		}
 	})
 
 	t.Run("cancelled: tears down session and updates status to Cancelled", func(t *testing.T) {

--- a/internal/services/jobs/shell_job_test.go
+++ b/internal/services/jobs/shell_job_test.go
@@ -48,7 +48,7 @@ func waitTerminal(t *testing.T, sup *Supervisor, id string) domain.JobStatus {
 func TestShellJob_CompletesAndNotifies(t *testing.T) {
 	tracker := utils.NewShellTracker(10)
 	queue := &domainmocks.FakeMessageQueue{}
-	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{}, nil)
 	defer sup.Stop()
 
 	shell := startShell(t, "s-ok", "true")
@@ -68,7 +68,7 @@ func TestShellJob_CompletesAndNotifies(t *testing.T) {
 
 func TestShellJob_FailureRecordsExitCode(t *testing.T) {
 	tracker := utils.NewShellTracker(10)
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	defer sup.Stop()
 
 	shell := startShell(t, "s-fail", "false")
@@ -85,14 +85,14 @@ func TestShellJob_FailureRecordsExitCode(t *testing.T) {
 
 func TestShellJob_WindStopCancels(t *testing.T) {
 	tracker := utils.NewShellTracker(10)
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	defer sup.Stop()
 
 	shell := startShell(t, "s-sleep", "sleep", "60")
 	_ = tracker.Add(shell)
 	sup.Submit(NewShellJob(shell, tracker))
 
-	time.Sleep(20 * time.Millisecond) // let the monitor start waiting
+	time.Sleep(20 * time.Millisecond)
 	if err := sup.Wind("s-sleep", domain.WindStop); err != nil {
 		t.Fatalf("Wind: %v", err)
 	}

--- a/internal/services/jobs/supervisor.go
+++ b/internal/services/jobs/supervisor.go
@@ -71,12 +71,10 @@ func NewSupervisor(messageQueue domain.MessageQueue, conversationRepo domain.Con
 	}
 }
 
-// notify pushes an event to the UI loop. It is nil-safe so a zero-value
-// Supervisor (e.g. one built directly in a test) never panics.
+// notify pushes an event to the UI loop. NewSupervisor defaults a nil notifier to
+// NoopUINotifier, so s.notifier is always non-nil here.
 func (s *Supervisor) notify(event any) {
-	if s.notifier != nil {
-		s.notifier.Notify(event)
-	}
+	s.notifier.Notify(event)
 }
 
 // SetConversationRepo wires the conversation repository used to format finished

--- a/internal/services/jobs/supervisor.go
+++ b/internal/services/jobs/supervisor.go
@@ -18,6 +18,7 @@ import (
 
 	sdk "github.com/inference-gateway/sdk"
 
+	constants "github.com/inference-gateway/cli/internal/constants"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	logger "github.com/inference-gateway/cli/internal/logger"
 )
@@ -26,6 +27,7 @@ import (
 type Supervisor struct {
 	messageQueue     domain.MessageQueue
 	conversationRepo domain.ConversationRepository
+	notifier         domain.UINotifier
 
 	mu              sync.RWMutex
 	jobs            map[string]*supervised
@@ -46,18 +48,34 @@ type supervised struct {
 	completedAt *time.Time
 	lastNote    string
 	cancel      context.CancelFunc
+	warnedLong  bool // a "job running long" warning has been emitted once
 }
 
 // NewSupervisor constructs a supervisor. messageQueue and conversationRepo are
 // long-lived singletons used to deliver finished jobs' results back onto the
 // conversation; either may be nil (the supervisor degrades to event-only).
-func NewSupervisor(messageQueue domain.MessageQueue, conversationRepo domain.ConversationRepository) *Supervisor {
+// notifier is the single UI ingress used to push DrainQueueEvent (so landed work
+// drains promptly) and BackgroundTasksChangedEvent (so the task view refreshes);
+// a nil notifier degrades to no UI pushes.
+func NewSupervisor(messageQueue domain.MessageQueue, conversationRepo domain.ConversationRepository, notifier domain.UINotifier) *Supervisor {
+	if notifier == nil {
+		notifier = domain.NoopUINotifier{}
+	}
 	return &Supervisor{
 		messageQueue:     messageQueue,
 		conversationRepo: conversationRepo,
+		notifier:         notifier,
 		jobs:             make(map[string]*supervised),
 		retentionByKind:  make(map[domain.JobKind]int),
 		stopCleanup:      make(chan struct{}),
+	}
+}
+
+// notify pushes an event to the UI loop. It is nil-safe so a zero-value
+// Supervisor (e.g. one built directly in a test) never panics.
+func (s *Supervisor) notify(event any) {
+	if s.notifier != nil {
+		s.notifier.Notify(event)
 	}
 }
 
@@ -143,6 +161,7 @@ func (s *Supervisor) Submit(job domain.BackgroundJob) {
 	}
 
 	go s.monitor(ctx, sj)
+	s.notify(domain.BackgroundTasksChangedEvent{})
 }
 
 // monitor runs one job to completion and then delivers its outcome. A panicking
@@ -164,14 +183,15 @@ func (s *Supervisor) monitor(ctx context.Context, sj *supervised) {
 }
 
 // onSignal records a job's intermediate status and, when the signal asks for it,
-// lands the note on the shared queue. The chat-UI queue-drain ticker (and the
-// headless waiter) deliver it to the agent - the supervisor never touches a
-// per-request channel.
+// lands the note on the shared queue. enqueue pushes a DrainQueueEvent so the
+// idle agent picks the note up; the supervisor never touches a per-request
+// channel. A BackgroundTasksChangedEvent refreshes the task view's last-note.
 func (s *Supervisor) onSignal(sj *supervised, sig domain.JobSignal) {
 	if sig.Note != "" {
 		s.mu.Lock()
 		sj.lastNote = sig.Note
 		s.mu.Unlock()
+		s.notify(domain.BackgroundTasksChangedEvent{})
 	}
 
 	if sig.Enqueue && sig.Note != "" {
@@ -182,7 +202,8 @@ func (s *Supervisor) onSignal(sj *supervised, sig domain.JobSignal) {
 // finish marks a job terminal and lands its result on the shared queue (unless
 // the job is Silent and delivered its own per-turn notes). The entry is KEPT
 // (terminal) so the task view can show it; Cleanup reaps it after the retention
-// window. The chat-UI queue-drain ticker delivers the note to the agent.
+// window. enqueue pushes a DrainQueueEvent so the agent picks up the note, and a
+// BackgroundTasksChangedEvent refreshes the task view's status.
 func (s *Supervisor) finish(sj *supervised, result domain.ToolExecutionResult) {
 	now := time.Now()
 	status := domain.JobCompleted
@@ -199,6 +220,8 @@ func (s *Supervisor) finish(sj *supervised, result domain.ToolExecutionResult) {
 	for _, v := range evicted {
 		v.job.Close()
 	}
+
+	s.notify(domain.BackgroundTasksChangedEvent{})
 
 	if !sj.meta.Silent {
 		res := result
@@ -282,7 +305,11 @@ func asNotifier(job domain.BackgroundJob) domain.JobNotifier {
 	return nil
 }
 
-// enqueue lands content on the shared message queue as a user-role message.
+// enqueue lands content on the shared message queue as a user-role message and
+// pushes a DrainQueueEvent so an idle agent on the chat view starts a turn to
+// read it. The gate (HandleDrainQueueEvent) drops the event when the agent is
+// busy or off-chat; that work is then picked up at the next turn completion or on
+// returning to chat.
 func (s *Supervisor) enqueue(content string) {
 	if s.messageQueue == nil {
 		return
@@ -291,6 +318,7 @@ func (s *Supervisor) enqueue(content string) {
 		Role:    sdk.User,
 		Content: sdk.NewMessageContent(content),
 	}, "system")
+	s.notify(domain.DrainQueueEvent{})
 }
 
 // Wind delivers a graceful wind-down or hard stop to a single running job by id.
@@ -370,14 +398,23 @@ func (s *Supervisor) CountRunning(kind domain.JobKind) int {
 
 // Cleanup reaps finished jobs whose terminal timestamp is older than olderThan,
 // running each one's Wind(WindStop) teardown (kill pane, remove temp files)
-// before dropping it. Running jobs are never reaped. Returns the number removed.
+// before dropping it. Running jobs are never reaped. The same sweep emits a
+// one-time "job running long" warning for any still-running job that has exceeded
+// JobRunningLongThreshold. Returns the number removed.
 func (s *Supervisor) Cleanup(olderThan time.Duration) int {
-	cutoff := time.Now().Add(-olderThan)
+	now := time.Now()
+	cutoff := now.Add(-olderThan)
+	longCutoff := now.Add(-constants.JobRunningLongThreshold)
 
 	s.mu.Lock()
 	var reaped []*supervised
+	var longRunning []domain.JobMeta
 	for id, sj := range s.jobs {
 		if !sj.status.IsTerminal() {
+			if !sj.warnedLong && sj.meta.StartedAt.Before(longCutoff) {
+				sj.warnedLong = true
+				longRunning = append(longRunning, sj.meta)
+			}
 			continue
 		}
 		if terminalTime(sj).After(cutoff) {
@@ -390,6 +427,13 @@ func (s *Supervisor) Cleanup(olderThan time.Duration) int {
 
 	for _, sj := range reaped {
 		sj.job.Close()
+	}
+	for _, m := range longRunning {
+		logger.Warn("job running long",
+			"kind", string(m.Kind),
+			"label", m.Label,
+			"elapsed_s", int(now.Sub(m.StartedAt).Seconds()),
+		)
 	}
 	return len(reaped)
 }

--- a/internal/services/jobs/supervisor.go
+++ b/internal/services/jobs/supervisor.go
@@ -48,7 +48,7 @@ type supervised struct {
 	completedAt *time.Time
 	lastNote    string
 	cancel      context.CancelFunc
-	warnedLong  bool // a "job running long" warning has been emitted once
+	warnedLong  bool
 }
 
 // NewSupervisor constructs a supervisor. messageQueue and conversationRepo are

--- a/internal/services/jobs/supervisor_notifier_test.go
+++ b/internal/services/jobs/supervisor_notifier_test.go
@@ -1,0 +1,112 @@
+package jobs
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	zap "go.uber.org/zap"
+	zapcore "go.uber.org/zap/zapcore"
+	observer "go.uber.org/zap/zaptest/observer"
+
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	logger "github.com/inference-gateway/cli/internal/logger"
+)
+
+// recNotifier is a thread-safe domain.UINotifier that records pushed events by
+// type, so tests can assert what the supervisor emitted from its goroutines.
+type recNotifier struct {
+	mu     sync.Mutex
+	events []any
+}
+
+func (r *recNotifier) Notify(e any) {
+	r.mu.Lock()
+	r.events = append(r.events, e)
+	r.mu.Unlock()
+}
+
+func (r *recNotifier) counts() map[string]int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	m := map[string]int{}
+	for _, e := range r.events {
+		m[fmt.Sprintf("%T", e)]++
+	}
+	return m
+}
+
+// A non-silent job pushes UI events through the notifier instead of relying on a
+// poller: BackgroundTasksChangedEvent on submit and on finish, and a single
+// DrainQueueEvent when the completion note lands on the queue.
+func TestSupervisor_PushesNotifierEvents(t *testing.T) {
+	rec := &recNotifier{}
+	queue := &domainmocks.FakeMessageQueue{}
+	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{}, rec)
+
+	job := newFakeJob("job-1", domain.JobKindShell)
+	sup.Submit(job)
+	<-job.started
+	close(job.finish)
+	sup.Stop() // waits for the monitor goroutine, so finish has fully run
+
+	c := rec.counts()
+	if got := c["domain.DrainQueueEvent"]; got != 1 {
+		t.Errorf("DrainQueueEvent pushed %d times, want 1 (enqueue on finish)", got)
+	}
+	if got := c["domain.BackgroundTasksChangedEvent"]; got != 2 {
+		t.Errorf("BackgroundTasksChangedEvent pushed %d times, want 2 (submit + finish)", got)
+	}
+}
+
+// A signalled job that asks to enqueue its note pushes a DrainQueueEvent for that
+// signal. The job is silent so the finish path does not also enqueue, isolating
+// the signal-driven push.
+func TestSupervisor_SignalEnqueuePushesDrain(t *testing.T) {
+	rec := &recNotifier{}
+	queue := &domainmocks.FakeMessageQueue{}
+	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{}, rec)
+
+	job := newFakeJob("job-sig", domain.JobKindSubagent)
+	job.meta.Silent = true
+	job.signals = []domain.JobSignal{{Note: "progress", Enqueue: true}}
+	sup.Submit(job)
+	<-job.started
+	close(job.finish)
+	sup.Stop()
+
+	if got := rec.counts()["domain.DrainQueueEvent"]; got != 1 {
+		t.Errorf("DrainQueueEvent pushed %d times, want 1 (signal enqueue)", got)
+	}
+}
+
+// Cleanup warns exactly once for a still-running job that has exceeded
+// JobRunningLongThreshold; the warnedLong guard suppresses repeats on later sweeps.
+func TestSupervisor_CleanupWarnsLongRunningJobOnce(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	prev := logger.GetGlobalLogger()
+	logger.SetGlobalLogger(zap.New(core))
+	defer logger.SetGlobalLogger(prev)
+
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
+
+	job := newFakeJob("slow", domain.JobKindShell)
+	job.meta.StartedAt = time.Now().Add(-10 * time.Minute) // exceeds the 5m threshold
+	sup.Submit(job)
+	<-job.started
+
+	// The job is still running, so it is never reaped; only the long-run warning
+	// fires, and only on the first sweep.
+	sup.Cleanup(time.Hour)
+	sup.Cleanup(time.Hour)
+
+	close(job.finish)
+	sup.Stop()
+
+	if warns := logs.FilterMessage("job running long").Len(); warns != 1 {
+		t.Fatalf("expected exactly 1 'job running long' warning, got %d", warns)
+	}
+}

--- a/internal/services/jobs/supervisor_test.go
+++ b/internal/services/jobs/supervisor_test.go
@@ -81,20 +81,19 @@ func (f *fakeJob) closes() int {
 // per-request binding - it only ever produces queue messages.
 func TestSupervisor_FinishOnce(t *testing.T) {
 	queue := &domainmocks.FakeMessageQueue{}
-	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{}, nil)
 
 	job := newFakeJob("job-1", domain.JobKindShell)
 	sup.Submit(job)
 	<-job.started
 
 	close(job.finish)
-	sup.Stop() // waits for the monitor goroutine, so finish has fully run
+	sup.Stop()
 
 	if n := queue.EnqueueCallCount(); n != 1 {
 		t.Fatalf("Enqueue called %d times, want 1", n)
 	}
 
-	// The terminal job is kept for the task view until cleanup.
 	snap := sup.Snapshot()
 	if len(snap) != 1 || snap[0].Status != domain.JobCompleted {
 		t.Fatalf("snapshot = %+v, want one completed job", snap)
@@ -103,7 +102,7 @@ func TestSupervisor_FinishOnce(t *testing.T) {
 
 func TestSupervisor_SilentJobDoesNotEnqueue(t *testing.T) {
 	queue := &domainmocks.FakeMessageQueue{}
-	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{}, nil)
 	job := newFakeJob("silent", domain.JobKindSubagent)
 	job.meta.Silent = true
 	sup.Submit(job)
@@ -123,7 +122,7 @@ func TestSupervisor_SilentJobDoesNotEnqueue(t *testing.T) {
 // channel.
 func TestSupervisor_ConcurrentFinishEnqueuesEachOnce(t *testing.T) {
 	queue := &domainmocks.FakeMessageQueue{}
-	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(queue, &domainmocks.FakeConversationRepository{}, nil)
 
 	const n = 16
 	js := make([]*fakeJob, n)
@@ -147,7 +146,7 @@ func TestSupervisor_ConcurrentFinishEnqueuesEachOnce(t *testing.T) {
 }
 
 func TestSupervisor_WindStopCancelsRun(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	job := newFakeJob("j", domain.JobKindSubagent)
 	sup.Submit(job)
 	<-job.started
@@ -155,7 +154,7 @@ func TestSupervisor_WindStopCancelsRun(t *testing.T) {
 	if err := sup.Wind("j", domain.WindStop); err != nil {
 		t.Fatalf("Wind: %v", err)
 	}
-	sup.Stop() // Run returns because WindStop cancelled its ctx
+	sup.Stop()
 
 	winds := job.winds()
 	if len(winds) == 0 || winds[0] != domain.WindStop {
@@ -168,14 +167,14 @@ func TestSupervisor_WindStopCancelsRun(t *testing.T) {
 }
 
 func TestSupervisor_WindUnknownJob(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	if err := sup.Wind("missing", domain.WindWrapUp); err == nil {
 		t.Fatalf("expected error winding unknown job")
 	}
 }
 
 func TestSupervisor_CleanupReapsFinishedAndTearsDown(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	job := newFakeJob("j", domain.JobKindSubagent)
 	sup.Submit(job)
 	<-job.started
@@ -197,7 +196,7 @@ func TestSupervisor_CleanupReapsFinishedAndTearsDown(t *testing.T) {
 }
 
 func TestSupervisor_CountRunning(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 
 	sub := newFakeJob("subagent", domain.JobKindSubagent)
 	sup.Submit(sub)
@@ -218,7 +217,7 @@ func TestSupervisor_CountRunning(t *testing.T) {
 }
 
 func TestSupervisor_SubmitAfterStopIgnored(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	sup.Stop()
 	sup.Submit(newFakeJob("late", domain.JobKindShell))
 	if len(sup.Snapshot()) != 0 {
@@ -227,7 +226,7 @@ func TestSupervisor_SubmitAfterStopIgnored(t *testing.T) {
 }
 
 func TestSupervisor_DuplicateSubmitIgnored(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	job := newFakeJob("dup", domain.JobKindShell)
 	sup.Submit(job)
 	<-job.started
@@ -279,7 +278,7 @@ func waitFor(t *testing.T, cond func() bool) {
 // terminal job of its kind and tears it down (Close) exactly once. Jobs finish
 // sequentially with a gap so completedAt ordering is deterministic.
 func TestSupervisor_RetentionCountEvictsOldestOnFinish(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	sup.SetRetentionCount(domain.JobKindShell, 2)
 
 	js := make([]*fakeJob, 3)
@@ -319,7 +318,7 @@ func TestSupervisor_RetentionCountEvictsOldestOnFinish(t *testing.T) {
 // TestSupervisor_RetentionCountPerKindIndependent: caps are tracked per kind, so
 // finished shells never evict subagents and vice versa.
 func TestSupervisor_RetentionCountPerKindIndependent(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	sup.SetRetentionCount(domain.JobKindShell, 1)
 	sup.SetRetentionCount(domain.JobKindSubagent, 1)
 
@@ -365,7 +364,7 @@ func TestSupervisor_RetentionCountPerKindIndependent(t *testing.T) {
 // TestSupervisor_RetentionCountUnsetIsUnbounded: with no cap set, every terminal
 // job is retained (current behavior) and none is torn down by retention.
 func TestSupervisor_RetentionCountUnsetIsUnbounded(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 
 	js := make([]*fakeJob, 4)
 	for i := range js {
@@ -390,7 +389,7 @@ func TestSupervisor_RetentionCountUnsetIsUnbounded(t *testing.T) {
 // retention victim, so a burst of finished headless subagents cannot reap a live
 // interactive subagent pane.
 func TestSupervisor_RunningJobNeverEvicted(t *testing.T) {
-	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{})
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
 	sup.SetRetentionCount(domain.JobKindSubagent, 1)
 
 	live := newFakeJob("interactive", domain.JobKindSubagent)

--- a/internal/services/mcp_manager.go
+++ b/internal/services/mcp_manager.go
@@ -240,20 +240,24 @@ type MCPManager struct {
 	sessionID        domain.SessionID
 	config           *config.MCPConfig
 	containerRuntime domain.ContainerRuntime
+	notifier         domain.UINotifier
 	mu               sync.RWMutex
 	clients          map[string]*mcpClient
 	toolCounts       map[string]int
 	probeCancel      context.CancelFunc
 	probeWg          sync.WaitGroup
-	statusChan       chan domain.MCPServerStatusUpdateEvent
 	monitorStarted   bool
-	channelClosed    bool
 	containerIDs     map[string]string
 	assignedPorts    map[string]int
 }
 
-// NewMCPManager creates a new MCP manager
-func NewMCPManager(sessionID domain.SessionID, cfg *config.MCPConfig, runtime domain.ContainerRuntime) *MCPManager {
+// NewMCPManager creates a new MCP manager. notifier is the single UI ingress the
+// liveness probes push MCPServerStatusUpdateEvent through; a nil notifier
+// degrades to no UI pushes.
+func NewMCPManager(sessionID domain.SessionID, cfg *config.MCPConfig, runtime domain.ContainerRuntime, notifier domain.UINotifier) *MCPManager {
+	if notifier == nil {
+		notifier = domain.NoopUINotifier{}
+	}
 	clients := make(map[string]*mcpClient)
 
 	for _, server := range cfg.Servers {
@@ -271,10 +275,19 @@ func NewMCPManager(sessionID domain.SessionID, cfg *config.MCPConfig, runtime do
 		sessionID:        sessionID,
 		config:           cfg,
 		containerRuntime: runtime,
+		notifier:         notifier,
 		clients:          clients,
 		toolCounts:       make(map[string]int),
 		containerIDs:     make(map[string]string),
 		assignedPorts:    make(map[string]int),
+	}
+}
+
+// notify pushes an event to the UI loop. It is nil-safe so a zero-value manager
+// (e.g. one built directly in a test) never panics.
+func (m *MCPManager) notify(event any) {
+	if m.notifier != nil {
+		m.notifier.Notify(event)
 	}
 }
 
@@ -310,28 +323,28 @@ func (m *MCPManager) GetTotalServers() int {
 	return len(m.config.Servers)
 }
 
-// StartMonitoring begins background health monitoring and returns a channel for status updates
-// This method is idempotent - calling it multiple times returns the same channel
-func (m *MCPManager) StartMonitoring(ctx context.Context) <-chan domain.MCPServerStatusUpdateEvent {
+// StartMonitoring begins background health monitoring, pushing every
+// MCPServerStatusUpdateEvent through the injected UI notifier. It is idempotent -
+// subsequent calls are no-ops. The initial status is emitted from a goroutine
+// because Notify wraps the unbuffered (*tea.Program).Send, which blocks until the
+// Bubble Tea loop consumes; emitting it synchronously from app.Init (before the
+// loop runs) would deadlock.
+func (m *MCPManager) StartMonitoring(ctx context.Context) {
 	m.mu.Lock()
-
 	if m.monitorStarted {
 		m.mu.Unlock()
-		return m.statusChan
+		return
 	}
-
-	m.statusChan = make(chan domain.MCPServerStatusUpdateEvent, 10)
 	m.monitorStarted = true
 	m.mu.Unlock()
 
-	m.sendInitialStatusUpdate()
+	go m.sendInitialStatusUpdate()
 
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if !m.config.LivenessProbeEnabled {
-		close(m.statusChan)
-		m.channelClosed = true
-		m.mu.Unlock()
-		return m.statusChan
+		return
 	}
 
 	interval := time.Duration(m.config.LivenessProbeInterval) * time.Second
@@ -383,9 +396,6 @@ func (m *MCPManager) StartMonitoring(ctx context.Context) <-chan domain.MCPServe
 			}
 		}(client)
 	}
-	m.mu.Unlock()
-
-	return m.statusChan
 }
 
 // checkClientHealth performs a health check on a client and handles reconnection
@@ -532,19 +542,24 @@ func (m *MCPManager) calculateBackoff(attempt int, baseInterval time.Duration) t
 	return backoff
 }
 
-// sendInitialStatusUpdate sends the current status for all connected clients
+// sendInitialStatusUpdate pushes the current status for all connected clients. It
+// collects the connected server names under the lock, then emits after releasing
+// it: notify wraps the blocking program.Send, which must never run under m.mu.
 func (m *MCPManager) sendInitialStatusUpdate() {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
+	connected := make([]string, 0, len(m.clients))
 	for _, client := range m.clients {
 		client.mu.RLock()
 		isConnected := client.isConnected
 		client.mu.RUnlock()
-
 		if isConnected {
-			m.sendStatusUpdateWithTools(client.serverName, true, nil)
+			connected = append(connected, client.serverName)
 		}
+	}
+	m.mu.RUnlock()
+
+	for _, name := range connected {
+		m.sendStatusUpdateWithTools(name, true, nil)
 	}
 }
 
@@ -586,30 +601,20 @@ func (m *MCPManager) getMCPServerStatus() domain.MCPServerStatus {
 	}
 }
 
-// sendStatusUpdateWithTools sends a status update event with discovered tools
+// sendStatusUpdateWithTools pushes a status update event with discovered tools
+// through the UI notifier. getMCPServerStatus takes and releases m.mu before
+// notify runs, so the blocking program.Send is never called under the lock.
 func (m *MCPManager) sendStatusUpdateWithTools(serverName string, connected bool, tools []domain.MCPDiscoveredTool) {
-	if m.statusChan == nil {
-		logger.Warn("cannot send status update: status channel is nil", "server", serverName)
-		return
-	}
-
 	status := m.getMCPServerStatus()
 
-	event := domain.MCPServerStatusUpdateEvent{
+	m.notify(domain.MCPServerStatusUpdateEvent{
 		ServerName:       serverName,
 		Connected:        connected,
 		TotalServers:     status.TotalServers,
 		ConnectedServers: status.ConnectedServers,
 		TotalTools:       status.TotalTools,
 		Tools:            tools,
-	}
-
-	select {
-	case m.statusChan <- event:
-		logger.Debug("mCP status update sent successfully", "server", serverName)
-	default:
-		logger.Warn("mCP status channel full, skipping update", "server", serverName)
-	}
+	})
 }
 
 // UpdateToolCount updates the tool count for a specific server
@@ -641,14 +646,6 @@ func (m *MCPManager) Close() error {
 	m.mu.Unlock()
 
 	m.probeWg.Wait()
-
-	m.mu.Lock()
-	if m.statusChan != nil && !m.channelClosed {
-		close(m.statusChan)
-		m.channelClosed = true
-	}
-	m.statusChan = nil
-	m.mu.Unlock()
 
 	m.mu.RLock()
 	for _, client := range m.clients {

--- a/internal/services/mcp_manager.go
+++ b/internal/services/mcp_manager.go
@@ -283,12 +283,10 @@ func NewMCPManager(sessionID domain.SessionID, cfg *config.MCPConfig, runtime do
 	}
 }
 
-// notify pushes an event to the UI loop. It is nil-safe so a zero-value manager
-// (e.g. one built directly in a test) never panics.
+// notify pushes an event to the UI loop. NewMCPManager defaults a nil notifier to
+// NoopUINotifier, so m.notifier is always non-nil here.
 func (m *MCPManager) notify(event any) {
-	if m.notifier != nil {
-		m.notifier.Notify(event)
-	}
+	m.notifier.Notify(event)
 }
 
 // GetClients returns a list of MCP clients

--- a/internal/services/mcp_manager_test.go
+++ b/internal/services/mcp_manager_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ func TestNewMCPManager(t *testing.T) {
 	}
 
 	sessionID := domain.GenerateSessionID()
-	manager := NewMCPManager(sessionID, cfg, nil)
+	manager := NewMCPManager(sessionID, cfg, nil, nil)
 
 	if manager == nil {
 		t.Fatal("Expected non-nil manager")
@@ -50,7 +51,7 @@ func TestMCPManager_Close(t *testing.T) {
 	}
 
 	sessionID := domain.GenerateSessionID()
-	manager := NewMCPManager(sessionID, cfg, nil)
+	manager := NewMCPManager(sessionID, cfg, nil, nil)
 
 	err := manager.Close()
 	if err != nil {
@@ -65,7 +66,7 @@ func TestMCPManager_GetClients_NoServers(t *testing.T) {
 	}
 
 	sessionID := domain.GenerateSessionID()
-	manager := NewMCPManager(sessionID, cfg, nil)
+	manager := NewMCPManager(sessionID, cfg, nil, nil)
 
 	clients := manager.GetClients()
 
@@ -94,7 +95,7 @@ func TestMCPManager_GetClients_DisabledServer(t *testing.T) {
 	}
 
 	sessionID := domain.GenerateSessionID()
-	manager := NewMCPManager(sessionID, cfg, nil)
+	manager := NewMCPManager(sessionID, cfg, nil, nil)
 
 	clients := manager.GetClients()
 
@@ -135,7 +136,7 @@ func TestMCPManager_GetClients_MultipleServers(t *testing.T) {
 	}
 
 	sessionID := domain.GenerateSessionID()
-	manager := NewMCPManager(sessionID, cfg, nil)
+	manager := NewMCPManager(sessionID, cfg, nil, nil)
 
 	clients := manager.GetClients()
 
@@ -144,8 +145,40 @@ func TestMCPManager_GetClients_MultipleServers(t *testing.T) {
 	}
 }
 
-func TestMCPManager_StartMonitoring_Idempotent(t *testing.T) {
-	cfg := &config.MCPConfig{
+// recordingNotifier is a thread-safe domain.UINotifier that collects every
+// pushed event so tests can assert what a producer emitted.
+type recordingNotifier struct {
+	mu     sync.Mutex
+	events []any
+}
+
+func (r *recordingNotifier) Notify(event any) {
+	r.mu.Lock()
+	r.events = append(r.events, event)
+	r.mu.Unlock()
+}
+
+func (r *recordingNotifier) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.events)
+}
+
+// waitForCount polls until the recorder reaches at least n events or the deadline
+// passes, returning the final count. Pushes happen on a goroutine, so we poll.
+func (r *recordingNotifier) waitForCount(n int, within time.Duration) int {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if r.count() >= n {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return r.count()
+}
+
+func monitoringTestConfig() *config.MCPConfig {
+	return &config.MCPConfig{
 		Enabled:               true,
 		LivenessProbeEnabled:  false,
 		LivenessProbeInterval: 10,
@@ -160,55 +193,77 @@ func TestMCPManager_StartMonitoring_Idempotent(t *testing.T) {
 			},
 		},
 	}
+}
 
-	sessionID := domain.GenerateSessionID()
-	manager := NewMCPManager(sessionID, cfg, nil)
+// connectAll marks every client connected so the initial-status push fires
+// (initializeClient does not connect by itself - a live probe would).
+func connectAll(m *MCPManager) {
+	for _, c := range m.clients {
+		c.mu.Lock()
+		c.isConnected = true
+		c.mu.Unlock()
+	}
+}
+
+// sendStatusUpdateWithTools pushes an MCPServerStatusUpdateEvent through the
+// injected notifier (no channel). This is the synchronous push primitive every
+// probe path funnels through.
+func TestMCPManager_PushesStatusThroughNotifier(t *testing.T) {
+	rec := &recordingNotifier{}
+	manager := NewMCPManager(domain.GenerateSessionID(), monitoringTestConfig(), nil, rec)
+
+	manager.sendStatusUpdateWithTools("test-server", true, nil)
+
+	if got := rec.count(); got != 1 {
+		t.Fatalf("expected 1 push, got %d", got)
+	}
+	ev, ok := rec.events[0].(domain.MCPServerStatusUpdateEvent)
+	if !ok {
+		t.Fatalf("expected MCPServerStatusUpdateEvent, got %T", rec.events[0])
+	}
+	if ev.ServerName != "test-server" || !ev.Connected {
+		t.Errorf("unexpected event payload: %+v", ev)
+	}
+}
+
+// StartMonitoring pushes the initial status for connected clients through the
+// notifier - there is no channel to drain. A second call is a no-op (idempotent),
+// so the count stays at one connected client rather than doubling.
+func TestMCPManager_StartMonitoring_Idempotent(t *testing.T) {
+	rec := &recordingNotifier{}
+	manager := NewMCPManager(domain.GenerateSessionID(), monitoringTestConfig(), nil, rec)
+	connectAll(manager)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	chan1 := manager.StartMonitoring(ctx)
-	chan2 := manager.StartMonitoring(ctx)
+	manager.StartMonitoring(ctx)
+	manager.StartMonitoring(ctx)
 
-	if chan1 != chan2 {
-		t.Error("StartMonitoring should be idempotent and return the same channel")
+	rec.waitForCount(1, time.Second)
+	// Settle: give a hypothetical second initial-status goroutine time to fire.
+	time.Sleep(50 * time.Millisecond)
+	if got := rec.count(); got != 1 {
+		t.Errorf("expected exactly 1 initial status push (idempotent), got %d", got)
 	}
 
 	_ = manager.Close()
 }
 
+// With liveness probes disabled, StartMonitoring still pushes the initial status
+// once through the notifier and starts no probe goroutines.
 func TestMCPManager_StartMonitoring_DisabledProbes(t *testing.T) {
-	cfg := &config.MCPConfig{
-		Enabled:               true,
-		LivenessProbeEnabled:  false,
-		LivenessProbeInterval: 10,
-		Servers: []config.MCPServerEntry{
-			{
-				Name:    "test-server",
-				Scheme:  "http",
-				Host:    "localhost",
-				Ports:   []string{"8080:8080"},
-				Path:    "/mcp",
-				Enabled: true,
-			},
-		},
-	}
-
-	sessionID := domain.GenerateSessionID()
-	manager := NewMCPManager(sessionID, cfg, nil)
+	rec := &recordingNotifier{}
+	manager := NewMCPManager(domain.GenerateSessionID(), monitoringTestConfig(), nil, rec)
+	connectAll(manager)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	statusChan := manager.StartMonitoring(ctx)
+	manager.StartMonitoring(ctx)
 
-	select {
-	case _, ok := <-statusChan:
-		if ok {
-			t.Error("Expected channel to be closed when probes are disabled")
-		}
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Channel should be closed immediately when probes are disabled")
+	if got := rec.waitForCount(1, time.Second); got != 1 {
+		t.Errorf("expected 1 initial status push with probes disabled, got %d", got)
 	}
 
 	_ = manager.Close()

--- a/internal/ui/components/diff_viewer.go
+++ b/internal/ui/components/diff_viewer.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"time"
 
 	viewport "charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
@@ -15,10 +14,6 @@ import (
 	gitdiff "github.com/inference-gateway/cli/internal/services/gitdiff"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
-
-// diffRefreshInterval is how often the changes panel re-polls git while open,
-// so edits from the agent, an editor, or anywhere else show up "live".
-const diffRefreshInterval = time.Second
 
 const (
 	diffSidebarMinWidth = 24
@@ -121,9 +116,6 @@ type diffViewerLoadedMsg struct {
 	err      error
 }
 
-// diffViewerTickMsg drives the periodic live refresh.
-type diffViewerTickMsg struct{}
-
 // patchLoadedMsg carries the file patch loaded when entering patch (hunk) mode.
 type patchLoadedMsg struct {
 	patch  gitdiff.FilePatch
@@ -218,9 +210,12 @@ func NewDiffViewer(source gitdiff.Source, styleProvider *styles.Provider, themeS
 	}
 }
 
+// Init loads the current diff once. It refreshes thereafter on view-entry
+// (reopen re-runs this), on in-loop tool/bash completion events, on git
+// stage/unstage/discard actions, and on the manual refresh key - no polling tick.
 func (t *DiffViewerImpl) Init() tea.Cmd {
 	t.loading = true
-	return tea.Batch(t.loadCmd(), t.tickCmd())
+	return t.loadCmd()
 }
 
 // Reset clears state so the panel can be reused on a later open.
@@ -341,8 +336,10 @@ func (t *DiffViewerImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		t.patchMsg = m.err.Error()
 		t.dirtyDiff = true
 		return t, nil
-	case diffViewerTickMsg:
-		return t, tea.Batch(t.loadCmd(), t.tickCmd())
+	case domain.ToolExecutionCompletedEvent, domain.BashCommandCompletedEvent:
+		// The agent's edits and git commands are what change the staged/unstaged
+		// diff; re-poll off those in-loop events instead of a clock.
+		return t, t.loadCmd()
 	case tea.WindowSizeMsg:
 		t.SetWidth(m.Width)
 		t.SetHeight(m.Height)
@@ -393,6 +390,9 @@ func (t *DiffViewerImpl) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if pressed == "ctrl+c" { // universal escape; intentionally not remappable
 		t.cancel = true
 		return t, nil
+	}
+	if pressed == "ctrl+r" { // manual refresh (replaces the deleted 1s git poll)
+		return t, t.loadCmd()
 	}
 	switch t.keymap.match(pressed,
 		actDiffNavUp, actDiffNavDown, actDiffToggle, actDiffExpand, actDiffCollapse,
@@ -614,9 +614,6 @@ func (t *DiffViewerImpl) updateEditor(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		t.editor.write(encodeKey(m))
 		return t, nil
-	case diffViewerTickMsg:
-		// Keep the live-refresh tick chain alive while editing.
-		return t, t.tickCmd()
 	case tea.WindowSizeMsg:
 		t.SetWidth(m.Width)
 		t.SetHeight(m.Height)
@@ -1019,12 +1016,6 @@ func (t *DiffViewerImpl) loadCmd() tea.Cmd {
 		staged, unstaged, err := src.Changes()
 		return diffViewerLoadedMsg{staged: staged, unstaged: unstaged, err: err}
 	}
-}
-
-func (t *DiffViewerImpl) tickCmd() tea.Cmd {
-	return tea.Tick(diffRefreshInterval, func(_ time.Time) tea.Msg {
-		return diffViewerTickMsg{}
-	})
 }
 
 // --- tree model ---

--- a/internal/ui/components/file_explorer.go
+++ b/internal/ui/components/file_explorer.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"time"
 
 	viewport "charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
@@ -23,10 +22,6 @@ import (
 	diffview "github.com/inference-gateway/cli/internal/ui/components/diffview"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
-
-// explorerRefreshInterval is how often the explorer re-reads the expanded
-// directories so created/removed/renamed files show up "live".
-const explorerRefreshInterval = time.Second
 
 const (
 	explorerSidebarMinWidth = 24
@@ -75,9 +70,6 @@ type explorerRow struct {
 	depth    int
 	expanded bool // dirs only: whether currently expanded
 }
-
-// explorerTickMsg drives the periodic live refresh.
-type explorerTickMsg struct{}
 
 // explorerWalkDoneMsg carries the result of the async fuzzy-finder file walk.
 type explorerWalkDoneMsg struct {
@@ -186,7 +178,10 @@ func NewFileExplorer(root string, styleProvider *styles.Provider, themeService d
 	return t
 }
 
-func (t *FileExplorerImpl) Init() tea.Cmd { return t.tickCmd() }
+// Init does no work: the constructor and Reset already seed the root, and the
+// tree refreshes on view-entry (reopen re-runs this), on in-loop tool/bash
+// completion events, and on the manual refresh key - no polling tick.
+func (t *FileExplorerImpl) Init() tea.Cmd { return nil }
 
 // Reset clears state so the panel can be reused on a later open.
 func (t *FileExplorerImpl) Reset() {
@@ -278,9 +273,11 @@ func (t *FileExplorerImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return t.updateEditor(msg)
 	}
 	switch m := msg.(type) {
-	case explorerTickMsg:
-		t.handleTick()
-		return t, t.tickCmd()
+	case domain.ToolExecutionCompletedEvent, domain.BashCommandCompletedEvent:
+		// The agent's own edits / git commands are exactly what change the tree;
+		// refresh off those in-loop events instead of a clock.
+		t.refresh()
+		return t, nil
 	case explorerWalkDoneMsg:
 		t.handleWalkDone(m)
 		return t, nil
@@ -320,6 +317,10 @@ func (t *FileExplorerImpl) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	pressed := normalizeKey(msg.String())
 	if pressed == "ctrl+c" { // universal escape; intentionally not remappable
 		t.cancel = true
+		return t, nil
+	}
+	if pressed == "ctrl+r" { // manual refresh (replaces the deleted 1s poll)
+		t.refresh()
 		return t, nil
 	}
 	switch t.keymap.match(pressed,
@@ -416,21 +417,17 @@ func (t *FileExplorerImpl) toggleHidden() {
 	t.reanchorSelection()
 }
 
-func (t *FileExplorerImpl) handleTick() {
-	// Drop the cache and re-flatten: flatten() re-reads only the visible
-	// (expanded) directories via ensureChildren, so new/removed files there show
-	// up; collapsed directories are not re-read until expanded.
+// refresh re-reads the visible tree. It drops the cache and re-flattens:
+// flatten() re-reads only the expanded directories via ensureChildren, so
+// new/removed files there show up; collapsed directories are not re-read until
+// expanded. Called on view-entry, on in-loop tool/bash completion, on editor
+// exit, and on the manual refresh key.
+func (t *FileExplorerImpl) refresh() {
 	t.children = make(map[string][]explorerNode)
 	t.ensureChildren("")
 	t.flatten()
 	t.reanchorSelection()
 	t.dirtyPreview = true
-}
-
-func (t *FileExplorerImpl) tickCmd() tea.Cmd {
-	return tea.Tick(explorerRefreshInterval, func(_ time.Time) tea.Msg {
-		return explorerTickMsg{}
-	})
 }
 
 // --- edit mode (real editor in a PTY) ---
@@ -467,14 +464,11 @@ func (t *FileExplorerImpl) updateEditor(msg tea.Msg) (tea.Model, tea.Cmd) {
 		t.editor = nil
 		t.editMode = false
 		t.dirtyPreview = true
-		t.handleTick()
+		t.refresh()
 		return t, nil
 	case tea.KeyPressMsg:
 		t.editor.write(encodeKey(m))
 		return t, nil
-	case explorerTickMsg:
-		// Keep the live-refresh tick chain alive while editing.
-		return t, t.tickCmd()
 	case tea.WindowSizeMsg:
 		t.SetWidth(m.Width)
 		t.SetHeight(m.Height)

--- a/internal/ui/components/file_explorer_test.go
+++ b/internal/ui/components/file_explorer_test.go
@@ -164,7 +164,7 @@ func TestExplorer_ReanchorAcrossRefresh(t *testing.T) {
 	e.selectedKey = "b.txt"
 
 	writeTestFile(t, filepath.Join(root, "a2.txt"), "a2")
-	e.handleTick()
+	e.refresh()
 	if got := e.rows[e.cursor].node.relPath; got != "b.txt" {
 		t.Fatalf("selection should stay on b.txt across refresh, got %q", got)
 	}
@@ -172,7 +172,7 @@ func TestExplorer_ReanchorAcrossRefresh(t *testing.T) {
 	if err := os.Remove(filepath.Join(root, "b.txt")); err != nil {
 		t.Fatal(err)
 	}
-	e.handleTick()
+	e.refresh()
 	if e.cursor < 0 || e.cursor >= len(e.rows) {
 		t.Fatalf("cursor out of range after the selected file was removed: %d (rows=%d)", e.cursor, len(e.rows))
 	}
@@ -187,7 +187,7 @@ func TestExplorer_TickPicksUpNewFileInExpandedDir(t *testing.T) {
 	e.setExpanded(true)
 
 	writeTestFile(t, filepath.Join(root, "dir", "new.txt"), "n")
-	e.handleTick()
+	e.refresh()
 
 	if !explorerHasRow(e, "dir/new.txt") {
 		t.Fatalf("new file in an expanded dir should appear after a tick; rows=%v", rowRels(e))
@@ -201,7 +201,7 @@ func TestExplorer_TickIgnoresNewFileInCollapsedDir(t *testing.T) {
 	e := newTestExplorer(t, root) // dir is collapsed by default
 
 	writeTestFile(t, filepath.Join(root, "dir", "new.txt"), "n")
-	e.handleTick()
+	e.refresh()
 
 	if explorerHasRow(e, "dir/new.txt") {
 		t.Fatal("a file in a collapsed dir should not be read/shown on refresh")

--- a/internal/ui/components/task_management_view.go
+++ b/internal/ui/components/task_management_view.go
@@ -104,7 +104,20 @@ func NewTaskManager(
 }
 
 func (t *TaskManagerImpl) Init() tea.Cmd {
-	return tea.Batch(t.loadTasksCmd(), t.spinner.Tick)
+	return tea.Batch(t.loadTasksCmd(), t.spinner.Tick, t.refreshTickCmd())
+}
+
+// taskRefreshTickMsg drives the live "Elapsed" column. Status changes already
+// arrive as BackgroundTasksChangedEvents, but elapsed time advances on the wall
+// clock with no event, so a periodic re-render is the only way to show it live.
+type taskRefreshTickMsg struct{}
+
+// refreshTickCmd schedules the next live refresh. It is re-armed in Update ONLY
+// while the view is open and a task is actually running, so it stops the moment
+// nothing is running - a bounded animation tick (like the spinner), not an idle
+// poller.
+func (t *TaskManagerImpl) refreshTickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg { return taskRefreshTickMsg{} })
 }
 
 // Reset resets the task manager state for reuse
@@ -178,15 +191,8 @@ func (t *TaskManagerImpl) loadTasksCmd() tea.Cmd {
 			completedTasks = append(completedTasks, taskInfo)
 		}
 
-		// Shells and subagents come from the unified supervisor snapshot (running
-		// and recently-finished, bounded by each kind's completed_retention). A2A
-		// jobs are skipped here - their rows are sourced above from the richer A2A
-		// poller / retention service (history, artifacts, context id).
-		snapshotLen := 0
 		if t.backgroundJobRegistry != nil {
-			snapshot := t.backgroundJobRegistry.Snapshot()
-			snapshotLen = len(snapshot)
-			for _, job := range snapshot {
+			for _, job := range t.backgroundJobRegistry.Snapshot() {
 				if job.Meta.Kind == domain.JobKindA2A {
 					continue
 				}
@@ -198,15 +204,6 @@ func (t *TaskManagerImpl) loadTasksCmd() tea.Cmd {
 				}
 			}
 		}
-
-		logger.Debug("loaded /tasks rows",
-			"registry_nil", t.backgroundJobRegistry == nil,
-			"supervisor_snapshot", snapshotLen,
-			"a2a_polling", len(backgroundTasks),
-			"a2a_retained", len(retainedTaskInfos),
-			"active_total", len(activeTasks),
-			"completed_total", len(completedTasks),
-		)
 
 		interfaceActiveTasks := make([]any, len(activeTasks))
 		for i, task := range activeTasks {
@@ -271,14 +268,20 @@ func (t *TaskManagerImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case domain.TasksLoadedEvent:
 		return t.handleTasksLoaded(msg)
 	case domain.BackgroundTasksChangedEvent:
-		// A background job changed status (submitted/signalled/finished). Reload so
-		// the open /tasks view reflects it live, replacing render-time polling.
 		if t.loading {
 			return t, nil
 		}
 		return t, t.loadTasksCmd()
 	case domain.TaskCancelledEvent:
 		return t.handleTaskCancelled(msg)
+	case taskRefreshTickMsg:
+		if t.done || t.cancelled {
+			return t, nil
+		}
+		if !t.loading && len(t.activeTasks) == 0 {
+			return t, nil
+		}
+		return t, tea.Batch(t.loadTasksCmd(), t.refreshTickCmd())
 	case tea.WindowSizeMsg:
 		return t.handleWindowResize(msg)
 	case tea.KeyMsg:
@@ -388,8 +391,6 @@ func (t *TaskManagerImpl) handleKeyInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "c":
 		if len(t.filteredTasks) > 0 && t.selected < len(t.filteredTasks) {
 			task := t.filteredTasks[t.selected]
-			// Cancel is wired only for active A2A tasks; shells and subagents
-			// (also TaskRef == nil) are stopped from their own tools, not here.
 			if normalizeKind(task.Kind) == domain.JobKindA2A && task.TaskRef == nil {
 				t.confirmCancel = true
 				return t, nil
@@ -404,8 +405,6 @@ func (t *TaskManagerImpl) handleKeyInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		t.handleViewSwitch(msg.String())
 		return t, nil
 
-	case "r":
-		return t, t.loadTasksCmd()
 	}
 
 	return t, nil
@@ -1099,7 +1098,7 @@ func (t *TaskManagerImpl) writeFooter(b *strings.Builder) {
 		help := t.styleProvider.RenderDimText("Type to search, ↑↓ to navigate, Enter to view, Esc to clear search")
 		fmt.Fprintf(b, "%s", help)
 	} else {
-		help := t.styleProvider.RenderDimText("Use ↑↓ arrows to navigate, Enter/i for info, c to cancel, / to search, r to refresh, q/Esc to quit")
+		help := t.styleProvider.RenderDimText("Use ↑↓ arrows to navigate, Enter/i for info, c to cancel, / to search, q/Esc to quit")
 		fmt.Fprintf(b, "%s", help)
 	}
 }

--- a/internal/ui/components/task_management_view.go
+++ b/internal/ui/components/task_management_view.go
@@ -258,6 +258,13 @@ func (t *TaskManagerImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case domain.TasksLoadedEvent:
 		return t.handleTasksLoaded(msg)
+	case domain.BackgroundTasksChangedEvent:
+		// A background job changed status (submitted/signalled/finished). Reload so
+		// the open /tasks view reflects it live, replacing render-time polling.
+		if t.loading {
+			return t, nil
+		}
+		return t, t.loadTasksCmd()
 	case domain.TaskCancelledEvent:
 		return t.handleTaskCancelled(msg)
 	case tea.WindowSizeMsg:

--- a/internal/ui/components/task_management_view.go
+++ b/internal/ui/components/task_management_view.go
@@ -57,6 +57,8 @@ type TaskManagerImpl struct {
 	currentView           TaskViewMode
 	infoViewport          viewport.Model
 	spinner               spinner.Model
+	tickLive              bool
+	tickEpoch             int
 }
 
 type TaskViewMode int
@@ -104,20 +106,33 @@ func NewTaskManager(
 }
 
 func (t *TaskManagerImpl) Init() tea.Cmd {
-	return tea.Batch(t.loadTasksCmd(), t.spinner.Tick, t.refreshTickCmd())
+	return tea.Batch(t.loadTasksCmd(), t.spinner.Tick, t.armRefreshTick())
 }
 
 // taskRefreshTickMsg drives the live "Elapsed" column. Status changes already
 // arrive as BackgroundTasksChangedEvents, but elapsed time advances on the wall
 // clock with no event, so a periodic re-render is the only way to show it live.
-type taskRefreshTickMsg struct{}
+// epoch stamps which chain armed the tick so a superseded one is ignored.
+type taskRefreshTickMsg struct{ epoch int }
 
-// refreshTickCmd schedules the next live refresh. It is re-armed in Update ONLY
-// while the view is open and a task is actually running, so it stops the moment
-// nothing is running - a bounded animation tick (like the spinner), not an idle
-// poller.
+// refreshTickCmd schedules the next live refresh for the current chain. It is
+// re-armed in Update ONLY while the view is open and a task is actually running,
+// so it stops the moment nothing is running - a bounded animation tick (like the
+// spinner), not an idle poller.
 func (t *TaskManagerImpl) refreshTickCmd() tea.Cmd {
-	return tea.Tick(time.Second, func(time.Time) tea.Msg { return taskRefreshTickMsg{} })
+	epoch := t.tickEpoch
+	return tea.Tick(time.Second, func(time.Time) tea.Msg { return taskRefreshTickMsg{epoch: epoch} })
+}
+
+// armRefreshTick starts a NEW live-elapsed chain, bumping the epoch so any tick
+// armed by a prior chain (e.g. one still in flight from before a close/reopen) is
+// ignored when it fires - guaranteeing exactly one live chain. Callers must arm
+// only when t.tickLive is false (Init, or a new task arriving while the chain is
+// dead).
+func (t *TaskManagerImpl) armRefreshTick() tea.Cmd {
+	t.tickEpoch++
+	t.tickLive = true
+	return t.refreshTickCmd()
 }
 
 // Reset resets the task manager state for reuse
@@ -132,6 +147,7 @@ func (t *TaskManagerImpl) Reset() {
 	t.loading = true
 	t.loadError = nil
 	t.currentView = TaskViewAll
+	t.tickLive = false
 }
 
 func (t *TaskManagerImpl) loadTasksCmd() tea.Cmd {
@@ -271,14 +287,18 @@ func (t *TaskManagerImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if t.loading {
 			return t, nil
 		}
+		if !t.tickLive {
+			return t, tea.Batch(t.loadTasksCmd(), t.armRefreshTick())
+		}
 		return t, t.loadTasksCmd()
 	case domain.TaskCancelledEvent:
 		return t.handleTaskCancelled(msg)
 	case taskRefreshTickMsg:
-		if t.done || t.cancelled {
+		if msg.epoch != t.tickEpoch {
 			return t, nil
 		}
-		if !t.loading && len(t.activeTasks) == 0 {
+		if t.done || t.cancelled || (!t.loading && len(t.activeTasks) == 0) {
+			t.tickLive = false
 			return t, nil
 		}
 		return t, tea.Batch(t.loadTasksCmd(), t.refreshTickCmd())
@@ -329,12 +349,10 @@ func (t *TaskManagerImpl) handleTasksLoaded(msg domain.TasksLoadedEvent) (tea.Mo
 func (t *TaskManagerImpl) handleTaskCancelled(msg domain.TaskCancelledEvent) (tea.Model, tea.Cmd) {
 	if msg.Error != nil {
 		logger.Error("task cancellation failed", "task_id", msg.TaskID, "error", msg.Error)
-		// Even if cancellation failed, reload tasks to show current state
 	} else {
 		logger.Info("task cancelled, reloading tasks", "task_id", msg.TaskID)
 	}
 
-	// Reload tasks to reflect the canceled task in completed tasks list
 	return t, t.loadTasksCmd()
 }
 

--- a/internal/ui/components/task_management_view.go
+++ b/internal/ui/components/task_management_view.go
@@ -182,8 +182,11 @@ func (t *TaskManagerImpl) loadTasksCmd() tea.Cmd {
 		// and recently-finished, bounded by each kind's completed_retention). A2A
 		// jobs are skipped here - their rows are sourced above from the richer A2A
 		// poller / retention service (history, artifacts, context id).
+		snapshotLen := 0
 		if t.backgroundJobRegistry != nil {
-			for _, job := range t.backgroundJobRegistry.Snapshot() {
+			snapshot := t.backgroundJobRegistry.Snapshot()
+			snapshotLen = len(snapshot)
+			for _, job := range snapshot {
 				if job.Meta.Kind == domain.JobKindA2A {
 					continue
 				}
@@ -195,6 +198,15 @@ func (t *TaskManagerImpl) loadTasksCmd() tea.Cmd {
 				}
 			}
 		}
+
+		logger.Debug("loaded /tasks rows",
+			"registry_nil", t.backgroundJobRegistry == nil,
+			"supervisor_snapshot", snapshotLen,
+			"a2a_polling", len(backgroundTasks),
+			"a2a_retained", len(retainedTaskInfos),
+			"active_total", len(activeTasks),
+			"completed_total", len(completedTasks),
+		)
 
 		interfaceActiveTasks := make([]any, len(activeTasks))
 		for i, task := range activeTasks {

--- a/internal/ui/components/task_management_view_test.go
+++ b/internal/ui/components/task_management_view_test.go
@@ -213,3 +213,52 @@ func TestWriteTaskSections_RendersPerKindTables(t *testing.T) {
 		}
 	}
 }
+
+// TestRefreshTick_ReArmsAndDedups exercises the live-elapsed tick lifecycle: a
+// running view keeps the chain alive, an emptied view stops it, a new task
+// (BackgroundTasksChangedEvent) restarts a dead chain exactly once, a task
+// arriving while the chain is alive never spawns a second chain, and a tick
+// stamped with a superseded epoch is dropped so chains never overlap.
+func TestRefreshTick_ReArmsAndDedups(t *testing.T) {
+	running := []TaskInfo{{TaskPollingState: domain.TaskPollingState{TaskID: "shell-1"}, Kind: domain.JobKindShell, Status: "Running"}}
+
+	tm := &TaskManagerImpl{tickLive: true, tickEpoch: 3, activeTasks: running}
+	if _, cmd := tm.Update(taskRefreshTickMsg{epoch: 3}); cmd == nil {
+		t.Fatal("running view: tick must re-arm (non-nil cmd)")
+	}
+	if !tm.tickLive {
+		t.Fatal("running view: tickLive must stay true")
+	}
+
+	tm = &TaskManagerImpl{tickLive: true, tickEpoch: 3, loading: false}
+	if _, cmd := tm.Update(taskRefreshTickMsg{epoch: 3}); cmd != nil {
+		t.Fatal("empty view: tick must stop (nil cmd)")
+	}
+	if tm.tickLive {
+		t.Fatal("empty view: tickLive must clear")
+	}
+
+	tm = &TaskManagerImpl{tickLive: false, tickEpoch: 3, loading: false}
+	if _, cmd := tm.Update(domain.BackgroundTasksChangedEvent{}); cmd == nil {
+		t.Fatal("new task while dead: must re-arm (non-nil cmd)")
+	}
+	if !tm.tickLive || tm.tickEpoch != 4 {
+		t.Fatalf("new task: want tickLive=true epoch=4, got %v/%d", tm.tickLive, tm.tickEpoch)
+	}
+
+	tm = &TaskManagerImpl{tickLive: true, tickEpoch: 4, loading: false, activeTasks: running}
+	if _, cmd := tm.Update(domain.BackgroundTasksChangedEvent{}); cmd == nil {
+		t.Fatal("new task while alive: must still reload (non-nil cmd)")
+	}
+	if tm.tickEpoch != 4 {
+		t.Fatalf("new task while alive: epoch must not bump, got %d", tm.tickEpoch)
+	}
+
+	tm = &TaskManagerImpl{tickLive: true, tickEpoch: 5, activeTasks: running}
+	if _, cmd := tm.Update(taskRefreshTickMsg{epoch: 4}); cmd != nil {
+		t.Fatal("stale epoch: tick must be dropped (nil cmd)")
+	}
+	if !tm.tickLive || tm.tickEpoch != 5 {
+		t.Fatalf("stale epoch: state must be untouched, got %v/%d", tm.tickLive, tm.tickEpoch)
+	}
+}


### PR DESCRIPTION
## Summary

Replaces every self-rescheduling loop that fed the single Bubble Tea `Update` loop with **one push ingress**: a tea-free `domain.UINotifier` backed by `(*tea.Program).Send`, injected into every background producer via a thread-safe container holder. The `Update` loop is now **purely reactive** — it renders on real events, not on a clock — and because there is exactly one ingress, it's instrumented in exactly one place.

Closes #688. `no docs ticket: internal-only refactor`.

## What was removed (all re-arming pollers)

| Ingress | Was | Now |
| --- | --- | --- |
| Queue-drain | forever `tea.Tick(500ms)` → `DrainQueueTickEvent`, self-re-arming | `DrainQueueEvent` pushed once per real trigger; gate-only handler |
| Agent-status | `time.Sleep(500ms)` Cmd re-arm | pushed from the container status callback on change |
| MCP status | `StartMonitoring` returned a channel the app re-armed (`waitForMCPStatusUpdate`/`mcpStatusUpdateWithChannel`) | monitor pushes `MCPServerStatusUpdateEvent` through the notifier |
| File explorer / diff viewer | `tea.Tick(1s)` git/fs re-poll | refresh off in-loop `ToolExecutionCompletedEvent`/`BashCommandCompletedEvent` + view-entry + manual `ctrl+r` |
| Computer-use forwarder | bespoke `program.Send` ×2 | routed through the one notifier |

The only `tea.Tick`s left are the three **one-shot** UI deferrals the design keeps (todo auto-collapse, two background-row removals).

## Design

- `internal/domain/ui_notifier.go` — `UINotifier interface{ Notify(any) }` + `NoopUINotifier` (useful zero value) + `NotifierFunc` (test adapter). `any`, not `tea.Msg`, so the domain stays tea-free.
- `internal/container` — a thread-safe `uiNotifierHolder` (RWMutex + swappable inner, default Noop) is the single synchronized primitive. Producers capture it at construction and never lock; `SetUINotifier` swaps the inner once at startup.
- `cmd/chat.go` — `programNotifier{program}` is the **only** place `(*tea.Program).Send` is ever called; `services.SetUINotifier(...)` runs after `tea.NewProgram` and before `program.Run`.

## Correctness notes

- **No-strand guarantee.** `HandleDrainQueueEvent` is a pure gate (returns `nil` in every no-op branch — regression guard against re-introducing a ticker). Drains are pushed from three sources: supervisor `enqueue`, terminal turn completion (`HandleChatCompleteEvent`), and a single central chat-re-entry edge in `Update`. Added the symmetric `EndToolExecution()` on terminal completion so the agent is reliably idle when the drain runs — nothing strands without a poller.
- **No deadlock.** `(*tea.Program).Send` is unbuffered and blocks until `Run` consumes, so `Notify` is only ever called from producer goroutines; the MCP initial-status emit now runs in a goroutine.
- **Interface change.** `MCPManager.StartMonitoring` drops its channel return → `mcp_manager_test.go` rewritten to assert notifier pushes via a recording notifier (MCPManager has no generated counterfeiter fake).

## Observability

One slow-update warn around the `Update` dispatch (`SlowUpdateThreshold`) and a one-time long-running-job warn in the supervisor cleanup sweep (`JobRunningLongThreshold`, reusing `meta.StartedAt`).

## Acceptance

- [x] `program.Send` called in exactly one place (grep-proven).
- [x] Zero self-rescheduling pollers / re-arming wait-Cmds remain; only one-shot deferrals survive.
- [x] `HandleDrainQueueEvent` is gate-only; asserted in `chat_handler_drain_test.go`.
- [x] Agent-status, MCP-status, `/tasks` update on real change pushed through the notifier — no clock.
- [x] Explorer/diff refresh off in-loop tool/bash events + view-entry + manual key; 1s `tickCmd`s deleted; **no fsnotify in the TUI**.
- [x] New tests: supervisor fires on enqueue and on status change; terminal-emit decision; readiness/MCP push; `EndToolExecution` symmetry; slow-update + long-job warns via an observed zap core.
- [x] `task build`, `task test`, `task lint` (0 issues), `task fmt` green; `go test -race` clean on touched packages.

## Verification left for review

The interactive runtime checks from the issue (idle on `/model` shows no periodic re-render, drain-while-modal scenarios, live `/tasks`, diff/explorer refresh off agent edits) need a running gateway + TTY and are best confirmed manually; the behavior is covered by the unit tests above.

## Out of scope / unchanged

One-shot UI deferrals (todo auto-collapse, background-row removal), the agent state-machine `CheckingQueue` in-turn drain, and `EventBridge`'s floating-window multicast.

