### PR TITLE
fix(a2a): retain completed background tasks in /tasks (#691)

### DIFF
--- a/internal/agent/tools/a2a_job.go
+++ b/internal/agent/tools/a2a_job.go
@@ -2,6 +2,10 @@ package tools
 
 import (
 	"context"
+	"strings"
+	"time"
+
+	adk "github.com/inference-gateway/adk/types"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
@@ -44,5 +48,53 @@ func (j *a2aJob) Wind(_ context.Context, _ domain.WindSignal) error { return nil
 func (j *a2aJob) Close() {
 	if j.tool.taskTracker != nil {
 		j.tool.taskTracker.StopPolling(j.taskID)
+	}
+}
+
+// RetainedTask implements domain.TaskRetainer: when the polling loop returns a
+// terminal result, hand the supervisor a TaskInfo so the completed/failed/canceled
+// task stays in the task view (which reads completed A2A rows only from the
+// retention service). result.Data is the live in-memory A2ASubmitTaskResult, so the
+// type assertion is safe here (no JSON round-trip). Completed/failed carry the full
+// *adk.Task; canceled does not, so reconstruct a minimal task from the polling state
+// and reported state. input-required (and any non-terminal state) opts out.
+func (j *a2aJob) RetainedTask(result domain.ToolExecutionResult) (domain.TaskInfo, bool) {
+	submit, ok := result.Data.(A2ASubmitTaskResult)
+	if !ok || submit.TaskID == "" {
+		return domain.TaskInfo{}, false
+	}
+
+	task := adk.Task{
+		ID:        submit.TaskID,
+		ContextID: submit.ContextID,
+		Status:    adk.TaskStatus{State: adk.TaskState(submit.State)},
+	}
+	if submit.Task != nil {
+		task = *submit.Task
+	}
+
+	if !retainableA2AState(task.Status.State) {
+		return domain.TaskInfo{}, false
+	}
+
+	return domain.TaskInfo{
+		Task:        task,
+		AgentURL:    submit.AgentURL,
+		StartedAt:   j.state.StartedAt,
+		CompletedAt: time.Now(),
+	}, true
+}
+
+// retainableA2AState reports whether a terminal A2A task state should be kept in the
+// task view. adk states are prefixed enums (TASK_STATE_COMPLETED, ...) but a remote
+// may report bare forms, so normalize the same way handleTaskState does - lowercase
+// and drop a "task_state_" prefix - before matching. input-required is a pause, not a
+// terminal outcome, so it (and anything non-terminal) is not retained.
+func retainableA2AState(state adk.TaskState) bool {
+	switch strings.TrimPrefix(strings.ToLower(string(state)), "task_state_") {
+	case "completed", "failed", "cancelled", "canceled":
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/agent/tools/a2a_job_test.go
+++ b/internal/agent/tools/a2a_job_test.go
@@ -52,3 +52,118 @@ func TestA2AJob_PollsRemoteTaskToCompletion(t *testing.T) {
 		t.Fatalf("StopPolling was not called when the task completed")
 	}
 }
+
+// TestA2AJob_RetainedTask covers the domain.TaskRetainer the supervisor calls on
+// finish: completed/failed carry the full *adk.Task; canceled does not, so the task
+// is reconstructed from the polling state and reported state; input-required and
+// non-A2A results opt out. The asserted fields (state, ids, agent URL, started-at)
+// are exactly what the task view reads off a retained TaskInfo.
+func TestA2AJob_RetainedTask(t *testing.T) {
+	started := time.Now().Add(-2 * time.Minute)
+	fullTask := &adk.Task{ID: "t1", ContextID: "ctx1", Status: adk.TaskStatus{State: adk.TaskStateCompleted}}
+
+	tests := []struct {
+		name      string
+		data      any
+		wantOK    bool
+		wantState adk.TaskState
+		wantID    string
+		wantCtx   string
+		wantURL   string
+	}{
+		{
+			name:      "completed carries the full task",
+			data:      A2ASubmitTaskResult{TaskID: "t1", ContextID: "ctx1", AgentURL: "http://agent", State: string(adk.TaskStateCompleted), Task: fullTask},
+			wantOK:    true,
+			wantState: adk.TaskStateCompleted,
+			wantID:    "t1", wantCtx: "ctx1", wantURL: "http://agent",
+		},
+		{
+			name:      "failed carries the full task",
+			data:      A2ASubmitTaskResult{TaskID: "t2", ContextID: "ctx2", AgentURL: "http://agent", State: string(adk.TaskStateFailed), Task: &adk.Task{ID: "t2", ContextID: "ctx2", Status: adk.TaskStatus{State: adk.TaskStateFailed}}},
+			wantOK:    true,
+			wantState: adk.TaskStateFailed,
+			wantID:    "t2", wantCtx: "ctx2", wantURL: "http://agent",
+		},
+		{
+			name:      "canceled without task is reconstructed from state",
+			data:      A2ASubmitTaskResult{TaskID: "t3", ContextID: "ctx3", AgentURL: "http://agent", State: string(adk.TaskStateCancelled)},
+			wantOK:    true,
+			wantState: adk.TaskStateCancelled,
+			wantID:    "t3", wantCtx: "ctx3", wantURL: "http://agent",
+		},
+		{
+			name:   "input-required is not retained",
+			data:   A2ASubmitTaskResult{TaskID: "t4", AgentURL: "http://agent", State: string(adk.TaskStateInputRequired)},
+			wantOK: false,
+		},
+		{
+			name:   "non-submit data is not retained",
+			data:   "unrelated",
+			wantOK: false,
+		},
+		{
+			name:   "empty task id is not retained",
+			data:   A2ASubmitTaskResult{TaskID: "", State: string(adk.TaskStateCompleted)},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := &a2aJob{state: &domain.TaskPollingState{StartedAt: started}}
+			info, ok := j.RetainedTask(domain.ToolExecutionResult{Data: tt.data})
+			if ok != tt.wantOK {
+				t.Fatalf("RetainedTask ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if info.Task.Status.State != tt.wantState {
+				t.Errorf("state = %q, want %q", info.Task.Status.State, tt.wantState)
+			}
+			if info.Task.ID != tt.wantID {
+				t.Errorf("task id = %q, want %q", info.Task.ID, tt.wantID)
+			}
+			if info.Task.ContextID != tt.wantCtx {
+				t.Errorf("context id = %q, want %q", info.Task.ContextID, tt.wantCtx)
+			}
+			if info.AgentURL != tt.wantURL {
+				t.Errorf("agent url = %q, want %q", info.AgentURL, tt.wantURL)
+			}
+			if !info.StartedAt.Equal(started) {
+				t.Errorf("started at = %v, want %v", info.StartedAt, started)
+			}
+			if info.CompletedAt.IsZero() {
+				t.Error("completed at should be set")
+			}
+		})
+	}
+}
+
+// TestRetainableA2AState exercises the state matcher against both the prefixed adk
+// enum (TASK_STATE_*) and bare/alternate spellings a remote might report.
+func TestRetainableA2AState(t *testing.T) {
+	tests := []struct {
+		state adk.TaskState
+		want  bool
+	}{
+		{adk.TaskStateCompleted, true},
+		{adk.TaskStateFailed, true},
+		{adk.TaskStateCancelled, true},
+		{"completed", true},
+		{"canceled", true},
+		{"CANCELLED", true},
+		{adk.TaskStateInputRequired, false},
+		{adk.TaskStateWorking, false},
+		{adk.TaskStateSubmitted, false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			if got := retainableA2AState(tt.state); got != tt.want {
+				t.Errorf("retainableA2AState(%q) = %v, want %v", tt.state, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -440,6 +440,10 @@ func (c *ServiceContainer) initializeServices() {
 		maxTaskRetention := c.config.A2A.Task.CompletedTaskRetention
 		c.taskRetentionService = services.NewTaskRetentionService(maxTaskRetention)
 
+		if c.jobSupervisor != nil {
+			c.jobSupervisor.SetTaskRetention(c.taskRetentionService)
+		}
+
 		c.backgroundTaskService = services.NewBackgroundTaskService(c.backgroundTaskRegistry)
 	}
 

--- a/internal/domain/background_job.go
+++ b/internal/domain/background_job.go
@@ -126,6 +126,16 @@ type JobNotifier interface {
 	Notification(result ToolExecutionResult) string
 }
 
+// TaskRetainer is an optional BackgroundJob extension. A job that implements it
+// contributes a TaskInfo to the A2A task-retention view when it reaches a terminal
+// state, so a completed/failed/canceled task stays listed in the task view after its
+// monitor goroutine exits (the supervisor drops it from the live "active" set on
+// finish). ok=false opts out (e.g. a non-terminal-for-retention state such as
+// input-required). Jobs that do not implement it are never retained.
+type TaskRetainer interface {
+	RetainedTask(result ToolExecutionResult) (TaskInfo, bool)
+}
+
 // TrackedJob is a point-in-time snapshot of one supervised job for the task view
 // and status line.
 type TrackedJob struct {

--- a/internal/services/jobs/supervisor.go
+++ b/internal/services/jobs/supervisor.go
@@ -28,6 +28,7 @@ type Supervisor struct {
 	messageQueue     domain.MessageQueue
 	conversationRepo domain.ConversationRepository
 	notifier         domain.UINotifier
+	taskRetention    domain.TaskRetentionService
 
 	mu              sync.RWMutex
 	jobs            map[string]*supervised
@@ -83,6 +84,17 @@ func (s *Supervisor) notify(event any) {
 func (s *Supervisor) SetConversationRepo(repo domain.ConversationRepository) {
 	s.mu.Lock()
 	s.conversationRepo = repo
+	s.mu.Unlock()
+}
+
+// SetTaskRetention wires the A2A task-retention service that finished jobs
+// implementing domain.TaskRetainer populate for the task view. Like the
+// conversation repo, it is set after construction because the retention service is
+// built later in the container than the supervisor. A nil service disables
+// retention (finish just skips it).
+func (s *Supervisor) SetTaskRetention(svc domain.TaskRetentionService) {
+	s.mu.Lock()
+	s.taskRetention = svc
 	s.mu.Unlock()
 }
 
@@ -213,10 +225,19 @@ func (s *Supervisor) finish(sj *supervised, result domain.ToolExecutionResult) {
 	sj.status = status
 	sj.completedAt = &now
 	evicted := s.evictOverCapLocked(sj.meta.Kind)
+	retention := s.taskRetention // set-once during construction; read under the lock that guards the setter
 	s.mu.Unlock()
 
 	for _, v := range evicted {
 		v.job.Close()
+	}
+
+	if retention != nil {
+		if r := asRetainer(sj.job); r != nil {
+			if info, ok := r.RetainedTask(result); ok {
+				retention.AddTask(info)
+			}
+		}
 	}
 
 	s.notify(domain.BackgroundTasksChangedEvent{})
@@ -299,6 +320,14 @@ func (s *Supervisor) formatResult(job domain.BackgroundJob, meta domain.JobMeta,
 func asNotifier(job domain.BackgroundJob) domain.JobNotifier {
 	if n, ok := job.(domain.JobNotifier); ok {
 		return n
+	}
+	return nil
+}
+
+// asRetainer returns the job as a TaskRetainer if it implements one.
+func asRetainer(job domain.BackgroundJob) domain.TaskRetainer {
+	if r, ok := job.(domain.TaskRetainer); ok {
+		return r
 	}
 	return nil
 }

--- a/internal/services/jobs/supervisor_test.go
+++ b/internal/services/jobs/supervisor_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	adk "github.com/inference-gateway/adk/types"
+
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -73,6 +75,19 @@ func (f *fakeJob) closes() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.closeCalls
+}
+
+// fakeRetainerJob is a fakeJob that also implements domain.TaskRetainer, returning a
+// preset TaskInfo/ok so the supervisor's retain-on-finish path can be tested in
+// isolation from any real job's extraction logic.
+type fakeRetainerJob struct {
+	*fakeJob
+	info domain.TaskInfo
+	ok   bool
+}
+
+func (j *fakeRetainerJob) RetainedTask(domain.ToolExecutionResult) (domain.TaskInfo, bool) {
+	return j.info, j.ok
 }
 
 // TestSupervisor_FinishOnce: a finished non-silent job lands exactly one note on
@@ -423,4 +438,79 @@ func TestSupervisor_RunningJobNeverEvicted(t *testing.T) {
 	}
 
 	sup.Stop()
+}
+
+// TestSupervisor_FinishRetainsTerminalTask: a finished job implementing TaskRetainer
+// (opting in) has its TaskInfo handed to the retention service exactly once, so the
+// completed A2A task stays in the task view after its monitor goroutine exits.
+func TestSupervisor_FinishRetainsTerminalTask(t *testing.T) {
+	retention := &domainmocks.FakeTaskRetentionService{}
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
+	sup.SetTaskRetention(retention)
+
+	info := domain.TaskInfo{AgentURL: "http://agent", Task: adk.Task{ID: "t1", Status: adk.TaskStatus{State: adk.TaskStateCompleted}}}
+	job := &fakeRetainerJob{fakeJob: newFakeJob("t1", domain.JobKindA2A), info: info, ok: true}
+	sup.Submit(job)
+	<-job.started
+	close(job.finish)
+	sup.Stop()
+
+	if n := retention.AddTaskCallCount(); n != 1 {
+		t.Fatalf("AddTask called %d times, want 1", n)
+	}
+	if got := retention.AddTaskArgsForCall(0); got.AgentURL != "http://agent" || got.Task.ID != "t1" {
+		t.Fatalf("AddTask got %+v, want AgentURL=http://agent Task.ID=t1", got)
+	}
+}
+
+// TestSupervisor_FinishSkipsRetention: retention is untouched when the job is not a
+// TaskRetainer, or is one that opts out (ok=false).
+func TestSupervisor_FinishSkipsRetention(t *testing.T) {
+	t.Run("not a retainer", func(t *testing.T) {
+		retention := &domainmocks.FakeTaskRetentionService{}
+		sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
+		sup.SetTaskRetention(retention)
+
+		job := newFakeJob("plain", domain.JobKindShell)
+		sup.Submit(job)
+		<-job.started
+		close(job.finish)
+		sup.Stop()
+
+		if n := retention.AddTaskCallCount(); n != 0 {
+			t.Fatalf("AddTask called %d times, want 0", n)
+		}
+	})
+
+	t.Run("retainer opts out", func(t *testing.T) {
+		retention := &domainmocks.FakeTaskRetentionService{}
+		sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
+		sup.SetTaskRetention(retention)
+
+		job := &fakeRetainerJob{fakeJob: newFakeJob("optout", domain.JobKindA2A), ok: false}
+		sup.Submit(job)
+		<-job.started
+		close(job.finish)
+		sup.Stop()
+
+		if n := retention.AddTaskCallCount(); n != 0 {
+			t.Fatalf("AddTask called %d times, want 0", n)
+		}
+	})
+}
+
+// TestSupervisor_FinishWithoutRetentionService: a retainer job finishing with no
+// retention service wired must not panic, and the job still completes normally.
+func TestSupervisor_FinishWithoutRetentionService(t *testing.T) {
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
+
+	job := &fakeRetainerJob{fakeJob: newFakeJob("t1", domain.JobKindA2A), info: domain.TaskInfo{AgentURL: "http://agent"}, ok: true}
+	sup.Submit(job)
+	<-job.started
+	close(job.finish)
+	sup.Stop()
+
+	if j, ok := snapByID(sup, "t1"); !ok || j.Status != domain.JobCompleted {
+		t.Fatalf("job should complete normally, got ok=%v %+v", ok, j)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #691 — completed background A2A tasks vanished from `/tasks` instead of being retained (the documented `a2a.task.completed_task_retention: 5` was effectively ignored).

## Root cause

The `/tasks` view sources completed A2A rows **only** from `taskRetentionService.GetTasks()` (it skips A2A rows from the supervisor snapshot), so a completed A2A task shows up **iff** something calls `taskRetentionService.AddTask(...)`. Nothing did, for background tasks:

- The only retention call site is the `a2acoord` coordinator's `retainTaskFromResult`, reached solely from `HandleTaskCompleted` — i.e. only when a `domain.A2ATaskCompletedEvent` is dispatched.
- But **every A2A lifecycle event (`A2ATaskCompletedEvent`, …) is constructed only in `*_test.go`; none are emitted in production.** That whole coordinator → retention pipeline is unreachable.

So the issue's first guess ("retention runs with a `Task`-less result") isn't what happens — retention is never called at all for background tasks. The real background-completion path is the job **supervisor**: when an `a2aJob`'s polling loop reaches a terminal state, `Supervisor.finish()` surfaces the result (enqueue → agent notification) but never populates the retention service. Tellingly, the container already calls `SetRetentionCount(domain.JobKindA2A, …)` — a half-wired seam.

## Fix

`Supervisor.finish()` now populates the retention service via a small **optional `TaskRetainer` `BackgroundJob` extension** implemented by `a2aJob` — mirroring the existing `JobNotifier`/`asNotifier` pattern:

- `internal/domain/background_job.go` — new `TaskRetainer` optional extension (sibling of `JobNotifier`).
- `internal/agent/tools/a2a_job.go` — `a2aJob.RetainedTask` builds a `TaskInfo` from the **live in-memory `*adk.Task`** (no JSON round-trip fragility), reconstructing it from the reported state when the result carries no task (canceled). `retainableA2AState` whitelists completed/failed/canceled (normalizing the `TASK_STATE_*` enum), excluding `input-required`.
- `internal/services/jobs/supervisor.go` — `taskRetention` field + late-injected `SetTaskRetention` setter (mirrors `SetConversationRepo`), an `asRetainer` helper, and a retain step in `finish()` (field read under the existing lock; retains before the `BackgroundTasksChangedEvent` refresh; independent of `Silent`).
- `internal/container/container.go` — wire `SetTaskRetention` where the retention service is built.

The supervisor stays domain-only (no `tools` import). The existing result-surfacing path is unchanged, so there's no double-rendering, and the dead `A2ATaskCompletedEvent` pipeline is **not** resurrected.

## Testing

- `internal/agent/tools/a2a_job_test.go` — table tests for `RetainedTask` (completed/failed carry the full task; canceled reconstructs from state; input-required / non-A2A data / empty id opt out) and `retainableA2AState` (prefixed enum + bare/alternate spellings).
- `internal/services/jobs/supervisor_test.go` — finish retains a `TaskRetainer` job's `TaskInfo` exactly once; non-retainer and opt-out jobs are skipped; no retention service wired → no panic.
- `task test` (full suite, `-race` on affected packages) and `task lint` are green.

## Scope / notes

- Retains completed/failed/canceled terminal states. `input-required` (a pause) is intentionally not retained.
- The unreachable `a2acoord` A2A event pipeline is left as-is (resurrecting/removing it is out of scope for this bug).
- No cross-repo impact; no docs ticket (internal bug fix, no public surface/config change).
