### PR TITLE
feat(history): each subagent gets its own history file

### DIFF
--- a/internal/agent/tools/agent.go
+++ b/internal/agent/tools/agent.go
@@ -437,6 +437,12 @@ func (t *AgentTool) buildChatPaneCommand(spec AgentTaskSpec, sessionID string) s
 		parts = append(parts, "INFER_AGENT_MODEL="+shellQuote(spec.Model))
 	}
 
+	historyName := spec.Label
+	if historyName == "" {
+		historyName = sessionID
+	}
+	parts = append(parts, domain.EnvSubagentHistoryName+"="+shellQuote(historyName))
+
 	parts = append(parts, domain.EnvSubagentResultFile+"="+shellQuote(subagentResultFilePath(sessionID)))
 	parts = append(parts, domain.EnvSubagentApprovalFile+"="+shellQuote(subagentApprovalFilePath(sessionID)))
 	parts = append(parts, shellQuote(t.binary), "chat")

--- a/internal/agent/tools/agent.go
+++ b/internal/agent/tools/agent.go
@@ -437,9 +437,9 @@ func (t *AgentTool) buildChatPaneCommand(spec AgentTaskSpec, sessionID string) s
 		parts = append(parts, "INFER_AGENT_MODEL="+shellQuote(spec.Model))
 	}
 
-	historyName := spec.Label
+	historyName := sanitizeSlug(spec.Label)
 	if historyName == "" {
-		historyName = sessionID
+		historyName = domain.SubagentHistoryMemoryOnly
 	}
 	parts = append(parts, domain.EnvSubagentHistoryName+"="+shellQuote(historyName))
 

--- a/internal/agent/tools/agent_test.go
+++ b/internal/agent/tools/agent_test.go
@@ -178,6 +178,23 @@ func TestBuildChatPaneCommand_PassesResultFile(t *testing.T) {
 	}
 }
 
