### PR TITLE
fix(logging): use structured key/value form at misused call sites

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,8 +37,6 @@ linters:
     nestif:
       min-complexity: 4
     loggercheck:
-      # Guard against printf-style format strings (%s/%v) passed to the
-      # structured key/value logger. Teach loggercheck our wrapper funcs.
       no-printf-like: true
       rules:
         - github.com/inference-gateway/cli/internal/logger.Debug

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - funlen
     - gocognit
     - nestif
+    - loggercheck
   disable:
     - exhaustruct
     - varnamelen
@@ -35,6 +36,16 @@ linters:
       min-complexity: 45
     nestif:
       min-complexity: 4
+    loggercheck:
+      # Guard against printf-style format strings (%s/%v) passed to the
+      # structured key/value logger. Teach loggercheck our wrapper funcs.
+      no-printf-like: true
+      rules:
+        - github.com/inference-gateway/cli/internal/logger.Debug
+        - github.com/inference-gateway/cli/internal/logger.Info
+        - github.com/inference-gateway/cli/internal/logger.Warn
+        - github.com/inference-gateway/cli/internal/logger.Error
+        - github.com/inference-gateway/cli/internal/logger.Fatal
   exclusions:
     rules:
       # staticcheck SA5011 reports a "possible nil-pointer deref" after

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,10 +46,6 @@ linters:
         - github.com/inference-gateway/cli/internal/logger.Fatal
   exclusions:
     rules:
