### PR TITLE
feat(chat): make status indicators selectable with /tools and /a2a views

### DIFF
--- a/.agents/skills/a2a-protocol/SKILL.md
+++ b/.agents/skills/a2a-protocol/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: a2a
+name: a2a-protocol
 description: >
   Build, consume, debug, or reason about Agent2Agent (A2A) protocol agents -
   Agent Cards and discovery, the Task lifecycle, Messages/Parts/Artifacts, the

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ An agentic command-line assistant that writes code, understands project context,
 - **Customizable Keybindings**: Fully configurable keyboard shortcuts for the chat interface
 - **Selectable Status Indicators**: Press `↓` in chat to select the indicators below the input and
   open the matching view with `enter` (model → model selection, theme → theme selection,
-  `🔧` tools → available tools, `⚙` jobs → task management)
+  `A2A:` → registered agents, `Tools:` → available tools, `⚙` jobs → task management)
 - **Model Thinking Visualization**: When models use extended thinking,
   their internal reasoning process is displayed as collapsible blocks above responses (toggle with **ctrl+k** by default, configurable via `display_toggle_thinking`)
 - **Extensible Shortcuts System**: Create custom commands with AI-powered snippets - [Learn more →](docs/shortcuts-guide.md)
@@ -1004,6 +1004,7 @@ actions.
 - `/diff` - Open the changes panel (interactive diff viewer)
 - `/explorer` - Open the file explorer (tree + fuzzy finder) - [Learn more →](docs/explorer.md)
 - `/tools` - Show the tools available to the agent (read-only, filterable list)
+- `/a2a` - Show registered A2A agents and their status (requires A2A)
 - `/tasks` - Show the A2A task-management interface (requires A2A) - [Learn more →](docs/tasks-management.md)
 - `/release-notes [version]` - Show release notes from GitHub Releases (latest, or a specific version)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ An agentic command-line assistant that writes code, understands project context,
   the agent works from full context without a redundant `gh issue view` lookup. Gracefully
   no-ops when `gh` is not installed or the repo has no remote.
 - **Customizable Keybindings**: Fully configurable keyboard shortcuts for the chat interface
+- **Selectable Status Indicators**: Press `↓` in chat to select the indicators below the input and
+  open the matching view with `enter` (model → model selection, theme → theme selection, `⚙` jobs → task management)
 - **Model Thinking Visualization**: When models use extended thinking,
   their internal reasoning process is displayed as collapsible blocks above responses (toggle with **ctrl+k** by default, configurable via `display_toggle_thinking`)
 - **Extensible Shortcuts System**: Create custom commands with AI-powered snippets - [Learn more →](docs/shortcuts-guide.md)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ An agentic command-line assistant that writes code, understands project context,
   no-ops when `gh` is not installed or the repo has no remote.
 - **Customizable Keybindings**: Fully configurable keyboard shortcuts for the chat interface
 - **Selectable Status Indicators**: Press `↓` in chat to select the indicators below the input and
-  open the matching view with `enter` (model → model selection, theme → theme selection, `⚙` jobs → task management)
+  open the matching view with `enter` (model → model selection, theme → theme selection,
+  `🔧` tools → available tools, `⚙` jobs → task management)
 - **Model Thinking Visualization**: When models use extended thinking,
   their internal reasoning process is displayed as collapsible blocks above responses (toggle with **ctrl+k** by default, configurable via `display_toggle_thinking`)
 - **Extensible Shortcuts System**: Create custom commands with AI-powered snippets - [Learn more →](docs/shortcuts-guide.md)
@@ -1002,6 +1003,7 @@ actions.
 
 - `/diff` - Open the changes panel (interactive diff viewer)
 - `/explorer` - Open the file explorer (tree + fuzzy finder) - [Learn more →](docs/explorer.md)
+- `/tools` - Show the tools available to the agent (read-only, filterable list)
 - `/tasks` - Show the A2A task-management interface (requires A2A) - [Learn more →](docs/tasks-management.md)
 - `/release-notes [version]` - Show release notes from GitHub Releases (latest, or a specific version)
 

--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -272,7 +272,7 @@ func addTextEditingBindings(bindings map[string]KeyBindingEntry) {
 	}
 	bindings[ActionID(NamespaceTextEditing, "history_down")] = KeyBindingEntry{
 		Keys:        []string{"down"},
-		Description: "navigate to next message in history",
+		Description: "navigate to next message in history / select status indicator",
 		Category:    "text_editing",
 		Enabled:     &enabled,
 	}

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -284,6 +284,11 @@ select models and have conversations.
 - **ctrl+o** (default): Toggle expanded view of tool results (configurable via `tools_toggle_tool_expansion`)
 - **ctrl+k** (default): Toggle expanded view of model thinking blocks (configurable via `display_toggle_thinking`)
 - **shift+tab**: Cycle agent mode (Standard → Plan → Auto-Accept)