+// buildChatPaneCommand must slugify the LLM-supplied label into a safe, dashcase
+// history name (no spaces, path separators, or traversal) and fall back to the
+// memory-only sentinel when there is no usable label — never the per-spawn session id.
+func TestBuildChatPaneCommand_SlugifiesHistoryName(t *testing.T) {
+	tool := newTestAgentTool(t)
+
+	if got := tool.buildChatPaneCommand(AgentTaskSpec{Label: "Refactor Auth"}, "sess"); !strings.Contains(got, "INFER_SUBAGENT_HISTORY_NAME='refactor-auth'") {
+		t.Fatalf("label must be slugified to dashcase; cmd = %q", got)
+	}
+	if got := tool.buildChatPaneCommand(AgentTaskSpec{Label: "a/../../../tmp/pwned"}, "sess"); !strings.Contains(got, "INFER_SUBAGENT_HISTORY_NAME='a-tmp-pwned'") {
+		t.Fatalf("path separators/traversal must be sanitized out; cmd = %q", got)
+	}
+	if got := tool.buildChatPaneCommand(AgentTaskSpec{}, "subagent-parent-uuid"); !strings.Contains(got, "INFER_SUBAGENT_HISTORY_NAME='"+domain.SubagentHistoryMemoryOnly+"'") {
+		t.Fatalf("unlabeled subagent must use the memory-only sentinel, not the session id; cmd = %q", got)
+	}
+}
+
 func TestSubagentExtraEnv_EmitsSubagentMode(t *testing.T) {
 	t.Setenv("INFER_SUBAGENT_DEPTH", "")
 	if env := strings.Join(subagentExtraEnv(AgentTaskSpec{Mode: domain.AgentModeReadOnly}), " "); !strings.Contains(env, "INFER_SUBAGENT_AGENT_MODE=readonly") {

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -223,7 +223,8 @@ func NewChatApplication(
 		cv.SetAgentModelResolver(buildAgentModelResolver())
 	}
 
-	app.inputView = factory.CreateInputViewWithName(app.modelService, configDir, "")
+	historyName := os.Getenv(domain.EnvSubagentHistoryName)
+	app.inputView = factory.CreateInputViewWithName(app.modelService, configDir, historyName)
 	if iv, ok := app.inputView.(*components.InputView); ok {
 		iv.SetThemeService(app.themeService)
 		iv.SetStateManager(app.stateManager)

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -223,7 +223,7 @@ func NewChatApplication(
 		cv.SetAgentModelResolver(buildAgentModelResolver())
 	}
 
-	app.inputView = factory.CreateInputViewWithConfigDir(app.modelService, configDir)
+	app.inputView = factory.CreateInputViewWithName(app.modelService, configDir, "")
 	if iv, ok := app.inputView.(*components.InputView); ok {
 		iv.SetThemeService(app.themeService)
 		iv.SetStateManager(app.stateManager)

--- a/internal/domain/subagent.go
+++ b/internal/domain/subagent.go
@@ -45,8 +45,16 @@ const EnvSubagentApprovalFile = "INFER_SUBAGENT_APPROVAL_FILE"
 // EnvSubagentHistoryName names the environment variable the Agent tool sets on
 // an interactive subagent's `infer chat` so it uses its own history file
 // (<configDir>/history/history-<name>) instead of the main agent's history.
-// When unset or empty, the subagent falls back to the main history file.
+// When unset or empty, the subagent falls back to the main history file; the
+// reserved value SubagentHistoryMemoryOnly selects in-memory-only history.
 const EnvSubagentHistoryName = "INFER_SUBAGENT_HISTORY_NAME"
+
+// SubagentHistoryMemoryOnly is the reserved EnvSubagentHistoryName value telling an
+// interactive subagent to keep its input history in memory only (no file). The Agent
+// tool sets it for subagents without a usable label so they don't create a new
+// single-use history file per spawn. sanitizeSlug never yields this value (it contains
+// ':'), so it can't collide with a real slug.
+const SubagentHistoryMemoryOnly = ":memory:"
 
 // SubagentApprovalFile is the JSON an interactive subagent's chat writes while it
 // is blocked on a tool-approval prompt. It is an authoritative signal (written

--- a/internal/domain/subagent.go
+++ b/internal/domain/subagent.go
@@ -42,6 +42,12 @@ const EnvSubagentResultFile = "INFER_SUBAGENT_RESULT_FILE"
 // for normal `infer chat`, which writes nothing.
 const EnvSubagentApprovalFile = "INFER_SUBAGENT_APPROVAL_FILE"
 
+// EnvSubagentHistoryName names the environment variable the Agent tool sets on
+// an interactive subagent's `infer chat` so it uses its own history file
+// (<configDir>/history/history-<name>) instead of the main agent's history.
+// When unset or empty, the subagent falls back to the main history file.
+const EnvSubagentHistoryName = "INFER_SUBAGENT_HISTORY_NAME"
+
 // SubagentApprovalFile is the JSON an interactive subagent's chat writes while it
 // is blocked on a tool-approval prompt. It is an authoritative signal (written
 // the moment the chat blocks, removed when it resolves) so the parent does not

--- a/internal/ui/components/factory/factory.go
+++ b/internal/ui/components/factory/factory.go
@@ -20,9 +20,11 @@ func CreateInputView(modelService domain.ModelService) ui.InputComponent {
 	return components.NewInputView(modelService)
 }
 
-// CreateInputViewWithConfigDir creates a new input view component with config directory
-func CreateInputViewWithConfigDir(modelService domain.ModelService, configDir string) ui.InputComponent {
-	return components.NewInputViewWithConfigDir(modelService, configDir)
+// CreateInputViewWithName creates a new input view component with config directory and name.
+// When name is empty, the history file is stored at <configDir>/history/history (the main agent).
+// When name is non-empty, the history file is stored at <configDir>/history/history-<name> (e.g. for subagents).
+func CreateInputViewWithName(modelService domain.ModelService, configDir, name string) ui.InputComponent {
+	return components.NewInputViewWithName(modelService, configDir, name)
 }
 
 // CreateAutocomplete creates a new autocomplete component

--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -63,9 +63,13 @@ func NewInputViewWithName(modelService domain.ModelService, configDir, name stri
 		configDir = ".infer"
 	}
 
-	historyManager, err := history.NewHistoryManagerWithName(5, configDir, name)
-	if err != nil {
+	var historyManager *history.HistoryManager
+	if name == domain.SubagentHistoryMemoryOnly {
 		historyManager = history.NewMemoryOnlyHistoryManager(5)
+	} else if hm, err := history.NewHistoryManagerWithName(5, configDir, name); err != nil {
+		historyManager = history.NewMemoryOnlyHistoryManager(5)
+	} else {
+		historyManager = hm
 	}
 
 	return &InputView{

--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -55,15 +55,15 @@ type InputView struct {
 }
 
 func NewInputView(modelService domain.ModelService) *InputView {
-	return NewInputViewWithConfigDir(modelService, "")
+	return NewInputViewWithName(modelService, "", "")
 }
 
-func NewInputViewWithConfigDir(modelService domain.ModelService, configDir string) *InputView {
+func NewInputViewWithName(modelService domain.ModelService, configDir, name string) *InputView {
 	if configDir == "" {
 		configDir = ".infer"
 	}
 
-	historyManager, err := history.NewHistoryManagerWithDir(5, configDir)
+	historyManager, err := history.NewHistoryManagerWithName(5, configDir, name)
 	if err != nil {
 		historyManager = history.NewMemoryOnlyHistoryManager(5)
 	}

--- a/internal/ui/components/input_view_test.go
+++ b/internal/ui/components/input_view_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +54,23 @@ func createInputViewWithTheme(modelService domain.ModelService) *InputView {
 	iv.styleProvider = styles.NewProvider(fakeThemeService)
 
 	return iv
+}
+
+// NewInputViewWithName must map the memory-only sentinel to a manager with no backing
+// file (unlabeled subagents), and a real name to <configDir>/history/history-<name>.
+func TestNewInputViewWithName_HistorySelection(t *testing.T) {
+	ms := createMockModelService()
+
+	iv := NewInputViewWithName(ms, "cfgdir", domain.SubagentHistoryMemoryOnly)
+	if got := iv.historyManager.GetShellHistoryFile(); got != "" {
+		t.Errorf("memory-only sentinel must have no history file, got %q", got)
+	}
+
+	iv = NewInputViewWithName(ms, "cfgdir", "refactor")
+	want := filepath.Join("cfgdir", "history", "history-refactor")
+	if got := iv.historyManager.GetShellHistoryFile(); got != want {
+		t.Errorf("named subagent history: want %q, got %q", want, got)
+	}
 }
 
 func TestNewInputView(t *testing.T) {

--- a/internal/ui/history/history_manager.go
+++ b/internal/ui/history/history_manager.go
@@ -19,12 +19,15 @@ type HistoryManager struct {
 
 // NewHistoryManager creates a new history manager
 func NewHistoryManager(maxInMemory int) (*HistoryManager, error) {
-	return NewHistoryManagerWithDir(maxInMemory, ".infer")
+	return NewHistoryManagerWithName(maxInMemory, ".infer", "")
 }
 
-// NewHistoryManagerWithDir creates a new history manager with a custom config directory
-func NewHistoryManagerWithDir(maxInMemory int, configDir string) (*HistoryManager, error) {
-	shellHistory, err := NewShellHistoryWithDir(configDir)
+// NewHistoryManagerWithName creates a new history manager with a custom config directory
+// and an optional name. When name is empty, the history file is stored at
+// <configDir>/history/history (the main agent). When name is non-empty, the history
+// file is stored at <configDir>/history/history-<name> (e.g. for subagents).
+func NewHistoryManagerWithName(maxInMemory int, configDir, name string) (*HistoryManager, error) {
+	shellHistory, err := NewShellHistoryWithName(configDir, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize shell history: %w", err)
 	}

--- a/internal/ui/history/history_manager_test.go
+++ b/internal/ui/history/history_manager_test.go
@@ -1,4 +1,4 @@
-package history_test
+package history_test //nolint:cyclop // Integration tests with temp dir setup
 
 import (
 	"os"
@@ -38,7 +38,12 @@ func TestHistoryManager_PublicAPI(t *testing.T) {
 		t.Fatalf("Failed to create .infer directory: %v", err)
 	}
 
-	historyFile := filepath.Join(inferDir, "history")
+	historyDir := filepath.Join(inferDir, "history")
+	if err := os.MkdirAll(historyDir, 0755); err != nil {
+		t.Fatalf("Failed to create history directory: %v", err)
+	}
+
+	historyFile := filepath.Join(historyDir, "history")
 	content := "existing command\n"
 	if err := os.WriteFile(historyFile, []byte(content), 0644); err != nil {
 		t.Fatalf("Failed to write test history file: %v", err)
@@ -115,7 +120,12 @@ func TestNewHistoryManager_Integration(t *testing.T) {
 		t.Fatalf("Failed to create .infer directory: %v", err)
 	}
 
-	historyFile := filepath.Join(inferDir, "history")
+	historyDir := filepath.Join(inferDir, "history")
+	if err := os.MkdirAll(historyDir, 0755); err != nil {
+		t.Fatalf("Failed to create history directory: %v", err)
+	}
+
+	historyFile := filepath.Join(historyDir, "history")
 	content := "git status\nls -la\npwd\n"
 	if err := os.WriteFile(historyFile, []byte(content), 0644); err != nil {
 		t.Fatalf("Failed to write test history file: %v", err)

--- a/internal/ui/history/shell_history.go
+++ b/internal/ui/history/shell_history.go
@@ -22,12 +22,21 @@ type ShellHistory struct {
 
 // NewShellHistory creates a new shell history provider
 func NewShellHistory() (*ShellHistory, error) {
-	return NewShellHistoryWithDir(".infer")
+	return NewShellHistoryWithName(".infer", "")
 }
 
-// NewShellHistoryWithDir creates a new shell history provider with a custom directory
-func NewShellHistoryWithDir(configDir string) (*ShellHistory, error) {
-	historyFile := filepath.Join(configDir, "history")
+// NewShellHistoryWithName creates a new shell history provider with a custom config
+// directory and an optional name. When name is empty, the history file is stored at
+// <configDir>/history/history (the main agent). When name is non-empty, the history
+// file is stored at <configDir>/history/history-<name> (e.g. for subagents).
+func NewShellHistoryWithName(configDir, name string) (*ShellHistory, error) {
+	historyDir := filepath.Join(configDir, "history")
+	var historyFile string
+	if name == "" {
+		historyFile = filepath.Join(historyDir, "history")
+	} else {
+		historyFile = filepath.Join(historyDir, "history-"+name)
+	}
 
 	return &ShellHistory{
 		historyFile: historyFile,

--- a/internal/ui/history/shell_history.go
+++ b/internal/ui/history/shell_history.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	logger "github.com/inference-gateway/cli/internal/logger"
 )
 
 // ShellHistoryProvider interface defines methods for shell history operations
@@ -31,6 +33,11 @@ func NewShellHistory() (*ShellHistory, error) {
 // file is stored at <configDir>/history/history-<name> (e.g. for subagents).
 func NewShellHistoryWithName(configDir, name string) (*ShellHistory, error) {
 	historyDir := filepath.Join(configDir, "history")
+
+	if err := migrateLegacyMainHistory(historyDir); err != nil {
+		logger.Warn("could not migrate legacy history file", "error", err)
+	}
+
 	var historyFile string
 	if name == "" {
 		historyFile = filepath.Join(historyDir, "history")
@@ -41,6 +48,37 @@ func NewShellHistoryWithName(configDir, name string) (*ShellHistory, error) {
 	return &ShellHistory{
 		historyFile: historyFile,
 	}, nil
+}
+
+// migrateLegacyMainHistory upgrades the pre-history/ layout in place. Older
+// versions stored the main history at <configDir>/history as a plain file;
+// the current layout needs <configDir>/history to be a directory (holding
+// history/history and history/history-<name>). When the legacy file is present
+// it is moved to history/history so existing history survives and directory
+// creation does not fail with ENOTDIR. No-op when the path is absent or is
+// already a directory.
+//
+// TODO: this one-time migration can be removed in a future version once
+// existing installs have upgraded past the history/ layout change.
+func migrateLegacyMainHistory(historyDir string) error {
+	info, err := os.Stat(historyDir)
+	if err != nil || info.IsDir() {
+		return nil
+	}
+
+	staged := historyDir + ".migrating"
+	if err := os.Rename(historyDir, staged); err != nil {
+		return fmt.Errorf("staging legacy history file: %w", err)
+	}
+	if err := os.MkdirAll(historyDir, 0755); err != nil {
+		_ = os.Rename(staged, historyDir)
+		return fmt.Errorf("creating history directory: %w", err)
+	}
+	if err := os.Rename(staged, filepath.Join(historyDir, "history")); err != nil {
+		return fmt.Errorf("moving legacy history into place: %w", err)
+	}
+
+	return nil
 }
 
 // LoadHistory loads commands from history file

--- a/internal/ui/history/shell_history_test.go
+++ b/internal/ui/history/shell_history_test.go
@@ -36,6 +36,105 @@ func TestNewShellHistoryWithName(t *testing.T) {
 	}
 }
 
+func TestNewShellHistoryWithName_MigratesLegacyMainHistory(t *testing.T) {
+	tempDir := t.TempDir()
+
+	legacy := filepath.Join(tempDir, "history")
+	content := "echo one\necho two\n"
+	if err := os.WriteFile(legacy, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to seed legacy history file: %v", err)
+	}
+
+	sh, err := NewShellHistoryWithName(tempDir, "")
+	if err != nil {
+		t.Fatalf("NewShellHistoryWithName failed: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(tempDir, "history"))
+	if err != nil {
+		t.Fatalf("history path stat failed: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory after migration", filepath.Join(tempDir, "history"))
+	}
+
+	want := filepath.Join(tempDir, "history", "history")
+	if sh.historyFile != want {
+		t.Errorf("history file: expected %s, got %s", want, sh.historyFile)
+	}
+
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("failed to read migrated history: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("migrated content: expected %q, got %q", content, string(got))
+	}
+
+	cmds, err := sh.LoadHistory()
+	if err != nil {
+		t.Fatalf("LoadHistory failed: %v", err)
+	}
+	if len(cmds) != 2 || cmds[0] != "echo one" || cmds[1] != "echo two" {
+		t.Errorf("unexpected loaded history: %v", cmds)
+	}
+	if err := sh.SaveToHistory("echo three"); err != nil {
+		t.Fatalf("SaveToHistory after migration failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tempDir, "history.migrating")); !os.IsNotExist(err) {
+		t.Errorf("expected staged temp file to be gone, stat err = %v", err)
+	}
+}
+
+func TestNewShellHistoryWithName_NoMigrationWhenDirExists(t *testing.T) {
+	tempDir := t.TempDir()
+
+	historyDir := filepath.Join(tempDir, "history")
+	if err := os.MkdirAll(historyDir, 0755); err != nil {
+		t.Fatalf("failed to create history dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(historyDir, "history"), []byte("echo kept\n"), 0644); err != nil {
+		t.Fatalf("failed to seed history: %v", err)
+	}
+
+	sh, err := NewShellHistoryWithName(tempDir, "")
+	if err != nil {
+		t.Fatalf("NewShellHistoryWithName failed: %v", err)
+	}
+
+	got, err := os.ReadFile(sh.historyFile)
+	if err != nil {
+		t.Fatalf("failed to read history: %v", err)
+	}
+	if string(got) != "echo kept\n" {
+		t.Errorf("expected existing history untouched, got %q", string(got))
+	}
+}
+
+func TestNewShellHistoryWithName_MigrationIsNameAgnostic(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "history"), []byte("echo main\n"), 0644); err != nil {
+		t.Fatalf("failed to seed legacy history: %v", err)
+	}
+
+	sh, err := NewShellHistoryWithName(tempDir, "refactor")
+	if err != nil {
+		t.Fatalf("NewShellHistoryWithName failed: %v", err)
+	}
+
+	if want := filepath.Join(tempDir, "history", "history-refactor"); sh.historyFile != want {
+		t.Errorf("subagent history file: expected %s, got %s", want, sh.historyFile)
+	}
+	got, err := os.ReadFile(filepath.Join(tempDir, "history", "history"))
+	if err != nil {
+		t.Fatalf("expected migrated main history: %v", err)
+	}
+	if string(got) != "echo main\n" {
+		t.Errorf("migrated main content: expected %q, got %q", "echo main\n", string(got))
+	}
+}
+
 func TestLoadHistory(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "shell_history_test")
 	if err != nil {

--- a/internal/ui/history/shell_history_test.go
+++ b/internal/ui/history/shell_history_test.go
@@ -12,7 +12,7 @@ func TestNewShellHistory(t *testing.T) {
 		t.Fatalf("Failed to create shell history: %v", err)
 	}
 
-	expectedPath := filepath.Join(".infer", "history")
+	expectedPath := filepath.Join(".infer", "history", "history")
 	if sh.historyFile != expectedPath {
 		t.Errorf("Expected history file path %s, got %s", expectedPath, sh.historyFile)
 	}
@@ -165,7 +165,7 @@ func TestGetHistoryFile(t *testing.T) {
 		t.Fatalf("Failed to create shell history: %v", err)
 	}
 
-	expectedPath := filepath.Join(".infer", "history")
+	expectedPath := filepath.Join(".infer", "history", "history")
 	if sh.GetHistoryFile() != expectedPath {
 		t.Errorf("Expected GetHistoryFile() to return %s, got %s", expectedPath, sh.GetHistoryFile())
 	}

--- a/internal/ui/history/shell_history_test.go
+++ b/internal/ui/history/shell_history_test.go
@@ -18,6 +18,24 @@ func TestNewShellHistory(t *testing.T) {
 	}
 }
 
+func TestNewShellHistoryWithName(t *testing.T) {
+	main, err := NewShellHistoryWithName("cfgdir", "")
+	if err != nil {
+		t.Fatalf("NewShellHistoryWithName(main) failed: %v", err)
+	}
+	if want := filepath.Join("cfgdir", "history", "history"); main.historyFile != want {
+		t.Errorf("main history path: expected %s, got %s", want, main.historyFile)
+	}
+
+	sub, err := NewShellHistoryWithName("cfgdir", "refactor")
+	if err != nil {
+		t.Fatalf("NewShellHistoryWithName(subagent) failed: %v", err)
+	}
+	if want := filepath.Join("cfgdir", "history", "history-refactor"); sub.historyFile != want {
+		t.Errorf("subagent history path: expected %s, got %s", want, sub.historyFile)
+	}
+}
+
 func TestLoadHistory(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "shell_history_test")
 	if err != nil {
@@ -88,7 +106,7 @@ func TestSaveToHistory(t *testing.T) {
 	}()
 
 	t.Run("save command", func(t *testing.T) {
-		historyFile := filepath.Join(tempDir, ".infer", "history")
+		historyFile := filepath.Join(tempDir, ".infer", "history", "history")
 
 		sh := &ShellHistory{
 			historyFile: historyFile,
@@ -111,7 +129,7 @@ func TestSaveToHistory(t *testing.T) {
 	})
 
 	t.Run("append to existing history", func(t *testing.T) {
-		historyFile := filepath.Join(tempDir, ".infer", "history2")
+		historyFile := filepath.Join(tempDir, ".infer", "history", "history-append")
 
 		if err := os.MkdirAll(filepath.Dir(historyFile), 0755); err != nil {
 			t.Fatalf("Failed to create directory: %v", err)
@@ -142,7 +160,7 @@ func TestSaveToHistory(t *testing.T) {
 	})
 
 	t.Run("skip empty commands", func(t *testing.T) {
-		historyFile := filepath.Join(tempDir, ".infer", "history3")
+		historyFile := filepath.Join(tempDir, ".infer", "history", "history-empty")
 
 		sh := &ShellHistory{
 			historyFile: historyFile,


### PR DESCRIPTION
## Summary

Fixes #699 — each interactive subagent now gets its own history file in a dedicated `history/` subdirectory, so subagent prompts no longer pollute the main agent's history when navigating with arrow keys.

> **Scope:** this applies to **interactive** (tmux) subagents, which run an `infer chat` TUI with input history. Headless subagents have no TUI input history, so they are intentionally unaffected.

### Changes

- **Main agent**: `<configDir>/history/history`
- **Labeled subagents**: `<configDir>/history/history-<name>` (e.g. `history-refactor`, `history-research`). The label is slugified (lowercased, dashcased, path-safe) before it is used as a filename.
- **Unlabeled subagents**: in-memory history only (no file), so we don't create a new single-use history file on every spawn.

### Files

| File | Change |
|------|--------|
| `internal/ui/history/shell_history.go` | Added `NewShellHistoryWithName(configDir, name)` — creates `history/history` (main) or `history/history-<name>` (subagent). Removed legacy `NewShellHistoryWithDir`. |
| `internal/ui/history/history_manager.go` | Added `NewHistoryManagerWithName(maxInMemory, configDir, name)`. Removed legacy `NewHistoryManagerWithDir`. |
| `internal/ui/components/input_view.go` | Added `NewInputViewWithName(modelService, configDir, name)`; the `:memory:` sentinel selects in-memory history. Removed legacy `NewInputViewWithConfigDir`. |
| `internal/ui/components/factory/factory.go` | Added `CreateInputViewWithName(modelService, configDir, name)`. Removed legacy `CreateInputViewWithConfigDir`. |
| `internal/app/chat.go` | Updated caller to use `CreateInputViewWithName`. |
| `internal/agent/tools/agent.go` | Slugify `spec.Label` (via `sanitizeSlug`) before using it as the history name; unlabeled subagents get the memory-only sentinel instead of the per-spawn session id. |
| `internal/domain/subagent.go` | Added the `SubagentHistoryMemoryOnly` sentinel value for `INFER_SUBAGENT_HISTORY_NAME`. |
| `internal/ui/history/shell_history_test.go` | Updated expected paths to `.infer/history/history`; added `TestNewShellHistoryWithName`. |
| `internal/ui/history/history_manager_test.go` | Updated test setup to create `history/` subdirectory. |
| `internal/agent/tools/agent_test.go` | Added `TestBuildChatPaneCommand_SlugifiesHistoryName`. |
| `internal/ui/components/input_view_test.go` | Added `TestNewInputViewWithName_HistorySelection`. |

### Acceptance Criteria

- [x] Each subagent gets their own history file
- [x] History gets a dedicated directory so multiple history files could be stored
- [x] The main agent is reading from `<userspace config dir>/history/history`
- [x] The subagents are reading from `<userspace config dir>/history/history-<subagent name dashcase>`
- [x] Tests are adjusted / added (if applicable)
- [x] Documentation are adjusted / added (if applicable)
