### PR TITLE
feat(plan): compact context and start a fresh session when a plan is approved

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -236,7 +236,7 @@ chat:
       session_tokens: true
       git_branch: true
 compact:
-  enabled: false # Enable automatic conversation compaction
+  enabled: true # Enable automatic conversation compaction
   auto_at: 80 # Compact when context reaches this percentage (20-100)
 ```
 
@@ -308,7 +308,11 @@ compact:
 
 ### Compact Settings
 
-- **compact.enabled**: Enable automatic conversation compaction to reduce token usage (default: false)
+- **compact.enabled**: Enable automatic mid-conversation compaction at the `auto_at`
+  threshold to reduce token usage (default: true). This flag does **not** gate
+  compaction on plan approval - approving a plan in [Plan Mode](plan-mode.md) always
+  summarizes the exploration-heavy planning conversation and continues execution in a
+  fresh, smaller session, regardless of this setting.
 - **compact.auto_at**: Percentage of context window (20-100) at which to automatically trigger compaction (default: 80)
 
 ### Agent Settings
@@ -749,7 +753,7 @@ http://browser-agent:8080
 
 ### Compact Configuration
 
-- `INFER_COMPACT_ENABLED`: Enable automatic conversation compaction (default: `false`)
+- `INFER_COMPACT_ENABLED`: Enable automatic conversation compaction (default: `true`)
 - `INFER_COMPACT_AUTO_AT`: Auto-compact after N messages (default: `100`)
 
 ### Git Configuration

--- a/docs/plan-mode.md
+++ b/docs/plan-mode.md
@@ -131,6 +131,27 @@ When the model calls `RequestPlanApproval`, the chat TUI:
 In all three cases the plan file remains on disk. Rejecting a plan does
 **not** delete it.
 
+## Context compaction on approval
+
+Planning is read-heavy: the model runs `Read`, `Grep`, and `Tree` across the
+codebase before it writes a plan. Once you **Accept** (or **Accept &
+Auto-Approve**), that exploration is dead weight for execution. So approving a
+plan always:
+
+1. Summarizes the planning conversation into a short `--- Context Summary ---`.
+2. Saves the planning session and continues in a **fresh session** seeded with
+   that summary - so execution starts with an optimized, much smaller context
+   window.
+3. Points the agent back at the saved plan file (`<configDir>/plans/…`), which
+   it re-reads to execute step by step. The plan itself is never lost - it lives
+   on disk and is captured in the summary.
+
+This happens regardless of the `compact.enabled` setting - that flag only
+controls the *automatic* mid-conversation compaction (see the
+[Configuration Reference](configuration-reference.md)). Compaction on approval
+fails open: if summarization errors or times out, execution still proceeds on
+the un-compacted conversation.
+
 ## Iterating on a plan
 
 Plan mode encourages a back-and-forth before the tool call lands. Typical

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -270,11 +270,12 @@ func (p *eventPublisher) publishTodoUpdate(todos []domain.TodoItem) {
 }
 
 // publishPlanApprovalRequest publishes a PlanApprovalRequestedEvent when RequestPlanApproval tool executes
-func (p *eventPublisher) publishPlanApprovalRequest(planContent string) {
+func (p *eventPublisher) publishPlanApprovalRequest(planContent, planPath string) {
 	event := domain.PlanApprovalRequestedEvent{
 		RequestID:    p.requestID,
 		Timestamp:    time.Now(),
 		PlanContent:  planContent,
+		PlanPath:     planPath,
 		ResponseChan: nil,
 	}
 
@@ -1066,7 +1067,7 @@ func (s *AgentServiceImpl) handleToolResults(
 	eventPublisher *eventPublisher,
 	req *domain.AgentRequest,
 ) bool {
-	hasRejection, planContent := s.checkToolResultsStatus(toolResults)
+	hasRejection, planContent, planPath := s.checkToolResultsStatus(toolResults)
 
 	s.addToolResultsToConversation(toolResults, conversation)
 
@@ -1077,7 +1078,7 @@ func (s *AgentServiceImpl) handleToolResults(
 	}
 
 	if planContent != "" {
-		s.createPlanMessage(planContent, conversation, eventPublisher, req)
+		s.createPlanMessage(planContent, planPath, conversation, eventPublisher, req)
 		return true
 	}
 
@@ -1085,19 +1086,20 @@ func (s *AgentServiceImpl) handleToolResults(
 }
 
 // checkToolResultsStatus checks for rejections and plan approval in tool results
-func (s *AgentServiceImpl) checkToolResultsStatus(toolResults []domain.ConversationEntry) (hasRejection bool, planContent string) {
+func (s *AgentServiceImpl) checkToolResultsStatus(toolResults []domain.ConversationEntry) (hasRejection bool, planContent, planPath string) {
 	for _, entry := range toolResults {
 		if entry.ToolExecution != nil {
 			if entry.ToolExecution.Rejected {
-				return true, ""
+				return true, "", ""
 			}
 			if entry.ToolExecution.ToolName == "RequestPlanApproval" && entry.ToolExecution.Success {
 				planContent = extractPlanContent(entry.ToolExecution)
+				planPath = extractPlanPath(entry.ToolExecution)
 				logger.Info("requestPlanApproval tool executed - stopping agent loop to wait for user approval", "planLength", len(planContent))
 			}
 		}
 	}
-	return false, planContent
+	return false, planContent, planPath
 }
 
 // addToolResultsToConversation adds tool results and images to the conversation
@@ -1117,6 +1119,7 @@ func (s *AgentServiceImpl) addToolResultsToConversation(toolResults []domain.Con
 // createPlanMessage creates and stores a plan message for approval
 func (s *AgentServiceImpl) createPlanMessage(
 	planContent string,
+	planPath string,
 	conversation *[]sdk.Message,
 	eventPublisher *eventPublisher,
 	req *domain.AgentRequest,
@@ -1137,7 +1140,7 @@ func (s *AgentServiceImpl) createPlanMessage(
 		logger.Error("failed to store plan message", "error", err)
 	}
 
-	eventPublisher.publishPlanApprovalRequest(planContent)
+	eventPublisher.publishPlanApprovalRequest(planContent, planPath)
 
 	logger.Info("plan approval requested - stopping agent loop")
 	eventPublisher.publishChatComplete("", []sdk.ChatCompletionMessageToolCall{}, s.GetMetrics(req.RequestID))
@@ -1160,6 +1163,27 @@ func extractPlanContent(result *domain.ToolExecutionResult) string {
 	}
 
 	return plan
+}
+
+// extractPlanPath extracts the saved plan file path from a RequestPlanApproval
+// tool result. The path lets the post-approval continuation prompt point the
+// agent back at the plan on disk after the planning context is compacted away.
+func extractPlanPath(result *domain.ToolExecutionResult) string {
+	if result == nil || result.Data == nil {
+		return ""
+	}
+
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	path, ok := data["path"].(string)
+	if !ok {
+		return ""
+	}
+
+	return path
 }
 
 // addImageMessageFromToolResults adds images from tool results as a separate hidden user message

--- a/internal/agent/agent_helpers_test.go
+++ b/internal/agent/agent_helpers_test.go
@@ -119,6 +119,7 @@ func TestCheckToolResultsStatus(t *testing.T) {
 		toolResults       []domain.ConversationEntry
 		expectedRejection bool
 		expectedPlan      string
+		expectedPath      string
 	}{
 		{
 			name:              "no_results",
@@ -179,13 +180,67 @@ func TestCheckToolResultsStatus(t *testing.T) {
 			expectedRejection: true,
 			expectedPlan:      "",
 		},
+		{
+			name: "with_plan_approval",
+			toolResults: []domain.ConversationEntry{
+				{
+					Message: sdk.Message{Role: sdk.Tool, Content: sdk.NewMessageContent("plan")},
+					ToolExecution: &domain.ToolExecutionResult{
+						ToolName: "RequestPlanApproval",
+						Success:  true,
+						Data: map[string]any{
+							"plan": "# Plan\n- step 1",
+							"path": ".infer/plans/2026-06-28-090000-plan.md",
+						},
+					},
+				},
+			},
+			expectedRejection: false,
+			expectedPlan:      "# Plan\n- step 1",
+			expectedPath:      ".infer/plans/2026-06-28-090000-plan.md",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hasRejection, planContent := agentService.checkToolResultsStatus(tt.toolResults)
+			hasRejection, planContent, planPath := agentService.checkToolResultsStatus(tt.toolResults)
 			assert.Equal(t, tt.expectedRejection, hasRejection)
 			assert.Equal(t, tt.expectedPlan, planContent)
+			assert.Equal(t, tt.expectedPath, planPath)
+		})
+	}
+}
+
+// TestExtractPlanPath tests pulling the saved plan file path out of a
+// RequestPlanApproval tool result, including defensive/degenerate cases.
+func TestExtractPlanPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   *domain.ToolExecutionResult
+		expected string
+	}{
+		{name: "nil_result", result: nil, expected: ""},
+		{name: "nil_data", result: &domain.ToolExecutionResult{}, expected: ""},
+		{
+			name:     "data_not_a_map",
+			result:   &domain.ToolExecutionResult{Data: "oops"},
+			expected: "",
+		},
+		{
+			name:     "missing_path_key",
+			result:   &domain.ToolExecutionResult{Data: map[string]any{"plan": "x"}},
+			expected: "",
+		},
+		{
+			name:     "path_present",
+			result:   &domain.ToolExecutionResult{Data: map[string]any{"path": ".infer/plans/p.md"}},
+			expected: ".infer/plans/p.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractPlanPath(tt.result))
 		})
 	}
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -314,11 +314,6 @@ func (c *ServiceContainer) initializeDomainServices() {
 		c.tokenizer = services.NewTokenizerService(services.DefaultTokenizerConfig())
 	}
 
-	// The optimizer is constructed unconditionally: compact.enabled only gates the
-	// automatic mid-conversation compaction (OptimizeMessages with force=false) and
-	// the headless session rollover below. Compaction on plan approval always runs
-	// (it calls OptimizeMessages with force=true, which ignores the enabled flag),
-	// so the optimizer must exist even when compact.enabled is false.
 	summaryClient := c.createAgentSDKClient()
 	c.conversationOptimizer = services.NewConversationOptimizer(services.OptimizerConfig{
 		Enabled:           c.config.Compact.Enabled,

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -314,19 +314,24 @@ func (c *ServiceContainer) initializeDomainServices() {
 		c.tokenizer = services.NewTokenizerService(services.DefaultTokenizerConfig())
 	}
 
-	if c.config.Compact.Enabled {
-		summaryClient := c.createAgentSDKClient()
-		c.conversationOptimizer = services.NewConversationOptimizer(services.OptimizerConfig{
-			Enabled:           c.config.Compact.Enabled,
-			AutoAt:            c.config.Compact.AutoAt,
-			BufferSize:        2,
-			KeepFirstMessages: c.config.Compact.KeepFirstMessages,
-			Client:            summaryClient,
-			Config:            c.config,
-			Tokenizer:         c.tokenizer,
-			Repo:              c.conversationRepo,
-		})
+	// The optimizer is constructed unconditionally: compact.enabled only gates the
+	// automatic mid-conversation compaction (OptimizeMessages with force=false) and
+	// the headless session rollover below. Compaction on plan approval always runs
+	// (it calls OptimizeMessages with force=true, which ignores the enabled flag),
+	// so the optimizer must exist even when compact.enabled is false.
+	summaryClient := c.createAgentSDKClient()
+	c.conversationOptimizer = services.NewConversationOptimizer(services.OptimizerConfig{
+		Enabled:           c.config.Compact.Enabled,
+		AutoAt:            c.config.Compact.AutoAt,
+		BufferSize:        2,
+		KeepFirstMessages: c.config.Compact.KeepFirstMessages,
+		Client:            summaryClient,
+		Config:            c.config,
+		Tokenizer:         c.tokenizer,
+		Repo:              c.conversationRepo,
+	})
 
+	if c.config.Compact.Enabled {
 		if persistentRepo, ok := c.conversationRepo.(*services.PersistentConversationRepository); ok {
 			c.sessionRolloverManager = services.NewSessionRolloverManager(
 				c.config,

--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -310,6 +310,7 @@ type PlanApprovalRequestedEvent struct {
 	RequestID    string
 	Timestamp    time.Time
 	PlanContent  string
+	PlanPath     string
 	ResponseChan chan PlanApprovalAction `json:"-"`
 }
 

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -367,7 +367,7 @@ type ApprovalUIManager interface {
 
 // PlanApprovalUIManager handles plan approval UI state
 type PlanApprovalUIManager interface {
-	SetupPlanApprovalUIState(planContent string, responseChan chan PlanApprovalAction)
+	SetupPlanApprovalUIState(planContent, planPath string, responseChan chan PlanApprovalAction)
 	GetPlanApprovalUIState() *PlanApprovalUIState
 	SetPlanApprovalSelectedIndex(index int)
 	ClearPlanApprovalUIState()

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -393,6 +393,7 @@ type ApprovalUIState struct {
 type PlanApprovalUIState struct {
 	SelectedIndex int                     `json:"selected_index"`
 	PlanContent   string                  `json:"plan_content"`
+	PlanPath      string                  `json:"plan_path"`
 	ResponseChan  chan PlanApprovalAction `json:"-"`
 }
 
@@ -901,10 +902,11 @@ func (s *ApplicationState) ClearApprovalUIState() {
 // Plan Approval State Management
 
 // SetupPlanApprovalUIState initializes plan approval UI state
-func (s *ApplicationState) SetupPlanApprovalUIState(planContent string, responseChan chan PlanApprovalAction) {
+func (s *ApplicationState) SetupPlanApprovalUIState(planContent, planPath string, responseChan chan PlanApprovalAction) {
 	s.planApprovalUIState = &PlanApprovalUIState{
 		SelectedIndex: int(PlanApprovalAccept),
 		PlanContent:   planContent,
+		PlanPath:      planPath,
 		ResponseChan:  responseChan,
 	}
 }

--- a/internal/handlers/chat_compaction.go
+++ b/internal/handlers/chat_compaction.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"fmt"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	logger "github.com/inference-gateway/cli/internal/logger"
+	sdk "github.com/inference-gateway/sdk"
+)
+
+// compactionTimeout bounds the LLM summarization call so a wedged gateway can't
+// hang the UI thread. Shared by /compact and the post-plan-approval flow.
+const compactionTimeout = 70 * time.Second
+
+// nonHiddenMessages returns the current conversation's user-visible messages
+// (hidden system reminders / continue prompts are excluded from summarization).
+func (h *ChatHandler) nonHiddenMessages() []sdk.Message {
+	entries := h.conversationRepo.GetMessages()
+	messages := make([]sdk.Message, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Hidden {
+			continue
+		}
+		messages = append(messages, entry.Message)
+	}
+	return messages
+}
+
+// optimizeWithTimeout force-compacts messages under a hard timeout. It returns
+// (optimized, true) on success and (nil, false) if the summarization timed out.
+func (h *ChatHandler) optimizeWithTimeout(messages []sdk.Message, model string) ([]sdk.Message, bool) {
+	optimizedChan := make(chan []sdk.Message, 1)
+	go func() {
+		optimizedChan <- h.conversationOptimizer.OptimizeMessages(messages, model, true)
+	}()
+
+	select {
+	case optimized := <-optimizedChan:
+		return optimized, true
+	case <-time.After(compactionTimeout):
+		logger.Error("optimization timed out", "timeout", compactionTimeout)
+		return nil, false
+	}
+}
+
+// reseedConversationWithMessages saves the current conversation and starts a
+// fresh one titled "Continued from <old title>", seeded with the given messages.
+// The old conversation is preserved in storage; only the in-memory working set
+// is replaced.
+func (h *ChatHandler) reseedConversationWithMessages(messages []sdk.Message, model string) error {
+	newTitle := fmt.Sprintf("Continued from %s", h.conversationRepo.GetCurrentConversationTitle())
+	if err := h.conversationRepo.StartNewConversation(newTitle); err != nil {
+		return err
+	}
+	for _, msg := range messages {
+		entry := domain.ConversationEntry{
+			Message: msg,
+			Model:   model,
+			Time:    time.Now(),
+		}
+		if err := h.conversationRepo.AddMessage(entry); err != nil {
+			logger.Error("failed to add optimized message", "error", err)
+		}
+	}
+	return nil
+}
+
+// addHiddenUserMessage appends a hidden user message to the current conversation.
+func (h *ChatHandler) addHiddenUserMessage(content string) error {
+	return h.conversationRepo.AddMessage(domain.ConversationEntry{
+		Message: sdk.Message{
+			Role:    sdk.User,
+			Content: sdk.NewMessageContent(content),
+		},
+		Time:   time.Now(),
+		Hidden: true,
+	})
+}
+
+// planExecutionContinuePrompt tells the agent to resume and execute an approved
+// plan. When the planning context has been compacted away we point it back at
+// the plan file on disk so it can recall the full plan without keeping it in
+// context.
+func planExecutionContinuePrompt(planPath string) string {
+	if planPath == "" {
+		return "The plan has been approved. Please proceed with executing it step by step. " +
+			"Start by taking the first action required to implement the plan."
+	}
+	return fmt.Sprintf(
+		"The plan has been approved and the planning context has been compacted to save space. "+
+			"The full approved plan is saved at %s. Read that file to recall the plan, then execute "+
+			"it step by step, starting with the first action required to implement it.",
+		planPath,
+	)
+}
+
+// compactPlanningContext force-compacts the (usually exploration-heavy) planning
+// conversation into a fresh session. It returns true when a new session was
+// seeded - meaning the prior messages, including the plan, were summarized away.
+// Any failure returns false and leaves the conversation intact (fail open).
+func (h *ChatHandler) compactPlanningContext() bool {
+	messages := h.nonHiddenMessages()
+	model := h.modelService.GetCurrentModel()
+	if h.conversationOptimizer == nil || len(messages) == 0 || model == "" {
+		return false
+	}
+
+	optimized, ok := h.optimizeWithTimeout(messages, model)
+	if !ok || len(optimized) >= len(messages) {
+		return false
+	}
+
+	if err := h.reseedConversationWithMessages(optimized, model); err != nil {
+		logger.Error("failed to start new session after plan approval", "error", err)
+		return false
+	}
+
+	logger.Info("compacted planning context after plan approval",
+		"messages_before", len(messages), "messages_after", len(optimized))
+	return true
+}
+
+// compactThenExecutePlanCmd compacts the planning conversation into a fresh
+// session and then resumes the agent to execute the approved plan. Because the
+// agent re-reads the plan from disk (planPath), the plan itself need not survive
+// in context. When compaction reseeds a new session it also wiped the generic
+// continue message the coordinator queued, so we re-add a plan-path-aware one;
+// when it doesn't reseed (short conversation, timeout, disabled), that generic
+// message and the plan are still in context, so we add nothing to avoid a dupe.
+func (h *ChatHandler) compactThenExecutePlanCmd(planPath string) tea.Cmd {
+	return func() tea.Msg {
+		if h.compactPlanningContext() {
+			if err := h.addHiddenUserMessage(planExecutionContinuePrompt(planPath)); err != nil {
+				logger.Error("failed to add plan execution continue message", "error", err)
+			}
+		}
+
+		return tea.Batch(
+			func() tea.Msg {
+				return domain.UpdateHistoryEvent{History: h.conversationRepo.GetMessages()}
+			},
+			h.startChatCompletion(),
+		)()
+	}
+}

--- a/internal/handlers/chat_compaction_test.go
+++ b/internal/handlers/chat_compaction_test.go
@@ -1,0 +1,137 @@
+package handlers
+
+import (
+	"testing"
+
+	sdk "github.com/inference-gateway/sdk"
+	assert "github.com/stretchr/testify/assert"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	mocks "github.com/inference-gateway/cli/tests/mocks/domain"
+)
+
+// stubOptimizer is a minimal domain.ConversationOptimizer for tests: it returns
+// a fixed message set regardless of input, letting a test dictate whether
+// compaction "reduces" the conversation.
+type stubOptimizer struct {
+	out []sdk.Message
+}
+
+func (s stubOptimizer) OptimizeMessages(_ []sdk.Message, _ string, _ bool) []sdk.Message {
+	return s.out
+}
+
+func entriesOfLen(n int) []domain.ConversationEntry {
+	entries := make([]domain.ConversationEntry, n)
+	for i := range entries {
+		entries[i] = domain.ConversationEntry{
+			Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("m")},
+		}
+	}
+	return entries
+}
+
+func messagesOfLen(n int) []sdk.Message {
+	msgs := make([]sdk.Message, n)
+	for i := range msgs {
+		msgs[i] = sdk.Message{Role: sdk.Assistant, Content: sdk.NewMessageContent("s")}
+	}
+	return msgs
+}
+
+func TestPlanExecutionContinuePrompt(t *testing.T) {
+	t.Run("points the agent at the plan file when a path is given", func(t *testing.T) {
+		got := planExecutionContinuePrompt(".infer/plans/2026-06-28-plan.md")
+		assert.Contains(t, got, ".infer/plans/2026-06-28-plan.md")
+		assert.Contains(t, got, "Read")
+	})
+
+	t.Run("falls back to a generic prompt without a path", func(t *testing.T) {
+		got := planExecutionContinuePrompt("")
+		assert.NotContains(t, got, "Read that file")
+		assert.Contains(t, got, "proceed")
+	})
+}
+
+func TestCompactPlanningContext(t *testing.T) {
+	t.Run("reseeds a new session when the optimizer reduces messages", func(t *testing.T) {
+		repo := &mocks.FakeConversationRepository{}
+		repo.GetMessagesReturns(entriesOfLen(3))
+		repo.GetCurrentConversationTitleReturns("Original")
+		model := &mocks.FakeModelService{}
+		model.GetCurrentModelReturns("anthropic/claude")
+
+		h := &ChatHandler{
+			conversationOptimizer: stubOptimizer{out: messagesOfLen(1)},
+			conversationRepo:      repo,
+			modelService:          model,
+		}
+
+		if !h.compactPlanningContext() {
+			t.Fatalf("expected compaction to reseed a new session")
+		}
+		if repo.StartNewConversationCallCount() != 1 {
+			t.Fatalf("expected StartNewConversation once, got %d", repo.StartNewConversationCallCount())
+		}
+		if repo.AddMessageCallCount() != 1 {
+			t.Errorf("expected the single optimized message to be re-added, got %d adds", repo.AddMessageCallCount())
+		}
+	})
+
+	t.Run("does not reseed when the optimizer cannot reduce", func(t *testing.T) {
+		repo := &mocks.FakeConversationRepository{}
+		repo.GetMessagesReturns(entriesOfLen(3))
+		model := &mocks.FakeModelService{}
+		model.GetCurrentModelReturns("anthropic/claude")
+
+		h := &ChatHandler{
+			conversationOptimizer: stubOptimizer{out: messagesOfLen(3)},
+			conversationRepo:      repo,
+			modelService:          model,
+		}
+
+		if h.compactPlanningContext() {
+			t.Fatalf("expected no reseed when nothing was compacted")
+		}
+		if repo.StartNewConversationCallCount() != 0 {
+			t.Errorf("expected StartNewConversation not called, got %d", repo.StartNewConversationCallCount())
+		}
+	})
+
+	t.Run("no-op when the optimizer is absent (defensive)", func(t *testing.T) {
+		repo := &mocks.FakeConversationRepository{}
+		repo.GetMessagesReturns(entriesOfLen(3))
+		model := &mocks.FakeModelService{}
+		model.GetCurrentModelReturns("anthropic/claude")
+
+		h := &ChatHandler{
+			conversationOptimizer: nil,
+			conversationRepo:      repo,
+			modelService:          model,
+		}
+
+		if h.compactPlanningContext() {
+			t.Fatalf("expected no reseed when the optimizer is nil")
+		}
+		if repo.StartNewConversationCallCount() != 0 {
+			t.Errorf("expected StartNewConversation not called")
+		}
+	})
+
+	t.Run("no-op when no model is selected", func(t *testing.T) {
+		repo := &mocks.FakeConversationRepository{}
+		repo.GetMessagesReturns(entriesOfLen(3))
+		model := &mocks.FakeModelService{}
+		model.GetCurrentModelReturns("")
+
+		h := &ChatHandler{
+			conversationOptimizer: stubOptimizer{out: messagesOfLen(1)},
+			conversationRepo:      repo,
+			modelService:          model,
+		}
+
+		if h.compactPlanningContext() {
+			t.Fatalf("expected no reseed when no model is selected")
+		}
+	})
+}

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -466,9 +466,25 @@ func (h *ChatHandler) HandleUserQuestionRequestedEvent(
 func (h *ChatHandler) HandlePlanApprovalResponseEvent(
 	msg domain.PlanApprovalResponseEvent,
 ) tea.Cmd {
+	// Capture the saved plan path before the coordinator clears the UI state; on
+	// approval we compact the planning context away and point the agent back at
+	// the plan file to execute.
+	planPath := ""
+	if st := h.stateManager.GetPlanApprovalUIState(); st != nil {
+		planPath = st.PlanPath
+	}
+
 	cmd, restart := h.approvalCoordinator.HandlePlanApprovalResponse(msg)
 	if !restart {
 		return cmd
+	}
+
+	// Compaction on approval runs independently of compact.enabled (that flag only
+	// governs the automatic mid-conversation compaction). We only need the optimizer
+	// to be constructed and a saved plan file to point the agent back at; otherwise
+	// fall back to executing in place.
+	if h.conversationOptimizer != nil && planPath != "" {
+		return tea.Batch(cmd, h.compactThenExecutePlanCmd(planPath))
 	}
 	return tea.Batch(cmd, h.startChatCompletion())
 }

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -466,9 +466,6 @@ func (h *ChatHandler) HandleUserQuestionRequestedEvent(
 func (h *ChatHandler) HandlePlanApprovalResponseEvent(
 	msg domain.PlanApprovalResponseEvent,
 ) tea.Cmd {
-	// Capture the saved plan path before the coordinator clears the UI state; on
-	// approval we compact the planning context away and point the agent back at
-	// the plan file to execute.
 	planPath := ""
 	if st := h.stateManager.GetPlanApprovalUIState(); st != nil {
 		planPath = st.PlanPath
@@ -479,10 +476,6 @@ func (h *ChatHandler) HandlePlanApprovalResponseEvent(
 		return cmd
 	}
 
-	// Compaction on approval runs independently of compact.enabled (that flag only
-	// governs the automatic mid-conversation compaction). We only need the optimizer
-	// to be constructed and a saved plan file to point the agent back at; otherwise
-	// fall back to executing in place.
 	if h.conversationOptimizer != nil && planPath != "" {
 		return tea.Batch(cmd, h.compactThenExecutePlanCmd(planPath))
 	}

--- a/internal/handlers/chat_shortcut_handler.go
+++ b/internal/handlers/chat_shortcut_handler.go
@@ -562,7 +562,8 @@ func (s *ChatShortcutHandler) handleCompactConversationSideEffect() tea.Msg {
 
 func (s *ChatShortcutHandler) performCompactAsync() tea.Cmd {
 	return func() tea.Msg {
-		if s.handler.conversationOptimizer == nil {
+		h := s.handler
+		if h.conversationOptimizer == nil {
 			return domain.SetStatusEvent{
 				Message:    "Conversation optimizer is not enabled in configuration",
 				Spinner:    false,
@@ -570,8 +571,8 @@ func (s *ChatShortcutHandler) performCompactAsync() tea.Cmd {
 			}
 		}
 
-		entries := s.handler.conversationRepo.GetMessages()
-		if len(entries) == 0 {
+		messages := h.nonHiddenMessages()
+		if len(messages) == 0 {
 			return domain.SetStatusEvent{
 				Message:    "No messages to compact",
 				Spinner:    false,
@@ -579,19 +580,7 @@ func (s *ChatShortcutHandler) performCompactAsync() tea.Cmd {
 			}
 		}
 
-		logger.Info("starting conversation compaction", "message_count", len(entries))
-
-		originalTitle := s.handler.conversationRepo.GetCurrentConversationTitle()
-
-		messages := make([]sdk.Message, 0, len(entries))
-		for _, entry := range entries {
-			if entry.Hidden {
-				continue
-			}
-			messages = append(messages, entry.Message)
-		}
-
-		currentModel := s.handler.modelService.GetCurrentModel()
+		currentModel := h.modelService.GetCurrentModel()
 		if currentModel == "" {
 			return domain.SetStatusEvent{
 				Message:    "No model selected - please select a model first",
@@ -602,24 +591,15 @@ func (s *ChatShortcutHandler) performCompactAsync() tea.Cmd {
 
 		logger.Info("optimizing conversation", "model", currentModel, "message_count", len(messages))
 
-		optimizedChan := make(chan []sdk.Message, 1)
-		go func() {
-			optimized := s.handler.conversationOptimizer.OptimizeMessages(messages, currentModel, true)
-			optimizedChan <- optimized
-		}()
-
-		var optimizedMessages []sdk.Message
-		select {
-		case optimizedMessages = <-optimizedChan:
-			logger.Info("optimization complete", "original_count", len(messages), "optimized_count", len(optimizedMessages))
-		case <-time.After(70 * time.Second):
-			logger.Error("optimization timed out after 70 seconds")
+		optimizedMessages, ok := h.optimizeWithTimeout(messages, currentModel)
+		if !ok {
 			return domain.SetStatusEvent{
 				Message:    "Conversation optimization timed out - try again or check gateway logs",
 				Spinner:    false,
 				StatusType: domain.StatusError,
 			}
 		}
+		logger.Info("optimization complete", "original_count", len(messages), "optimized_count", len(optimizedMessages))
 
 		if len(optimizedMessages) >= len(messages) {
 			return domain.SetStatusEvent{
@@ -629,8 +609,7 @@ func (s *ChatShortcutHandler) performCompactAsync() tea.Cmd {
 			}
 		}
 
-		newTitle := fmt.Sprintf("Continued from %s", originalTitle)
-		if err := s.handler.conversationRepo.StartNewConversation(newTitle); err != nil {
+		if err := h.reseedConversationWithMessages(optimizedMessages, currentModel); err != nil {
 			logger.Error("failed to start new conversation", "error", err)
 			return domain.SetStatusEvent{
 				Message:    fmt.Sprintf("Failed to start new conversation: %v", err),
@@ -639,21 +618,10 @@ func (s *ChatShortcutHandler) performCompactAsync() tea.Cmd {
 			}
 		}
 
-		for _, msg := range optimizedMessages {
-			entry := domain.ConversationEntry{
-				Message: msg,
-				Model:   currentModel,
-				Time:    time.Now(),
-			}
-			if err := s.handler.conversationRepo.AddMessage(entry); err != nil {
-				logger.Error("failed to add optimized message", "error", err)
-			}
-		}
-
 		return tea.Batch(
 			func() tea.Msg {
 				return domain.UpdateHistoryEvent{
-					History: s.handler.conversationRepo.GetMessages(),
+					History: h.conversationRepo.GetMessages(),
 				}
 			},
 			func() tea.Msg {

--- a/internal/services/approvalcoord/coordinator.go
+++ b/internal/services/approvalcoord/coordinator.go
@@ -48,7 +48,7 @@ func NewService(opts Options) *Service {
 func (s *Service) HandlePlanApprovalRequested(msg domain.PlanApprovalRequestedEvent) tea.Cmd {
 	logger.Info("approvalCoordinator.HandlePlanApprovalRequested called")
 
-	s.stateManager.SetupPlanApprovalUIState(msg.PlanContent, msg.ResponseChan)
+	s.stateManager.SetupPlanApprovalUIState(msg.PlanContent, msg.PlanPath, msg.ResponseChan)
 
 	return tea.Batch(s.planApprovalRequestedCmds(msg.PlanContent)...)
 }

--- a/internal/services/approvalcoord/coordinator_test.go
+++ b/internal/services/approvalcoord/coordinator_test.go
@@ -33,6 +33,7 @@ func TestService_HandlePlanApprovalRequested(t *testing.T) {
 
 		cmd := svc.HandlePlanApprovalRequested(domain.PlanApprovalRequestedEvent{
 			PlanContent:  "# Plan\n- step 1",
+			PlanPath:     ".infer/plans/2026-06-28-090000-plan.md",
 			ResponseChan: responseChan,
 		})
 
@@ -42,9 +43,12 @@ func TestService_HandlePlanApprovalRequested(t *testing.T) {
 		if state.SetupPlanApprovalUIStateCallCount() != 1 {
 			t.Fatalf("expected SetupPlanApprovalUIState once, got %d", state.SetupPlanApprovalUIStateCallCount())
 		}
-		gotContent, gotChan := state.SetupPlanApprovalUIStateArgsForCall(0)
+		gotContent, gotPath, gotChan := state.SetupPlanApprovalUIStateArgsForCall(0)
 		if gotContent != "# Plan\n- step 1" {
 			t.Errorf("unexpected plan content: %q", gotContent)
+		}
+		if gotPath != ".infer/plans/2026-06-28-090000-plan.md" {
+			t.Errorf("expected plan path to be forwarded to state manager, got %q", gotPath)
 		}
 		if gotChan != responseChan {
 			t.Errorf("expected response channel to be forwarded to state manager")

--- a/internal/services/state_manager.go
+++ b/internal/services/state_manager.go
@@ -582,11 +582,11 @@ func (sm *StateManager) BroadcastEvent(event domain.ChatEvent) {
 // Plan approval state methods
 
 // SetupPlanApprovalUIState initializes plan approval UI state
-func (sm *StateManager) SetupPlanApprovalUIState(planContent string, responseChan chan domain.PlanApprovalAction) {
+func (sm *StateManager) SetupPlanApprovalUIState(planContent, planPath string, responseChan chan domain.PlanApprovalAction) {
 	sm.mutex.Lock()
 	defer sm.mutex.Unlock()
 
-	sm.state.SetupPlanApprovalUIState(planContent, responseChan)
+	sm.state.SetupPlanApprovalUIState(planContent, planPath, responseChan)
 }
 
 // GetPlanApprovalUIState returns the current plan approval UI state

--- a/tests/mocks/domain/fake_state_manager.go
+++ b/tests/mocks/domain/fake_state_manager.go
@@ -432,11 +432,12 @@ type FakeStateManager struct {
 	setupFileSelectionArgsForCall []struct {
 		arg1 []string
 	}
-	SetupPlanApprovalUIStateStub        func(string, chan domain.PlanApprovalAction)
+	SetupPlanApprovalUIStateStub        func(string, string, chan domain.PlanApprovalAction)
 	setupPlanApprovalUIStateMutex       sync.RWMutex
 	setupPlanApprovalUIStateArgsForCall []struct {
 		arg1 string
-		arg2 chan domain.PlanApprovalAction
+		arg2 string
+		arg3 chan domain.PlanApprovalAction
 	}
 	SetupUserQuestionUIStateStub        func([]domain.UserQuestion, chan []domain.UserQuestionAnswer)
 	setupUserQuestionUIStateMutex       sync.RWMutex
@@ -2880,17 +2881,18 @@ func (fake *FakeStateManager) SetupFileSelectionArgsForCall(i int) []string {
 	return argsForCall.arg1
 }
 
-func (fake *FakeStateManager) SetupPlanApprovalUIState(arg1 string, arg2 chan domain.PlanApprovalAction) {
+func (fake *FakeStateManager) SetupPlanApprovalUIState(arg1 string, arg2 string, arg3 chan domain.PlanApprovalAction) {
 	fake.setupPlanApprovalUIStateMutex.Lock()
 	fake.setupPlanApprovalUIStateArgsForCall = append(fake.setupPlanApprovalUIStateArgsForCall, struct {
 		arg1 string
-		arg2 chan domain.PlanApprovalAction
-	}{arg1, arg2})
+		arg2 string
+		arg3 chan domain.PlanApprovalAction
+	}{arg1, arg2, arg3})
 	stub := fake.SetupPlanApprovalUIStateStub
-	fake.recordInvocation("SetupPlanApprovalUIState", []interface{}{arg1, arg2})
+	fake.recordInvocation("SetupPlanApprovalUIState", []interface{}{arg1, arg2, arg3})
 	fake.setupPlanApprovalUIStateMutex.Unlock()
 	if stub != nil {
-		fake.SetupPlanApprovalUIStateStub(arg1, arg2)
+		fake.SetupPlanApprovalUIStateStub(arg1, arg2, arg3)
 	}
 }
 
@@ -2900,17 +2902,17 @@ func (fake *FakeStateManager) SetupPlanApprovalUIStateCallCount() int {
 	return len(fake.setupPlanApprovalUIStateArgsForCall)
 }
 
-func (fake *FakeStateManager) SetupPlanApprovalUIStateCalls(stub func(string, chan domain.PlanApprovalAction)) {
+func (fake *FakeStateManager) SetupPlanApprovalUIStateCalls(stub func(string, string, chan domain.PlanApprovalAction)) {
 	fake.setupPlanApprovalUIStateMutex.Lock()
 	defer fake.setupPlanApprovalUIStateMutex.Unlock()
 	fake.SetupPlanApprovalUIStateStub = stub
 }
 
-func (fake *FakeStateManager) SetupPlanApprovalUIStateArgsForCall(i int) (string, chan domain.PlanApprovalAction) {
+func (fake *FakeStateManager) SetupPlanApprovalUIStateArgsForCall(i int) (string, string, chan domain.PlanApprovalAction) {
 	fake.setupPlanApprovalUIStateMutex.RLock()
 	defer fake.setupPlanApprovalUIStateMutex.RUnlock()
 	argsForCall := fake.setupPlanApprovalUIStateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeStateManager) SetupUserQuestionUIState(arg1 []domain.UserQuestion, arg2 chan []domain.UserQuestionAnswer) {


### PR DESCRIPTION
## Summary

Closes #677.

When a plan is approved in Plan Mode, the agent now **compacts the (usually exploration-heavy) planning conversation into a summary, starts a fresh session, and re-reads the approved plan from disk to execute** — so execution begins with an optimized, much smaller context window.

Planning is read-heavy (`Read`/`Grep`/`Tree` all over the codebase), and none of that exploration is needed once the plan is accepted. This reuses the existing `/compact` machinery at plan-approval time.

## Behaviour

| `compact.enabled` | Auto-compact at `auto_at` (80%) | Compact on plan approval |
| --- | --- | --- |
| `true` (default) | ✅ | ✅ |
| `false` | ❌ | ✅ (always) |

Compaction on plan approval runs **regardless of `compact.enabled`** — that flag only governs the automatic mid-conversation compaction and the headless session rollover. It also **fails open**: if summarization errors or times out, execution still proceeds on the un-compacted conversation.

> Note: the approved plan is never lost — it lives on disk under `<configDir>/plans/…` and is captured in the summary; the continuation prompt points the agent back at that file to execute step by step.

## Changes

- **Plan-path plumbing** — the saved plan path from the `RequestPlanApproval` tool result flows through `PlanApprovalRequestedEvent` → `PlanApprovalUIState`, so the post-approval continuation prompt can reference it (`internal/agent/agent.go`, `internal/domain/{events,state,interfaces}.go`, `internal/services/state_manager.go`, `internal/services/approvalcoord/coordinator.go`).
- **Orchestration** — `HandlePlanApprovalResponseEvent` captures the path and, on accept, runs a new `compactThenExecutePlanCmd`: async optimize under a 70s timeout → reseed a new session → add a plan-path-aware continue message → resume the agent (`internal/handlers/chat_handler.go`, new `internal/handlers/chat_compaction.go`).
- **Shared helpers** — extracted `optimizeWithTimeout` / `reseedConversationWithMessages` / `nonHiddenMessages`; the `/compact` shortcut now reuses them (behaviour unchanged).
- **Optimizer always constructed** — `internal/container/container.go` builds the `ConversationOptimizer` unconditionally so approval compaction works even with `compact.enabled: false` (`force=true` bypasses the enabled check).
- **Docs** — new "Context compaction on approval" section in `docs/plan-mode.md`; fixed the stale `compact.enabled` default (it is `true`, not `false`) in `docs/configuration-reference.md`.

## Testing

- `task build`, full `go test ./...`, `golangci-lint` (0 issues), `markdownlint` — all green.
- New unit tests: `extractPlanPath` (edge cases), `checkToolResultsStatus` path extraction, `planExecutionContinuePrompt`, and `compactPlanningContext` (reseed / no-reduce / absent optimizer / no model), plus plan-path forwarding in the coordinator test.

### Manual check to run before merge
Interactive TUI + live gateway (not runnable in CI): Shift+Tab into Plan Mode, ask for a multi-file change so the model reads several files, **Accept** the plan, and confirm the history collapses to a `--- Context Summary ---`, the agent re-`Read`s the plan file, and `/context` shows a smaller token count. Repeat with **Accept & Auto-Approve**, and with `compact.enabled: false`.

## Docs follow-up

A matching `[DOCS]` issue should be filed for `inference-gateway/docs` (Plan Mode / compaction pages) per the docs follow-up rule.
