### PR TITLE
fix(tools): guard concurrent gitignore and screenshot caches

### DIFF
--- a/internal/agent/tools/get_latest_screenshot.go
+++ b/internal/agent/tools/get_latest_screenshot.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	config "github.com/inference-gateway/cli/config"
@@ -17,6 +18,7 @@ type GetLatestScreenshotTool struct {
 	enabled         bool
 	formatter       domain.BaseFormatter
 	provider        domain.ScreenshotProvider
+	lastCallMu      sync.Mutex
 	lastCallTime    time.Time
 	minCallInterval time.Duration
 }
@@ -57,10 +59,12 @@ func (t *GetLatestScreenshotTool) Definition() sdk.ChatCompletionTool {
 func (t *GetLatestScreenshotTool) Execute(ctx context.Context, args map[string]any) (*domain.ToolExecutionResult, error) {
 	start := time.Now()
 
+	t.lastCallMu.Lock()
 	if !t.lastCallTime.IsZero() {
 		timeSinceLastCall := time.Since(t.lastCallTime)
 		if timeSinceLastCall < t.minCallInterval {
 			waitTime := t.minCallInterval - timeSinceLastCall
+			t.lastCallMu.Unlock()
 			return &domain.ToolExecutionResult{
 				ToolName:  "GetLatestScreenshot",
 				Arguments: args,
@@ -70,8 +74,8 @@ func (t *GetLatestScreenshotTool) Execute(ctx context.Context, args map[string]a
 			}, nil
 		}
 	}
-
 	t.lastCallTime = time.Now()
+	t.lastCallMu.Unlock()
 
 	if t.provider == nil {
 		return &domain.ToolExecutionResult{

--- a/internal/agent/tools/tree.go
+++ b/internal/agent/tools/tree.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	config "github.com/inference-gateway/cli/config"
@@ -22,6 +23,7 @@ type TreeTool struct {
 	enabled        bool
 	gitignore      *ignore.GitIgnore
 	gitignoreCache map[string]*ignore.GitIgnore
+	cacheMutex     sync.RWMutex
 	formatter      domain.BaseFormatter
 }
 
@@ -489,6 +491,16 @@ func (t *TreeTool) loadGitignore() {
 
 // getOrLoadDirGitignore loads and caches .gitignore for a specific directory
 func (t *TreeTool) getOrLoadDirGitignore(dirPath string) *ignore.GitIgnore {
+	t.cacheMutex.RLock()
+	if cached, exists := t.gitignoreCache[dirPath]; exists {
+		t.cacheMutex.RUnlock()
+		return cached
+	}
+	t.cacheMutex.RUnlock()
+
+	t.cacheMutex.Lock()
+	defer t.cacheMutex.Unlock()
+
 	if cached, exists := t.gitignoreCache[dirPath]; exists {
 		return cached
 	}

--- a/internal/agent/tools/tree_test.go
+++ b/internal/agent/tools/tree_test.go
@@ -2,9 +2,11 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/inference-gateway/cli/config"
@@ -623,4 +625,52 @@ func TestTreeTool_ValidatePath(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTreeTool_ConcurrentGitignoreCache exercises getOrLoadDirGitignore from many
+// goroutines at once. TreeTool is a process singleton and a turn's tool calls run
+// concurrently, so the gitignore cache must be safe for concurrent access. Without
+// the cache mutex this fails under `go test -race` (and can trigger a fatal
+// "concurrent map read and map write"). See issue #712.
+func TestTreeTool_ConcurrentGitignoreCache(t *testing.T) {
+	cfg := &config.Config{
+		Tools: config.ToolsConfig{
+			Enabled: true,
+			Tree: config.TreeToolConfig{
+				Enabled: true,
+			},
+		},
+	}
+
+	tool := NewTreeTool(cfg)
+
+	root := t.TempDir()
+	dirs := make([]string, 0, 16)
+	for i := range 16 {
+		dir := filepath.Join(root, fmt.Sprintf("dir%d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create dir: %v", err)
+		}
+		// Half the directories carry a .gitignore so both cache-write branches run.
+		if i%2 == 0 {
+			if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.tmp\n"), 0o644); err != nil {
+				t.Fatalf("failed to write .gitignore: %v", err)
+			}
+		}
+		dirs = append(dirs, dir)
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				for _, dir := range dirs {
+					_ = tool.getOrLoadDirGitignore(dir)
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
The Tree tool's gitignoreCache map was read and written without synchronization in getOrLoadDirGitignore. Tools run concurrently within a turn (up to MaxConcurrentTools), so two Tree executions could touch the map at once and trigger a fatal "concurrent map read and map write", killing the infer process. This mirrors the RWMutex + double-checked lock the Grep tool already uses.

Also guards GetLatestScreenshotTool.lastCallTime (read/write in Execute) with a sync.Mutex, as the issue requested, since it is the same singleton plus concurrent-goroutine class.

Validation:
- go test -race ./internal/agent/tools/ passes; the new TestTreeTool_ConcurrentGitignoreCache fatals with "concurrent map writes" without the fix and passes with it
- golangci-lint run: 0 issues; go vet clean; go fmt and go mod tidy leave the tree clean

Fixes #712