+- **↓** (when not navigating input history): Select the status indicators below the input.
+  `←`/`→` (or `tab`/`shift+tab`) move between the actionable indicators, **enter** opens the
+  matching view (model indicator → model selection, theme indicator → theme selection,
+  background-jobs `⚙` indicator → task management), **↑**/**esc** return to the input, and
+  typing any other key lands back in the input seamlessly
 
 **Agent Modes:**
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -287,8 +287,9 @@ select models and have conversations.
 - **↓** (when not navigating input history): Select the status indicators below the input.
   `←`/`→` (or `tab`/`shift+tab`) move between the actionable indicators, **enter** opens the
   matching view (model indicator → model selection, theme indicator → theme selection,
-  `🔧` tools indicator → available tools, background-jobs `⚙` indicator → task management),
-  **↑**/**esc** return to the input, and typing any other key lands back in the input seamlessly
+  `A2A:` indicator → registered A2A agents, `Tools:` indicator → available tools,
+  background-jobs `⚙` indicator → task management), **↑**/**esc** return to the input, and
+  typing any other key lands back in the input seamlessly
 
 **Agent Modes:**
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -287,8 +287,8 @@ select models and have conversations.
 - **↓** (when not navigating input history): Select the status indicators below the input.
   `←`/`→` (or `tab`/`shift+tab`) move between the actionable indicators, **enter** opens the
   matching view (model indicator → model selection, theme indicator → theme selection,
-  background-jobs `⚙` indicator → task management), **↑**/**esc** return to the input, and
-  typing any other key lands back in the input seamlessly
+  `🔧` tools indicator → available tools, background-jobs `⚙` indicator → task management),
+  **↑**/**esc** return to the input, and typing any other key lands back in the input seamlessly
 
 **Agent Modes:**
 

--- a/docs/shortcuts-guide.md
+++ b/docs/shortcuts-guide.md
@@ -61,6 +61,7 @@ These shortcuts are available out of the box:
 - `/diff` - Open the changes panel (interactive diff viewer)
 - `/explorer` - Open the file explorer (tree + fuzzy finder)
 - `/tools` - Show the tools available to the agent (read-only, filterable list)
+- `/a2a` - Show registered A2A agents and their status (requires A2A)
 - `/tasks` - Show the A2A task-management interface (requires A2A)
 - `/release-notes [version]` - Show GitHub release notes for a version or the latest (requires the `gh` CLI installed and authenticated)
 

--- a/docs/shortcuts-guide.md
+++ b/docs/shortcuts-guide.md
@@ -60,6 +60,7 @@ These shortcuts are available out of the box:
 
 - `/diff` - Open the changes panel (interactive diff viewer)
 - `/explorer` - Open the file explorer (tree + fuzzy finder)
+- `/tools` - Show the tools available to the agent (read-only, filterable list)
 - `/tasks` - Show the A2A task-management interface (requires A2A)
 - `/release-notes [version]` - Show GitHub release notes for a version or the latest (requires the `gh` CLI installed and authenticated)
 

--- a/docs/tasks-management.md
+++ b/docs/tasks-management.md
@@ -17,8 +17,11 @@ system with better visibility into task status and history.
 
 ### Task Management Interface (`/tasks`)
 
-- **Access**: Type `/tasks` in the chat to open the task management interface
-- **Requirements**: Only available when A2A is enabled in configuration
+- **Access**: Type `/tasks` in the chat, or press `↓` in the chat input, select the `⚙`
+  background-jobs indicator with `←`/`→`, and press `enter`
+- **Requirements**: The `/tasks` shortcut requires A2A to be enabled in configuration; the
+  status-indicator route works whenever the `⚙` indicator shows running jobs (shells,
+  subagents, or A2A tasks)
 - **Default View**: Opens in "All" view showing both active and completed tasks
 - **Views**: Switch between Active, Completed, and All tasks using number keys 1, 2, 3
 
@@ -56,6 +59,9 @@ When viewing task details (`i` key), you can see:
 ```text
 /tasks
 ```
+
+Or, without typing a command: press `↓` in the chat input (while not navigating input
+history), move to the `⚙` background-jobs indicator with `←`/`→`, and press `enter`.
 
 ### Canceling a Task
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -96,6 +96,7 @@ type ChatApplication struct {
 	fileExplorer         *components.FileExplorerImpl
 	helpView             *components.HelpViewImpl
 	toolsView            *components.ToolsViewImpl
+	a2aAgentsView        *components.A2AAgentsViewImpl
 
 	snippetAttachmentsView *components.SnippetAttachmentsView
 
@@ -296,6 +297,7 @@ func NewChatApplication(
 	app.modelSelector = components.NewModelSelector(models, app.modelService, app.pricingService, app.config, styleProvider)
 	app.themeSelector = components.NewThemeSelector(app.themeService, styleProvider)
 	app.toolsView = components.NewToolsView(app.toolService, app.stateManager, styleProvider)
+	app.a2aAgentsView = components.NewA2AAgentsView(app.stateManager, styleProvider)
 	app.initGithubActionView = components.NewInitGithubActionView(styleProvider)
 
 	app.initGithubActionView.SetSecretsExistChecker(func(appID string) bool {
@@ -639,6 +641,8 @@ func (app *ChatApplication) handleViewSpecificMessages(msg tea.Msg) []tea.Cmd {
 		return app.handleHelpView(msg)
 	case domain.ViewStateToolsList:
 		return app.handleToolsListView(msg)
+	case domain.ViewStateA2AAgents:
+		return app.handleA2AAgentsView(msg)
 	default:
 		return nil
 	}
@@ -869,6 +873,15 @@ func (app *ChatApplication) activateSelectedIndicator() []tea.Cmd {
 				StatusType: domain.StatusDefault,
 			}
 		}}
+	case ui.StatusIndicatorActionA2AAgents:
+		_ = app.stateManager.TransitionToView(domain.ViewStateA2AAgents)
+		return []tea.Cmd{func() tea.Msg {
+			return domain.SetStatusEvent{
+				Message:    "",
+				Spinner:    false,
+				StatusType: domain.StatusDefault,
+			}
+		}}
 	case ui.StatusIndicatorActionTaskManagement:
 		if err := app.stateManager.TransitionToView(domain.ViewStateA2ATaskManagement); err != nil {
 			return []tea.Cmd{func() tea.Msg {
@@ -1069,6 +1082,8 @@ func (app *ChatApplication) viewContent() string {
 		return app.renderHelp()
 	case domain.ViewStateToolsList:
 		return app.renderToolsList()
+	case domain.ViewStateA2AAgents:
+		return app.renderA2AAgents()
 	default:
 		return fmt.Sprintf("Unknown view state: %v", currentView)
 	}
@@ -1670,6 +1685,44 @@ func (app *ChatApplication) renderToolsList() string {
 	app.toolsView.SetWidth(width)
 	app.toolsView.SetHeight(height)
 	return app.toolsView.View().Content
+}
+
+// handleA2AAgentsView drives the read-only A2A agents list, mirroring
+// handleToolsListView: a leftover cancelled flag means re-entry, so Reset
+// rebuilds the items from the latest agent readiness.
+func (app *ChatApplication) handleA2AAgentsView(msg tea.Msg) []tea.Cmd {
+	var cmds []tea.Cmd
+
+	if app.a2aAgentsView.IsCancelled() {
+		app.a2aAgentsView.Reset()
+	}
+
+	model, cmd := app.a2aAgentsView.Update(msg)
+	app.a2aAgentsView = model.(*components.A2AAgentsViewImpl)
+	if cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+
+	if app.a2aAgentsView.IsCancelled() {
+		if err := app.stateManager.TransitionToView(domain.ViewStateChat); err != nil {
+			cmds = append(cmds, func() tea.Msg {
+				return domain.ShowErrorEvent{
+					Error:  fmt.Sprintf("Failed to return to chat: %v", err),
+					Sticky: false,
+				}
+			})
+		}
+		app.focusedComponent = app.inputView
+	}
+
+	return cmds
+}
+
+func (app *ChatApplication) renderA2AAgents() string {
+	width, height := app.stateManager.GetDimensions()
+	app.a2aAgentsView.SetWidth(width)
+	app.a2aAgentsView.SetHeight(height)
+	return app.a2aAgentsView.View().Content
 }
 
 func (app *ChatApplication) renderConversationSelection() string {

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -114,6 +114,10 @@ type ChatApplication struct {
 	pendingSnippets    []components.SnippetSelection
 	attachmentsFocused bool
 
+	// Keyboard focus on the status-indicator row below the input, entered
+	// with arrow-down when input-history navigation is idle.
+	statusBarFocused bool
+
 	// Key binding system
 	keyBindingManager *keybinding.KeyBindingManager
 
@@ -592,20 +596,22 @@ func (app *ChatApplication) handleMCPStatusUpdate(event domain.MCPServerStatusUp
 func (app *ChatApplication) handleViewSpecificMessages(msg tea.Msg) []tea.Cmd {
 	currentView := app.stateManager.GetCurrentView()
 
-	if inputView, ok := app.inputView.(*components.InputView); ok {
-		inHistoryMode := false
-		if cv, ok := app.conversationView.(*components.ConversationView); ok {
-			inHistoryMode = cv.IsInMessageHistoryMode()
-		}
+	inHistoryMode := false
+	if cv, ok := app.conversationView.(*components.ConversationView); ok {
+		inHistoryMode = cv.IsInMessageHistoryMode()
+	}
 
-		if app.stateManager.GetApprovalUIState() != nil || app.stateManager.GetPlanApprovalUIState() != nil ||
-			app.stateManager.GetUserQuestionUIState() != nil ||
-			inHistoryMode || currentView == domain.ViewStateDiffViewer ||
-			currentView == domain.ViewStateExplorer || currentView == domain.ViewStateHelp {
-			inputView.SetDisabled(true)
-		} else {
-			inputView.SetDisabled(false)
-		}
+	inputBlocked := app.stateManager.GetApprovalUIState() != nil || app.stateManager.GetPlanApprovalUIState() != nil ||
+		app.stateManager.GetUserQuestionUIState() != nil ||
+		inHistoryMode || currentView == domain.ViewStateDiffViewer ||
+		currentView == domain.ViewStateExplorer || currentView == domain.ViewStateHelp
+
+	if inputView, ok := app.inputView.(*components.InputView); ok {
+		inputView.SetDisabled(inputBlocked)
+	}
+
+	if app.statusBarFocused && (inputBlocked || currentView != domain.ViewStateChat) {
+		app.blurStatusBar()
 	}
 
 	switch currentView {
@@ -697,6 +703,13 @@ func (app *ChatApplication) handleChatView(msg tea.Msg) []tea.Cmd {
 		return cmds
 	}
 
+	if _, ok := msg.(domain.FocusStatusBarEvent); ok {
+		if app.inputStatusBar.Focus() {
+			app.statusBarFocused = true
+		}
+		return cmds
+	}
+
 	keyMsg, ok := msg.(tea.KeyPressMsg)
 	if !ok {
 		return cmds
@@ -721,6 +734,11 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 
 	if app.attachmentsFocused && keyMsg.String() != "ctrl+c" {
 		return app.handleAttachmentsKeys(keyMsg)
+	}
+	if app.statusBarFocused && keyMsg.String() != "ctrl+c" {
+		if cmds, handled := app.handleStatusBarKeys(keyMsg); handled {
+			return cmds
+		}
 	}
 	if !app.attachmentsFocused && len(app.pendingSnippets) > 0 && app.matchesFocusAttachments(keyMsg) {
 		app.attachmentsFocused = true
@@ -779,6 +797,87 @@ func (app *ChatApplication) removeFocusedSnippet() {
 	app.pendingSnippets = append(app.pendingSnippets[:idx], app.pendingSnippets[idx+1:]...)
 	if len(app.pendingSnippets) == 0 {
 		app.attachmentsFocused = false
+	}
+}
+
+// handleStatusBarKeys interprets keys while the status-indicator row holds
+// focus. Unhandled keys blur the row and report handled=false so they flow
+// on to the normal chain - typing lands back in the input.
+func (app *ChatApplication) handleStatusBarKeys(keyMsg tea.KeyPressMsg) ([]tea.Cmd, bool) {
+	switch keyMsg.String() {
+	case "left", "shift+tab":
+		app.inputStatusBar.SelectPrev()
+		return nil, true
+	case "right", "tab":
+		app.inputStatusBar.SelectNext()
+		return nil, true
+	case "down":
+		return nil, true
+	case "up", "esc":
+		app.blurStatusBar()
+		return nil, true
+	case "enter":
+		return app.activateSelectedIndicator(), true
+	default:
+		app.blurStatusBar()
+		return nil, false
+	}
+}
+
+// blurStatusBar returns keyboard focus from the indicator row to the input.
+func (app *ChatApplication) blurStatusBar() {
+	app.statusBarFocused = false
+	app.inputStatusBar.Blur()
+}
+
+// activateSelectedIndicator opens the view behind the selected indicator,
+// mirroring the /model and /tasks shortcut side effects. The task view is
+// not gated on A2A - it shows shells and subagents too.
+func (app *ChatApplication) activateSelectedIndicator() []tea.Cmd {
+	action := app.inputStatusBar.SelectedAction()
+	app.blurStatusBar()
+
+	switch action {
+	case ui.StatusIndicatorActionModelSelection:
+		_ = app.stateManager.TransitionToView(domain.ViewStateModelSelection)
+		return []tea.Cmd{func() tea.Msg {
+			return domain.SetStatusEvent{
+				Message:    "Select a model from the dropdown",
+				Spinner:    false,
+				StatusType: domain.StatusDefault,
+			}
+		}}
+	case ui.StatusIndicatorActionThemeSelection:
+		_ = app.stateManager.TransitionToView(domain.ViewStateThemeSelection)
+		return []tea.Cmd{func() tea.Msg {
+			return domain.SetStatusEvent{
+				Message:    "",
+				Spinner:    false,
+				StatusType: domain.StatusDefault,
+			}
+		}}
+	case ui.StatusIndicatorActionTaskManagement:
+		if err := app.stateManager.TransitionToView(domain.ViewStateA2ATaskManagement); err != nil {
+			return []tea.Cmd{func() tea.Msg {
+				return domain.ShowErrorEvent{
+					Error:  fmt.Sprintf("Failed to show task management: %v", err),
+					Sticky: false,
+				}
+			}}
+		}
+		hasBackgroundTasks := false
+		if app.backgroundTaskService != nil {
+			hasBackgroundTasks = len(app.backgroundTaskService.GetBackgroundTasks()) > 0
+		}
+		return []tea.Cmd{func() tea.Msg {
+			return domain.SetStatusEvent{
+				Message:    "Task management interface",
+				Spinner:    hasBackgroundTasks,
+				StatusType: domain.StatusDefault,
+			}
+		}}
+	default:
+		return nil
 	}
 }
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -95,6 +95,7 @@ type ChatApplication struct {
 	diffViewer           *components.DiffViewerImpl
 	fileExplorer         *components.FileExplorerImpl
 	helpView             *components.HelpViewImpl
+	toolsView            *components.ToolsViewImpl
 
 	snippetAttachmentsView *components.SnippetAttachmentsView
 
@@ -294,6 +295,7 @@ func NewChatApplication(
 	app.toolCallRenderer.SetKeyHintFormatter(keyHintFormatter)
 	app.modelSelector = components.NewModelSelector(models, app.modelService, app.pricingService, app.config, styleProvider)
 	app.themeSelector = components.NewThemeSelector(app.themeService, styleProvider)
+	app.toolsView = components.NewToolsView(app.toolService, app.stateManager, styleProvider)
 	app.initGithubActionView = components.NewInitGithubActionView(styleProvider)
 
 	app.initGithubActionView.SetSecretsExistChecker(func(appID string) bool {
@@ -635,6 +637,8 @@ func (app *ChatApplication) handleViewSpecificMessages(msg tea.Msg) []tea.Cmd {
 		return app.handleExplorerView(msg)
 	case domain.ViewStateHelp:
 		return app.handleHelpView(msg)
+	case domain.ViewStateToolsList:
+		return app.handleToolsListView(msg)
 	default:
 		return nil
 	}
@@ -856,6 +860,15 @@ func (app *ChatApplication) activateSelectedIndicator() []tea.Cmd {
 				StatusType: domain.StatusDefault,
 			}
 		}}
+	case ui.StatusIndicatorActionToolsList:
+		_ = app.stateManager.TransitionToView(domain.ViewStateToolsList)
+		return []tea.Cmd{func() tea.Msg {
+			return domain.SetStatusEvent{
+				Message:    "",
+				Spinner:    false,
+				StatusType: domain.StatusDefault,
+			}
+		}}
 	case ui.StatusIndicatorActionTaskManagement:
 		if err := app.stateManager.TransitionToView(domain.ViewStateA2ATaskManagement); err != nil {
 			return []tea.Cmd{func() tea.Msg {
@@ -1054,6 +1067,8 @@ func (app *ChatApplication) viewContent() string {
 		return app.renderExplorer()
 	case domain.ViewStateHelp:
 		return app.renderHelp()
+	case domain.ViewStateToolsList:
+		return app.renderToolsList()
 	default:
 		return fmt.Sprintf("Unknown view state: %v", currentView)
 	}
@@ -1616,6 +1631,45 @@ func (app *ChatApplication) renderThemeSelection() string {
 	app.themeSelector.SetWidth(width)
 	app.themeSelector.SetHeight(height)
 	return app.themeSelector.View().Content
+}
+
+// handleToolsListView drives the read-only tools list. A cancelled flag left
+// over from the previous visit means we are re-entering: Reset rebuilds the
+// items so the list reflects the current agent mode and any MCP tools
+// registered since.
+func (app *ChatApplication) handleToolsListView(msg tea.Msg) []tea.Cmd {
+	var cmds []tea.Cmd
+
+	if app.toolsView.IsCancelled() {
+		app.toolsView.Reset()
+	}
+
+	model, cmd := app.toolsView.Update(msg)
+	app.toolsView = model.(*components.ToolsViewImpl)
+	if cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+
+	if app.toolsView.IsCancelled() {
+		if err := app.stateManager.TransitionToView(domain.ViewStateChat); err != nil {
+			cmds = append(cmds, func() tea.Msg {
+				return domain.ShowErrorEvent{
+					Error:  fmt.Sprintf("Failed to return to chat: %v", err),
+					Sticky: false,
+				}
+			})
+		}
+		app.focusedComponent = app.inputView
+	}
+
+	return cmds
+}
+
+func (app *ChatApplication) renderToolsList() string {
+	width, height := app.stateManager.GetDimensions()
+	app.toolsView.SetWidth(width)
+	app.toolsView.SetHeight(height)
+	return app.toolsView.View().Content
 }
 
 func (app *ChatApplication) renderConversationSelection() string {

--- a/internal/app/chat_status_bar_test.go
+++ b/internal/app/chat_status_bar_test.go
@@ -5,6 +5,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	sdk "github.com/inference-gateway/sdk"
+
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 
 	config "github.com/inference-gateway/cli/config"
@@ -115,6 +117,41 @@ func TestStatusBarEnterOpensThemeSelection(t *testing.T) {
 	}
 	if got := stateManager.TransitionToViewArgsForCall(0); got != domain.ViewStateThemeSelection {
 		t.Errorf("transitioned to %v, want theme selection", got)
+	}
+	if len(cmds) != 1 {
+		t.Fatalf("expected one status command, got %d", len(cmds))
+	}
+	if _, ok := cmds[0]().(domain.SetStatusEvent); !ok {
+		t.Fatalf("expected a SetStatusEvent, got %T", cmds[0]())
+	}
+}
+
+// toolStatsEstimator is a minimal domain.TokenEstimator so the tools
+// indicator renders in tests.
+type toolStatsEstimator struct{}
+
+func (toolStatsEstimator) GetToolStats(domain.ToolService, domain.AgentMode) (int, int) {
+	return 8017, 25
+}
+
+func (toolStatsEstimator) EstimateMessagesTokens([]sdk.Message) int { return 0 }
+
+func TestStatusBarEnterOpensToolsList(t *testing.T) {
+	app, stateManager := newStatusBarTestApp(t, false, false)
+	statusBar := app.inputStatusBar.(*components.InputStatusBar)
+	statusBar.SetToolService(&domainmocks.FakeToolService{})
+	statusBar.SetTokenEstimator(toolStatsEstimator{})
+
+	app.handleChatView(domain.FocusStatusBarEvent{})
+
+	_ = app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyRight})
+	cmds := app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if stateManager.TransitionToViewCallCount() != 1 {
+		t.Fatalf("expected one view transition, got %d", stateManager.TransitionToViewCallCount())
+	}
+	if got := stateManager.TransitionToViewArgsForCall(0); got != domain.ViewStateToolsList {
+		t.Errorf("transitioned to %v, want the tools list", got)
 	}
 	if len(cmds) != 1 {
 		t.Fatalf("expected one status command, got %d", len(cmds))

--- a/internal/app/chat_status_bar_test.go
+++ b/internal/app/chat_status_bar_test.go
@@ -161,6 +161,32 @@ func TestStatusBarEnterOpensToolsList(t *testing.T) {
 	}
 }
 
+func TestStatusBarEnterOpensA2AAgents(t *testing.T) {
+	app, stateManager := newStatusBarTestApp(t, false, false)
+	statusBar := app.inputStatusBar.(*components.InputStatusBar)
+	barStateManager := &domainmocks.FakeStateManager{}
+	barStateManager.GetAgentReadinessReturns(&domain.AgentReadinessState{TotalAgents: 1, ReadyAgents: 1})
+	statusBar.SetStateManager(barStateManager)
+
+	app.handleChatView(domain.FocusStatusBarEvent{})
+
+	_ = app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyRight})
+	cmds := app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if stateManager.TransitionToViewCallCount() != 1 {
+		t.Fatalf("expected one view transition, got %d", stateManager.TransitionToViewCallCount())
+	}
+	if got := stateManager.TransitionToViewArgsForCall(0); got != domain.ViewStateA2AAgents {
+		t.Errorf("transitioned to %v, want the A2A agents view", got)
+	}
+	if len(cmds) != 1 {
+		t.Fatalf("expected one status command, got %d", len(cmds))
+	}
+	if _, ok := cmds[0]().(domain.SetStatusEvent); !ok {
+		t.Fatalf("expected a SetStatusEvent, got %T", cmds[0]())
+	}
+}
+
 func TestStatusBarEnterOpensTaskManagement(t *testing.T) {
 	app, stateManager := newStatusBarTestApp(t, true, false)
 	app.handleChatView(domain.FocusStatusBarEvent{})

--- a/internal/app/chat_status_bar_test.go
+++ b/internal/app/chat_status_bar_test.go
@@ -1,0 +1,191 @@
+package app
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	components "github.com/inference-gateway/cli/internal/ui/components"
+)
+
+// newStatusBarTestApp wires the minimal ChatApplication surface used by the
+// status-indicator focus flow: a real InputStatusBar with a visible model
+// indicator (plus, optionally, theme and jobs indicators) and a fake state
+// manager capturing view transitions.
+func newStatusBarTestApp(t *testing.T, withJobs, withTheme bool) (*ChatApplication, *domainmocks.FakeStateManager) {
+	t.Helper()
+
+	modelService := &domainmocks.FakeModelService{}
+	modelService.GetCurrentModelReturns("test-model")
+
+	statusBar := components.NewInputStatusBar(nil)
+	statusBar.SetModelService(modelService)
+	statusBar.SetConfig(config.DefaultConfig())
+
+	if withJobs {
+		registry := &domainmocks.FakeBackgroundTaskRegistry{}
+		registry.CountRunningJobsReturns(1)
+		statusBar.SetBackgroundTaskRegistry(registry)
+	}
+
+	if withTheme {
+		themeService := &domainmocks.FakeThemeService{}
+		themeService.GetCurrentThemeNameReturns("tokyo-night")
+		statusBar.SetThemeService(themeService)
+	}
+
+	stateManager := &domainmocks.FakeStateManager{}
+
+	app := &ChatApplication{
+		inputStatusBar: statusBar,
+		stateManager:   stateManager,
+	}
+	return app, stateManager
+}
+
+func TestFocusStatusBarEventFocusesRow(t *testing.T) {
+	app, _ := newStatusBarTestApp(t, false, false)
+
+	app.handleChatView(domain.FocusStatusBarEvent{})
+	if !app.statusBarFocused {
+		t.Fatal("FocusStatusBarEvent should focus the row when an indicator is actionable")
+	}
+	if !app.inputStatusBar.IsFocused() {
+		t.Fatal("the status bar component should be focused too")
+	}
+}
+
+func TestFocusStatusBarEventNoopsWithoutActionableIndicator(t *testing.T) {
+	app, _ := newStatusBarTestApp(t, false, false)
+	statusBar := app.inputStatusBar.(*components.InputStatusBar)
+	cfg := config.DefaultConfig()
+	cfg.Chat.StatusBar.Indicators.Model = false
+	statusBar.SetConfig(cfg)
+
+	app.handleChatView(domain.FocusStatusBarEvent{})
+	if app.statusBarFocused {
+		t.Fatal("nothing actionable: focus must stay in the input")
+	}
+}
+
+// TestStatusBarEnterOpensModelSelection drives the full chat-view key path:
+// enter on the focused row transitions to model selection with the same
+// status message the /model shortcut emits.
+func TestStatusBarEnterOpensModelSelection(t *testing.T) {
+	app, stateManager := newStatusBarTestApp(t, false, false)
+	app.handleChatView(domain.FocusStatusBarEvent{})
+
+	cmds := app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if stateManager.TransitionToViewCallCount() != 1 {
+		t.Fatalf("expected one view transition, got %d", stateManager.TransitionToViewCallCount())
+	}
+	if got := stateManager.TransitionToViewArgsForCall(0); got != domain.ViewStateModelSelection {
+		t.Errorf("transitioned to %v, want model selection", got)
+	}
+	if app.statusBarFocused || app.inputStatusBar.IsFocused() {
+		t.Error("activation must return focus to the input")
+	}
+
+	if len(cmds) != 1 {
+		t.Fatalf("expected one status command, got %d", len(cmds))
+	}
+	ev, ok := cmds[0]().(domain.SetStatusEvent)
+	if !ok {
+		t.Fatalf("expected a SetStatusEvent, got %T", cmds[0]())
+	}
+	if ev.Message != "Select a model from the dropdown" {
+		t.Errorf("unexpected status message %q", ev.Message)
+	}
+}
+
+func TestStatusBarEnterOpensThemeSelection(t *testing.T) {
+	app, stateManager := newStatusBarTestApp(t, false, true)
+	app.handleChatView(domain.FocusStatusBarEvent{})
+
+	_ = app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyRight})
+	cmds := app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if stateManager.TransitionToViewCallCount() != 1 {
+		t.Fatalf("expected one view transition, got %d", stateManager.TransitionToViewCallCount())
+	}
+	if got := stateManager.TransitionToViewArgsForCall(0); got != domain.ViewStateThemeSelection {
+		t.Errorf("transitioned to %v, want theme selection", got)
+	}
+	if len(cmds) != 1 {
+		t.Fatalf("expected one status command, got %d", len(cmds))
+	}
+	if _, ok := cmds[0]().(domain.SetStatusEvent); !ok {
+		t.Fatalf("expected a SetStatusEvent, got %T", cmds[0]())
+	}
+}
+
+func TestStatusBarEnterOpensTaskManagement(t *testing.T) {
+	app, stateManager := newStatusBarTestApp(t, true, false)
+	app.handleChatView(domain.FocusStatusBarEvent{})
+
+	_ = app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyRight})
+	cmds := app.handleChatViewKeyPress(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if stateManager.TransitionToViewCallCount() != 1 {
+		t.Fatalf("expected one view transition, got %d", stateManager.TransitionToViewCallCount())
+	}
+	if got := stateManager.TransitionToViewArgsForCall(0); got != domain.ViewStateA2ATaskManagement {
+		t.Errorf("transitioned to %v, want task management", got)
+	}
+
+	if len(cmds) != 1 {
+		t.Fatalf("expected one status command, got %d", len(cmds))
+	}
+	ev, ok := cmds[0]().(domain.SetStatusEvent)
+	if !ok {
+		t.Fatalf("expected a SetStatusEvent, got %T", cmds[0]())
+	}
+	if ev.Message != "Task management interface" {
+		t.Errorf("unexpected status message %q", ev.Message)
+	}
+}
+
+func TestStatusBarNavigationAndExitKeys(t *testing.T) {
+	app, stateManager := newStatusBarTestApp(t, true, false)
+
+	tests := []struct {
+		name      string
+		key       tea.KeyPressMsg
+		handled   bool
+		stillOpen bool
+	}{
+		{"right selects next", tea.KeyPressMsg{Code: tea.KeyRight}, true, true},
+		{"left selects previous", tea.KeyPressMsg{Code: tea.KeyLeft}, true, true},
+		{"tab selects next", tea.KeyPressMsg{Code: tea.KeyTab}, true, true},
+		{"down is consumed", tea.KeyPressMsg{Code: tea.KeyDown}, true, true},
+		{"esc returns to input", tea.KeyPressMsg{Code: tea.KeyEscape}, true, false},
+		{"up returns to input", tea.KeyPressMsg{Code: tea.KeyUp}, true, false},
+		{"typing falls through to the input", tea.KeyPressMsg{Text: "a", Code: 'a'}, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app.handleChatView(domain.FocusStatusBarEvent{})
+			if !app.statusBarFocused {
+				t.Fatal("precondition failed: row not focused")
+			}
+
+			_, handled := app.handleStatusBarKeys(tt.key)
+			if handled != tt.handled {
+				t.Errorf("handled = %v, want %v", handled, tt.handled)
+			}
+			if app.statusBarFocused != tt.stillOpen {
+				t.Errorf("statusBarFocused = %v, want %v", app.statusBarFocused, tt.stillOpen)
+			}
+		})
+	}
+
+	if stateManager.TransitionToViewCallCount() != 0 {
+		t.Errorf("navigation and exit keys must not transition views, got %d", stateManager.TransitionToViewCallCount())
+	}
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -529,6 +529,7 @@ func (c *ServiceContainer) registerDefaultCommands() {
 	c.shortcutRegistry.Register(shortcuts.NewExitShortcut())
 	c.shortcutRegistry.Register(shortcuts.NewSwitchShortcut(c.modelService))
 	c.shortcutRegistry.Register(shortcuts.NewThemeShortcut(c.themeService))
+	c.shortcutRegistry.Register(shortcuts.NewToolsShortcut())
 	c.shortcutRegistry.Register(shortcuts.NewHelpShortcut(c.shortcutRegistry))
 	c.shortcutRegistry.Register(shortcuts.NewDiffShortcut())
 	c.shortcutRegistry.Register(shortcuts.NewExplorerShortcut())

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -546,6 +546,7 @@ func (c *ServiceContainer) registerDefaultCommands() {
 
 	if c.config.IsA2AToolsEnabled() {
 		c.shortcutRegistry.Register(shortcuts.NewA2ATaskManagementShortcut(c.config))
+		c.shortcutRegistry.Register(shortcuts.NewA2AAgentsShortcut())
 	}
 
 	if c.config.IsSpeechToTextEnabled() {

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -75,6 +75,7 @@ const (
 	ViewStateDiffViewer
 	ViewStateExplorer
 	ViewStateHelp
+	ViewStateToolsList
 )
 
 // AgentMode represents the operational mode of the agent
@@ -153,6 +154,8 @@ func (v ViewState) String() string {
 		return "Explorer"
 	case ViewStateHelp:
 		return "Help"
+	case ViewStateToolsList:
+		return "ToolsList"
 	default:
 		return "Unknown"
 	}
@@ -525,6 +528,7 @@ func (s *ApplicationState) isValidTransition(from, to ViewState) bool {
 			ViewStateDiffViewer,
 			ViewStateExplorer,
 			ViewStateHelp,
+			ViewStateToolsList,
 		},
 		ViewStateFileSelection:         {ViewStateChat},
 		ViewStateConversationSelection: {ViewStateChat},
@@ -535,6 +539,7 @@ func (s *ApplicationState) isValidTransition(from, to ViewState) bool {
 		ViewStateDiffViewer:            {ViewStateChat},
 		ViewStateExplorer:              {ViewStateChat},
 		ViewStateHelp:                  {ViewStateChat},
+		ViewStateToolsList:             {ViewStateChat},
 	}
 
 	allowed, exists := validTransitions[from]

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -76,6 +76,7 @@ const (
 	ViewStateExplorer
 	ViewStateHelp
 	ViewStateToolsList
+	ViewStateA2AAgents
 )
 
 // AgentMode represents the operational mode of the agent
@@ -156,6 +157,8 @@ func (v ViewState) String() string {
 		return "Help"
 	case ViewStateToolsList:
 		return "ToolsList"
+	case ViewStateA2AAgents:
+		return "A2AAgents"
 	default:
 		return "Unknown"
 	}
@@ -529,6 +532,7 @@ func (s *ApplicationState) isValidTransition(from, to ViewState) bool {
 			ViewStateExplorer,
 			ViewStateHelp,
 			ViewStateToolsList,
+			ViewStateA2AAgents,
 		},
 		ViewStateFileSelection:         {ViewStateChat},
 		ViewStateConversationSelection: {ViewStateChat},
@@ -540,6 +544,7 @@ func (s *ApplicationState) isValidTransition(from, to ViewState) bool {
 		ViewStateExplorer:              {ViewStateChat},
 		ViewStateHelp:                  {ViewStateChat},
 		ViewStateToolsList:             {ViewStateChat},
+		ViewStateA2AAgents:             {ViewStateChat},
 	}
 
 	allowed, exists := validTransitions[from]

--- a/internal/domain/ui_events.go
+++ b/internal/domain/ui_events.go
@@ -65,6 +65,10 @@ type SetInputEvent struct {
 	Text string
 }
 
+// FocusStatusBarEvent moves keyboard focus to the status-indicator row below
+// the input, fired when arrow-down would otherwise be a no-op
+type FocusStatusBarEvent struct{}
+
 // AutocompleteUpdateEvent is fired when input text changes and autocomplete should update
 type AutocompleteUpdateEvent struct {
 	Text      string

--- a/internal/handlers/chat_shortcut_handler.go
+++ b/internal/handlers/chat_shortcut_handler.go
@@ -213,6 +213,8 @@ func (s *ChatShortcutHandler) handleShortcutSideEffect(sideEffect shortcuts.Side
 		return s.handleShowDiffViewerSideEffect()
 	case shortcuts.SideEffectShowExplorer:
 		return s.handleShowExplorerSideEffect()
+	case shortcuts.SideEffectShowToolsList:
+		return s.handleShowToolsListSideEffect()
 	case shortcuts.SideEffectSetInput:
 		return s.handleSetInputSideEffect(data)
 	case shortcuts.SideEffectGenerateSnippet:
@@ -244,6 +246,15 @@ func (s *ChatShortcutHandler) handleSwitchModelSideEffect() tea.Msg {
 
 func (s *ChatShortcutHandler) handleSwitchThemeSideEffect() tea.Msg {
 	_ = s.handler.stateManager.TransitionToView(domain.ViewStateThemeSelection)
+	return domain.SetStatusEvent{
+		Message:    "",
+		Spinner:    false,
+		StatusType: domain.StatusDefault,
+	}
+}
+
+func (s *ChatShortcutHandler) handleShowToolsListSideEffect() tea.Msg {
+	_ = s.handler.stateManager.TransitionToView(domain.ViewStateToolsList)
 	return domain.SetStatusEvent{
 		Message:    "",
 		Spinner:    false,

--- a/internal/handlers/chat_shortcut_handler.go
+++ b/internal/handlers/chat_shortcut_handler.go
@@ -215,6 +215,8 @@ func (s *ChatShortcutHandler) handleShortcutSideEffect(sideEffect shortcuts.Side
 		return s.handleShowExplorerSideEffect()
 	case shortcuts.SideEffectShowToolsList:
 		return s.handleShowToolsListSideEffect()
+	case shortcuts.SideEffectShowA2AAgents:
+		return s.handleShowA2AAgentsSideEffect()
 	case shortcuts.SideEffectSetInput:
 		return s.handleSetInputSideEffect(data)
 	case shortcuts.SideEffectGenerateSnippet:
@@ -255,6 +257,15 @@ func (s *ChatShortcutHandler) handleSwitchThemeSideEffect() tea.Msg {
 
 func (s *ChatShortcutHandler) handleShowToolsListSideEffect() tea.Msg {
 	_ = s.handler.stateManager.TransitionToView(domain.ViewStateToolsList)
+	return domain.SetStatusEvent{
+		Message:    "",
+		Spinner:    false,
+		StatusType: domain.StatusDefault,
+	}
+}
+
+func (s *ChatShortcutHandler) handleShowA2AAgentsSideEffect() tea.Msg {
+	_ = s.handler.stateManager.TransitionToView(domain.ViewStateA2AAgents)
 	return domain.SetStatusEvent{
 		Message:    "",
 		Spinner:    false,

--- a/internal/shortcuts/core.go
+++ b/internal/shortcuts/core.go
@@ -524,3 +524,25 @@ func (c *ToolsShortcut) Execute(ctx context.Context, args []string) (ShortcutRes
 		SideEffect: SideEffectShowToolsList,
 	}, nil
 }
+
+// A2AAgentsShortcut shows the registered A2A agents and their readiness
+type A2AAgentsShortcut struct{}
+
+func NewA2AAgentsShortcut() *A2AAgentsShortcut {
+	return &A2AAgentsShortcut{}
+}
+
+func (c *A2AAgentsShortcut) GetName() string { return "a2a" }
+func (c *A2AAgentsShortcut) GetDescription() string {
+	return "Show registered A2A agents and their status"
+}
+func (c *A2AAgentsShortcut) GetUsage() string              { return "/a2a" }
+func (c *A2AAgentsShortcut) CanExecute(args []string) bool { return len(args) == 0 }
+
+func (c *A2AAgentsShortcut) Execute(ctx context.Context, args []string) (ShortcutResult, error) {
+	return ShortcutResult{
+		Output:     "",
+		Success:    true,
+		SideEffect: SideEffectShowA2AAgents,
+	}, nil
+}

--- a/internal/shortcuts/core.go
+++ b/internal/shortcuts/core.go
@@ -504,3 +504,23 @@ func (c *ThemeShortcut) Execute(ctx context.Context, args []string) (ShortcutRes
 		Data:       themeName,
 	}, nil
 }
+
+// ToolsShortcut shows the tools currently available to the agent
+type ToolsShortcut struct{}
+
+func NewToolsShortcut() *ToolsShortcut {
+	return &ToolsShortcut{}
+}
+
+func (c *ToolsShortcut) GetName() string               { return "tools" }
+func (c *ToolsShortcut) GetDescription() string        { return "Show the tools available to the agent" }
+func (c *ToolsShortcut) GetUsage() string              { return "/tools" }
+func (c *ToolsShortcut) CanExecute(args []string) bool { return len(args) == 0 }
+
+func (c *ToolsShortcut) Execute(ctx context.Context, args []string) (ShortcutResult, error) {
+	return ShortcutResult{
+		Output:     "",
+		Success:    true,
+		SideEffect: SideEffectShowToolsList,
+	}, nil
+}

--- a/internal/shortcuts/core_test.go
+++ b/internal/shortcuts/core_test.go
@@ -187,3 +187,29 @@ func TestToolsShortcut_Execute_OpensToolsList(t *testing.T) {
 		t.Error("expected Success to be true")
 	}
 }
+
+func TestA2AAgentsShortcut_Execute_OpensAgentsView(t *testing.T) {
+	a2a := NewA2AAgentsShortcut()
+
+	if !a2a.CanExecute(nil) {
+		t.Error("expected /a2a to accept no arguments")
+	}
+	if a2a.CanExecute([]string{"extra"}) {
+		t.Error("expected /a2a to reject arguments")
+	}
+
+	res, err := a2a.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if res.Output != "" {
+		t.Errorf("expected empty output so nothing is appended to the conversation, got: %q", res.Output)
+	}
+	if res.SideEffect != SideEffectShowA2AAgents {
+		t.Errorf("expected SideEffectShowA2AAgents to drive the view, got: %v", res.SideEffect)
+	}
+	if !res.Success {
+		t.Error("expected Success to be true")
+	}
+}

--- a/internal/shortcuts/core_test.go
+++ b/internal/shortcuts/core_test.go
@@ -161,3 +161,29 @@ func TestHelpShortcut_Execute_UnknownShortcut(t *testing.T) {
 		t.Errorf("expected an 'Unknown shortcut' message, got: %q", res.Output)
 	}
 }
+
+func TestToolsShortcut_Execute_OpensToolsList(t *testing.T) {
+	tools := NewToolsShortcut()
+
+	if !tools.CanExecute(nil) {
+		t.Error("expected /tools to accept no arguments")
+	}
+	if tools.CanExecute([]string{"extra"}) {
+		t.Error("expected /tools to reject arguments")
+	}
+
+	res, err := tools.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if res.Output != "" {
+		t.Errorf("expected empty output so nothing is appended to the conversation, got: %q", res.Output)
+	}
+	if res.SideEffect != SideEffectShowToolsList {
+		t.Errorf("expected SideEffectShowToolsList to drive the view, got: %v", res.SideEffect)
+	}
+	if !res.Success {
+		t.Error("expected Success to be true")
+	}
+}

--- a/internal/shortcuts/interfaces.go
+++ b/internal/shortcuts/interfaces.go
@@ -47,6 +47,7 @@ const (
 	SideEffectShowDiffViewer
 	SideEffectShowExplorer
 	SideEffectShowToolsList
+	SideEffectShowA2AAgents
 )
 
 // PersistentConversationRepository interface for conversation persistence

--- a/internal/shortcuts/interfaces.go
+++ b/internal/shortcuts/interfaces.go
@@ -46,6 +46,7 @@ const (
 	SideEffectSendMessageWithModel
 	SideEffectShowDiffViewer
 	SideEffectShowExplorer
+	SideEffectShowToolsList
 )
 
 // PersistentConversationRepository interface for conversation persistence

--- a/internal/ui/components/a2a_agents_view.go
+++ b/internal/ui/components/a2a_agents_view.go
@@ -1,0 +1,222 @@
+package components
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+
+	list "charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+// a2aAgentItem is a single row in the A2A agents list.
+type a2aAgentItem struct {
+	name   string
+	url    string
+	state  string
+	failed bool
+	detail string
+}
+
+// FilterValue is what the list filters against when the user searches (/).
+func (i a2aAgentItem) FilterValue() string { return i.name }
+
+// a2aAgentDelegate renders an a2aAgentItem as a single line: a caret on the
+// highlighted row, the agent name, its state (error-colored on failure), and
+// the URL dimmed.
+type a2aAgentDelegate struct {
+	styleProvider *styles.Provider
+}
+
+func (d a2aAgentDelegate) Height() int                             { return 1 }
+func (d a2aAgentDelegate) Spacing() int                            { return 0 }
+func (d a2aAgentDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d a2aAgentDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	it, ok := item.(a2aAgentItem)
+	if !ok {
+		return
+	}
+
+	selected := index == m.Index()
+
+	prefix := "  "
+	if selected {
+		prefix = "▶ "
+	}
+
+	name := prefix + it.name
+	if selected {
+		name = d.styleProvider.RenderWithColor(name, d.styleProvider.GetThemeColor("accent"))
+	}
+
+	stateColor := d.styleProvider.GetThemeColor("status")
+	if it.failed {
+		stateColor = d.styleProvider.GetThemeColor("error")
+	}
+	state := d.styleProvider.RenderWithColor(" ["+it.state+"]", stateColor)
+
+	detail := it.detail
+	if detail == "" {
+		detail = it.url
+	}
+	if detail != "" {
+		detail = d.styleProvider.RenderWithColor(" — "+detail, d.styleProvider.GetThemeColor("dim"))
+	}
+
+	_, _ = fmt.Fprint(w, name+state+detail)
+}
+
+// A2AAgentsViewImpl is a read-only, filterable list of the registered A2A
+// agents and their readiness. Like the tools view it is display-only for now.
+type A2AAgentsViewImpl struct {
+	list          list.Model
+	width         int
+	height        int
+	cancelled     bool
+	stateManager  domain.StateManager
+	styleProvider *styles.Provider
+}
+
+// NewA2AAgentsView creates the A2A agents list view. Items are populated by
+// Reset on every entry because agent readiness changes as agents start up.
+func NewA2AAgentsView(stateManager domain.StateManager, styleProvider *styles.Provider) *A2AAgentsViewImpl {
+	l := list.New(
+		nil,
+		a2aAgentDelegate{styleProvider: styleProvider},
+		80, 24,
+	)
+	l.SetShowStatusBar(true)
+	l.SetFilteringEnabled(true)
+	l.SetShowHelp(true)
+	l.DisableQuitKeybindings()
+	l.Styles.Title = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(styleProvider.GetThemeColor("accent"))).
+		Bold(true)
+
+	m := &A2AAgentsViewImpl{
+		list:          l,
+		width:         80,
+		height:        24,
+		stateManager:  stateManager,
+		styleProvider: styleProvider,
+	}
+	m.Reset()
+	return m
+}
+
+// agentItems builds the list items from the current agent readiness state,
+// sorted by name for a stable order.
+func (m *A2AAgentsViewImpl) agentItems() ([]list.Item, int, int) {
+	if m.stateManager == nil {
+		return nil, 0, 0
+	}
+
+	readiness := m.stateManager.GetAgentReadiness()
+	if readiness == nil {
+		return nil, 0, 0
+	}
+
+	items := make([]list.Item, 0, len(readiness.Agents))
+	for _, name := range slices.Sorted(maps.Keys(readiness.Agents)) {
+		status := readiness.Agents[name]
+		if status == nil {
+			continue
+		}
+		item := a2aAgentItem{
+			name:   status.Name,
+			url:    status.URL,
+			state:  status.State.DisplayName(),
+			failed: status.State == domain.AgentStateFailed,
+		}
+		if item.name == "" {
+			item.name = name
+		}
+		if status.Error != "" {
+			item.detail = status.Error
+		} else if status.Message != "" {
+			item.detail = status.Message
+		}
+		items = append(items, item)
+	}
+	return items, readiness.ReadyAgents, readiness.TotalAgents
+}
+
+func (m *A2AAgentsViewImpl) Init() tea.Cmd { return nil }
+
+func (m *A2AAgentsViewImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.list.SetSize(msg.Width, msg.Height)
+		return m, nil
+	case tea.KeyPressMsg:
+		if handled, cmd := m.handleKey(msg); handled {
+			return m, cmd
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+// handleKey intercepts the cancel keys when the list is not actively
+// filtering; otherwise it lets the list own typing, enter (apply filter) and
+// esc (clear filter). Enter outside filtering is consumed as a no-op.
+func (m *A2AAgentsViewImpl) handleKey(msg tea.KeyPressMsg) (handled bool, cmd tea.Cmd) {
+	if m.list.FilterState() == list.Filtering {
+		return false, nil
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		m.cancelled = true
+		return true, nil
+	case "esc":
+		if m.list.FilterState() == list.FilterApplied {
+			return false, nil
+		}
+		m.cancelled = true
+		return true, nil
+	case "enter", " ":
+		return true, nil
+	}
+	return false, nil
+}
+
+func (m *A2AAgentsViewImpl) View() tea.View {
+	return tea.NewView(m.list.View())
+}
+
+// IsCancelled returns true once the user has dismissed the view.
+func (m *A2AAgentsViewImpl) IsCancelled() bool { return m.cancelled }
+
+// SetWidth sets the width of the agents view.
+func (m *A2AAgentsViewImpl) SetWidth(width int) {
+	m.width = width
+	m.list.SetSize(width, m.height)
+}
+
+// SetHeight sets the height of the agents view.
+func (m *A2AAgentsViewImpl) SetHeight(height int) {
+	m.height = height
+	m.list.SetSize(m.width, height)
+}
+
+// Reset returns the view to its initial state and rebuilds the items so the
+// list reflects the latest agent readiness.
+func (m *A2AAgentsViewImpl) Reset() {
+	m.cancelled = false
+	m.list.ResetFilter()
+	items, ready, total := m.agentItems()
+	m.list.SetItems(items)
+	m.list.Select(0)
+	m.list.Title = fmt.Sprintf("A2A Agents (%d/%d ready)", ready, total)
+}

--- a/internal/ui/components/a2a_agents_view_test.go
+++ b/internal/ui/components/a2a_agents_view_test.go
@@ -1,0 +1,119 @@
+package components
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+// newA2AAgentsViewForTest builds an agents view backed by a fake state
+// manager reporting the given readiness.
+func newA2AAgentsViewForTest(readiness *domain.AgentReadinessState) (*A2AAgentsViewImpl, *domainmocks.FakeStateManager) {
+	fakeTheme := &uimocks.FakeTheme{}
+	fakeTheme.GetAccentColorReturns("#ff9e64")
+	fakeTheme.GetDimColorReturns("#888888")
+	fakeTheme.GetStatusColorReturns("#e0af68")
+	fakeTheme.GetErrorColorReturns("#f7768e")
+	themeService := &domainmocks.FakeThemeService{}
+	themeService.GetCurrentThemeReturns(fakeTheme)
+
+	stateManager := &domainmocks.FakeStateManager{}
+	stateManager.GetAgentReadinessReturns(readiness)
+
+	view := NewA2AAgentsView(stateManager, styles.NewProvider(themeService))
+	return view, stateManager
+}
+
+func TestA2AAgentsView_ItemsReflectReadiness(t *testing.T) {
+	view, _ := newA2AAgentsViewForTest(&domain.AgentReadinessState{
+		TotalAgents: 2,
+		ReadyAgents: 1,
+		Agents: map[string]*domain.AgentStatus{
+			"writer": {Name: "writer", URL: "http://localhost:8081", State: domain.AgentStateReady},
+			"coder":  {Name: "coder", URL: "http://localhost:8082", State: domain.AgentStateFailed, Error: "connection refused"},
+		},
+	})
+
+	items := view.list.Items()
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	first := items[0].(a2aAgentItem)
+	if first.name != "coder" || !first.failed || first.detail != "connection refused" {
+		t.Errorf("items must be sorted by name with failure details, got %+v", first)
+	}
+	second := items[1].(a2aAgentItem)
+	if second.name != "writer" || second.failed || second.state != "ready" {
+		t.Errorf("unexpected second item: %+v", second)
+	}
+
+	if view.list.Title != "A2A Agents (1/2 ready)" {
+		t.Errorf("title = %q, want the readiness summary", view.list.Title)
+	}
+}
+
+func TestA2AAgentsView_NilReadinessIsSafe(t *testing.T) {
+	view, _ := newA2AAgentsViewForTest(nil)
+
+	if got := len(view.list.Items()); got != 0 {
+		t.Fatalf("expected no items without readiness, got %d", got)
+	}
+	if view.list.Title != "A2A Agents (0/0 ready)" {
+		t.Errorf("title = %q, want an empty readiness summary", view.list.Title)
+	}
+}
+
+func TestA2AAgentsView_EscCancelsEnterDoesNot(t *testing.T) {
+	view, _ := newA2AAgentsViewForTest(&domain.AgentReadinessState{
+		TotalAgents: 1,
+		ReadyAgents: 1,
+		Agents:      map[string]*domain.AgentStatus{"writer": {Name: "writer", State: domain.AgentStateReady}},
+	})
+
+	model, _ := view.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	view = model.(*A2AAgentsViewImpl)
+	if view.IsCancelled() {
+		t.Fatal("enter is a no-op in the read-only agents view")
+	}
+
+	model, _ = view.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	view = model.(*A2AAgentsViewImpl)
+	if !view.IsCancelled() {
+		t.Fatal("esc should cancel the agents view")
+	}
+}
+
+func TestA2AAgentsView_ResetRefreshesReadiness(t *testing.T) {
+	view, stateManager := newA2AAgentsViewForTest(&domain.AgentReadinessState{
+		TotalAgents: 1,
+		ReadyAgents: 0,
+		Agents:      map[string]*domain.AgentStatus{"writer": {Name: "writer", State: domain.AgentStateStarting}},
+	})
+
+	model, _ := view.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	view = model.(*A2AAgentsViewImpl)
+
+	stateManager.GetAgentReadinessReturns(&domain.AgentReadinessState{
+		TotalAgents: 1,
+		ReadyAgents: 1,
+		Agents:      map[string]*domain.AgentStatus{"writer": {Name: "writer", State: domain.AgentStateReady}},
+	})
+	view.Reset()
+
+	if view.IsCancelled() {
+		t.Error("Reset must clear the cancelled flag")
+	}
+	if view.list.Title != "A2A Agents (1/1 ready)" {
+		t.Errorf("title = %q, want the refreshed readiness", view.list.Title)
+	}
+	if got := view.list.Items()[0].(a2aAgentItem); got.state != "ready" {
+		t.Errorf("Reset should re-read agent state, got %+v", got)
+	}
+}

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -343,7 +343,7 @@ func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []indicatorP
 
 	if isb.shouldShowIndicator("tools") {
 		if toolInfo := isb.getToolInfo(); toolInfo != "" {
-			parts = append(parts, indicatorPart{text: toolInfo})
+			parts = append(parts, indicatorPart{text: toolInfo, action: ui.StatusIndicatorActionToolsList})
 		}
 	}
 
@@ -380,6 +380,10 @@ func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []indicatorP
 	return parts
 }
 
+// selectedIndicatorPadding is the extra width the selected part's pill adds:
+// one column of padding on each side (see Provider.RenderSelectedIndicator).
+const selectedIndicatorPadding = 2
+
 // splitPartsIntoLines splits indicator parts into line groups based on available width
 func (isb *InputStatusBar) splitPartsIntoLines(parts []indicatorPart, availableWidth, maxLines, separatorWidth int) [][]indicatorPart {
 	var lineGroups [][]indicatorPart
@@ -388,6 +392,9 @@ func (isb *InputStatusBar) splitPartsIntoLines(parts []indicatorPart, availableW
 
 	for i, part := range parts {
 		itemWidth := len(part.text)
+		if part.selected {
+			itemWidth += selectedIndicatorPadding
+		}
 		separatorLen := 0
 
 		if len(currentLineItems) > 0 {

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -11,6 +11,7 @@ import (
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	models "github.com/inference-gateway/cli/internal/models"
+	ui "github.com/inference-gateway/cli/internal/ui"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
@@ -30,6 +31,19 @@ type InputStatusBar struct {
 	mcpStatus              *domain.MCPServerStatus
 	styleProvider          *styles.Provider
 	currentInputText       string
+
+	// Keyboard focus state: when focused, selected indexes the actionable
+	// indicators (those that open a view) in build order.
+	focused  bool
+	selected int
+}
+
+// indicatorPart is one status-bar segment plus the view it opens when
+// activated (StatusIndicatorActionNone for display-only segments).
+type indicatorPart struct {
+	text     string
+	action   ui.StatusIndicatorAction
+	selected bool
 }
 
 // NewInputStatusBar creates a new input status bar
@@ -109,6 +123,76 @@ func (isb *InputStatusBar) SetHeight(height int) {
 	// Status bar has fixed height
 }
 
+// Focus moves keyboard focus onto the indicator row, selecting the first
+// actionable indicator. Reports false when nothing is actionable so the
+// caller can keep focus in the input.
+func (isb *InputStatusBar) Focus() bool {
+	if len(isb.actionableActions()) == 0 {
+		return false
+	}
+	isb.focused = true
+	isb.selected = 0
+	return true
+}
+
+// Blur returns the indicator row to its passive display-only state.
+func (isb *InputStatusBar) Blur() {
+	isb.focused = false
+}
+
+// IsFocused reports whether the indicator row holds keyboard focus.
+func (isb *InputStatusBar) IsFocused() bool {
+	return isb.focused
+}
+
+// SelectNext moves the selection to the next actionable indicator, wrapping.
+func (isb *InputStatusBar) SelectNext() {
+	if count := len(isb.actionableActions()); count > 0 {
+		isb.clampSelection(count)
+		isb.selected = (isb.selected + 1) % count
+	}
+}
+
+// SelectPrev moves the selection to the previous actionable indicator, wrapping.
+func (isb *InputStatusBar) SelectPrev() {
+	if count := len(isb.actionableActions()); count > 0 {
+		isb.clampSelection(count)
+		isb.selected = (isb.selected - 1 + count) % count
+	}
+}
+
+// SelectedAction returns the action of the selected indicator, clamping the
+// selection when indicators disappeared since it was set (e.g. jobs finished).
+func (isb *InputStatusBar) SelectedAction() ui.StatusIndicatorAction {
+	actions := isb.actionableActions()
+	if len(actions) == 0 {
+		return ui.StatusIndicatorActionNone
+	}
+	isb.clampSelection(len(actions))
+	return actions[isb.selected]
+}
+
+// actionableActions lists the actions of the currently visible indicators
+// that open a view, in build order.
+func (isb *InputStatusBar) actionableActions() []ui.StatusIndicatorAction {
+	var actions []ui.StatusIndicatorAction
+	for _, part := range isb.getAllIndicatorParts() {
+		if part.action != ui.StatusIndicatorActionNone {
+			actions = append(actions, part.action)
+		}
+	}
+	return actions
+}
+
+func (isb *InputStatusBar) clampSelection(count int) {
+	if isb.selected >= count {
+		isb.selected = count - 1
+	}
+	if isb.selected < 0 {
+		isb.selected = 0
+	}
+}
+
 func (isb *InputStatusBar) Render() string {
 	if isb.config != nil && !isb.config.Chat.StatusBar.Enabled {
 		return ""
@@ -141,14 +225,16 @@ func (isb *InputStatusBar) buildStatusLines() []string {
 		return []string{leftPadding + "\u00A0"}
 	}
 
+	if isb.focused {
+		parts = isb.markSelected(parts)
+	}
+
 	lineGroups := isb.splitPartsIntoLines(parts, availableWidth, maxLines, separatorWidth)
 	lineGroups = capIndicatorLines(lineGroups, maxLines)
 
 	var lines []string
 	for _, lineItems := range lineGroups {
-		lineText := strings.Join(lineItems, " • ")
-		renderedLine := isb.styleProvider.RenderWithColor(lineText, dimColor)
-		lines = append(lines, leftPadding+renderedLine)
+		lines = append(lines, leftPadding+isb.renderIndicatorLine(lineItems, dimColor))
 	}
 
 	if len(lines) == 0 {
@@ -158,15 +244,70 @@ func (isb *InputStatusBar) buildStatusLines() []string {
 	return lines
 }
 
+// markSelected returns a copy of parts with the selected actionable part
+// flagged for highlighting.
+func (isb *InputStatusBar) markSelected(parts []indicatorPart) []indicatorPart {
+	marked := make([]indicatorPart, len(parts))
+	copy(marked, parts)
+
+	actionable := 0
+	for _, part := range marked {
+		if part.action != ui.StatusIndicatorActionNone {
+			actionable++
+		}
+	}
+	if actionable == 0 {
+		return marked
+	}
+	isb.clampSelection(actionable)
+
+	ordinal := 0
+	for i := range marked {
+		if marked[i].action == ui.StatusIndicatorActionNone {
+			continue
+		}
+		if ordinal == isb.selected {
+			marked[i].selected = true
+			break
+		}
+		ordinal++
+	}
+	return marked
+}
+
+// renderIndicatorLine styles one row of indicators. Unfocused rows keep the
+// single dim style; focused rows style per part so the selected one stands
+// out on a background highlight.
+func (isb *InputStatusBar) renderIndicatorLine(parts []indicatorPart, dimColor string) string {
+	texts := make([]string, len(parts))
+	for i, part := range parts {
+		texts[i] = part.text
+	}
+
+	if !isb.focused {
+		return isb.styleProvider.RenderWithColor(strings.Join(texts, " • "), dimColor)
+	}
+
+	styled := make([]string, len(parts))
+	for i, part := range parts {
+		if part.selected {
+			styled[i] = isb.styleProvider.RenderSelectedIndicator(texts[i])
+		} else {
+			styled[i] = isb.styleProvider.RenderWithColor(texts[i], dimColor)
+		}
+	}
+	return strings.Join(styled, isb.styleProvider.RenderWithColor(" • ", dimColor))
+}
+
 // getAllIndicatorParts returns all indicator parts as a slice
-func (isb *InputStatusBar) getAllIndicatorParts() []string {
+func (isb *InputStatusBar) getAllIndicatorParts() []indicatorPart {
 	if isb.modelService == nil {
-		return []string{}
+		return nil
 	}
 
 	currentModel := isb.modelService.GetCurrentModel()
 	if currentModel == "" {
-		return []string{}
+		return nil
 	}
 
 	return isb.buildIndicatorParts(currentModel)
@@ -175,64 +316,64 @@ func (isb *InputStatusBar) getAllIndicatorParts() []string {
 // buildIndicatorParts builds individual indicator parts without joining them.
 // The git branch is not included here - it is rendered in the input box top
 // border by InputView, not in the status bar.
-func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []string {
-	parts := []string{}
+func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []indicatorPart {
+	parts := []indicatorPart{}
 
 	if isb.shouldShowIndicator("model") {
-		parts = append(parts, currentModel)
+		parts = append(parts, indicatorPart{text: currentModel, action: ui.StatusIndicatorActionModelSelection})
 	}
 
 	if isb.shouldShowIndicator("theme") {
 		if themePart := isb.buildThemeIndicator(); themePart != "" {
-			parts = append(parts, themePart)
+			parts = append(parts, indicatorPart{text: themePart, action: ui.StatusIndicatorActionThemeSelection})
 		}
 	}
 
 	if isb.shouldShowIndicator("max_output") {
 		if maxOutputPart := isb.buildMaxOutputIndicator(); maxOutputPart != "" {
-			parts = append(parts, maxOutputPart)
+			parts = append(parts, indicatorPart{text: maxOutputPart})
 		}
 	}
 
 	if isb.shouldShowIndicator("a2a_agents") {
 		if agentsPart := isb.buildA2AAgentsIndicator(); agentsPart != "" {
-			parts = append(parts, agentsPart)
+			parts = append(parts, indicatorPart{text: agentsPart})
 		}
 	}
 
 	if isb.shouldShowIndicator("tools") {
 		if toolInfo := isb.getToolInfo(); toolInfo != "" {
-			parts = append(parts, toolInfo)
+			parts = append(parts, indicatorPart{text: toolInfo})
 		}
 	}
 
 	if isb.shouldShowIndicator("background_shells") || isb.shouldShowIndicator("a2a_tasks") {
 		if jobsInfo := isb.getBackgroundJobsInfo(); jobsInfo != "" {
-			parts = append(parts, jobsInfo)
+			parts = append(parts, indicatorPart{text: jobsInfo, action: ui.StatusIndicatorActionTaskManagement})
 		}
 	}
 
 	if isb.shouldShowIndicator("mcp") {
 		if mcpPart := isb.buildMCPIndicator(); mcpPart != "" {
-			parts = append(parts, mcpPart)
+			parts = append(parts, indicatorPart{text: mcpPart})
 		}
 	}
 
 	if isb.shouldShowIndicator("context_usage") {
 		if contextIndicator := isb.getContextUsageIndicator(currentModel); contextIndicator != "" {
-			parts = append(parts, contextIndicator)
+			parts = append(parts, indicatorPart{text: contextIndicator})
 		}
 	}
 
 	if isb.shouldShowIndicator("session_tokens") {
 		if sessionTokensPart := isb.buildSessionTokensIndicator(); sessionTokensPart != "" {
-			parts = append(parts, sessionTokensPart)
+			parts = append(parts, indicatorPart{text: sessionTokensPart})
 		}
 	}
 
 	if isb.shouldShowIndicator("cost") {
 		if costPart := isb.buildCostIndicator(); costPart != "" {
-			parts = append(parts, costPart)
+			parts = append(parts, indicatorPart{text: costPart})
 		}
 	}
 
@@ -240,13 +381,13 @@ func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []string {
 }
 
 // splitPartsIntoLines splits indicator parts into line groups based on available width
-func (isb *InputStatusBar) splitPartsIntoLines(parts []string, availableWidth, maxLines, separatorWidth int) [][]string {
-	var lineGroups [][]string
-	currentLineItems := []string{}
+func (isb *InputStatusBar) splitPartsIntoLines(parts []indicatorPart, availableWidth, maxLines, separatorWidth int) [][]indicatorPart {
+	var lineGroups [][]indicatorPart
+	currentLineItems := []indicatorPart{}
 	currentLineWidth := 0
 
 	for i, part := range parts {
-		itemWidth := len(part)
+		itemWidth := len(part.text)
 		separatorLen := 0
 
 		if len(currentLineItems) > 0 {
@@ -256,7 +397,7 @@ func (isb *InputStatusBar) splitPartsIntoLines(parts []string, availableWidth, m
 		needsNewLine := len(currentLineItems) > 0 && currentLineWidth+separatorLen+itemWidth > availableWidth
 		if needsNewLine {
 			lineGroups = append(lineGroups, currentLineItems)
-			currentLineItems = []string{part}
+			currentLineItems = []indicatorPart{part}
 			currentLineWidth = itemWidth
 
 			if isb.shouldAddOverflowAndBreak(len(lineGroups), maxLines, i, len(parts), currentLineWidth, separatorWidth, availableWidth, &currentLineItems) {
@@ -280,7 +421,7 @@ func (isb *InputStatusBar) splitPartsIntoLines(parts []string, availableWidth, m
 // indicators never exceed their share of the status bar so the branch row keeps
 // the bar at a stable height. When rows are dropped, an ellipsis is appended to
 // the last kept row to signal the overflow.
-func capIndicatorLines(lineGroups [][]string, maxLines int) [][]string {
+func capIndicatorLines(lineGroups [][]indicatorPart, maxLines int) [][]indicatorPart {
 	if maxLines <= 0 {
 		return nil
 	}
@@ -290,14 +431,14 @@ func capIndicatorLines(lineGroups [][]string, maxLines int) [][]string {
 
 	capped := lineGroups[:maxLines]
 	last := capped[maxLines-1]
-	if n := len(last); n == 0 || (last[n-1] != "…" && last[n-1] != "...") {
-		capped[maxLines-1] = append(last, "…")
+	if n := len(last); n == 0 || (last[n-1].text != "…" && last[n-1].text != "...") {
+		capped[maxLines-1] = append(last, indicatorPart{text: "…"})
 	}
 	return capped
 }
 
 // shouldAddOverflowAndBreak checks if we've reached max lines and adds overflow indicator if needed
-func (isb *InputStatusBar) shouldAddOverflowAndBreak(currentLines, maxLines, currentIndex, totalParts, lineWidth, separatorWidth, availableWidth int, lineItems *[]string) bool {
+func (isb *InputStatusBar) shouldAddOverflowAndBreak(currentLines, maxLines, currentIndex, totalParts, lineWidth, separatorWidth, availableWidth int, lineItems *[]indicatorPart) bool {
 	if currentLines < maxLines {
 		return false
 	}
@@ -305,7 +446,7 @@ func (isb *InputStatusBar) shouldAddOverflowAndBreak(currentLines, maxLines, cur
 	if currentIndex < totalParts-1 {
 		overflowWidth := 3
 		if lineWidth+separatorWidth+overflowWidth <= availableWidth {
-			*lineItems = append(*lineItems, "...")
+			*lineItems = append(*lineItems, indicatorPart{text: "..."})
 		}
 	}
 

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -337,7 +337,7 @@ func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []indicatorP
 
 	if isb.shouldShowIndicator("a2a_agents") {
 		if agentsPart := isb.buildA2AAgentsIndicator(); agentsPart != "" {
-			parts = append(parts, indicatorPart{text: agentsPart})
+			parts = append(parts, indicatorPart{text: agentsPart, action: ui.StatusIndicatorActionA2AAgents})
 		}
 	}
 
@@ -582,7 +582,7 @@ func (isb *InputStatusBar) buildA2AAgentsIndicator() string {
 		return ""
 	}
 	if readiness := isb.stateManager.GetAgentReadiness(); readiness != nil && readiness.TotalAgents > 0 {
-		return fmt.Sprintf("Agents: %d/%d", readiness.ReadyAgents, readiness.TotalAgents)
+		return fmt.Sprintf("A2A: %d/%d", readiness.ReadyAgents, readiness.TotalAgents)
 	}
 	return ""
 }
@@ -718,7 +718,7 @@ func (isb *InputStatusBar) getToolInfo() string {
 		return ""
 	}
 
-	return fmt.Sprintf("🔧 %d (%d)", count, tokens)
+	return fmt.Sprintf("Tools: %d (%d)", count, tokens)
 }
 
 // getBackgroundInfo returns background process count information

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -16,11 +17,13 @@ import (
 )
 
 type stubTokenEstimator struct {
-	estimate int
+	estimate   int
+	toolTokens int
+	toolCount  int
 }
 
 func (s *stubTokenEstimator) GetToolStats(domain.ToolService, domain.AgentMode) (int, int) {
-	return 0, 0
+	return s.toolTokens, s.toolCount
 }
 
 func (s *stubTokenEstimator) EstimateMessagesTokens([]sdk.Message) int {
@@ -794,6 +797,8 @@ func TestInputStatusBar_FocusRequiresActionableIndicator(t *testing.T) {
 
 func TestInputStatusBar_SelectionCyclesActionableIndicators(t *testing.T) {
 	statusBar := newSelectableStatusBar(true)
+	statusBar.toolService = &domainmocks.FakeToolService{}
+	statusBar.tokenEstimator = &stubTokenEstimator{toolTokens: 8017, toolCount: 25}
 	if !statusBar.Focus() {
 		t.Fatal("Focus should succeed")
 	}
@@ -808,8 +813,13 @@ func TestInputStatusBar_SelectionCyclesActionableIndicators(t *testing.T) {
 	}
 
 	statusBar.SelectNext()
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionToolsList {
+		t.Errorf("after second SelectNext: %v, want tools list", got)
+	}
+
+	statusBar.SelectNext()
 	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionTaskManagement {
-		t.Errorf("after second SelectNext: %v, want task management", got)
+		t.Errorf("after third SelectNext: %v, want task management", got)
 	}
 
 	statusBar.SelectNext()
@@ -891,9 +901,31 @@ func TestInputStatusBar_FocusedRenderHighlightsSelection(t *testing.T) {
 	if focused == unfocused {
 		t.Error("focused render should apply the selection highlight and differ from the unfocused render")
 	}
+	ansi := regexp.MustCompile("\x1b\\[[0-9;]*m")
+	focusedWidth := len(ansi.ReplaceAllString(focused, ""))
+	unfocusedWidth := len(ansi.ReplaceAllString(unfocused, ""))
+	if focusedWidth != unfocusedWidth+2 {
+		t.Errorf("the selected pill should add one column of padding per side: focused width %d, unfocused %d", focusedWidth, unfocusedWidth)
+	}
 
 	statusBar.Blur()
 	if got := statusBar.Render(); got != unfocused {
 		t.Errorf("blurred render should match the original unfocused render")
+	}
+}
+
+func TestInputStatusBar_SelectedPillWidthForcesWrap(t *testing.T) {
+	statusBar := &InputStatusBar{}
+	parts := []indicatorPart{{text: "aaaa"}, {text: "bbbb"}}
+
+	groups := statusBar.splitPartsIntoLines(parts, 11, 2, 3)
+	if len(groups) != 1 {
+		t.Fatalf("unselected parts should fit on one line, got %d", len(groups))
+	}
+
+	parts[1].selected = true
+	groups = statusBar.splitPartsIntoLines(parts, 11, 2, 3)
+	if len(groups) != 2 {
+		t.Fatalf("the selected pill's padding must count toward the line width, got %d line(s)", len(groups))
 	}
 }

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -7,9 +7,12 @@ import (
 	sdk "github.com/inference-gateway/sdk"
 
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	ui "github.com/inference-gateway/cli/internal/ui"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
 type stubTokenEstimator struct {
@@ -727,5 +730,170 @@ func TestInputStatusBar_NilStyleProviderFallback(t *testing.T) {
 
 	if len(lines) != 1 {
 		t.Fatalf("expected a single fallback row with a nil provider, got %d: %#v", len(lines), lines)
+	}
+}
+
+// newSelectableStatusBar builds a status bar with visible model and theme
+// indicators and, optionally, a background-jobs indicator (two running jobs
+// per kind).
+func newSelectableStatusBar(withJobs bool) *InputStatusBar {
+	modelService := &domainmocks.FakeModelService{}
+	modelService.GetCurrentModelReturns("test-model")
+
+	themeService := &domainmocks.FakeThemeService{}
+	themeService.GetCurrentThemeNameReturns("tokyo-night")
+
+	statusBar := &InputStatusBar{
+		width:        100,
+		modelService: modelService,
+		themeService: themeService,
+		config:       config.DefaultConfig(),
+	}
+
+	if withJobs {
+		registry := &domainmocks.FakeBackgroundTaskRegistry{}
+		registry.CountRunningJobsReturns(2)
+		statusBar.backgroundTaskRegistry = registry
+	}
+
+	return statusBar
+}
+
+func TestInputStatusBar_FocusRequiresActionableIndicator(t *testing.T) {
+	statusBar := &InputStatusBar{width: 100, config: config.DefaultConfig()}
+	if statusBar.Focus() {
+		t.Error("Focus should fail without a model service (no indicators at all)")
+	}
+
+	statusBar = newSelectableStatusBar(false)
+	statusBar.config.Chat.StatusBar.Indicators.Model = false
+	statusBar.config.Chat.StatusBar.Indicators.Theme = false
+	if statusBar.Focus() {
+		t.Error("Focus should fail when no visible indicator opens a view")
+	}
+	if statusBar.IsFocused() {
+		t.Error("a failed Focus must not leave the bar focused")
+	}
+
+	statusBar = newSelectableStatusBar(false)
+	if !statusBar.Focus() {
+		t.Fatal("Focus should succeed with the model indicator visible")
+	}
+	if !statusBar.IsFocused() {
+		t.Error("a successful Focus must report focused")
+	}
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionModelSelection {
+		t.Errorf("initial selection = %v, want model selection", got)
+	}
+
+	statusBar.Blur()
+	if statusBar.IsFocused() {
+		t.Error("Blur must clear focus")
+	}
+}
+
+func TestInputStatusBar_SelectionCyclesActionableIndicators(t *testing.T) {
+	statusBar := newSelectableStatusBar(true)
+	if !statusBar.Focus() {
+		t.Fatal("Focus should succeed")
+	}
+
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionModelSelection {
+		t.Fatalf("initial selection = %v, want model selection", got)
+	}
+
+	statusBar.SelectNext()
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionThemeSelection {
+		t.Errorf("after SelectNext: %v, want theme selection", got)
+	}
+
+	statusBar.SelectNext()
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionTaskManagement {
+		t.Errorf("after second SelectNext: %v, want task management", got)
+	}
+
+	statusBar.SelectNext()
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionModelSelection {
+		t.Errorf("SelectNext should wrap back to model selection, got %v", got)
+	}
+
+	statusBar.SelectPrev()
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionTaskManagement {
+		t.Errorf("SelectPrev should wrap to task management, got %v", got)
+	}
+}
+
+func TestInputStatusBar_SelectionClampsWhenIndicatorsDisappear(t *testing.T) {
+	statusBar := newSelectableStatusBar(true)
+	if !statusBar.Focus() {
+		t.Fatal("Focus should succeed")
+	}
+	statusBar.SelectNext()
+	statusBar.SelectNext()
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionTaskManagement {
+		t.Fatalf("precondition failed: expected task management selected, got %v", got)
+	}
+
+	registry := statusBar.backgroundTaskRegistry.(*domainmocks.FakeBackgroundTaskRegistry)
+	registry.CountRunningJobsReturns(0)
+
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionThemeSelection {
+		t.Errorf("selection should clamp to the last remaining indicator, got %v", got)
+	}
+}
+
+func TestInputStatusBar_MarkSelectedFlagsSelectedIndicator(t *testing.T) {
+	statusBar := newSelectableStatusBar(true)
+	if !statusBar.Focus() {
+		t.Fatal("Focus should succeed")
+	}
+	statusBar.SelectNext()
+
+	marked := statusBar.markSelected(statusBar.getAllIndicatorParts())
+
+	var flagged []string
+	for _, part := range marked {
+		if part.selected {
+			flagged = append(flagged, part.text)
+		}
+	}
+	if len(flagged) != 1 {
+		t.Fatalf("exactly one part must be flagged, got %d: %v", len(flagged), flagged)
+	}
+	if flagged[0] != "tokyo-night" {
+		t.Errorf("flagged part = %q, want the theme indicator", flagged[0])
+	}
+}
+
+func TestInputStatusBar_FocusedRenderHighlightsSelection(t *testing.T) {
+	fakeTheme := &uimocks.FakeTheme{}
+	fakeTheme.GetDimColorReturns("#888888")
+	fakeTheme.GetAccentColorReturns("#ff9e64")
+	fakeTheme.GetBorderColorReturns("#3b4261")
+	themeService := &domainmocks.FakeThemeService{}
+	themeService.GetCurrentThemeReturns(fakeTheme)
+
+	statusBar := newSelectableStatusBar(false)
+	statusBar.styleProvider = styles.NewProvider(themeService)
+
+	unfocused := statusBar.Render()
+	if !strings.Contains(unfocused, "test-model") {
+		t.Fatalf("render should contain the model indicator, got %q", unfocused)
+	}
+
+	if !statusBar.Focus() {
+		t.Fatal("Focus should succeed")
+	}
+	focused := statusBar.Render()
+	if !strings.Contains(focused, "test-model") {
+		t.Fatalf("focused render should still contain the model indicator, got %q", focused)
+	}
+	if focused == unfocused {
+		t.Error("focused render should apply the selection highlight and differ from the unfocused render")
+	}
+
+	statusBar.Blur()
+	if got := statusBar.Render(); got != unfocused {
+		t.Errorf("blurred render should match the original unfocused render")
 	}
 }

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -280,7 +280,7 @@ func TestInputStatusBar_BuildA2AAgentsIndicator(t *testing.T) {
 				TotalAgents: 5,
 				ReadyAgents: 3,
 			},
-			expectedText: "Agents: 3/5",
+			expectedText: "A2A: 3/5",
 			expectEmpty:  false,
 		},
 		{
@@ -799,6 +799,9 @@ func TestInputStatusBar_SelectionCyclesActionableIndicators(t *testing.T) {
 	statusBar := newSelectableStatusBar(true)
 	statusBar.toolService = &domainmocks.FakeToolService{}
 	statusBar.tokenEstimator = &stubTokenEstimator{toolTokens: 8017, toolCount: 25}
+	stateManager := &domainmocks.FakeStateManager{}
+	stateManager.GetAgentReadinessReturns(&domain.AgentReadinessState{TotalAgents: 1, ReadyAgents: 1})
+	statusBar.stateManager = stateManager
 	if !statusBar.Focus() {
 		t.Fatal("Focus should succeed")
 	}
@@ -813,13 +816,18 @@ func TestInputStatusBar_SelectionCyclesActionableIndicators(t *testing.T) {
 	}
 
 	statusBar.SelectNext()
+	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionA2AAgents {
+		t.Errorf("after second SelectNext: %v, want A2A agents", got)
+	}
+
+	statusBar.SelectNext()
 	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionToolsList {
-		t.Errorf("after second SelectNext: %v, want tools list", got)
+		t.Errorf("after third SelectNext: %v, want tools list", got)
 	}
 
 	statusBar.SelectNext()
 	if got := statusBar.SelectedAction(); got != ui.StatusIndicatorActionTaskManagement {
-		t.Errorf("after third SelectNext: %v, want task management", got)
+		t.Errorf("after fourth SelectNext: %v, want task management", got)
 	}
 
 	statusBar.SelectNext()

--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -440,6 +440,12 @@ func (iv *InputView) NavigateHistoryDown() {
 	iv.navigateHistoryDown()
 }
 
+// IsNavigatingHistory reports whether input-history navigation is active,
+// i.e. whether arrow-down still has an entry to return to
+func (iv *InputView) IsNavigatingHistory() bool {
+	return iv.historyManager.IsNavigating()
+}
+
 // navigateHistoryUp moves up in history (to older messages)
 func (iv *InputView) navigateHistoryUp() {
 	newText := iv.historyManager.NavigateUp(iv.text)
@@ -529,6 +535,9 @@ func (iv *InputView) HandleKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		iv.navigateHistoryUp()
 		return iv, nil
 	case "down":
+		if !iv.IsNavigatingHistory() {
+			return iv, func() tea.Msg { return domain.FocusStatusBarEvent{} }
+		}
 		iv.navigateHistoryDown()
 		return iv, nil
 	}

--- a/internal/ui/components/input_view_test.go
+++ b/internal/ui/components/input_view_test.go
@@ -599,3 +599,27 @@ func TestInputView_BashCommandCompletedInvalidatesBranchCache(t *testing.T) {
 
 	require.Empty(t, iv.gitBranchCache)
 }
+
+func TestInputView_ArrowDownHandsOffToStatusBarWhenIdle(t *testing.T) {
+	iv := &InputView{historyManager: history.NewMemoryOnlyHistoryManager(10)}
+
+	require.False(t, iv.IsNavigatingHistory(), "fresh input must not be navigating history")
+
+	_, cmd := iv.HandleKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	require.NotNil(t, cmd, "expected a command handing focus to the status bar")
+	_, ok := cmd().(domain.FocusStatusBarEvent)
+	require.True(t, ok, "expected a FocusStatusBarEvent")
+}
+
+func TestInputView_ArrowDownNavigatesWhileInHistory(t *testing.T) {
+	iv := &InputView{historyManager: history.NewMemoryOnlyHistoryManager(10)}
+	require.NoError(t, iv.AddToHistory("previous message"))
+
+	_, _ = iv.HandleKey(tea.KeyPressMsg{Code: tea.KeyUp})
+	require.True(t, iv.IsNavigatingHistory(), "arrow up should enter history navigation")
+	require.Equal(t, "previous message", iv.GetInput())
+
+	_, cmd := iv.HandleKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	require.Nil(t, cmd, "arrow down must keep navigating history, not hand off focus")
+	require.False(t, iv.IsNavigatingHistory(), "returning to the newest entry leaves history navigation")
+}

--- a/internal/ui/components/tools_view.go
+++ b/internal/ui/components/tools_view.go
@@ -1,0 +1,205 @@
+package components
+
+import (
+	"fmt"
+	"io"
+
+	list "charm.land/bubbles/v2/list"
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+// toolItem is a single row in the tools list: a tool name and its (possibly
+// empty) description.
+type toolItem struct {
+	name        string
+	description string
+}
+
+// FilterValue is what the list filters against when the user searches (/).
+func (i toolItem) FilterValue() string { return i.name }
+
+// toolDelegate renders a toolItem as a single line: a caret on the highlighted
+// row, the tool name in accent, and the description dimmed and truncated to
+// the available width.
+type toolDelegate struct {
+	styleProvider *styles.Provider
+}
+
+func (d toolDelegate) Height() int                             { return 1 }
+func (d toolDelegate) Spacing() int                            { return 0 }
+func (d toolDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d toolDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	it, ok := item.(toolItem)
+	if !ok {
+		return
+	}
+
+	selected := index == m.Index()
+
+	prefix := "  "
+	if selected {
+		prefix = "▶ "
+	}
+
+	desc := it.description
+	if maxDesc := m.Width() - len(prefix) - len(it.name) - 3; maxDesc > 0 && len(desc) > maxDesc {
+		desc = desc[:maxDesc-1] + "…"
+	}
+
+	name := prefix + it.name
+	if selected {
+		name = d.styleProvider.RenderWithColor(name, d.styleProvider.GetThemeColor("accent"))
+	}
+	if desc != "" {
+		desc = d.styleProvider.RenderWithColor(" — "+desc, d.styleProvider.GetThemeColor("dim"))
+	}
+
+	_, _ = fmt.Fprint(w, name+desc)
+}
+
+// ToolsViewImpl is a read-only, filterable list of the tools currently
+// available to the agent. It reuses the bubbles/v2 list plumbing from the
+// theme selector; enter deliberately does nothing yet - selecting a tool to
+// inspect or execute it is future work.
+type ToolsViewImpl struct {
+	list          list.Model
+	width         int
+	height        int
+	cancelled     bool
+	toolService   domain.ToolService
+	stateManager  domain.StateManager
+	styleProvider *styles.Provider
+}
+
+// NewToolsView creates the tools list view. Items are populated by Reset on
+// every entry because the tool set changes with the agent mode and with async
+// MCP tool registration.
+func NewToolsView(toolService domain.ToolService, stateManager domain.StateManager, styleProvider *styles.Provider) *ToolsViewImpl {
+	l := list.New(
+		nil,
+		toolDelegate{styleProvider: styleProvider},
+		80, 24,
+	)
+	l.SetShowStatusBar(true)
+	l.SetFilteringEnabled(true)
+	l.SetShowHelp(true)
+	l.DisableQuitKeybindings()
+	l.Styles.Title = lipgloss.NewStyle().
+		Foreground(lipgloss.Color(styleProvider.GetThemeColor("accent"))).
+		Bold(true)
+
+	m := &ToolsViewImpl{
+		list:          l,
+		width:         80,
+		height:        24,
+		toolService:   toolService,
+		stateManager:  stateManager,
+		styleProvider: styleProvider,
+	}
+	m.Reset()
+	return m
+}
+
+// toolItems builds the list items from the tools the agent can currently use.
+func (m *ToolsViewImpl) toolItems() []list.Item {
+	if m.toolService == nil {
+		return nil
+	}
+
+	mode := domain.AgentModeStandard
+	if m.stateManager != nil {
+		mode = m.stateManager.GetAgentMode()
+	}
+
+	tools := m.toolService.ListToolsForMode(mode)
+	items := make([]list.Item, len(tools))
+	for i, tool := range tools {
+		item := toolItem{name: tool.Function.Name}
+		if tool.Function.Description != nil {
+			item.description = *tool.Function.Description
+		}
+		items[i] = item
+	}
+	return items
+}
+
+func (m *ToolsViewImpl) Init() tea.Cmd { return nil }
+
+func (m *ToolsViewImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.list.SetSize(msg.Width, msg.Height)
+		return m, nil
+	case tea.KeyPressMsg:
+		if handled, cmd := m.handleKey(msg); handled {
+			return m, cmd
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+// handleKey intercepts the cancel keys when the list is not actively
+// filtering; otherwise it lets the list own typing, enter (apply filter) and
+// esc (clear filter). Enter outside filtering is consumed as a no-op: the
+// view is read-only for now.
+func (m *ToolsViewImpl) handleKey(msg tea.KeyPressMsg) (handled bool, cmd tea.Cmd) {
+	if m.list.FilterState() == list.Filtering {
+		return false, nil
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		m.cancelled = true
+		return true, nil
+	case "esc":
+		if m.list.FilterState() == list.FilterApplied {
+			return false, nil
+		}
+		m.cancelled = true
+		return true, nil
+	case "enter", " ":
+		return true, nil
+	}
+	return false, nil
+}
+
+func (m *ToolsViewImpl) View() tea.View {
+	return tea.NewView(m.list.View())
+}
+
+// IsCancelled returns true once the user has dismissed the view.
+func (m *ToolsViewImpl) IsCancelled() bool { return m.cancelled }
+
+// SetWidth sets the width of the tools view.
+func (m *ToolsViewImpl) SetWidth(width int) {
+	m.width = width
+	m.list.SetSize(width, m.height)
+}
+
+// SetHeight sets the height of the tools view.
+func (m *ToolsViewImpl) SetHeight(height int) {
+	m.height = height
+	m.list.SetSize(m.width, height)
+}
+
+// Reset returns the view to its initial state and rebuilds the items so the
+// list reflects the current agent mode and any MCP tools registered since it
+// was last shown.
+func (m *ToolsViewImpl) Reset() {
+	m.cancelled = false
+	m.list.ResetFilter()
+	items := m.toolItems()
+	m.list.SetItems(items)
+	m.list.Select(0)
+	m.list.Title = fmt.Sprintf("Available Tools (%d)", len(items))
+}

--- a/internal/ui/components/tools_view.go
+++ b/internal/ui/components/tools_view.go
@@ -2,11 +2,13 @@ package components
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	list "charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
+	ansi "github.com/charmbracelet/x/ansi"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
@@ -39,14 +41,49 @@ func summarizeDescription(s string) string {
 	return ""
 }
 
-// newToolDelegate builds the default two-line delegate restyled with the
-// current theme: accent bar + accent name on the selected row, dim
-// descriptions, underlined filter matches.
-func newToolDelegate(styleProvider *styles.Provider) list.DefaultDelegate {
+// toolDescLines is how many wrapped description lines an item may use before
+// the last one is cut with an ellipsis.
+const toolDescLines = 2
+
+// toolDelegate wraps the default delegate to word-wrap the description to the
+// list width at render time instead of cutting it to a single line.
+type toolDelegate struct {
+	list.DefaultDelegate
+}
+
+func (d toolDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	if it, ok := item.(toolItem); ok {
+		it.description = wrapDescription(it.description, m.Width()-4)
+		item = it
+	}
+	d.DefaultDelegate.Render(w, m, index, item)
+}
+
+// wrapDescription word-wraps a one-line description to at most toolDescLines
+// lines of the given width, ending the last line with an ellipsis when text
+// is cut. The width discounts the delegate's item padding; on absurdly narrow
+// widths the text is left for the delegate's own truncation.
+func wrapDescription(desc string, width int) string {
+	if desc == "" || width < 8 {
+		return desc
+	}
+	lines := strings.Split(ansi.Wrap(desc, width, ""), "\n")
+	if len(lines) > toolDescLines {
+		lines = lines[:toolDescLines]
+		lines[toolDescLines-1] = ansi.Truncate(lines[toolDescLines-1], width-1, "") + "…"
+	}
+	return strings.Join(lines, "\n")
+}
+
+// newToolDelegate builds the default delegate restyled with the current
+// theme - accent bar + accent name on the selected row, dim descriptions,
+// underlined filter matches - sized for a name plus wrapped description.
+func newToolDelegate(styleProvider *styles.Provider) toolDelegate {
 	accent := lipgloss.Color(styleProvider.GetThemeColor("accent"))
 	dim := lipgloss.Color(styleProvider.GetThemeColor("dim"))
 
 	d := list.NewDefaultDelegate()
+	d.SetHeight(1 + toolDescLines)
 	d.Styles.NormalTitle = lipgloss.NewStyle().Padding(0, 0, 0, 2)
 	d.Styles.NormalDesc = d.Styles.NormalTitle.Foreground(dim)
 	d.Styles.SelectedTitle = lipgloss.NewStyle().
@@ -59,7 +96,7 @@ func newToolDelegate(styleProvider *styles.Provider) list.DefaultDelegate {
 	d.Styles.DimmedTitle = lipgloss.NewStyle().Foreground(dim).Padding(0, 0, 0, 2)
 	d.Styles.DimmedDesc = d.Styles.DimmedTitle
 	d.Styles.FilterMatch = lipgloss.NewStyle().Underline(true).Foreground(accent)
-	return d
+	return toolDelegate{DefaultDelegate: d}
 }
 
 // toolsTitleStyle matches the status-bar selection pill: accent-on-background

--- a/internal/ui/components/tools_view.go
+++ b/internal/ui/components/tools_view.go
@@ -2,7 +2,7 @@ package components
 
 import (
 	"fmt"
-	"io"
+	"strings"
 
 	list "charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
@@ -12,8 +12,8 @@ import (
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
-// toolItem is a single row in the tools list: a tool name and its (possibly
-// empty) description.
+// toolItem is a single row in the tools list: a tool name and a one-line
+// summary of its (possibly empty) description.
 type toolItem struct {
 	name        string
 	description string
@@ -22,44 +22,54 @@ type toolItem struct {
 // FilterValue is what the list filters against when the user searches (/).
 func (i toolItem) FilterValue() string { return i.name }
 
-// toolDelegate renders a toolItem as a single line: a caret on the highlighted
-// row, the tool name in accent, and the description dimmed and truncated to
-// the available width.
-type toolDelegate struct {
-	styleProvider *styles.Provider
+// Title and Description satisfy list.DefaultItem so the default delegate can
+// render the item as name + dim summary line.
+func (i toolItem) Title() string       { return i.name }
+func (i toolItem) Description() string { return i.description }
+
+// summarizeDescription collapses a tool description to a single line: the
+// first non-empty line with its whitespace normalized. Tool descriptions
+// often carry multi-line usage blocks that would wreck a list row.
+func summarizeDescription(s string) string {
+	for line := range strings.Lines(s) {
+		if fields := strings.Fields(line); len(fields) > 0 {
+			return strings.Join(fields, " ")
+		}
+	}
+	return ""
 }
 
-func (d toolDelegate) Height() int                             { return 1 }
-func (d toolDelegate) Spacing() int                            { return 0 }
-func (d toolDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+// newToolDelegate builds the default two-line delegate restyled with the
+// current theme: accent bar + accent name on the selected row, dim
+// descriptions, underlined filter matches.
+func newToolDelegate(styleProvider *styles.Provider) list.DefaultDelegate {
+	accent := lipgloss.Color(styleProvider.GetThemeColor("accent"))
+	dim := lipgloss.Color(styleProvider.GetThemeColor("dim"))
 
-func (d toolDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
-	it, ok := item.(toolItem)
-	if !ok {
-		return
-	}
+	d := list.NewDefaultDelegate()
+	d.Styles.NormalTitle = lipgloss.NewStyle().Padding(0, 0, 0, 2)
+	d.Styles.NormalDesc = d.Styles.NormalTitle.Foreground(dim)
+	d.Styles.SelectedTitle = lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, false, false, true).
+		BorderForeground(accent).
+		Foreground(accent).
+		Bold(true).
+		Padding(0, 0, 0, 1)
+	d.Styles.SelectedDesc = d.Styles.SelectedTitle.Bold(false).Foreground(dim)
+	d.Styles.DimmedTitle = lipgloss.NewStyle().Foreground(dim).Padding(0, 0, 0, 2)
+	d.Styles.DimmedDesc = d.Styles.DimmedTitle
+	d.Styles.FilterMatch = lipgloss.NewStyle().Underline(true).Foreground(accent)
+	return d
+}
 
-	selected := index == m.Index()
-
-	prefix := "  "
-	if selected {
-		prefix = "▶ "
-	}
-
-	desc := it.description
-	if maxDesc := m.Width() - len(prefix) - len(it.name) - 3; maxDesc > 0 && len(desc) > maxDesc {
-		desc = desc[:maxDesc-1] + "…"
-	}
-
-	name := prefix + it.name
-	if selected {
-		name = d.styleProvider.RenderWithColor(name, d.styleProvider.GetThemeColor("accent"))
-	}
-	if desc != "" {
-		desc = d.styleProvider.RenderWithColor(" — "+desc, d.styleProvider.GetThemeColor("dim"))
-	}
-
-	_, _ = fmt.Fprint(w, name+desc)
+// toolsTitleStyle matches the status-bar selection pill: accent-on-background
+// via reverse video, padded.
+func toolsTitleStyle(styleProvider *styles.Provider) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color(styleProvider.GetThemeColor("accent"))).
+		Reverse(true).
+		Bold(true).
+		Padding(0, 1)
 }
 
 // ToolsViewImpl is a read-only, filterable list of the tools currently
@@ -82,16 +92,14 @@ type ToolsViewImpl struct {
 func NewToolsView(toolService domain.ToolService, stateManager domain.StateManager, styleProvider *styles.Provider) *ToolsViewImpl {
 	l := list.New(
 		nil,
-		toolDelegate{styleProvider: styleProvider},
+		newToolDelegate(styleProvider),
 		80, 24,
 	)
 	l.SetShowStatusBar(true)
 	l.SetFilteringEnabled(true)
 	l.SetShowHelp(true)
 	l.DisableQuitKeybindings()
-	l.Styles.Title = lipgloss.NewStyle().
-		Foreground(lipgloss.Color(styleProvider.GetThemeColor("accent"))).
-		Bold(true)
+	l.SetStatusBarItemName("tool", "tools")
 
 	m := &ToolsViewImpl{
 		list:          l,
@@ -121,7 +129,7 @@ func (m *ToolsViewImpl) toolItems() []list.Item {
 	for i, tool := range tools {
 		item := toolItem{name: tool.Function.Name}
 		if tool.Function.Description != nil {
-			item.description = *tool.Function.Description
+			item.description = summarizeDescription(*tool.Function.Description)
 		}
 		items[i] = item
 	}
@@ -194,10 +202,13 @@ func (m *ToolsViewImpl) SetHeight(height int) {
 
 // Reset returns the view to its initial state and rebuilds the items so the
 // list reflects the current agent mode and any MCP tools registered since it
-// was last shown.
+// was last shown. The delegate and title styles are rebuilt too so a theme
+// switch is picked up on re-entry.
 func (m *ToolsViewImpl) Reset() {
 	m.cancelled = false
 	m.list.ResetFilter()
+	m.list.SetDelegate(newToolDelegate(m.styleProvider))
+	m.list.Styles.Title = toolsTitleStyle(m.styleProvider)
 	items := m.toolItems()
 	m.list.SetItems(items)
 	m.list.Select(0)

--- a/internal/ui/components/tools_view_test.go
+++ b/internal/ui/components/tools_view_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"strings"
 	"testing"
 
 	list "charm.land/bubbles/v2/list"
@@ -97,6 +98,30 @@ func TestToolsView_MultilineDescriptionsCollapse(t *testing.T) {
 	}
 	if first.Title() != "Write" {
 		t.Errorf("Title() = %q, want the tool name", first.Title())
+	}
+}
+
+// TestToolsView_LongDescriptionsWrap: a description too wide for one line
+// continues on the next line instead of being cut, and one that exceeds the
+// wrapped-line budget ends with an ellipsis.
+func TestToolsView_LongDescriptionsWrap(t *testing.T) {
+	long := strings.Repeat("alpha ", 10) + "omega"
+	view, _, _ := newToolsViewForTest([]sdk.ChatCompletionTool{toolDef("Bash", long)})
+	view.SetWidth(40)
+	view.SetHeight(20)
+
+	if got := stripANSI(view.View().Content); !strings.Contains(got, "omega") {
+		t.Errorf("the tail of a long description must wrap into view, got:\n%s", got)
+	}
+
+	view, _, _ = newToolsViewForTest([]sdk.ChatCompletionTool{
+		toolDef("Bash", strings.Repeat("word ", 40)),
+	})
+	view.SetWidth(40)
+	view.SetHeight(20)
+
+	if got := stripANSI(view.View().Content); !strings.Contains(got, "…") {
+		t.Errorf("a description beyond %d wrapped lines must end with an ellipsis, got:\n%s", toolDescLines, got)
 	}
 }
 

--- a/internal/ui/components/tools_view_test.go
+++ b/internal/ui/components/tools_view_test.go
@@ -1,0 +1,115 @@
+package components
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+func toolDef(name, description string) sdk.ChatCompletionTool {
+	tool := sdk.ChatCompletionTool{}
+	tool.Function.Name = name
+	if description != "" {
+		tool.Function.Description = &description
+	}
+	return tool
+}
+
+// newToolsViewForTest builds a tools view backed by fakes: the tool service
+// returns the given tools for any mode and the state manager reports plan
+// mode, so the mode propagation is observable.
+func newToolsViewForTest(tools []sdk.ChatCompletionTool) (*ToolsViewImpl, *domainmocks.FakeToolService, *domainmocks.FakeStateManager) {
+	fakeTheme := &uimocks.FakeTheme{}
+	fakeTheme.GetAccentColorReturns("#ff9e64")
+	fakeTheme.GetDimColorReturns("#888888")
+	themeService := &domainmocks.FakeThemeService{}
+	themeService.GetCurrentThemeReturns(fakeTheme)
+
+	toolService := &domainmocks.FakeToolService{}
+	toolService.ListToolsForModeReturns(tools)
+
+	stateManager := &domainmocks.FakeStateManager{}
+	stateManager.GetAgentModeReturns(domain.AgentModePlan)
+
+	view := NewToolsView(toolService, stateManager, styles.NewProvider(themeService))
+	return view, toolService, stateManager
+}
+
+func TestToolsView_ItemsReflectAvailableTools(t *testing.T) {
+	view, toolService, _ := newToolsViewForTest([]sdk.ChatCompletionTool{
+		toolDef("Read", "Read a file from the filesystem"),
+		toolDef("Bash", ""), // nil description must be safe
+	})
+
+	items := view.list.Items()
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	first, ok := items[0].(toolItem)
+	if !ok {
+		t.Fatalf("expected a toolItem, got %T", items[0])
+	}
+	if first.name != "Read" || first.description != "Read a file from the filesystem" {
+		t.Errorf("unexpected first item: %+v", first)
+	}
+	second := items[1].(toolItem)
+	if second.name != "Bash" || second.description != "" {
+		t.Errorf("a nil description should map to an empty string, got %+v", second)
+	}
+
+	if view.list.Title != "Available Tools (2)" {
+		t.Errorf("title = %q, want the tool count", view.list.Title)
+	}
+
+	if got := toolService.ListToolsForModeArgsForCall(0); got != domain.AgentModePlan {
+		t.Errorf("tools must be listed for the current agent mode, got %v", got)
+	}
+}
+
+func TestToolsView_EscCancelsEnterDoesNot(t *testing.T) {
+	view, _, _ := newToolsViewForTest([]sdk.ChatCompletionTool{toolDef("Read", "")})
+
+	model, _ := view.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	view = model.(*ToolsViewImpl)
+	if view.IsCancelled() {
+		t.Fatal("enter is a no-op in the read-only tools view")
+	}
+
+	model, _ = view.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	view = model.(*ToolsViewImpl)
+	if !view.IsCancelled() {
+		t.Fatal("esc should cancel the tools view")
+	}
+}
+
+func TestToolsView_ResetRebuildsItems(t *testing.T) {
+	view, toolService, _ := newToolsViewForTest([]sdk.ChatCompletionTool{toolDef("Read", "")})
+
+	model, _ := view.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	view = model.(*ToolsViewImpl)
+
+	toolService.ListToolsForModeReturns([]sdk.ChatCompletionTool{
+		toolDef("Read", ""),
+		toolDef("Write", ""),
+		toolDef("Bash", ""),
+	})
+	view.Reset()
+
+	if view.IsCancelled() {
+		t.Error("Reset must clear the cancelled flag")
+	}
+	if got := len(view.list.Items()); got != 3 {
+		t.Errorf("Reset should re-read the tool service, got %d items", got)
+	}
+	if view.list.Title != "Available Tools (3)" {
+		t.Errorf("title = %q, want the refreshed count", view.list.Title)
+	}
+}

--- a/internal/ui/components/tools_view_test.go
+++ b/internal/ui/components/tools_view_test.go
@@ -3,6 +3,7 @@ package components
 import (
 	"testing"
 
+	list "charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 
 	sdk "github.com/inference-gateway/sdk"
@@ -13,6 +14,9 @@ import (
 	domain "github.com/inference-gateway/cli/internal/domain"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
+
+// The default delegate renders items through the DefaultItem interface.
+var _ list.DefaultItem = toolItem{}
 
 func toolDef(name, description string) sdk.ChatCompletionTool {
 	tool := sdk.ChatCompletionTool{}
@@ -71,6 +75,28 @@ func TestToolsView_ItemsReflectAvailableTools(t *testing.T) {
 
 	if got := toolService.ListToolsForModeArgsForCall(0); got != domain.AgentModePlan {
 		t.Errorf("tools must be listed for the current agent mode, got %v", got)
+	}
+}
+
+// TestToolsView_MultilineDescriptionsCollapse guards the layout: tool
+// descriptions often carry multi-line usage blocks, and a newline in a list
+// row would wreck the whole view.
+func TestToolsView_MultilineDescriptionsCollapse(t *testing.T) {
+	view, _, _ := newToolsViewForTest([]sdk.ChatCompletionTool{
+		toolDef("Write", "Writes a file to disk.\n\nUsage:\n- overwrites the existing file"),
+		toolDef("Read", "\n\n  Reads   a file\t from disk.\nMore detail."),
+	})
+
+	first := view.list.Items()[0].(toolItem)
+	if got := first.Description(); got != "Writes a file to disk." {
+		t.Errorf("Description() = %q, want the first line only", got)
+	}
+	second := view.list.Items()[1].(toolItem)
+	if got := second.Description(); got != "Reads a file from disk." {
+		t.Errorf("Description() = %q, want the first non-empty line with whitespace collapsed", got)
+	}
+	if first.Title() != "Write" {
+		t.Errorf("Title() = %q, want the tool name", first.Title())
 	}
 }
 

--- a/internal/ui/interfaces.go
+++ b/internal/ui/interfaces.go
@@ -122,6 +122,7 @@ const (
 	StatusIndicatorActionTaskManagement
 	StatusIndicatorActionThemeSelection
 	StatusIndicatorActionToolsList
+	StatusIndicatorActionA2AAgents
 )
 
 // InputStatusBarComponent interface for input status bar

--- a/internal/ui/interfaces.go
+++ b/internal/ui/interfaces.go
@@ -86,6 +86,7 @@ type InputComponent interface {
 	CanHandle(key tea.KeyPressMsg) bool
 	NavigateHistoryUp()
 	NavigateHistoryDown()
+	IsNavigatingHistory() bool
 	AddImageAttachment(image domain.ImageAttachment)
 	GetImageAttachments() []domain.ImageAttachment
 	ClearImageAttachments()
@@ -111,12 +112,29 @@ type StatusComponent interface {
 	HasSavedState() bool
 }
 
+// StatusIndicatorAction identifies the view a status-bar indicator opens when
+// activated; indicators without a view map to StatusIndicatorActionNone
+type StatusIndicatorAction int
+
+const (
+	StatusIndicatorActionNone StatusIndicatorAction = iota
+	StatusIndicatorActionModelSelection
+	StatusIndicatorActionTaskManagement
+	StatusIndicatorActionThemeSelection
+)
+
 // InputStatusBarComponent interface for input status bar
 type InputStatusBarComponent interface {
 	SetWidth(width int)
 	SetHeight(height int)
 	SetInputText(text string)
 	UpdateMCPStatus(status *domain.MCPServerStatus)
+	Focus() bool
+	Blur()
+	IsFocused() bool
+	SelectNext()
+	SelectPrev()
+	SelectedAction() StatusIndicatorAction
 	Render() string
 }
 

--- a/internal/ui/interfaces.go
+++ b/internal/ui/interfaces.go
@@ -121,6 +121,7 @@ const (
 	StatusIndicatorActionModelSelection
 	StatusIndicatorActionTaskManagement
 	StatusIndicatorActionThemeSelection
+	StatusIndicatorActionToolsList
 )
 
 // InputStatusBarComponent interface for input status bar

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -456,7 +456,7 @@ func (r *Registry) createHistoryActions() []*KeyAction {
 			Namespace:   config.NamespaceTextEditing,
 			ID:          config.ActionID(config.NamespaceTextEditing, "history_down"),
 			Keys:        []string{"down"},
-			Description: "navigate to next message in history",
+			Description: "navigate to next message in history / select status indicator",
 			Category:    "text_editing",
 			Handler:     handleHistoryDown,
 			Priority:    200,
@@ -1283,6 +1283,9 @@ func handleHistoryDown(app KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cmd {
 		if autocomplete != nil && autocomplete.IsVisible() {
 			autocomplete.HandleKey(keyMsg)
 			return nil
+		}
+		if !inputView.IsNavigatingHistory() {
+			return func() tea.Msg { return domain.FocusStatusBarEvent{} }
 		}
 		inputView.NavigateHistoryDown()
 	}

--- a/internal/ui/keybinding/actions_internal_test.go
+++ b/internal/ui/keybinding/actions_internal_test.go
@@ -148,3 +148,68 @@ func TestClipboardFlashDurationIsAFlash(t *testing.T) {
 		t.Errorf("clipboardFlashDuration must be a brief flash within 3s, got %s", clipboardFlashDuration)
 	}
 }
+
+// historyNavTestCtx is a minimal KeyHandlerContext for the arrow-down
+// history/status-bar handoff, overriding only the accessors handleHistoryDown
+// uses (hand-rolled for the same import-cycle reason as flashTestCtx).
+type historyNavTestCtx struct {
+	KeyHandlerContext
+	input        ui.InputComponent
+	autocomplete ui.AutocompleteComponent
+}
+
+func (c *historyNavTestCtx) GetInputView() ui.InputComponent           { return c.input }
+func (c *historyNavTestCtx) GetAutocomplete() ui.AutocompleteComponent { return c.autocomplete }
+
+// TestHandleHistoryDownNavigatesWhileInHistory verifies arrow-down keeps
+// walking the input history while navigation is active.
+func TestHandleHistoryDownNavigatesWhileInHistory(t *testing.T) {
+	input := &uimocks.FakeInputComponent{}
+	input.IsNavigatingHistoryReturns(true)
+	ctx := &historyNavTestCtx{input: input}
+
+	if cmd := handleHistoryDown(ctx, tea.KeyPressMsg{Code: tea.KeyDown}); cmd != nil {
+		t.Fatal("expected no command while navigating history")
+	}
+	if input.NavigateHistoryDownCallCount() != 1 {
+		t.Errorf("expected one NavigateHistoryDown call, got %d", input.NavigateHistoryDownCallCount())
+	}
+}
+
+// TestHandleHistoryDownFocusesStatusBarWhenIdle verifies arrow-down hands
+// focus to the status-indicator row exactly when it would otherwise no-op.
+func TestHandleHistoryDownFocusesStatusBarWhenIdle(t *testing.T) {
+	input := &uimocks.FakeInputComponent{}
+	input.IsNavigatingHistoryReturns(false)
+	ctx := &historyNavTestCtx{input: input}
+
+	cmd := handleHistoryDown(ctx, tea.KeyPressMsg{Code: tea.KeyDown})
+	if cmd == nil {
+		t.Fatal("expected a command when history navigation is idle")
+	}
+	if _, ok := cmd().(domain.FocusStatusBarEvent); !ok {
+		t.Fatalf("expected a FocusStatusBarEvent, got %T", cmd())
+	}
+	if input.NavigateHistoryDownCallCount() != 0 {
+		t.Errorf("history must not move when handing focus to the status bar, got %d calls", input.NavigateHistoryDownCallCount())
+	}
+}
+
+// TestHandleHistoryDownPrefersAutocomplete verifies a visible autocomplete
+// dropdown keeps owning arrow-down.
+func TestHandleHistoryDownPrefersAutocomplete(t *testing.T) {
+	input := &uimocks.FakeInputComponent{}
+	autocomplete := &uimocks.FakeAutocompleteComponent{}
+	autocomplete.IsVisibleReturns(true)
+	ctx := &historyNavTestCtx{input: input, autocomplete: autocomplete}
+
+	if cmd := handleHistoryDown(ctx, tea.KeyPressMsg{Code: tea.KeyDown}); cmd != nil {
+		t.Fatal("expected no command while autocomplete is visible")
+	}
+	if autocomplete.HandleKeyCallCount() != 1 {
+		t.Errorf("expected the key routed to autocomplete, got %d calls", autocomplete.HandleKeyCallCount())
+	}
+	if input.IsNavigatingHistoryCallCount() != 0 || input.NavigateHistoryDownCallCount() != 0 {
+		t.Error("history navigation must not be touched while autocomplete is visible")
+	}
+}

--- a/internal/ui/styles/provider.go
+++ b/internal/ui/styles/provider.go
@@ -306,6 +306,18 @@ func (p *Provider) RenderDimText(text string) string {
 	return style.Render(text)
 }
 
+// RenderSelectedIndicator renders the status-bar indicator holding the
+// selection: the RenderButton selected palette without padding, so the
+// highlight adds no width.
+func (p *Provider) RenderSelectedIndicator(text string) string {
+	theme := p.themeService.GetCurrentTheme()
+	style := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.GetAccentColor())).
+		Background(lipgloss.Color(theme.GetBorderColor())).
+		Bold(true)
+	return style.Render(text)
+}
+
 // RenderPathText renders a file path with accent color and bold
 func (p *Provider) RenderPathText(text string) string {
 	theme := p.themeService.GetCurrentTheme()

--- a/internal/ui/styles/provider.go
+++ b/internal/ui/styles/provider.go
@@ -307,14 +307,17 @@ func (p *Provider) RenderDimText(text string) string {
 }
 
 // RenderSelectedIndicator renders the status-bar indicator holding the
-// selection: the RenderButton selected palette without padding, so the
-// highlight adds no width.
+// selection as a padded pill: reverse video paints the cell background in the
+// accent color with the terminal background as text color, which works on any
+// theme (Theme exposes no background color). The one-column side padding adds
+// two columns of width - splitPartsIntoLines accounts for it.
 func (p *Provider) RenderSelectedIndicator(text string) string {
 	theme := p.themeService.GetCurrentTheme()
 	style := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.GetAccentColor())).
-		Background(lipgloss.Color(theme.GetBorderColor())).
-		Bold(true)
+		Reverse(true).
+		Bold(true).
+		Padding(0, 1)
 	return style.Render(text)
 }
 

--- a/tests/mocks/ui/fake_input_component.go
+++ b/tests/mocks/ui/fake_input_component.go
@@ -108,6 +108,16 @@ type FakeInputComponent struct {
 	isDisabledReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	IsNavigatingHistoryStub        func() bool
+	isNavigatingHistoryMutex       sync.RWMutex
+	isNavigatingHistoryArgsForCall []struct {
+	}
+	isNavigatingHistoryReturns struct {
+		result1 bool
+	}
+	isNavigatingHistoryReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	NavigateHistoryDownStub        func()
 	navigateHistoryDownMutex       sync.RWMutex
 	navigateHistoryDownArgsForCall []struct {
@@ -687,6 +697,59 @@ func (fake *FakeInputComponent) IsDisabledReturnsOnCall(i int, result1 bool) {
 		})
 	}
 	fake.isDisabledReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeInputComponent) IsNavigatingHistory() bool {
+	fake.isNavigatingHistoryMutex.Lock()
+	ret, specificReturn := fake.isNavigatingHistoryReturnsOnCall[len(fake.isNavigatingHistoryArgsForCall)]
+	fake.isNavigatingHistoryArgsForCall = append(fake.isNavigatingHistoryArgsForCall, struct {
+	}{})
+	stub := fake.IsNavigatingHistoryStub
+	fakeReturns := fake.isNavigatingHistoryReturns
+	fake.recordInvocation("IsNavigatingHistory", []interface{}{})
+	fake.isNavigatingHistoryMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeInputComponent) IsNavigatingHistoryCallCount() int {
+	fake.isNavigatingHistoryMutex.RLock()
+	defer fake.isNavigatingHistoryMutex.RUnlock()
+	return len(fake.isNavigatingHistoryArgsForCall)
+}
+
+func (fake *FakeInputComponent) IsNavigatingHistoryCalls(stub func() bool) {
+	fake.isNavigatingHistoryMutex.Lock()
+	defer fake.isNavigatingHistoryMutex.Unlock()
+	fake.IsNavigatingHistoryStub = stub
+}
+
+func (fake *FakeInputComponent) IsNavigatingHistoryReturns(result1 bool) {
+	fake.isNavigatingHistoryMutex.Lock()
+	defer fake.isNavigatingHistoryMutex.Unlock()
+	fake.IsNavigatingHistoryStub = nil
+	fake.isNavigatingHistoryReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeInputComponent) IsNavigatingHistoryReturnsOnCall(i int, result1 bool) {
+	fake.isNavigatingHistoryMutex.Lock()
+	defer fake.isNavigatingHistoryMutex.Unlock()
+	fake.IsNavigatingHistoryStub = nil
+	if fake.isNavigatingHistoryReturnsOnCall == nil {
+		fake.isNavigatingHistoryReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isNavigatingHistoryReturnsOnCall[i] = struct {
 		result1 bool
 	}{result1}
 }


### PR DESCRIPTION
Closes #717

## What

Makes the status indicators below the chat input keyboard-selectable and gives two of them dedicated views:

- Press the down arrow from the input to focus the indicator row; left/right cycles through the indicators; Enter opens the matching view; Esc or up returns to the input. The selected indicator renders as a padded reverse-video pill in the accent color.
- Indicators are labeled for clarity: "Tools: N (mode)" and "A2A: X/Y".
- New `/tools` view (also opened via the tools indicator): a read-only, filterable list of the tools available in the current agent mode. Two-line rows (name plus description), word-wrapped descriptions up to two lines with an ellipsis only on overflow, accent selection bar, filter-match underlining, and a "N tools" status line. Multi-line tool descriptions are collapsed to their first meaningful line so embedded usage blocks cannot break the layout.
- New `/a2a` view (also opened via the A2A indicator): the registered A2A agents with their connection state.
- Both views rebuild their items, delegate, and title style on every entry, so agent-mode changes, async MCP tool registration, and theme switches are picked up.

## How

- `internal/ui/components/tools_view.go` and `a2a_view.go` reuse the bubbles/v2 list plumbing from the theme selector. The tools view embeds `list.DefaultDelegate` and overrides only `Render` to word-wrap the description to the live list width (`ansi.Wrap` plus `ansi.Truncate`), keeping the default delegate's styling, filtering, and pagination.
- Status-bar selection state lives in the chat application model; the indicator row renders the pill via the shared style provider so it follows the active theme.

## Testing

- New unit tests cover indicator selection and cycling, the tools view (items reflect the tool service and agent mode, multi-line descriptions collapse, long descriptions wrap and ellipsize, Esc cancels while Enter does not, Reset rebuilds items), and the A2A view.
- `task build`, `task test`, and `task lint` all pass.

## Docs follow-up

Draft for a docs ticket in `inference-gateway/docs`, to be filed alongside this PR:

> **Title:** [DOCS] Document status-indicator keyboard selection in the CLI chat
>
> **Body:** The CLI chat TUI now supports selecting the status indicators below the input (down arrow to focus, left/right to cycle, Enter to open, Esc to return) and adds two views: `/tools` (read-only, filterable list of the tools available in the current agent mode) and `/a2a` (registered A2A agents and their connection state). The tools and A2A indicators are labeled "Tools: N (mode)" and "A2A: X/Y". Document the keybindings and both views in the chat interface docs.
>
> **Affected pages:** CLI chat interface guide, commands/shortcuts reference.
>
> **Source:** inference-gateway/cli#717 and this PR.
