### PR TITLE
fix(tools): guard Registry.tools with RWMutex against concurrent MCP registration

### DIFF
--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -34,6 +34,7 @@ import (
 // Registry manages all available tools
 type Registry struct {
 	config             *config.Config
+	toolsMu            sync.RWMutex
 	tools              map[string]domain.Tool
 	readToolUsed       bool
 	readFiles          map[string]fileReadSnapshot
@@ -93,12 +94,16 @@ func (r *Registry) SetScreenshotProvider(provider domain.ScreenshotProvider) {
 		displayProvider, err := display.DetectDisplay()
 		if err == nil {
 			rateLimiter := utils.NewRateLimiter(cfg.ComputerUse.RateLimit)
+			r.toolsMu.Lock()
 			r.tools["MouseClick"] = NewMouseClickTool(cfg, rateLimiter, displayProvider, r.stateManager)
+			r.toolsMu.Unlock()
 		}
 	}
 }
 
-// registerTools initializes and registers all available tools
+// registerTools initializes and registers all available tools. It runs during
+// construction, before the Registry is shared with other goroutines, so it
+// does not take toolsMu.
 func (r *Registry) registerTools() {
 	cfg := r.config
 
@@ -180,13 +185,17 @@ func (r *Registry) registerTools() {
 func (r *Registry) SetMemoryBackend(backend domain.MemoryBackend) {
 	r.memoryBackend = backend
 	if r.config.Memory.Enabled {
+		r.toolsMu.Lock()
 		r.tools["Memory"] = NewMemoryTool(r.config, backend)
+		r.toolsMu.Unlock()
 	}
 }
 
 // GetTool retrieves a tool by name
 func (r *Registry) GetTool(name string) (domain.Tool, error) {
+	r.toolsMu.RLock()
 	tool, exists := r.tools[name]
+	r.toolsMu.RUnlock()
 	if !exists {
 		return nil, fmt.Errorf("unknown tool: %s", name)
 	}
@@ -195,6 +204,8 @@ func (r *Registry) GetTool(name string) (domain.Tool, error) {
 
 // ListAvailableTools returns names of all available and enabled tools
 func (r *Registry) ListAvailableTools() []string {
+	r.toolsMu.RLock()
+	defer r.toolsMu.RUnlock()
 	var tools []string
 	for name, tool := range r.tools {
 		if tool.IsEnabled() {
@@ -206,6 +217,8 @@ func (r *Registry) ListAvailableTools() []string {
 
 // GetToolDefinitions returns definitions for all enabled tools
 func (r *Registry) GetToolDefinitions() []sdk.ChatCompletionTool {
+	r.toolsMu.RLock()
+	defer r.toolsMu.RUnlock()
 	var definitions []sdk.ChatCompletionTool
 	for _, tool := range r.tools {
 		if tool.IsEnabled() {
@@ -217,7 +230,9 @@ func (r *Registry) GetToolDefinitions() []sdk.ChatCompletionTool {
 
 // IsToolEnabled checks if a specific tool is enabled
 func (r *Registry) IsToolEnabled(name string) bool {
+	r.toolsMu.RLock()
 	tool, exists := r.tools[name]
+	r.toolsMu.RUnlock()
 	if !exists {
 		return false
 	}
@@ -241,6 +256,7 @@ func (r *Registry) RegisterMCPServerTools(serverName string, tools []domain.MCPD
 	toolCount := 0
 	cfg := r.config
 
+	r.toolsMu.Lock()
 	for _, tool := range tools {
 		fullToolName := fmt.Sprintf("MCP_%s_%s", serverName, tool.Name)
 
@@ -261,6 +277,7 @@ func (r *Registry) RegisterMCPServerTools(serverName string, tools []domain.MCPD
 			"server", serverName,
 			"description", tool.Description)
 	}
+	r.toolsMu.Unlock()
 
 	r.mcpManager.UpdateToolCount(serverName, toolCount)
 
@@ -272,12 +289,14 @@ func (r *Registry) UnregisterMCPServerTools(serverName string) int {
 	removedCount := 0
 	prefix := fmt.Sprintf("MCP_%s_", serverName)
 
+	r.toolsMu.Lock()
 	for toolName := range r.tools {
 		if strings.HasPrefix(toolName, prefix) {
 			delete(r.tools, toolName)
 			removedCount++
 		}
 	}
+	r.toolsMu.Unlock()
 
 	if removedCount > 0 {
 		logger.Debug("unregistered MCP tools from disconnected server", "server", serverName, "count", removedCount)
@@ -304,7 +323,9 @@ func (r *Registry) SetScreenshotServer(provider domain.ScreenshotProvider) {
 	r.SetScreenshotProvider(provider)
 
 	getLatestTool := NewGetLatestScreenshotTool(cfg, provider)
+	r.toolsMu.Lock()
 	r.tools["GetLatestScreenshot"] = getLatestTool
+	r.toolsMu.Unlock()
 
 	logger.Info("dynamically registered GetLatestScreenshot tool for streaming mode")
 }

--- a/internal/agent/tools/registry_test.go
+++ b/internal/agent/tools/registry_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -607,4 +608,70 @@ func TestRegistry_NewRegistry_DoesNotBlockOnMCP(t *testing.T) {
 	// but it must not block the constructor return. We do NOT assert
 	// !blocker.getClientsCalled here because background discovery is
 	// permissible; we only assert the constructor returned in time above.
+}
+
+// stubMCPManager is a minimal domain.MCPManager whose GetClient always
+// resolves, so RegisterMCPServerTools reaches the tools-map writes.
+type stubMCPManager struct{ client domain.MCPClient }
+
+func (m *stubMCPManager) GetClients() []domain.MCPClient     { return []domain.MCPClient{m.client} }
+func (m *stubMCPManager) GetClient(string) domain.MCPClient  { return m.client }
+func (m *stubMCPManager) GetTotalServers() int               { return 1 }
+func (m *stubMCPManager) UpdateToolCount(string, int)        {}
+func (m *stubMCPManager) ClearToolCount(string)              {}
+func (m *stubMCPManager) StartServers(context.Context) error { return nil }
+func (m *stubMCPManager) StopServers(context.Context) error  { return nil }
+func (m *stubMCPManager) Close() error                       { return nil }
+func (m *stubMCPManager) StartMonitoring(context.Context)    {}
+
+// TestRegistry_ConcurrentMCPToolAccess is a regression test for issue #708:
+// the MCP liveness probe registers/unregisters MCP_* tools from its own
+// goroutine while the main loop reads the same map via GetTool /
+// ListAvailableTools / GetToolDefinitions / IsToolEnabled. It is meaningful
+// under -race: without the registry's toolsMu it fails with a detected data
+// race (or a concurrent map read/write panic).
+func TestRegistry_ConcurrentMCPToolAccess(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Bash: config.BashToolConfig{
+				Enabled: true,
+				Mode: config.BashModesConfig{
+					All: config.BashModeAllowConfig{Allow: []string{"echo"}},
+				},
+			},
+		},
+		MCP: config.MCPConfig{
+			Enabled: true,
+			Servers: []config.MCPServerEntry{
+				{Name: "flappy", Enabled: true},
+			},
+		},
+		Prompts: *config.DefaultPromptsConfig(),
+	}
+
+	registry := NewRegistry(cfg, nil, &stubMCPManager{client: &mocks.FakeMCPClient{}}, nil, nil, nil, nil)
+
+	discovered := []domain.MCPDiscoveredTool{
+		{ServerName: "flappy", Name: "alpha", Description: "a", InputSchema: map[string]any{}},
+		{ServerName: "flappy", Name: "beta", Description: "b", InputSchema: map[string]any{}},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			registry.RegisterMCPServerTools("flappy", discovered)
+			registry.UnregisterMCPServerTools("flappy")
+		}
+	}()
+
+	for range 200 {
+		_, _ = registry.GetTool("MCP_flappy_alpha")
+		registry.ListAvailableTools()
+		registry.GetToolDefinitions()
+		registry.IsToolEnabled("MCP_flappy_beta")
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary

Fixes the data race on the tool `Registry.tools` map reported in #708: the MCP liveness-probe goroutine registers/unregisters `MCP_*` tools (`RegisterMCPServerTools` / `UnregisterMCPServerTools`) while the main loop reads the same map (`GetTool` / `ListAvailableTools` / `GetToolDefinitions` / `IsToolEnabled`) with no synchronization — flagged by `-race`, and a potential `fatal error: concurrent map read and map write` panic.

## Changes

- `internal/agent/tools/registry.go`: add `toolsMu sync.RWMutex` guarding `tools`. The four read accessors take `RLock`; every post-construction writer takes `Lock` — the MCP probe paths plus `SetMemoryBackend`, `SetScreenshotProvider`, and `SetScreenshotServer`. `registerTools` deliberately stays lock-free (documented): it runs inside `NewRegistry` before the registry is shared, and no tool constructor calls back into a locking accessor, so there is no re-entrancy hazard.
- `internal/agent/tools/registry_test.go`: `TestRegistry_ConcurrentMCPToolAccess` regression test — churns MCP register/unregister from a goroutine (minimal `stubMCPManager` + counterfeiter `FakeMCPClient`) while the test goroutine hammers all four read accessors.

## Verification

- With the fix reverted, the new test fails under `-race` with multiple DATA RACE reports — it locks in the regression.
- With the fix: `go test -race ./internal/agent/tools/` passes, `golangci-lint run ./internal/agent/tools/...` reports 0 issues, `go build ./...` compiles clean.

Closes #708