### PR TITLE
fix(a2a): route active A2A reads and HasPending through the job supervisor (#693)

### DIFF
--- a/internal/agent/tools/a2a_job.go
+++ b/internal/agent/tools/a2a_job.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	adk "github.com/inference-gateway/adk/types"
@@ -15,10 +16,12 @@ import (
 // returning the terminal result. The supervisor owns the goroutine - this is the
 // A2A side of retiring A2ATaskPoller.
 type a2aJob struct {
-	tool     *A2ASubmitTaskTool
-	agentURL string
-	taskID   string
-	state    *domain.TaskPollingState
+	tool           *A2ASubmitTaskTool
+	agentURL       string
+	taskID         string
+	state          *domain.TaskPollingState
+	mu             sync.RWMutex
+	lastKnownState string
 }
 
 // Meta describes the A2A task for the task view.
@@ -33,9 +36,49 @@ func (j *a2aJob) Meta() domain.JobMeta {
 	}
 }
 
-// Run polls the remote agent until the task terminates.
+// Run polls the remote agent until the task terminates. It records each remote
+// state change through the emit wrapper so A2APollingState can report the live
+// status to the task view without racing the poll goroutine on the shared state.
 func (j *a2aJob) Run(ctx context.Context, emit func(domain.JobSignal)) domain.ToolExecutionResult {
-	return j.tool.runA2APolling(ctx, j.agentURL, j.taskID, j.state, emit)
+	return j.tool.runA2APolling(ctx, j.agentURL, j.taskID, j.state, func(sig domain.JobSignal) {
+		j.recordState(sig.State)
+		if emit != nil {
+			emit(sig)
+		}
+	})
+}
+
+// recordState stores the latest non-empty remote state under mu so A2APollingState
+// can read it without racing the poll goroutine.
+func (j *a2aJob) recordState(state string) {
+	if state == "" {
+		return
+	}
+	j.mu.Lock()
+	j.lastKnownState = state
+	j.mu.Unlock()
+}
+
+// A2APollingState implements domain.A2AStateProvider so the supervisor is the
+// single source for active A2A rows. Identity fields are immutable after submit;
+// only LastKnownState is read under mu (the poll goroutine writes it).
+func (j *a2aJob) A2APollingState() domain.TaskPollingState {
+	j.mu.RLock()
+	last := j.lastKnownState
+	j.mu.RUnlock()
+
+	st := domain.TaskPollingState{
+		TaskID:         j.taskID,
+		AgentURL:       j.agentURL,
+		LastKnownState: last,
+		IsPolling:      true,
+	}
+	if j.state != nil {
+		st.ContextID = j.state.ContextID
+		st.TaskDescription = j.state.TaskDescription
+		st.StartedAt = j.state.StartedAt
+	}
+	return st
 }
 
 // Wind is a no-op: the supervisor cancels Run's context on WindStop, which stops

--- a/internal/agent/tools/a2a_job_test.go
+++ b/internal/agent/tools/a2a_job_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -166,4 +167,55 @@ func TestRetainableA2AState(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestA2AJob_A2APollingState asserts A2APollingState composes the immutable
+// identity fields with the mutex-guarded last known state, and is nil-state safe.
+func TestA2AJob_A2APollingState(t *testing.T) {
+	started := time.Now().Add(-time.Minute)
+	j := &a2aJob{
+		taskID:   "t1",
+		agentURL: "http://agent",
+		state:    &domain.TaskPollingState{ContextID: "ctx1", TaskDescription: "do work", StartedAt: started},
+	}
+	j.recordState(string(adk.TaskStateWorking))
+
+	got := j.A2APollingState()
+	if got.TaskID != "t1" || got.AgentURL != "http://agent" || got.ContextID != "ctx1" ||
+		got.TaskDescription != "do work" || got.LastKnownState != string(adk.TaskStateWorking) {
+		t.Errorf("A2APollingState = %+v, missing composed fields", got)
+	}
+	if !got.StartedAt.Equal(started) {
+		t.Errorf("StartedAt = %v, want %v", got.StartedAt, started)
+	}
+	if !got.IsPolling {
+		t.Error("IsPolling should be true for a running job")
+	}
+
+	if nilState := (&a2aJob{taskID: "t2", agentURL: "http://a"}).A2APollingState(); nilState.TaskID != "t2" || nilState.ContextID != "" {
+		t.Errorf("nil-state A2APollingState = %+v, want minimal without panic", nilState)
+	}
+}
+
+// TestA2AJob_A2APollingStateConcurrent runs the guarded write (recordState, the
+// poll goroutine's path) against the read (A2APollingState, the task view's path)
+// so `go test -race` proves the mutex closes the shared-state data race.
+func TestA2AJob_A2APollingStateConcurrent(t *testing.T) {
+	j := &a2aJob{taskID: "t1", agentURL: "http://a", state: &domain.TaskPollingState{ContextID: "ctx1", StartedAt: time.Now()}}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			j.recordState("working")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			_ = j.A2APollingState()
+		}
+	}()
+	wg.Wait()
 }

