### PR TITLE
fix(ui): update dim color from #565f89 to #7a7f9a for improved contrast

### DIFF
--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -67,7 +67,7 @@ func (fakeHint) GetKeyOnly(string) string { return "ctrl+o" }
 func newTestStyleProvider() *styles.Provider {
 	theme := &uimocks.FakeTheme{}
 	theme.GetAccentColorReturns("#7aa2f7")
-	theme.GetDimColorReturns("#565f89")
+	theme.GetDimColorReturns("#7a7f9a")
 	theme.GetSuccessColorReturns("#9ece6a")
 	theme.GetErrorColorReturns("#f7768e")
 	theme.GetAssistantColorReturns("#a9b1d6")

--- a/internal/ui/components/diffview/style.go
+++ b/internal/ui/components/diffview/style.go
@@ -28,7 +28,7 @@ type Style struct {
 const (
 	darkBg          = "#1a1b26"
 	darkFg          = "#a9b1d6"
-	darkDim         = "#565f89"
+	darkDim         = "#7a7f9a"
 	darkGutterBg    = "#1f2030"
 	darkHunkFg      = "#7aa2f7"
 	darkHunkBg      = "#24283b"

--- a/internal/ui/styles/colors/colors.go
+++ b/internal/ui/styles/colors/colors.go
@@ -17,7 +17,7 @@ const (
 	Cyan          = "\033[38;2;125;207;255m" // #7dcfff - cyan variant
 	Magenta       = "\033[38;2;187;154;247m" // #bb9af7 - purple for secondary
 	White         = "\033[38;2;169;177;214m" // #a9b1d6 - light gray-blue for primary text
-	Gray          = "\033[38;2;86;95;137m"   // #565f89 - dim gray
+	Gray          = "\033[38;2;122;127;154m" // #7a7f9a - dim gray
 	LightGray     = "\033[38;2;102;102;102m" // #666666 - light gray
 	Amber         = "\033[38;2;224;175;104m" // #e0af68 - amber for warnings
 	BrightRed     = "\033[38;2;247;118;142m" // Same as Red
@@ -35,7 +35,7 @@ const (
 	LipglossCyan      = "#7dcfff"
 	LipglossMagenta   = "#bb9af7"
 	LipglossWhite     = "#a9b1d6"
-	LipglossGray      = "#565f89"
+	LipglossGray      = "#7a7f9a"
 	LipglossLightGray = "#666666"
 	LipglossAmber     = "#e0af68"
 	LipglossBlack     = "#000000"

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -332,7 +332,7 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            color: #565f89;
+            color: #7a7f9a;
             font-size: 14px;
         }
         .screenshot-skeleton.hidden {
@@ -350,7 +350,7 @@
             display: flex;
             justify-content: space-between;
             font-size: 11px;
-            color: #565f89;
+            color: #7a7f9a;
             padding-top: 8px;
             border-top: 1px solid #414868;
         }


### PR DESCRIPTION
## Summary

Updates the dim/gray color from `#565f89` to `#7a7f9a` across the codebase for improved contrast and readability.

## Changes

- **`internal/ui/styles/colors/colors.go`**: Updated `Gray` and `LipglossGray` constants
- **`internal/ui/components/diffview/style.go`**: Updated `darkDim` constant
- **`internal/services/tool_formatter_test.go`**: Updated test mock to match new color
- **`internal/web/templates/index.html`**: Updated CSS color values

## Testing

- All existing tests pass
- Visual contrast is improved with the lighter dim color