-      # staticcheck SA5011 reports a "possible nil-pointer deref" after
-      # `if x == nil { t.Fatal(...) }` blocks. testing.T.Fatal is NoReturn
-      # so the deref is safe; on some toolchains/platforms staticcheck
-      # fails to recognise this and flags the pattern. Suppress in tests.
       - linters:
           - staticcheck
         text: "SA5011"

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -606,7 +606,7 @@ func (s *AgentServiceImpl) buildWorkingDirectoryInfo() string {
 
 	workingDir, err := os.Getwd()
 	if err != nil {
-		logger.Debug("failed to get working directory: %v", err)
+		logger.Debug("failed to get working directory", "error", err)
 		return ""
 	}
 
@@ -679,7 +679,7 @@ func getGitRepositoryName() string {
 	cmd := exec.Command("git", "remote", "get-url", "origin")
 	output, err := cmd.Output()
 	if err != nil {
-		logger.Debug("failed to get git remote URL: %v", err)
+		logger.Debug("failed to get git remote URL", "error", err)
 		return ""
 	}
 
@@ -695,7 +695,7 @@ func getGitRepositoryName() string {
 		return matches[1]
 	}
 
-	logger.Debug("could not parse git repository name from URL: %s", remoteURL)
+	logger.Debug("could not parse git repository name from URL", "url", remoteURL)
 	return ""
 }
 
@@ -704,7 +704,7 @@ func getGitBranch() string {
 	cmd := exec.Command("git", "branch", "--show-current")
 	output, err := cmd.Output()
 	if err != nil {
-		logger.Debug("failed to get current git branch: %v", err)
+		logger.Debug("failed to get current git branch", "error", err)
 		return ""
 	}
 
@@ -732,7 +732,7 @@ func getRecentCommits(count int) []string {
 	cmd := exec.Command("git", "log", fmt.Sprintf("-%d", count), "--oneline", "--no-decorate")
 	output, err := cmd.Output()
 	if err != nil {
-		logger.Debug("failed to get recent commits: %v", err)
+		logger.Debug("failed to get recent commits", "error", err)
 		return nil
 	}
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -2281,7 +2281,7 @@ func (app *ChatApplication) SendMessage() tea.Cmd {
 	for _, img := range images {
 		if img.SourcePath != "" {
 			if err := os.Remove(img.SourcePath); err != nil {
-				logger.Warn("failed to clean up temporary image file %s: %v", img.SourcePath, err)
+				logger.Warn("failed to clean up temporary image file", "path", img.SourcePath, "error", err)
 			}
 		}
 	}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -418,9 +418,9 @@ func (c *ServiceContainer) handleStorageInitFailure(
 			"error", err,
 			"type", storageConfig.Type,
 			"enabled", c.config.Storage.Enabled)
-		logger.Error("storage backend '%s' is not available. "+
-			"Either fix the configuration or disable storage by setting 'storage.enabled: false'",
-			storageConfig.Type)
+		logger.Error("storage backend is not available; "+
+			"either fix the configuration or disable storage by setting 'storage.enabled: false'",
+			"type", storageConfig.Type)
 		panic(fmt.Sprintf("Failed to initialize storage backend '%s': %v\n\n"+
 			"To use in-memory storage instead, set:\n"+
 			"  storage.enabled: false\n\n"+

--- a/internal/services/channels/telegram.go
+++ b/internal/services/channels/telegram.go
@@ -86,7 +86,7 @@ func (t *TelegramChannel) Start(ctx context.Context, inbox chan<- domain.Inbound
 
 			if fileID, ok := msg.Metadata["photo_file_id"]; ok && fileID != "" {
 				if img, err := downloadTelegramPhoto(ctx, b, t.cfg.BotToken, fileID); err != nil {
-					logger.Error("failed to download photo: %v", err)
+					logger.Error("failed to download photo", "error", err)
 				} else {
 					msg.Images = append(msg.Images, *img)
 				}
@@ -188,7 +188,7 @@ func processUpdate(update *models.Update) *domain.InboundMessage {
 	msg := update.Message
 
 	if msg.Video != nil {
-		logger.Warn("skipping video message from %d", msg.Chat.ID)
+		logger.Warn("skipping video message", "chat_id", msg.Chat.ID)
 		return nil
 	}
 
@@ -260,7 +260,7 @@ func (t *TelegramChannel) applyVoiceTranscription(ctx context.Context, b *bot.Bo
 
 	text, err := t.transcribeVoice(ctx, b, fileID)
 	if err != nil {
-		logger.Error("failed to transcribe voice message: %v", err)
+		logger.Error("failed to transcribe voice message", "error", err)
 		return false
 	}
 	if strings.TrimSpace(text) == "" {
@@ -348,7 +348,7 @@ func fetchTelegramFile(ctx context.Context, b *bot.Bot, token, fileID string) ([
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			logger.Error("failed to close response body: %v", err)
+			logger.Error("failed to close response body", "error", err)
 		}
 	}()
 

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -919,14 +919,14 @@ func handleImagePaste(app KeyHandlerContext, imageService domain.ImageService, i
 	tmpDir := filepath.Join(app.GetConfigDir(), "tmp")
 
 	if err := os.MkdirAll(tmpDir, 0755); err != nil {
-		logger.Warn("failed to create %s/tmp directory: %v", app.GetConfigDir(), err)
+		logger.Warn("failed to create tmp directory", "path", tmpDir, "error", err)
 		return false
 	}
 
 	tmpPath := filepath.Join(tmpDir, fmt.Sprintf("clipboard-image-%s.png", timestamp))
 
 	if err := os.WriteFile(tmpPath, imageData, 0644); err != nil {
-		logger.Warn("failed to save clipboard image to %s/tmp: %v", app.GetConfigDir(), err)
+		logger.Warn("failed to save clipboard image", "path", tmpPath, "error", err)
 		return false
 	}
 
@@ -935,7 +935,7 @@ func handleImagePaste(app KeyHandlerContext, imageService domain.ImageService, i
 
 	imageAttachment, err := imageService.ReadImageFromFile(finalPath)
 	if err != nil {
-		logger.Warn("failed to read saved clipboard image: %v", err)
+		logger.Warn("failed to read saved clipboard image", "path", finalPath, "error", err)
 		return false
 	}
 
@@ -949,13 +949,13 @@ func handleImagePaste(app KeyHandlerContext, imageService domain.ImageService, i
 // Returns the final file path (which may have a different extension)
 func applyImageOptimization(tmpPath string, originalData []byte, cfg *config.Config) string {
 	if cfg == nil || !cfg.Image.ClipboardOptimize.Enabled {
-		logger.Info("clipboard image saved to: %s (you can inspect this file)", tmpPath)
+		logger.Info("clipboard image saved (you can inspect this file)", "path", tmpPath)
 		return tmpPath
 	}
 
 	result, err := optimizeClipboardImage(tmpPath, cfg.Image.ClipboardOptimize)
 	if err != nil {
-		logger.Warn("failed to optimize clipboard image, using original: %v", err)
+		logger.Warn("failed to optimize clipboard image, using original", "error", err)
 		return tmpPath
 	}
 
@@ -965,7 +965,7 @@ func applyImageOptimization(tmpPath string, originalData []byte, cfg *config.Con
 	}
 
 	if err := os.WriteFile(finalPath, result.Data, 0644); err != nil {
-		logger.Warn("failed to save optimized image: %v", err)
+		logger.Warn("failed to save optimized image", "path", finalPath, "error", err)
 		return tmpPath
 	}
 
@@ -973,8 +973,8 @@ func applyImageOptimization(tmpPath string, originalData []byte, cfg *config.Con
 		_ = os.Remove(tmpPath)
 	}
 
-	logger.Info("clipboard image optimized and saved to: %s (original: %d bytes, optimized: %d bytes)",
-		finalPath, len(originalData), len(result.Data))
+	logger.Info("clipboard image optimized and saved",
+		"path", finalPath, "original_bytes", len(originalData), "optimized_bytes", len(result.Data))
 
 	return finalPath
 }


### PR DESCRIPTION
## Summary

`internal/logger`'s `Debug/Info/Warn/Error/Fatal(msg string, args ...any)` forward to zap's sugared
**key/value** API (`Warnw`/`Errorw`/…). ~18 call sites instead passed a **printf-style** format string
(`%s`/`%v`/`%d`) with trailing positional args, so:

- the verbs were never expanded (a literal `%s` landed in the log), and
- the trailing args were misread as key/value pairs — an **odd** count left a dangling key, making zap
  emit an extra `error`-level `Ignored key without a value.` line.

This is the same defect class as the keybinding log flood (#722, fixed in #724, which corrected the two
worst offenders and tracked the rest in #723). This PR closes the remaining sites.

## Changes

- **Convert 18 call sites to structured key/value form**, following the #724 precedent
  (`logger.Warn("failed to …", "error", err)`). Multi-word keys use the repo's snake_case house style
  (`chat_id`, `original_bytes`).
  - `internal/ui/keybinding/actions.go` (7), `internal/agent/agent_utils.go` (5),
    `internal/services/channels/telegram.go` (4), `internal/app/chat.go` (1),
    `internal/container/container.go` (1)
- **Enable the `loggercheck` linter** (`no-printf-like` + wrapper rules for `internal/logger.*`) so
  this class cannot regress.

The 9 other logger calls that contain a `%` were verified as correct `fmt.Sprintf` usage (message
pre-formatted, or building a properly-keyed value) and left untouched.

## Verification

- `task build`, `task test` (full suite), and `task lint` (**0 issues**, loggercheck active) all pass.
- Confirmed the guard is live: a deliberate misuse is flagged by loggercheck
  (`odd number of arguments passed as key-value pairs for logging`); the fixed tree lints clean.

no docs ticket: internal-only fix

Closes #723