--- a/internal/agent/tools/a2a_task.go
+++ b/internal/agent/tools/a2a_task.go
@@ -311,7 +311,19 @@ func (t *A2ASubmitTaskTool) runA2APolling(
 	for {
 		select {
 		case <-ctx.Done():
-			return domain.ToolExecutionResult{ToolName: "A2A_SubmitTask", Success: false, Error: "task cancelled"}
+			return domain.ToolExecutionResult{
+				ToolName: "A2A_SubmitTask",
+				Success:  false,
+				Error:    "task cancelled",
+				Data: A2ASubmitTaskResult{
+					TaskID:    taskID,
+					ContextID: state.ContextID,
+					AgentURL:  agentURL,
+					State:     string(adk.TaskStateCancelled),
+					Success:   false,
+					Message:   "Task was canceled",
+				},
+			}
 
 		case <-ticker.C:
 			pollAttempt++

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -448,7 +448,7 @@ func (c *ServiceContainer) initializeServices() {
 			c.jobSupervisor.SetTaskRetention(c.taskRetentionService)
 		}
 
-		c.backgroundTaskService = services.NewBackgroundTaskService(c.backgroundTaskRegistry)
+		c.backgroundTaskService = services.NewBackgroundTaskService(c.backgroundTaskRegistry, c.jobSupervisor)
 	}
 
 	c.initializeChatOrchestrationServices()

--- a/internal/domain/background_job.go
+++ b/internal/domain/background_job.go
@@ -136,6 +136,14 @@ type TaskRetainer interface {
 	RetainedTask(result ToolExecutionResult) (TaskInfo, bool)
 }
 
+// A2AStateProvider is an optional BackgroundJob extension implemented by A2A task
+// jobs so the supervisor can surface their live polling state (context/agent/task
+// id and last known remote state) as the single source for the task view and
+// status bar, without the generic JobMeta/TrackedJob carrying A2A-specific fields.
+type A2AStateProvider interface {
+	A2APollingState() TaskPollingState
+}
+
 // TrackedJob is a point-in-time snapshot of one supervised job for the task view
 // and status line.
 type TrackedJob struct {

--- a/internal/services/background_task_registry.go
+++ b/internal/services/background_task_registry.go
@@ -60,7 +60,7 @@ func (r *backgroundTaskRegistry) WindJob(id string, sig domain.WindSignal) error
 // cross-type query the BackgroundTasksWaiter uses to decide whether the session
 // is safe to close.
 func (r *backgroundTaskRegistry) HasPending() bool {
-	if len(r.GetAllPollingTasks()) > 0 {
+	if r.supervisor.CountRunning(domain.JobKindA2A) > 0 {
 		return true
 	}
 	if r.ShellTracker != nil && r.CountRunning() > 0 {

--- a/internal/services/background_task_registry_test.go
+++ b/internal/services/background_task_registry_test.go
@@ -38,3 +38,27 @@ func TestHasPending_ExcludesInteractiveSubagents(t *testing.T) {
 		t.Fatalf("a running headless subagent should count as pending")
 	}
 }
+
+// TestHasPending_A2AViaSupervisor asserts A2A pending-state is read from the job
+// supervisor (single source of truth), not the parallel tracker polling set: a
+// StartPolling entry with no supervised job is NOT pending, while a submitted
+// (running) A2A job IS.
+func TestHasPending_A2AViaSupervisor(t *testing.T) {
+	sup := jobs.NewSupervisor(nil, nil, nil)
+	defer sup.Stop()
+	reg := NewBackgroundTaskRegistry(4, sup)
+
+	reg.RegisterContext("http://agent", "c1")
+	reg.StartPolling("t1", &domain.TaskPollingState{TaskID: "t1", ContextID: "c1", AgentURL: "http://agent"})
+	if reg.HasPending() {
+		t.Fatalf("StartPolling without a supervised job must not count as pending")
+	}
+
+	job := newFakeA2ABgJob("t1", domain.TaskPollingState{TaskID: "t1"})
+	reg.Submit(job)
+	<-job.started
+	if !reg.HasPending() {
+		t.Fatalf("a running supervised A2A job should count as pending")
+	}
+	close(job.finish)
+}

--- a/internal/services/background_task_service.go
+++ b/internal/services/background_task_service.go
@@ -12,40 +12,45 @@ import (
 	logger "github.com/inference-gateway/cli/internal/logger"
 )
 
+// a2aJobController is the narrow job-supervisor surface this service needs: the
+// live A2A polling states (the single source for active A2A rows, shared with the
+// status-bar indicator) and the wind control used to stop a task on cancel.
+// *jobs.Supervisor satisfies it.
+type a2aJobController interface {
+	A2APollingStates() []domain.TaskPollingState
+	Wind(id string, sig domain.WindSignal) error
+}
+
 // BackgroundTaskService handles background task operations (A2A-specific)
 // Only instantiated when A2A tools are enabled
 type BackgroundTaskService struct {
 	taskTracker     domain.A2ATaskTracker
+	jobs            a2aJobController
 	createADKClient func(agentURL string) client.A2AClient
 	mutex           sync.RWMutex
 }
 
-// NewBackgroundTaskService creates a new background task service
-func NewBackgroundTaskService(taskTracker domain.A2ATaskTracker) *BackgroundTaskService {
+// NewBackgroundTaskService creates a new background task service. jobs is the job
+// supervisor - the single source of truth for which A2A tasks are running - while
+// taskTracker still resolves the context graph and a task's agent URL for cancel.
+func NewBackgroundTaskService(taskTracker domain.A2ATaskTracker, jobs a2aJobController) *BackgroundTaskService {
 	return &BackgroundTaskService{
 		taskTracker: taskTracker,
+		jobs:        jobs,
 		createADKClient: func(agentURL string) client.A2AClient {
 			return client.NewClient(agentURL)
 		},
 	}
 }
 
-// GetBackgroundTasks returns all current background polling tasks
+// GetBackgroundTasks returns the active A2A tasks from the job supervisor - the
+// single source of truth shared with the status-bar indicator - so the /tasks
+// active list and the indicator can no longer diverge.
 func (s *BackgroundTaskService) GetBackgroundTasks() []domain.TaskPollingState {
-	if s.taskTracker == nil {
+	if s.jobs == nil {
 		return []domain.TaskPollingState{}
 	}
-
-	pollingTasks := s.taskTracker.GetAllPollingTasks()
-	tasks := make([]domain.TaskPollingState, 0, len(pollingTasks))
-
-	for _, taskID := range pollingTasks {
-		if state := s.taskTracker.GetPollingState(taskID); state != nil {
-			tasks = append(tasks, *state)
-		}
-	}
-
-	return tasks
+	return s.jobs.A2APollingStates()
 }
 
 // CancelBackgroundTask cancels a background task by task ID
@@ -72,6 +77,12 @@ func (s *BackgroundTaskService) CancelBackgroundTask(taskID string) error {
 
 	if targetTask.CancelFunc != nil {
 		targetTask.CancelFunc()
+	}
+
+	if s.jobs != nil {
+		if err := s.jobs.Wind(taskID, domain.WindStop); err != nil {
+			logger.Warn("failed to wind supervised A2A job on cancel", "task_id", taskID, "error", err)
+		}
 	}
 
 	s.taskTracker.StopPolling(taskID)

--- a/internal/services/background_task_service_test.go
+++ b/internal/services/background_task_service_test.go
@@ -1,0 +1,135 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	client "github.com/inference-gateway/adk/client"
+	adk "github.com/inference-gateway/adk/types"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	jobs "github.com/inference-gateway/cli/internal/services/jobs"
+	utils "github.com/inference-gateway/cli/internal/utils"
+	adkmocks "github.com/inference-gateway/cli/tests/mocks/adk"
+)
+
+// fakeA2ABgJob is a controllable A2A BackgroundJob: it stays running until finish
+// (or ctx) and reports A2A polling detail via domain.A2AStateProvider, so it is
+// visible to Supervisor.A2APollingStates / CountRunning while running.
+type fakeA2ABgJob struct {
+	id      string
+	state   domain.TaskPollingState
+	started chan struct{}
+	finish  chan struct{}
+}
+
+func newFakeA2ABgJob(id string, state domain.TaskPollingState) *fakeA2ABgJob {
+	return &fakeA2ABgJob{id: id, state: state, started: make(chan struct{}), finish: make(chan struct{})}
+}
+
+func (f *fakeA2ABgJob) Meta() domain.JobMeta {
+	return domain.JobMeta{ID: f.id, Kind: domain.JobKindA2A, StartedAt: time.Now()}
+}
+
+func (f *fakeA2ABgJob) Run(ctx context.Context, _ func(domain.JobSignal)) domain.ToolExecutionResult {
+	close(f.started)
+	select {
+	case <-f.finish:
+	case <-ctx.Done():
+	}
+	return domain.ToolExecutionResult{Success: true}
+}
+
+func (f *fakeA2ABgJob) Wind(context.Context, domain.WindSignal) error { return nil }
+func (f *fakeA2ABgJob) Close()                                        {}
+func (f *fakeA2ABgJob) A2APollingState() domain.TaskPollingState      { return f.state }
+
+// fakeA2AController stands in for the job supervisor when testing
+// BackgroundTaskService in isolation: it returns canned polling states and
+// records Wind calls.
+type fakeA2AController struct {
+	states   []domain.TaskPollingState
+	windIDs  []string
+	windSigs []domain.WindSignal
+}
+
+func (f *fakeA2AController) A2APollingStates() []domain.TaskPollingState { return f.states }
+
+func (f *fakeA2AController) Wind(id string, sig domain.WindSignal) error {
+	f.windIDs = append(f.windIDs, id)
+	f.windSigs = append(f.windSigs, sig)
+	return nil
+}
+
+// TestGetBackgroundTasks_SourcedFromSupervisor asserts the /tasks active A2A rows
+// come from the job supervisor (the single source shared with the status bar),
+// with their context/agent/state detail intact.
+func TestGetBackgroundTasks_SourcedFromSupervisor(t *testing.T) {
+	ctrl := &fakeA2AController{states: []domain.TaskPollingState{
+		{TaskID: "t1", ContextID: "c1", AgentURL: "http://agent", LastKnownState: "working"},
+	}}
+	svc := NewBackgroundTaskService(utils.NewA2ATaskTracker(), ctrl)
+
+	got := svc.GetBackgroundTasks()
+	if len(got) != 1 {
+		t.Fatalf("GetBackgroundTasks len = %d, want 1", len(got))
+	}
+	if got[0].TaskID != "t1" || got[0].ContextID != "c1" || got[0].AgentURL != "http://agent" || got[0].LastKnownState != "working" {
+		t.Errorf("A2A detail not preserved: %+v", got[0])
+	}
+}
+
+// TestCancelBackgroundTask_WindsSupervisor asserts cancel winds the supervised job
+// (so the status bar and active list drop it at once) alongside the remote cancel
+// and the tracker context-graph cleanup.
+func TestCancelBackgroundTask_WindsSupervisor(t *testing.T) {
+	tracker := utils.NewA2ATaskTracker()
+	tracker.RegisterContext("http://agent", "c1")
+	tracker.StartPolling("t1", &domain.TaskPollingState{TaskID: "t1", ContextID: "c1", AgentURL: "http://agent"})
+
+	ctrl := &fakeA2AController{}
+	svc := NewBackgroundTaskService(tracker, ctrl)
+
+	adkClient := &adkmocks.FakeA2AClient{}
+	adkClient.GetTaskReturns(&adk.JSONRPCSuccessResponse{Result: adk.Task{ID: "t1", Status: adk.TaskStatus{State: adk.TaskStateWorking}}}, nil)
+	adkClient.CancelTaskReturns(&adk.JSONRPCSuccessResponse{}, nil)
+	svc.createADKClient = func(string) client.A2AClient { return adkClient }
+
+	if err := svc.CancelBackgroundTask("t1"); err != nil {
+		t.Fatalf("CancelBackgroundTask: %v", err)
+	}
+	if len(ctrl.windIDs) != 1 || ctrl.windIDs[0] != "t1" || ctrl.windSigs[0] != domain.WindStop {
+		t.Fatalf("want Wind(t1, WindStop), got ids=%v sigs=%v", ctrl.windIDs, ctrl.windSigs)
+	}
+	if tracker.HasTask("t1") {
+		t.Errorf("cancel should remove the task from the tracker context graph")
+	}
+}
+
+// TestA2ADivergenceGone is the regression guard for #693: while an A2A task runs,
+// the status-bar count (CountRunningJobs) and the /tasks active list
+// (GetBackgroundTasks) agree because both derive from the supervisor, and when it
+// finishes both drop together.
+func TestA2ADivergenceGone(t *testing.T) {
+	sup := jobs.NewSupervisor(nil, nil, nil)
+	defer sup.Stop()
+	reg := NewBackgroundTaskRegistry(4, sup)
+	svc := NewBackgroundTaskService(reg, sup)
+
+	job := newFakeA2ABgJob("t1", domain.TaskPollingState{TaskID: "t1", ContextID: "c1", AgentURL: "http://agent"})
+	sup.Submit(job)
+	<-job.started
+
+	if c, l := reg.CountRunningJobs(domain.JobKindA2A), len(svc.GetBackgroundTasks()); c != 1 || l != 1 {
+		t.Fatalf("while running: CountRunningJobs=%d, GetBackgroundTasks=%d, want 1 and 1", c, l)
+	}
+
+	close(job.finish)
+	deadline := time.Now().Add(2 * time.Second)
+	for (reg.CountRunningJobs(domain.JobKindA2A) != 0 || len(svc.GetBackgroundTasks()) != 0) && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if c, l := reg.CountRunningJobs(domain.JobKindA2A), len(svc.GetBackgroundTasks()); c != 0 || l != 0 {
+		t.Fatalf("after finish: CountRunningJobs=%d, GetBackgroundTasks=%d, want 0 and 0", c, l)
+	}
+}

--- a/internal/services/background_tasks_waiter.go
+++ b/internal/services/background_tasks_waiter.go
@@ -115,7 +115,7 @@ func (w *BackgroundTasksWaiter) WaitAndDrain(ctx context.Context) []DrainedMessa
 		case <-ticker.C:
 		case <-deadline.C:
 			logger.Warn("timed out waiting for background tasks to complete",
-				"pending_a2a_tasks", len(w.registry.GetAllPollingTasks()),
+				"pending_a2a_tasks", w.registry.CountRunningJobs(domain.JobKindA2A),
 				"running_shells", w.registry.CountRunning(),
 				"max_wait_seconds", maxWaitSec)
 			return w.drainQueue()

--- a/internal/services/jobs/supervisor.go
+++ b/internal/services/jobs/supervisor.go
@@ -404,6 +404,26 @@ func (s *Supervisor) Snapshot() []domain.TrackedJob {
 	return out
 }
 
+// A2APollingStates returns the live polling state of every running A2A job, so
+// the task view and HasPending source A2A liveness from the supervisor (the
+// single source of truth) instead of the parallel A2ATaskTracker polling set.
+// Only running jobs are returned; terminal A2A tasks live in the retention view.
+func (s *Supervisor) A2APollingStates() []domain.TaskPollingState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]domain.TaskPollingState, 0)
+	for _, sj := range s.jobs {
+		if sj.meta.Kind != domain.JobKindA2A || sj.status != domain.JobRunning {
+			continue
+		}
+		if p, ok := sj.job.(domain.A2AStateProvider); ok {
+			out = append(out, p.A2APollingState())
+		}
+	}
+	return out
+}
+
 // CountRunning returns the number of jobs still running, optionally filtered to
 // one kind. Pass "" for all kinds.
 func (s *Supervisor) CountRunning(kind domain.JobKind) int {

--- a/internal/services/jobs/supervisor_test.go
+++ b/internal/services/jobs/supervisor_test.go
@@ -514,3 +514,42 @@ func TestSupervisor_FinishWithoutRetentionService(t *testing.T) {
 		t.Fatalf("job should complete normally, got ok=%v %+v", ok, j)
 	}
 }
+
+// fakeA2AJob is a fakeJob that also implements domain.A2AStateProvider, so it is
+// visible to Supervisor.A2APollingStates while running.
+type fakeA2AJob struct {
+	*fakeJob
+	state domain.TaskPollingState
+}
+
+func (f *fakeA2AJob) A2APollingState() domain.TaskPollingState { return f.state }
+
+// TestSupervisor_A2APollingStates asserts the supervisor is the single source for
+// active A2A rows: only running A2A jobs are returned, with their polling detail
+// intact, and a finished task drops out.
+func TestSupervisor_A2APollingStates(t *testing.T) {
+	sup := NewSupervisor(&domainmocks.FakeMessageQueue{}, &domainmocks.FakeConversationRepository{}, nil)
+	defer sup.Stop()
+
+	a2a := &fakeA2AJob{
+		fakeJob: newFakeJob("a1", domain.JobKindA2A),
+		state:   domain.TaskPollingState{TaskID: "a1", ContextID: "ctx1", AgentURL: "http://agent", LastKnownState: "working"},
+	}
+	shell := newFakeJob("s1", domain.JobKindShell)
+
+	sup.Submit(a2a)
+	sup.Submit(shell)
+	<-a2a.started
+	<-shell.started
+
+	states := sup.A2APollingStates()
+	if len(states) != 1 {
+		t.Fatalf("A2APollingStates len = %d, want 1 (A2A only, excludes shell)", len(states))
+	}
+	if got := states[0]; got.TaskID != "a1" || got.ContextID != "ctx1" || got.AgentURL != "http://agent" || got.LastKnownState != "working" {
+		t.Errorf("A2A detail not preserved: %+v", got)
+	}
+
+	close(a2a.finish)
+	waitFor(t, func() bool { return len(sup.A2APollingStates()) == 0 })
+}


### PR DESCRIPTION
## Summary

Closes #693.

A2A tasks were dual-tracked: the submit path registered each task in **both** the `jobs.Supervisor` (which the status-bar indicator counts via `CountRunningJobs`) and the `A2ATaskTracker` polling set (which the `/tasks` active list and `HasPending` read via `GetAllPollingTasks`). The two were cleaned up by independent paths and could diverge, so a running A2A task could be missing from the status-bar indicator while still showing in `/tasks`.

This makes the `jobs.Supervisor` the single source of truth for A2A liveness (matching #684's intent), while the `A2ATaskTracker` stays authoritative only for the context graph (resume) and the cancel agent-URL lookup.

## Changes

- **`a2aJob` exposes its live polling state** via the new optional `domain.A2AStateProvider`, and **`Supervisor.A2APollingStates()`** enumerates running A2A jobs. Because the job holds the same `*TaskPollingState` the poll loop mutates, this preserves the full A2A detail (context/agent id, last known state) with no A2A-specific fields added to the generic `JobMeta`/`TrackedJob`.
- **`BackgroundTaskService.GetBackgroundTasks()` and `backgroundTaskRegistry.HasPending()` now read the supervisor**, so the `/tasks` rows, the `/tasks` summary count, and the status-bar indicator all derive from one source and can no longer disagree. The headless `BackgroundTasksWaiter` exit path is unaffected (it goes through `HasPending`).
- **Cancel is unified:** `CancelBackgroundTask` now winds the supervised job (`WindStop`) so a cancelled task drops from the count/list at once instead of lingering until the poll independently observes the remote cancel. `runA2APolling`'s `ctx.Done()` branch now carries result `Data` so the retained "Canceled" row survives the wind.
- **Closed a pre-existing data race** on the shared `TaskPollingState`: `A2APollingState` composes the immutable identity fields with a mutex-guarded last-known state instead of copying the struct the poll goroutine mutates.

Interface-preserving: no counterfeiter mock regeneration required.

## Testing

- `task build`, `task test` (full suite), `task lint` (0 issues) — all green.
- `go test -race` clean on `internal/services`, `internal/services/jobs`, `internal/agent/tools` (validates the race fix).
- New tests: `Supervisor.A2APollingStates` (A2A-only, detail preserved, drops on finish); `HasPending` via the supervisor (a bare `StartPolling` no longer counts); `GetBackgroundTasks` sourced from the supervisor; `CancelBackgroundTask` winds the job; a concurrent `A2APollingState` race test; and `TestA2ADivergenceGone` — a regression guard proving the status-bar count and the `/tasks` list agree while running and drop together on finish.

## Follow-ups (filed)

Discovered while fixing this; tracked separately:

- #718 [BUG] `/clear` / new-conversation leave in-flight A2A tasks running in the supervisor (needs a kind-scoped `Supervisor.WindKind`).
- #719 [TASK] Refactor — remove dead `TaskPollingState.CancelFunc` plumbing.
- #720 [BUG] `A2A_QueryTask` passes agent URL where a task ID is expected (polling-active guard is a no-op).

no docs ticket: internal-only refactor
