### PR TITLE
fix(agent): report session-cumulative total_turns in completion logs

### DIFF
--- a/internal/agent/agent_event_driven.go
+++ b/internal/agent/agent_event_driven.go
@@ -128,7 +128,8 @@ func (a *EventDrivenAgent) registerStateHandlers() {
 		ToolExecutor:           &a.toolExecutor,
 		StartStreaming:         a.startStreaming,
 
-		GetMetrics: a.service.GetMetrics,
+		GetMetrics:   a.service.GetMetrics,
+		SessionTurns: func() int64 { return a.service.sessionTurns.Load() },
 		ShouldRequireApproval: func(toolCall *sdk.ChatCompletionMessageToolCall, isChatMode bool) bool {
 			if a.service.approvalPolicy == nil {
 				return false
@@ -136,8 +137,6 @@ func (a *EventDrivenAgent) registerStateHandlers() {
 			return a.service.approvalPolicy.ShouldRequireApproval(a.agentCtx.Ctx, toolCall, isChatMode)
 		},
 		ApprovalDelivery: func(toolCall *sdk.ChatCompletionMessageToolCall) string {
-			// This agent runs interactively (chat); no IPC broker is attached, so
-			// approval_behaviour=ipc has no approver and resolves to block too.
 			if a.service.config == nil {
 				return config.ApprovalBehaviourPrompt
 			}
@@ -254,7 +253,8 @@ func (a *EventDrivenAgent) processEvents() {
 
 			if currentState == domain.StateIdle {
 				logger.Debug("agent reached Idle state - turn complete",
-					"total_turns", a.agentCtx.Turns)
+					"total_turns", a.service.sessionTurns.Load(),
+					"run_turns", a.agentCtx.Turns)
 				return
 			}
 		}

--- a/internal/agent/agent_event_driven.go
+++ b/internal/agent/agent_event_driven.go
@@ -128,8 +128,7 @@ func (a *EventDrivenAgent) registerStateHandlers() {
 		ToolExecutor:           &a.toolExecutor,
 		StartStreaming:         a.startStreaming,
 
-		GetMetrics:   a.service.GetMetrics,
-		SessionTurns: func() int64 { return a.service.sessionTurns.Load() },
+		GetMetrics: a.service.GetMetrics,
 		ShouldRequireApproval: func(toolCall *sdk.ChatCompletionMessageToolCall, isChatMode bool) bool {
 			if a.service.approvalPolicy == nil {
 				return false
@@ -253,8 +252,7 @@ func (a *EventDrivenAgent) processEvents() {
 
 			if currentState == domain.StateIdle {
 				logger.Debug("agent reached Idle state - turn complete",
-					"total_turns", a.service.sessionTurns.Load(),
-					"run_turns", a.agentCtx.Turns)
+					"total_turns", a.service.sessionTurns.Load())
 				return
 			}
 		}

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -871,7 +871,6 @@ func (s *AgentServiceImpl) injectDueReminders(agentCtx *domain.AgentContext, hoo
 		}
 
 		logger.Debug("system reminder injected",
-			"turn", agentCtx.Turns,
 			"session_turn", sessionTurn,
 			"hook", string(hook),
 			"name", r.Name,

--- a/internal/agent/states/completing.go
+++ b/internal/agent/states/completing.go
@@ -45,8 +45,6 @@ func (s *CompletingState) Handle(event domain.AgentEvent) error {
 // otherwise it publishes the final completion event and transitions to Idle.
 func (s *CompletingState) complete() error {
 	logger.Debug("completing state: finalizing agent execution",
-		"total_turns", s.ctx.SessionTurns(),
-		"run_turns", s.ctx.AgentCtx.Turns,
 		"queue_empty", s.ctx.AgentCtx.MessageQueue.IsEmpty())
 
 	logger.Debug("sleeping 20ms for final queue check")
@@ -78,9 +76,6 @@ func (s *CompletingState) complete() error {
 		logger.Error("failed to transition to idle", "error", err)
 		return err
 	}
-	logger.Debug("agent execution completed successfully",
-		"total_turns", s.ctx.SessionTurns(),
-		"run_turns", s.ctx.AgentCtx.Turns)
 
 	return nil
 }

--- a/internal/agent/states/completing.go
+++ b/internal/agent/states/completing.go
@@ -45,7 +45,8 @@ func (s *CompletingState) Handle(event domain.AgentEvent) error {
 // otherwise it publishes the final completion event and transitions to Idle.
 func (s *CompletingState) complete() error {
 	logger.Debug("completing state: finalizing agent execution",
-		"total_turns", s.ctx.AgentCtx.Turns,
+		"total_turns", s.ctx.SessionTurns(),
+		"run_turns", s.ctx.AgentCtx.Turns,
 		"queue_empty", s.ctx.AgentCtx.MessageQueue.IsEmpty())
 
 	logger.Debug("sleeping 20ms for final queue check")
@@ -77,7 +78,9 @@ func (s *CompletingState) complete() error {
 		logger.Error("failed to transition to idle", "error", err)
 		return err
 	}
-	logger.Debug("agent execution completed successfully", "total_turns", s.ctx.AgentCtx.Turns)
+	logger.Debug("agent execution completed successfully",
+		"total_turns", s.ctx.SessionTurns(),
+		"run_turns", s.ctx.AgentCtx.Turns)
 
 	return nil
 }

--- a/internal/domain/agent_events.go
+++ b/internal/domain/agent_events.go
@@ -110,6 +110,7 @@ type StateContext struct {
 
 	// Helper methods - these will be implemented as methods that delegate to internal service
 	GetMetrics            func(requestID string) *ChatMetrics
+	SessionTurns          func() int64
 	ShouldRequireApproval func(toolCall *sdk.ChatCompletionMessageToolCall, isChatMode bool) bool
 	ApprovalDelivery      func(toolCall *sdk.ChatCompletionMessageToolCall) string
 	AddMessage            func(entry ConversationEntry) error

--- a/internal/domain/agent_events.go
+++ b/internal/domain/agent_events.go
@@ -110,7 +110,6 @@ type StateContext struct {
 
 	// Helper methods - these will be implemented as methods that delegate to internal service
 	GetMetrics            func(requestID string) *ChatMetrics
-	SessionTurns          func() int64
 	ShouldRequireApproval func(toolCall *sdk.ChatCompletionMessageToolCall, isChatMode bool) bool
 	ApprovalDelivery      func(toolCall *sdk.ChatCompletionMessageToolCall) string
 	AddMessage            func(entry ConversationEntry) error


### PR DESCRIPTION
## Summary

The `total_turns` field in the agent completion logs always read `1` in normal back-and-forth chat. It was sourced from the per-request `AgentContext.Turns`, which is rebuilt from `0` for every user message, so it could only ever reflect the current message's model-round count — never the conversation's running total. On top of that it was emitted **three times** per completion (two of them microseconds apart). Pure observability bug; nothing keys off the value.

## Fix

Log `total_turns` **once**, at the turn-complete boundary in `processEvents` (`"agent reached Idle state - turn complete"`), sourced from the session-cumulative `AgentServiceImpl.sessionTurns` — an `atomic.Int64` already maintained right alongside `Turns`, previously read only for reminder cadence. The two redundant `completing.go` copies are dropped (the "finalizing" trace keeps `queue_empty`; the duplicate "completed successfully" line is removed).

Observability only — `AgentContext.Turns`, `MaxTurns`, and the `ctx.Turns >= ctx.MaxTurns` limiter are untouched. Also drops a stale inline comment on `ApprovalDelivery`.

## Test

No log-observer harness exists in the repo (tests default to `zap.NewNop()`) and no behaviour branches on the value, so no new log-assertion test is warranted. `agent_reminder_emission_test.go` already asserts the session-vs-per-request counter distinction this fix relies on, and `TestHandleCompletingState` covers the completing-state path.

`go build ./...`, `golangci-lint` (0 issues), and full `go test ./...` all pass.

Closes #727
