### PR TITLE
fix(agent): drop redundant Idle transition that errored on every run

### DIFF
--- a/internal/agent/agent_event_driven.go
+++ b/internal/agent/agent_event_driven.go
@@ -194,12 +194,10 @@ func (a *EventDrivenAgent) registerHandler(handler domain.StateHandler) {
 	a.stateHandlers[handler.Name()] = handler
 }
 
-// Start begins the event-driven agent execution
+// Start begins the event-driven agent execution. The state machine already
+// begins in Idle, so seeding a MessageReceivedEvent drives the first transition
+// (Idle -> CheckingQueue) via the Idle state handler.
 func (a *EventDrivenAgent) Start() {
-	if err := a.stateMachine.Transition(a.agentCtx, domain.StateIdle); err != nil {
-		logger.Error("failed to transition to Idle state", "error", err)
-	}
-
 	a.wg.Add(1)
 	go a.processEvents()
 

--- a/internal/agent/agent_event_driven_test.go
+++ b/internal/agent/agent_event_driven_test.go
@@ -866,3 +866,32 @@ func TestHandleApprovingToolsState(t *testing.T) {
 		}
 	})
 }
+
+// TestStart_DoesNotRedundantlyTransitionToIdle verifies Start() issues no
+// redundant Idle transition: the machine already starts in Idle, so the first
+// transition must be Idle -> CheckingQueue from the seeded MessageReceivedEvent.
+func TestStart_DoesNotRedundantlyTransitionToIdle(t *testing.T) {
+	mocks := setupTestMocks()
+	ctx := createTestContext(mocks)
+	agent := createTestAgent(mocks, ctx)
+	agent.req = &domain.AgentRequest{RequestID: "test-123", Model: "test-model"}
+	mocks.stateMachine.TransitionReturns(nil)
+
+	agent.Start()
+
+	done := make(chan struct{})
+	go func() { agent.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not settle after Start(); processEvents never reached Idle")
+	}
+
+	if got := mocks.stateMachine.TransitionCallCount(); got < 1 {
+		t.Fatalf("expected Start() to drive at least one transition, got %d", got)
+	}
+	_, firstTarget := mocks.stateMachine.TransitionArgsForCall(0)
+	assert.NotEqual(t, domain.StateIdle, firstTarget,
+		"Start() must not issue a redundant Idle transition; the first should be "+
+			"Idle -> CheckingQueue from the seeded MessageReceivedEvent")
+}


### PR DESCRIPTION
## Summary

`EventDrivenAgent.Start()` unconditionally called `Transition(ctx, StateIdle)`, but the state machine is constructed in `Idle` and there is no `Idle -> Idle` edge — so the call failed on every run with `invalid transition from Idle to Idle` and logged an **error + full stacktrace** on every turn. It was harmless (the seeded `MessageReceivedEvent` drives the real `Idle -> CheckingQueue` flow) but became visible noise once #722 cleared the keybinding log flood that had masked it.

## Fix

Delete the redundant transition — the loop already begins in `Idle`. Zero state-machine semantic change: the call never succeeded, so nothing that passed can break.

## Test

`TestStart_DoesNotRedundantlyTransitionToIdle` asserts `Start()` issues no `Idle`-targeted transition (the first transition must be `Idle -> CheckingQueue` from the seeded event). Confirmed it fails if the removed line is restored.

`go test ./...`, `task lint` (0 issues), and `task build` all pass.

Closes #725
