### PR TITLE
fix(keybindings): stop "unknown keybinding action" log flood

### DIFF
--- a/cmd/keybindings.go
+++ b/cmd/keybindings.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	cobra "github.com/spf13/cobra"
@@ -378,17 +377,11 @@ func loadKeybindingsForWrite(cmd *cobra.Command) (string, *config.KeybindingsCon
 	return path, kbConfig, nil
 }
 
-// getValidActionIDs returns all valid action IDs by creating a temporary registry
+// getValidActionIDs returns every recognised action ID: runtime registry actions
+// plus the namespace-path actions from the default keybindings config (which are
+// resolved directly by components via config.ResolveNamespaceBindings). Sharing this
+// union with the runtime keeps `infer keybindings validate/set/enable/disable` in
+// agreement with what actually takes effect.
 func getValidActionIDs() []string {
-	cfg := config.DefaultConfig()
-	registry := keybinding.NewRegistry(cfg)
-	actions := registry.ListAllActions()
-
-	ids := make([]string, 0, len(actions))
-	for _, action := range actions {
-		ids = append(ids, action.ID)
-	}
-	slices.Sort(ids)
-
-	return ids
+	return keybinding.NewRegistry(config.DefaultConfig()).KnownActionIDs()
 }

--- a/cmd/keybindings_test.go
+++ b/cmd/keybindings_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestGetValidActionIDs_IncludesNamespacePathActions ensures the CLI validator's
+// notion of "valid" matches the runtime: registry-backed actions unioned with the
+// namespace-path actions (diff_viewer_*, explorer_*, chat_focus_attachments) that
+// components resolve via config.ResolveNamespaceBindings. Before the fix these were
+// wrongly reported as unknown by `infer keybindings validate`.
+func TestGetValidActionIDs_IncludesNamespacePathActions(t *testing.T) {
+	ids := getValidActionIDs()
+
+	want := []string{
+		"global_quit",
+		"chat_tab_key_handler",
+		"chat_focus_attachments",
+		"diff_viewer_nav_up",
+		"explorer_find",
+	}
+	for _, id := range want {
+		if !slices.Contains(ids, id) {
+			t.Errorf("getValidActionIDs() missing %q", id)
+		}
+	}
+}

--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -70,6 +70,20 @@ func GetDefaultKeybindings() map[string]KeyBindingEntry {
 	return bindings
 }
 
