### PR TITLE
fix(plan): accepting a plan switches to auto-accept mode by default

### DIFF
--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -296,7 +296,7 @@ func addPlanApprovalBindings(bindings map[string]KeyBindingEntry) {
 	}
 	bindings[ActionID(NamespacePlanApproval, "plan_approval_accept")] = KeyBindingEntry{
 		Keys:        []string{"enter", "y"},
-		Description: "accept plan",
+		Description: "accept plan and enable auto-approve mode",
 		Category:    "plan_approval",
 		Enabled:     &enabled,
 	}
@@ -306,9 +306,9 @@ func addPlanApprovalBindings(bindings map[string]KeyBindingEntry) {
 		Category:    "plan_approval",
 		Enabled:     &enabled,
 	}
-	bindings[ActionID(NamespacePlanApproval, "plan_approval_accept_and_auto_approve")] = KeyBindingEntry{
-		Keys:        []string{"a"},
-		Description: "accept plan and enable auto-approve mode",
+	bindings[ActionID(NamespacePlanApproval, "plan_approval_accept_standard")] = KeyBindingEntry{
+		Keys:        []string{"s"},
+		Description: "accept plan but approve each step (standard mode)",
 		Category:    "plan_approval",
 		Enabled:     &enabled,
 	}

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -540,7 +540,8 @@ When in doubt, use this tool. Being proactive with task management demonstrates 
 
 What happens:
 - The plan is written as a Markdown file to <configDir>/plans/<timestamp>-<slug>.md
-- The plan is displayed to the user with Accept / Reject / Accept-and-Auto-Approve options
+- The plan is displayed to the user with Accept / Reject / Approve Each Step options
+- Accept switches to auto-approve mode; Approve Each Step keeps standard mode (per-action approval)
 - If approved, you'll switch to execution mode with full tool access
 - If rejected, the file remains on disk as an audit trail and the user provides feedback
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -298,9 +298,9 @@ The chat interface supports three operational modes that can be toggled with **s
   - Is instructed to analyze tasks and create detailed plans without executing changes
   - Provides step-by-step breakdowns of what would be done in Standard mode
   - **Plan Approval**: When the agent completes planning, you'll be prompted to:
-    - **Accept**: Approve the plan and continue (stays in Plan Mode)
+    - **Accept** (Enter/y): Accept the plan and switch to Auto-Accept mode for execution
     - **Reject** (n or Esc): Reject the plan and provide feedback or changes
-    - **Accept & Auto-Approve** (a): Accept the plan AND switch to Auto-Accept mode for execution
+    - **Approve Each Step** (s): Accept the plan but stay in Standard mode, approving each action
   - Useful for understanding codebases or previewing changes before implementation
 
 - **⚡ Auto-Accept Mode** (YOLO mode): All tool executions are automatically approved without prompting. The agent:

--- a/docs/plan-mode.md
+++ b/docs/plan-mode.md
@@ -35,9 +35,9 @@ The cycle is:
 Standard → Plan Mode → Auto-Accept → Standard → …
 ```
 
-When a plan is **accepted**, the mode automatically flips back to Standard
-(or to Auto-Accept if you chose "Accept & Auto-Approve") and the agent
-begins executing.
+When a plan is **accepted**, the mode automatically switches to Auto-Accept
+(or to Standard if you chose "Approve Each Step") and the agent begins
+executing.
 
 ## What the model is told to do
 
@@ -122,11 +122,12 @@ When the model calls `RequestPlanApproval`, the chat TUI:
    to confirm`.
 3. Offers three options:
 
-   - **Accept** - agent flips to Standard mode and executes the plan.
-   - **Accept & Auto-Approve** - agent flips to Auto-Accept (no per-tool
-     approval prompts) and executes the plan.
-   - **Reject** - chat session ends; you can write a follow-up message
+   - **Accept** (`Enter`/`y`) - agent switches to Auto-Accept mode (no
+     per-tool approval prompts) and executes the plan.
+   - **Reject** (`n`) - chat session ends; you can write a follow-up message
      with feedback and the agent re-iterates the plan.
+   - **Approve Each Step** (`s`) - agent switches to Standard mode and
+     executes the plan, prompting for approval on each action.
 
 In all three cases the plan file remains on disk. Rejecting a plan does
 **not** delete it.
@@ -134,8 +135,8 @@ In all three cases the plan file remains on disk. Rejecting a plan does
 ## Context compaction on approval
 
 Planning is read-heavy: the model runs `Read`, `Grep`, and `Tree` across the
-codebase before it writes a plan. Once you **Accept** (or **Accept &
-Auto-Approve**), that exploration is dead weight for execution. So approving a
+codebase before it writes a plan. Once you **Accept** (or **Approve Each
+Step**), that exploration is dead weight for execution. So approving a
 plan always:
 
 1. Summarizes the planning conversation into a short `--- Context Summary ---`.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -534,7 +534,7 @@ is in **Plan Mode** (toggle via Shift+Tab in the chat TUI).
 **How it works:**
 
 - The plan is written atomically to `<configDir>/plans/<YYYY-MM-DD-HHMMSS>-<slug>.md` (e.g. `~/.infer/plans/2026-04-27-103015-add-login-flow.md`).
-- The chat TUI shows the rendered plan with **Accept**, **Reject**, and **Accept & Auto-Approve** options.
+- The chat TUI shows the rendered plan with **Accept** (auto-accept mode), **Reject**, and **Approve Each Step** (standard mode) options.
 - On accept, the agent switches out of plan mode and executes the plan.
 - On reject, the file remains on disk as an audit trail; the user can reply with feedback and the agent re-iterates.
 - The LLM is instructed to ask clarifying questions in normal assistant turns first, and only call this tool when the plan is complete.

--- a/internal/agent/tools/request_plan_approval.go
+++ b/internal/agent/tools/request_plan_approval.go
@@ -194,9 +194,9 @@ func (t *RequestPlanApprovalTool) FormatForLLM(result *domain.ToolExecutionResul
 
 	if result.Success {
 		if path := planPath(result); path != "" {
-			return fmt.Sprintf("Plan approval requested. Plan saved to %s. The user will review your plan and decide whether to accept, reject, or enable auto-approve mode.", path)
+			return fmt.Sprintf("Plan approval requested. Plan saved to %s. The user will review your plan and decide whether to accept (which enables auto-approve mode), approve each step (standard mode), or reject.", path)
 		}
-		return "Plan approval requested. The user will review your plan and decide whether to accept, reject, or enable auto-approve mode."
+		return "Plan approval requested. The user will review your plan and decide whether to accept (which enables auto-approve mode), approve each step (standard mode), or reject."
 	}
 
 	return fmt.Sprintf("Failed to request plan approval: %s", result.Error)

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -357,9 +357,13 @@ func (a ApprovalAction) String() string {
 type PlanApprovalAction int
 
 const (
+	// PlanApprovalAccept is the default choice: accept the plan and switch to
+	// auto-accept mode so execution proceeds without per-action approval.
 	PlanApprovalAccept PlanApprovalAction = iota
 	PlanApprovalReject
-	PlanApprovalAcceptAndAutoApprove
+	// PlanApprovalAcceptStandard accepts the plan but stays in standard mode,
+	// so the user still approves each action during execution.
+	PlanApprovalAcceptStandard
 )
 
 func (a PlanApprovalAction) String() string {
@@ -368,8 +372,8 @@ func (a PlanApprovalAction) String() string {
 		return "Accept"
 	case PlanApprovalReject:
 		return "Reject"
-	case PlanApprovalAcceptAndAutoApprove:
-		return "Accept & Auto-Approve"
+	case PlanApprovalAcceptStandard:
+		return "Approve Each Step"
 	default:
 		return "Unknown"
 	}

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -357,12 +357,8 @@ func (a ApprovalAction) String() string {
 type PlanApprovalAction int
 
 const (
-	// PlanApprovalAccept is the default choice: accept the plan and switch to
-	// auto-accept mode so execution proceeds without per-action approval.
 	PlanApprovalAccept PlanApprovalAction = iota
 	PlanApprovalReject
-	// PlanApprovalAcceptStandard accepts the plan but stays in standard mode,
-	// so the user still approves each action during execution.
 	PlanApprovalAcceptStandard
 )
 

--- a/internal/services/approvalcoord/coordinator.go
+++ b/internal/services/approvalcoord/coordinator.go
@@ -131,17 +131,17 @@ func (s *Service) HandlePlanApprovalResponse(msg domain.PlanApprovalResponseEven
 func (s *Service) applyPlanDecision(action domain.PlanApprovalAction) (string, bool) {
 	switch action {
 	case domain.PlanApprovalAccept:
-		logger.Info("switching to standard agent mode for plan execution")
-		s.stateManager.SetAgentMode(domain.AgentModeStandard)
-		logger.Info("adding hidden continue message to queue")
-		s.addHiddenContinueMessage()
-		return "Plan accepted - executing plan...", true
-	case domain.PlanApprovalAcceptAndAutoApprove:
 		logger.Info("switching to auto-accept mode for plan execution")
 		s.stateManager.SetAgentMode(domain.AgentModeAutoAccept)
 		logger.Info("adding hidden continue message to queue (auto-approve mode)")
 		s.addHiddenContinueMessage()
 		return "Plan accepted - Auto-Approve mode enabled, executing plan...", true
+	case domain.PlanApprovalAcceptStandard:
+		logger.Info("switching to standard agent mode for plan execution")
+		s.stateManager.SetAgentMode(domain.AgentModeStandard)
+		logger.Info("adding hidden continue message to queue")
+		s.addHiddenContinueMessage()
+		return "Plan accepted - executing plan (approving each step)...", true
 	case domain.PlanApprovalReject:
 		logger.Info("ending chat session due to plan rejection")
 		s.stateManager.EndChatSession()

--- a/internal/services/approvalcoord/coordinator_test.go
+++ b/internal/services/approvalcoord/coordinator_test.go
@@ -79,7 +79,7 @@ func TestService_HandlePlanApprovalResponse(t *testing.T) {
 		}
 	})
 
-	t.Run("Accept clears UI state, switches to standard mode, adds hidden continue, requests restart", func(t *testing.T) {
+	t.Run("Accept clears UI state, switches to auto-accept mode, adds hidden continue, requests restart", func(t *testing.T) {
 		svc, repo, state, _ := newCoordinator()
 		state.GetPlanApprovalUIStateReturns(&domain.PlanApprovalUIState{PlanContent: "p"})
 
@@ -99,8 +99,8 @@ func TestService_HandlePlanApprovalResponse(t *testing.T) {
 		if state.SetAgentModeCallCount() != 1 {
 			t.Errorf("expected SetAgentMode once")
 		}
-		if mode := state.SetAgentModeArgsForCall(0); mode != domain.AgentModeStandard {
-			t.Errorf("expected AgentModeStandard, got %v", mode)
+		if mode := state.SetAgentModeArgsForCall(0); mode != domain.AgentModeAutoAccept {
+			t.Errorf("expected AgentModeAutoAccept, got %v", mode)
 		}
 		if state.EndChatSessionCallCount() != 0 {
 			t.Errorf("EndChatSession should not be called on Accept")
@@ -110,19 +110,19 @@ func TestService_HandlePlanApprovalResponse(t *testing.T) {
 		}
 	})
 
-	t.Run("AcceptAndAutoApprove switches to auto-accept mode and requests restart", func(t *testing.T) {
+	t.Run("AcceptStandard switches to standard mode and requests restart", func(t *testing.T) {
 		svc, repo, state, _ := newCoordinator()
 		state.GetPlanApprovalUIStateReturns(&domain.PlanApprovalUIState{PlanContent: "p"})
 
 		_, restart := svc.HandlePlanApprovalResponse(domain.PlanApprovalResponseEvent{
-			Action: domain.PlanApprovalAcceptAndAutoApprove,
+			Action: domain.PlanApprovalAcceptStandard,
 		})
 
 		if !restart {
-			t.Errorf("AcceptAndAutoApprove should request restart")
+			t.Errorf("AcceptStandard should request restart")
 		}
-		if mode := state.SetAgentModeArgsForCall(0); mode != domain.AgentModeAutoAccept {
-			t.Errorf("expected AgentModeAutoAccept, got %v", mode)
+		if mode := state.SetAgentModeArgsForCall(0); mode != domain.AgentModeStandard {
+			t.Errorf("expected AgentModeStandard, got %v", mode)
 		}
 		if got := len(repo.GetMessages()); got != 1 {
 			t.Errorf("expected 1 hidden continue message added, got %d", got)

--- a/internal/services/conversation.go
+++ b/internal/services/conversation.go
@@ -99,7 +99,7 @@ func (r *InMemoryConversationRepository) UpdatePlanStatus(action domain.PlanAppr
 				r.messages[i].PlanApprovalStatus = domain.PlanApprovalAccepted
 			case domain.PlanApprovalReject:
 				r.messages[i].PlanApprovalStatus = domain.PlanApprovalRejected
-			case domain.PlanApprovalAcceptAndAutoApprove:
+			case domain.PlanApprovalAcceptStandard:
 				r.messages[i].PlanApprovalStatus = domain.PlanApprovalAccepted
 			}
 			break

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -2126,14 +2126,14 @@ func (cv *ConversationView) renderInlineApprovalButtons(_ int) string {
 
 	acceptText := "Accept"
 	rejectText := "Reject"
-	autoApproveText := "Auto-Approve"
+	standardText := "Approve Each Step"
 
 	successColor := cv.styleProvider.GetThemeColor("success")
 	errorColor := cv.styleProvider.GetThemeColor("error")
 	accentColor := cv.styleProvider.GetThemeColor("accent")
 	highlightBg := cv.styleProvider.GetThemeColor("selection_bg")
 
-	var acceptStyled, rejectStyled, autoApproveStyled string
+	var acceptStyled, rejectStyled, standardStyled string
 	if selectedIndex == int(domain.PlanApprovalAccept) {
 		acceptStyled = cv.styleProvider.RenderStyledText("[ "+acceptText+" ]", styles.StyleOptions{
 			Foreground: successColor,
@@ -2154,17 +2154,17 @@ func (cv *ConversationView) renderInlineApprovalButtons(_ int) string {
 		rejectStyled = cv.styleProvider.RenderWithColor("[ "+rejectText+" ]", errorColor)
 	}
 
-	if selectedIndex == int(domain.PlanApprovalAcceptAndAutoApprove) {
-		autoApproveStyled = cv.styleProvider.RenderStyledText("[ "+autoApproveText+" ]", styles.StyleOptions{
+	if selectedIndex == int(domain.PlanApprovalAcceptStandard) {
+		standardStyled = cv.styleProvider.RenderStyledText("[ "+standardText+" ]", styles.StyleOptions{
 			Foreground: accentColor,
 			Background: highlightBg,
 			Bold:       true,
 		})
 	} else {
-		autoApproveStyled = cv.styleProvider.RenderWithColor("[ "+autoApproveText+" ]", accentColor)
+		standardStyled = cv.styleProvider.RenderWithColor("[ "+standardText+" ]", accentColor)
 	}
 
-	return fmt.Sprintf("  %s  %s  %s", acceptStyled, rejectStyled, autoApproveStyled)
+	return fmt.Sprintf("  %s  %s  %s", acceptStyled, rejectStyled, standardStyled)
 }
 
 // renderPendingToolEntry renders a pending tool call that requires approval

--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -280,7 +280,7 @@ func (iv *InputView) renderDisabledPlaceholder() string {
 	}
 
 	if iv.stateManager.GetPlanApprovalUIState() != nil {
-		return iv.styleProvider.RenderDimText("⏸  Plan approval required - use ←/→ or h/l to navigate, Enter/y to accept, n to reject, a for auto-approve")
+		return iv.styleProvider.RenderDimText("⏸  Plan approval required - use ←/→ or h/l to navigate, Enter/y to accept (auto), n to reject, s to approve each step")
 	}
 
 	if iv.stateManager.GetApprovalUIState() != nil {

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -614,7 +614,7 @@ func (r *Registry) createApprovalActions() []*KeyAction {
 			Namespace:   config.NamespacePlanApproval,
 			ID:          config.ActionID(config.NamespacePlanApproval, "plan_approval_accept"),
 			Keys:        []string{"enter", "y"},
-			Description: "accept plan",
+			Description: "accept plan and enable auto-approve mode",
 			Category:    "plan_approval",
 			Handler:     handlePlanApprovalAccept,
 			Priority:    150,
@@ -638,11 +638,11 @@ func (r *Registry) createApprovalActions() []*KeyAction {
 		},
 		{
 			Namespace:   config.NamespacePlanApproval,
-			ID:          config.ActionID(config.NamespacePlanApproval, "plan_approval_accept_and_auto_approve"),
-			Keys:        []string{"a"},
-			Description: "accept plan and enable auto-approve mode",
+			ID:          config.ActionID(config.NamespacePlanApproval, "plan_approval_accept_standard"),
+			Keys:        []string{"s"},
+			Description: "accept plan but approve each step (standard mode)",
 			Category:    "plan_approval",
-			Handler:     handlePlanApprovalAcceptAndAutoApprove,
+			Handler:     handlePlanApprovalAcceptStandard,
 			Priority:    150,
 			Enabled:     true,
 			Context: KeyContext{
@@ -1169,7 +1169,7 @@ func handleCursorLeftOrPlanNav(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd
 	if planApprovalState != nil {
 		newIndex := planApprovalState.SelectedIndex - 1
 		if newIndex < 0 {
-			newIndex = int(domain.PlanApprovalAcceptAndAutoApprove)
+			newIndex = int(domain.PlanApprovalAcceptStandard)
 		}
 		stateManager.SetPlanApprovalSelectedIndex(newIndex)
 		return func() tea.Msg {
@@ -1206,7 +1206,7 @@ func handleCursorRightOrPlanNav(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cm
 	planApprovalState := stateManager.GetPlanApprovalUIState()
 	if planApprovalState != nil {
 		newIndex := planApprovalState.SelectedIndex + 1
-		if newIndex > int(domain.PlanApprovalAcceptAndAutoApprove) {
+		if newIndex > int(domain.PlanApprovalAcceptStandard) {
 			newIndex = 0
 		}
 		stateManager.SetPlanApprovalSelectedIndex(newIndex)
@@ -1863,7 +1863,7 @@ func handlePlanApprovalLeft(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 
 	newIndex := planApprovalState.SelectedIndex - 1
 	if newIndex < 0 {
-		newIndex = int(domain.PlanApprovalAcceptAndAutoApprove)
+		newIndex = int(domain.PlanApprovalAcceptStandard)
 	}
 	stateManager.SetPlanApprovalSelectedIndex(newIndex)
 
@@ -1880,7 +1880,7 @@ func handlePlanApprovalRight(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 	}
 
 	newIndex := planApprovalState.SelectedIndex + 1
-	if newIndex > int(domain.PlanApprovalAcceptAndAutoApprove) {
+	if newIndex > int(domain.PlanApprovalAcceptStandard) {
 		newIndex = 0
 	}
 	stateManager.SetPlanApprovalSelectedIndex(newIndex)
@@ -1917,10 +1917,10 @@ func handlePlanApprovalReject(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd 
 	}
 }
 
-func handlePlanApprovalAcceptAndAutoApprove(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
+func handlePlanApprovalAcceptStandard(app KeyHandlerContext, keyMsg tea.KeyMsg) tea.Cmd {
 	return func() tea.Msg {
 		return domain.PlanApprovalResponseEvent{
-			Action: domain.PlanApprovalAcceptAndAutoApprove,
+			Action: domain.PlanApprovalAcceptStandard,
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Accepting a plan dropped the agent into standard mode, forcing per-action approval during execution — the friction reported in #710. The default **Accept** now switches to **auto-accept mode**, so an already-reviewed plan executes without re-approving every step.

## Behavior

The plan-approval prompt now offers:

| Option | Key | Result |
| --- | --- | --- |
| **Accept** (default) | `Enter` / `y` | auto-accept mode (no per-action approval) |
| **Approve Each Step** | `s` | standard mode (approve every action) |
| **Reject** | `n` | ends the session (unchanged) |

The cautious per-step path is preserved as an explicit choice, so no capability is lost. The mode is set on the `StateManager` rather than the conversation, so it survives the post-approval context compaction + fresh session from #705.

> Note: the secondary keybinding changed from `a` to `s`.

## Changes

- `applyPlanDecision` (approval coordinator): `Accept` → `AutoAccept`; new `AcceptStandard` → `Standard`.
- Renamed the enum `PlanApprovalAcceptAndAutoApprove` → `PlanApprovalAcceptStandard`.
- UI: relabeled the third button to "Approve Each Step", updated the plan-approval hint text, and rekeyed `a` → `s`.
- Updated the `RequestPlanApproval` tool result + prompt copy to describe the new options.
- Updated the coordinator tests for the swapped semantics.

## Testing

- `task test` — full suite passes
- `task lint` — 0 issues (golangci-lint + markdownlint)

Closes #710