+// DefaultKeybindingActionIDs returns the set of every action ID present in the
+// default keybindings, including the namespace-path actions (chat_focus_attachments,
+// diff_viewer_*, explorer_*) that components resolve directly via ResolveNamespaceBindings
+// and that the runtime key registry never registers. Callers use it to tell a legitimate
+// (if unregistered) action from a typo.
+func DefaultKeybindingActionIDs() map[string]struct{} {
+	defaults := GetDefaultKeybindings()
+	ids := make(map[string]struct{}, len(defaults))
+	for id := range defaults {
+		ids[id] = struct{}{}
+	}
+	return ids
+}
+
 func addGlobalBindings(bindings map[string]KeyBindingEntry) {
 	enabled := true
 	bindings[ActionID(NamespaceGlobal, "quit")] = KeyBindingEntry{

--- a/internal/ui/keybinding/registry.go
+++ b/internal/ui/keybinding/registry.go
@@ -33,7 +33,7 @@ func NewRegistry(cfg *config.Config) *Registry {
 
 	if cfg != nil && cfg.Chat.Keybindings.Enabled {
 		if err := registry.ApplyConfigOverrides(cfg.Chat.Keybindings); err != nil {
-			logger.Warn("failed to apply keybinding overrides: %v", err)
+			logger.Warn("failed to apply keybinding overrides", "error", err)
 		}
 	}
 
@@ -358,10 +358,15 @@ func (r *Registry) ApplyConfigOverrides(cfg config.KeybindingsConfig) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
+	knownDefaults := config.DefaultKeybindingActionIDs()
+
 	for actionID, configBinding := range cfg.Bindings {
 		action, exists := r.actions[actionID]
 		if !exists {
-			logger.Warn("unknown keybinding action '%s' in config, ignoring", actionID)
+			if _, ok := knownDefaults[actionID]; ok {
+				continue
+			}
+			logger.Warn("unknown keybinding action in config, ignoring", "action", actionID)
 			continue
 		}
 
@@ -449,6 +454,32 @@ func (r *Registry) GetSequenceActionForPrefix(prefix string, app KeyHandlerConte
 	}
 
 	return nil
+}
+
+// KnownActionIDs returns every action ID the application recognises: the runtime
+// registry actions unioned with the default keybindings config IDs (which include
+// the namespace-path actions consumed directly via config.ResolveNamespaceBindings).
+// The CLI validator and ApplyConfigOverrides share this notion of "valid" so they
+// agree on what is a genuine typo.
+func (r *Registry) KnownActionIDs() []string {
+	ids := make(map[string]struct{})
+
+	r.mutex.RLock()
+	for id := range r.actions {
+		ids[id] = struct{}{}
+	}
+	r.mutex.RUnlock()
+
+	for id := range config.DefaultKeybindingActionIDs() {
+		ids[id] = struct{}{}
+	}
+
+	out := make([]string, 0, len(ids))
+	for id := range ids {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // ListAllActions returns all registered actions for debugging/management

--- a/internal/ui/keybinding/registry_warnings_test.go
+++ b/internal/ui/keybinding/registry_warnings_test.go
@@ -29,7 +29,7 @@ func TestApplyConfigOverrides_UnknownActionWarnings(t *testing.T) {
 		name      string
 		bindings  map[string]config.KeyBindingEntry
 		wantWarns int
-		wantField string // when set, asserted as the warn's action field
+		wantField string
 	}{
 		{
 			name:      "fresh default config is silent",
@@ -59,8 +59,6 @@ func TestApplyConfigOverrides_UnknownActionWarnings(t *testing.T) {
 			wantField: "diff_viewer_bogus",
 		},
 		{
-			// #714 renamed this action; a stale config keeps the old (doubled-prefix)
-			// ID, which is genuinely unknown now and should warn exactly once.
 			name:      "stale renamed action warns once",
 			bindings:  map[string]config.KeyBindingEntry{"plan_approval_plan_approval_accept_and_auto_approve": {Keys: []string{"a"}, Enabled: &enabled}},
 			wantWarns: 1,
@@ -78,15 +76,13 @@ func TestApplyConfigOverrides_UnknownActionWarnings(t *testing.T) {
 			cfg := &config.Config{}
 			cfg.Chat.Keybindings = config.KeybindingsConfig{Enabled: true, Bindings: tt.bindings}
 
-			_ = keybinding.NewRegistry(cfg) // triggers ApplyConfigOverrides
+			_ = keybinding.NewRegistry(cfg)
 
 			unknown := logs.FilterMessage("unknown keybinding action in config, ignoring").All()
 			if len(unknown) != tt.wantWarns {
 				t.Fatalf("unknown-keybinding warns = %d, want %d (all logs: %v)", len(unknown), tt.wantWarns, logs.All())
 			}
 
-			// Bug A regression guard: the structured logger must not emit zap's
-			// "Ignored key without a value." error from a dangling printf arg.
 			if n := logs.FilterMessageSnippet("Ignored key").Len(); n != 0 {
 				t.Fatalf("got %d spurious 'Ignored key without a value.' lines (Bug A regression)", n)
 			}

--- a/internal/ui/keybinding/registry_warnings_test.go
+++ b/internal/ui/keybinding/registry_warnings_test.go
@@ -1,0 +1,101 @@
+package keybinding_test
+
+import (
+	"testing"
+
+	zap "go.uber.org/zap"
+	zapcore "go.uber.org/zap/zapcore"
+	observer "go.uber.org/zap/zaptest/observer"
+
+	config "github.com/inference-gateway/cli/config"
+	logger "github.com/inference-gateway/cli/internal/logger"
+	keybinding "github.com/inference-gateway/cli/internal/ui/keybinding"
+)
+
+// TestApplyConfigOverrides_UnknownActionWarnings guards two regressions at once:
+//
+//   - Bug B: a stock `infer init` config must NOT warn about the namespace-path
+//     actions (chat_focus_attachments, diff_viewer_*, explorer_*) that the registry
+//     never registers but components consume via config.ResolveNamespaceBindings.
+//   - Bug A: the warning must be a structured log carrying an "action" field, never
+//     the printf misuse that made zap emit a second "Ignored key without a value."
+//     error line.
+//
+// The subtests mutate the package-global sugared logger, so they must not run in
+// parallel.
+func TestApplyConfigOverrides_UnknownActionWarnings(t *testing.T) {
+	enabled := true
+	tests := []struct {
+		name      string
+		bindings  map[string]config.KeyBindingEntry
+		wantWarns int
+		wantField string // when set, asserted as the warn's action field
+	}{
+		{
+			name:      "fresh default config is silent",
+			bindings:  config.GetDefaultKeybindings(),
+			wantWarns: 0,
+		},
+		{
+			name:      "namespace-path diff_viewer action not flagged",
+			bindings:  map[string]config.KeyBindingEntry{"diff_viewer_nav_up": {Keys: []string{"up"}, Enabled: &enabled}},
+			wantWarns: 0,
+		},
+		{
+			name:      "chat focus-attachments not flagged",
+			bindings:  map[string]config.KeyBindingEntry{"chat_focus_attachments": {Keys: []string{"ctrl+g"}, Enabled: &enabled}},
+			wantWarns: 0,
+		},
+		{
+			name:      "genuine typo warns once",
+			bindings:  map[string]config.KeyBindingEntry{"totally_bogus_action": {Keys: []string{"ctrl+x"}, Enabled: &enabled}},
+			wantWarns: 1,
+			wantField: "totally_bogus_action",
+		},
+		{
+			name:      "namespace typo still warns once",
+			bindings:  map[string]config.KeyBindingEntry{"diff_viewer_bogus": {Keys: []string{"ctrl+x"}, Enabled: &enabled}},
+			wantWarns: 1,
+			wantField: "diff_viewer_bogus",
+		},
+		{
+			// #714 renamed this action; a stale config keeps the old (doubled-prefix)
+			// ID, which is genuinely unknown now and should warn exactly once.
+			name:      "stale renamed action warns once",
+			bindings:  map[string]config.KeyBindingEntry{"plan_approval_plan_approval_accept_and_auto_approve": {Keys: []string{"a"}, Enabled: &enabled}},
+			wantWarns: 1,
+			wantField: "plan_approval_plan_approval_accept_and_auto_approve",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.WarnLevel)
+			prev := logger.GetGlobalLogger()
+			logger.SetGlobalLogger(zap.New(core))
+			defer logger.SetGlobalLogger(prev)
+
+			cfg := &config.Config{}
+			cfg.Chat.Keybindings = config.KeybindingsConfig{Enabled: true, Bindings: tt.bindings}
+
+			_ = keybinding.NewRegistry(cfg) // triggers ApplyConfigOverrides
+
+			unknown := logs.FilterMessage("unknown keybinding action in config, ignoring").All()
+			if len(unknown) != tt.wantWarns {
+				t.Fatalf("unknown-keybinding warns = %d, want %d (all logs: %v)", len(unknown), tt.wantWarns, logs.All())
+			}
+
+			// Bug A regression guard: the structured logger must not emit zap's
+			// "Ignored key without a value." error from a dangling printf arg.
+			if n := logs.FilterMessageSnippet("Ignored key").Len(); n != 0 {
+				t.Fatalf("got %d spurious 'Ignored key without a value.' lines (Bug A regression)", n)
+			}
+
+			if tt.wantField != "" {
+				if got := unknown[0].ContextMap()["action"]; got != tt.wantField {
+					t.Fatalf("warn action field = %v, want %q", got, tt.wantField)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the flood of `unknown keybinding action` warnings in `~/.infer/logs/app-<date>.log` - about **84 lines per `infer chat` launch** (42 warn + 42 error), even with a stock `infer init` config.

## Root cause

- **Structural drift (the flood).** `config.GetDefaultKeybindings()` includes 41 namespace-path actions (`chat_focus_attachments`, all `diff_viewer_*`, all `explorer_*`) that are consumed directly via `config.ResolveNamespaceBindings` and are never registered in the runtime `Registry`. `(*Registry).ApplyConfigOverrides` warned for every config ID absent from the registry, so it false-flagged all 41 on every launch. The CLI validator `getValidActionIDs()` shared the same blind spot.
- **Logger misuse (doubled the noise).** `registry.go:364` called `logger.Warn("... '%s' ...", actionID)`, but `logger.Warn(msg, args...)` forwards to zap's key/value sugared API (`Warnw`). So `%s` never expanded and the trailing `actionID` became a dangling key - which is why zap added a second, `error`-level `Ignored key without a value.` line.

## Fix

- New `config.DefaultKeybindingActionIDs()` - the config-side valid-ID set.
- `ApplyConfigOverrides` now warns only for IDs in **neither** the registry **nor** the defaults (exact-ID match, so genuine typos and stale/removed IDs still warn once), and logs structured (`"action", id`). The sibling misuse at `registry.go:36` is fixed too.
- New `Registry.KnownActionIDs()` (registry union defaults); the CLI validator uses it so `infer keybindings validate/set/enable/disable` agree with the runtime.
- Regression tests: a stock config is silent; a genuine/namespace typo warns exactly once with a structured `action` field and zero `Ignored key` lines; the validator includes namespace-path IDs.

## Verification

- `task build`, `task lint` (0 issues), `go test ./...` all pass.
- `infer keybindings validate` against a real stale config: **42 -> 1** unknown ID (only the genuinely-removed `plan_approval_..._accept_and_auto_approve` from #714). Runtime flood drops from 84 lines/launch to at most 1 clean structured warning.

## Notes

- No config regeneration - `GetDefaultKeybindings()` output is unchanged.
- The doubled `plan_approval_plan_approval_` prefix is intentionally left as-is (identical between registry and defaults; renaming would break existing user configs).
- The same printf-style structured-logger misuse exists at ~18 other call sites (same defect class, malformed logs); tracked separately in #723.

Closes #722
