### PR TITLE
feat(reminders): add merge:true to append/merge onto built-in defaults

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -322,14 +322,30 @@ func getEffectiveRemindersConfigPath() string {
 //  4. built-in defaults (LoadReminders returns them when the file is missing).
 //
 // Env wins over the flag, matching the documented flags < env layering.
+//
+// When the resolved config has Merge=true, its entries are merged onto the
+// built-in defaults by name instead of replacing them (see MergeWithDefaults).
+// This lets consumers add reminders without re-declaring the built-in set.
 func resolveRemindersConfig() (*config.RemindersConfig, error) {
+	var cfg *config.RemindersConfig
+	var err error
+
 	if inline := strings.TrimSpace(os.Getenv("INFER_REMINDERS_CONFIG")); inline != "" {
-		return config.ParseReminders([]byte(inline))
+		cfg, err = config.ParseReminders([]byte(inline))
+	} else if path := remindersFileOverride(); path != "" {
+		cfg, err = config.LoadReminders(path)
+	} else {
+		cfg, err = config.LoadReminders(getEffectiveRemindersConfigPath())
 	}
-	if path := remindersFileOverride(); path != "" {
-		return config.LoadReminders(path)
+	if err != nil {
+		return nil, err
 	}
-	return config.LoadReminders(getEffectiveRemindersConfigPath())
+
+	if cfg.Merge {
+		cfg = cfg.MergeWithDefaults()
+	}
+
+	return cfg, nil
 }
 
 // remindersFileOverride returns the --reminders-file persistent flag value when

--- a/cmd/config_reminders_test.go
+++ b/cmd/config_reminders_test.go
@@ -91,3 +91,55 @@ func TestApplyRemindersEnvOverrides_Enabled(t *testing.T) {
 		t.Error("INFER_REMINDERS_ENABLED=false should disable reminders")
 	}
 }
+
+// Merge:true via INFER_REMINDERS_CONFIG should add custom entries on top of
+// built-in defaults instead of replacing them. This guards the cfg.Merge
+// branch at resolveRemindersConfig (cmd/config.go:344).
+func TestResolveRemindersConfig_MergeTrue(t *testing.T) {
+	t.Setenv("INFER_REMINDERS_CONFIG", `enabled: true
+merge: true
+reminders:
+  - name: my-custom
+    text: custom nudge
+    hook: pre_stream
+    trigger: interval
+    interval: 5
+`)
+	cfg, err := resolveRemindersConfig()
+	if err != nil {
+		t.Fatalf("resolveRemindersConfig: %v", err)
+	}
+	if !cfg.Enabled {
+		t.Error("merged config should be enabled")
+	}
+	// Should have the built-in defaults (todo-hygiene, memory-consult, memory-hygiene) + 1 custom
+	wantLen := len(config.DefaultRemindersConfig().Reminders) + 1
+	if len(cfg.Reminders) != wantLen {
+		t.Fatalf("expected %d reminders (defaults + 1 custom), got %d:\n%+v", wantLen, len(cfg.Reminders), cfg.Reminders)
+	}
+	// Custom reminder should be present
+	found := false
+	for _, r := range cfg.Reminders {
+		if r.Name == "my-custom" {
+			found = true
+			if r.Interval != 5 {
+				t.Errorf("custom reminder interval = %d, want 5", r.Interval)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("custom reminder 'my-custom' not found in merged result")
+	}
+	// Built-in defaults should survive
+	hasTodo := false
+	for _, r := range cfg.Reminders {
+		if r.Name == "todo-hygiene" {
+			hasTodo = true
+			break
+		}
+	}
+	if !hasTodo {
+		t.Error("merged result should include built-in todo-hygiene reminder")
+	}
+}

--- a/cmd/config_reminders_test.go
+++ b/cmd/config_reminders_test.go
@@ -112,12 +112,10 @@ reminders:
 	if !cfg.Enabled {
 		t.Error("merged config should be enabled")
 	}
-	// Should have the built-in defaults (todo-hygiene, memory-consult, memory-hygiene) + 1 custom
 	wantLen := len(config.DefaultRemindersConfig().Reminders) + 1
 	if len(cfg.Reminders) != wantLen {
 		t.Fatalf("expected %d reminders (defaults + 1 custom), got %d:\n%+v", wantLen, len(cfg.Reminders), cfg.Reminders)
 	}
-	// Custom reminder should be present
 	found := false
 	for _, r := range cfg.Reminders {
 		if r.Name == "my-custom" {
@@ -131,7 +129,6 @@ reminders:
 	if !found {
 		t.Error("custom reminder 'my-custom' not found in merged result")
 	}
-	// Built-in defaults should survive
 	hasTodo := false
 	for _, r := range cfg.Reminders {
 		if r.Name == "todo-hygiene" {

--- a/config/reminders.go
+++ b/config/reminders.go
@@ -152,7 +152,7 @@ func ParseReminders(data []byte) (*RemindersConfig, error) {
 // merged on top of DefaultRemindersConfig by name. A supplied entry whose Name
 // matches a built-in overrides it; entries with new names are appended. The
 // receiver's Enabled value is preserved so the consumer's intent wins.
-func (r *RemindersConfig) MergeWithDefaults() *RemindersConfig {
+func (r RemindersConfig) MergeWithDefaults() *RemindersConfig {
 	defaults := DefaultRemindersConfig()
 
 	byName := make(map[string]int, len(defaults.Reminders))
@@ -160,8 +160,7 @@ func (r *RemindersConfig) MergeWithDefaults() *RemindersConfig {
 		byName[def.Name] = i
 	}
 
-	out := make([]ReminderConfig, len(defaults.Reminders))
-	copy(out, defaults.Reminders)
+	out := slices.Clone(defaults.Reminders)
 
 	for _, supplied := range r.Reminders {
 		if idx, ok := byName[supplied.Name]; ok {

--- a/config/reminders.go
+++ b/config/reminders.go
@@ -70,8 +70,13 @@ type ReminderConfig struct {
 // hook point (domain.HookPoint) with a trigger. RemindersConfig implements
 // domain.SystemReminderProvider. The companion executable hooks (#270) get their
 // own hooks.yaml so "inject text" and "run code" stay separate concerns.
+//
+// When Merge is true, the file's reminders are merged onto the built-in defaults
+// by name: a supplied entry with a built-in name overrides that entry; new names
+// are appended. When false (default), the file's reminders fully replace defaults.
 type RemindersConfig struct {
 	Enabled   bool             `yaml:"enabled" mapstructure:"enabled"`
+	Merge     bool             `yaml:"merge,omitempty" mapstructure:"merge"`
 	Reminders []ReminderConfig `yaml:"reminders" mapstructure:"reminders"`
 }
 
@@ -141,6 +146,37 @@ func ParseReminders(data []byte) (*RemindersConfig, error) {
 		return nil, fmt.Errorf("failed to parse reminders config: %w", err)
 	}
 	return cfg, nil
+}
+
+// MergeWithDefaults returns a new RemindersConfig with the receiver's entries
+// merged on top of DefaultRemindersConfig by name. A supplied entry whose Name
+// matches a built-in overrides it; entries with new names are appended. The
+// receiver's Enabled value is preserved so the consumer's intent wins.
+func (r *RemindersConfig) MergeWithDefaults() *RemindersConfig {
+	defaults := DefaultRemindersConfig()
+
+	// Index built-in reminders by name.
+	byName := make(map[string]int, len(defaults.Reminders))
+	for i, def := range defaults.Reminders {
+		byName[def.Name] = i
+	}
+
+	// Seed the result with built-ins, then apply overrides and appends.
+	out := make([]ReminderConfig, len(defaults.Reminders))
+	copy(out, defaults.Reminders)
+
+	for _, supplied := range r.Reminders {
+		if idx, ok := byName[supplied.Name]; ok {
+			out[idx] = supplied // override in-place
+		} else {
+			out = append(out, supplied) // append new
+		}
+	}
+
+	return &RemindersConfig{
+		Enabled:   r.Enabled,
+		Reminders: out,
+	}
 }
 
 // SaveReminders writes the reminders configuration to disk, creating any

--- a/config/reminders.go
+++ b/config/reminders.go
@@ -155,21 +155,19 @@ func ParseReminders(data []byte) (*RemindersConfig, error) {
 func (r *RemindersConfig) MergeWithDefaults() *RemindersConfig {
 	defaults := DefaultRemindersConfig()
 
-	// Index built-in reminders by name.
 	byName := make(map[string]int, len(defaults.Reminders))
 	for i, def := range defaults.Reminders {
 		byName[def.Name] = i
 	}
 
-	// Seed the result with built-ins, then apply overrides and appends.
 	out := make([]ReminderConfig, len(defaults.Reminders))
 	copy(out, defaults.Reminders)
 
 	for _, supplied := range r.Reminders {
 		if idx, ok := byName[supplied.Name]; ok {
-			out[idx] = supplied // override in-place
+			out[idx] = supplied
 		} else {
-			out = append(out, supplied) // append new
+			out = append(out, supplied)
 		}
 	}
 

--- a/config/reminders_test.go
+++ b/config/reminders_test.go
@@ -282,12 +282,10 @@ func TestMergeWithDefaults_AppendsNew(t *testing.T) {
 	if !merged.Enabled {
 		t.Error("merged config should keep Enabled=true")
 	}
-	// Should have built-ins plus the custom entry.
 	wantLen := len(config.DefaultRemindersConfig().Reminders) + 1
 	if len(merged.Reminders) != wantLen {
 		t.Fatalf("expected %d reminders (defaults + 1), got %d", wantLen, len(merged.Reminders))
 	}
-	// The custom entry must be present.
 	found := false
 	for _, r := range merged.Reminders {
 		if r.Name == "my-custom" {
@@ -301,7 +299,6 @@ func TestMergeWithDefaults_AppendsNew(t *testing.T) {
 	if !found {
 		t.Error("custom reminder 'my-custom' not found in merged result")
 	}
-	// Built-in entries must survive.
 	hasTodo := false
 	hasMemoryConsult := false
 	hasMemoryHygiene := false
@@ -338,12 +335,10 @@ func TestMergeWithDefaults_OverridesByName(t *testing.T) {
 	if !merged.Enabled {
 		t.Error("merged config should keep Enabled=true")
 	}
-	// The count should equal defaults (override, not append).
 	wantLen := len(config.DefaultRemindersConfig().Reminders)
 	if len(merged.Reminders) != wantLen {
 		t.Fatalf("expected %d reminders (same as defaults), got %d", wantLen, len(merged.Reminders))
 	}
-	// The todo-hygiene entry should have the overridden text at the same position.
 	for i, r := range merged.Reminders {
 		if r.Name == "todo-hygiene" {
 			if r.Text != "overridden text" {
@@ -355,7 +350,6 @@ func TestMergeWithDefaults_OverridesByName(t *testing.T) {
 			break
 		}
 	}
-	// Memory reminders must still be present.
 	hasMemoryConsult := false
 	for _, r := range merged.Reminders {
 		if r.Name == "memory-consult" {

--- a/config/reminders_test.go
+++ b/config/reminders_test.go
@@ -270,6 +270,135 @@ reminders:
 	}
 }
 
+func TestMergeWithDefaults_AppendsNew(t *testing.T) {
+	cfg := config.RemindersConfig{
+		Enabled: true,
+		Merge:   true,
+		Reminders: []config.ReminderConfig{
+			{Name: "my-custom", Text: "do the thing", Hook: domain.HookPreStream, Trigger: config.ReminderTriggerAlways},
+		},
+	}
+	merged := cfg.MergeWithDefaults()
+	if !merged.Enabled {
+		t.Error("merged config should keep Enabled=true")
+	}
+	// Should have built-ins plus the custom entry.
+	wantLen := len(config.DefaultRemindersConfig().Reminders) + 1
+	if len(merged.Reminders) != wantLen {
+		t.Fatalf("expected %d reminders (defaults + 1), got %d", wantLen, len(merged.Reminders))
+	}
+	// The custom entry must be present.
+	found := false
+	for _, r := range merged.Reminders {
+		if r.Name == "my-custom" {
+			found = true
+			if r.Text != "do the thing" {
+				t.Errorf("custom reminder text = %q, want %q", r.Text, "do the thing")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("custom reminder 'my-custom' not found in merged result")
+	}
+	// Built-in entries must survive.
+	hasTodo := false
+	hasMemoryConsult := false
+	hasMemoryHygiene := false
+	for _, r := range merged.Reminders {
+		switch r.Name {
+		case "todo-hygiene":
+			hasTodo = true
+		case "memory-consult":
+			hasMemoryConsult = true
+		case "memory-hygiene":
+			hasMemoryHygiene = true
+		}
+	}
+	if !hasTodo {
+		t.Error("merged result should include todo-hygiene")
+	}
+	if !hasMemoryConsult {
+		t.Error("merged result should include memory-consult")
+	}
+	if !hasMemoryHygiene {
+		t.Error("merged result should include memory-hygiene")
+	}
+}
+
+func TestMergeWithDefaults_OverridesByName(t *testing.T) {
+	cfg := config.RemindersConfig{
+		Enabled: true,
+		Merge:   true,
+		Reminders: []config.ReminderConfig{
+			{Name: "todo-hygiene", Text: "overridden text", Hook: domain.HookPreStream, Trigger: config.ReminderTriggerAlways},
+		},
+	}
+	merged := cfg.MergeWithDefaults()
+	if !merged.Enabled {
+		t.Error("merged config should keep Enabled=true")
+	}
+	// The count should equal defaults (override, not append).
+	wantLen := len(config.DefaultRemindersConfig().Reminders)
+	if len(merged.Reminders) != wantLen {
+		t.Fatalf("expected %d reminders (same as defaults), got %d", wantLen, len(merged.Reminders))
+	}
+	// The todo-hygiene entry should have the overridden text at the same position.
+	for i, r := range merged.Reminders {
+		if r.Name == "todo-hygiene" {
+			if r.Text != "overridden text" {
+				t.Errorf("todo-hygiene text = %q, want %q", r.Text, "overridden text")
+			}
+			if i != 0 {
+				t.Errorf("todo-hygiene should remain at index 0, got %d", i)
+			}
+			break
+		}
+	}
+	// Memory reminders must still be present.
+	hasMemoryConsult := false
+	for _, r := range merged.Reminders {
+		if r.Name == "memory-consult" {
+			hasMemoryConsult = true
+			break
+		}
+	}
+	if !hasMemoryConsult {
+		t.Error("merged result should include memory-consult")
+	}
+}
+
+func TestMergeWithDefaults_PreservesEnabled(t *testing.T) {
+	cfg := config.RemindersConfig{
+		Enabled: false,
+		Merge:   true,
+		Reminders: []config.ReminderConfig{
+			{Name: "custom", Text: "x"},
+		},
+	}
+	merged := cfg.MergeWithDefaults()
+	if merged.Enabled {
+		t.Error("merged config should keep Enabled=false from the receiver")
+	}
+}
+
+func TestParseReminders_ReplaceIsDefault(t *testing.T) {
+	cfg, err := config.ParseReminders([]byte(`enabled: true
+reminders:
+  - name: only-this
+    text: only this reminder
+`))
+	if err != nil {
+		t.Fatalf("ParseReminders: %v", err)
+	}
+	if cfg.Merge {
+		t.Error("merge should default to false when not specified")
+	}
+	if len(cfg.Reminders) != 1 || cfg.Reminders[0].Name != "only-this" {
+		t.Fatalf("expected only the supplied reminder, got %+v", cfg.Reminders)
+	}
+}
+
 func TestReminders_Validate(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -399,6 +399,12 @@ The `merge` flag works with all three supply paths (`INFER_REMINDERS_CONFIG`,
 `memory-consult`/`memory-hygiene` by name when memory is off) continues to work
 correctly against the merged list.
 
+> **Caveat:** `pruneMemoryRemindersIfDisabled` prunes by name, so any reminder
+> named `memory-consult` or `memory-hygiene` is dropped when memory is disabled,
+> **even if you overrode its content via `merge: true`**. If you override a
+> memory-named reminder and need it to survive with memory off, either rename it
+> or enable memory (`memory.enabled: true` in `memory.yaml`).
+
 ### Web Search Settings
 
 - **web_search.enabled**: Enable/disable web search tool for LLMs (default: true)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -330,6 +330,7 @@ When the file is absent the built-in defaults are used.
 
 ```yaml
 enabled: true # master switch for all reminders
+merge: false  # merge=true: merge entries onto built-in defaults by name instead of replacing them
 reminders:
   - name: todo-hygiene # unique identifier (required)
     text: | # reminder body injected into the conversation (required)
@@ -368,6 +369,35 @@ Embedded/CI consumers can provide reminders without writing `reminders.yaml`:
 Precedence, highest first: `INFER_REMINDERS_CONFIG` → `--reminders-file` → project
 `./.infer/reminders.yaml` → `~/.infer/reminders.yaml` → built-in defaults.
 `INFER_REMINDERS_ENABLED` toggles the master switch on top of whichever source is used.
+
+#### Merging onto defaults (`merge: true`)
+
+By default, a supplied reminders config **replaces** the built-in defaults entirely
+(`todo-hygiene` plus the memory reminders). Set `merge: true` at the top level to
+**merge** onto the built-in set by name instead:
+
+- A supplied entry whose `name` matches a built-in **overrides** that entry in-place.
+- Entries with new names are **appended** to the built-in list.
+- Built-in entries not overridden survive untouched.
+
+This lets consumers add a custom reminder without re-declaring `memory-consult` and
+`memory-hygiene`:
+
+```yaml
+enabled: true
+merge: true
+reminders:
+  - name: my-custom-reminder
+    text: "<system-reminder>Custom nudge</system-reminder>"
+    hook: pre_stream
+    trigger: interval
+    interval: 5
+```
+
+The `merge` flag works with all three supply paths (`INFER_REMINDERS_CONFIG`,
+`--reminders-file`, and file-based). `pruneMemoryRemindersIfDisabled` (which strips
+`memory-consult`/`memory-hygiene` by name when memory is off) continues to work
+correctly against the merged list.
 
 ### Web Search Settings
 


### PR DESCRIPTION
Add a top-level merge bool to RemindersConfig (default false, omitempty). When true, the supplied reminders are merged onto DefaultRemindersConfig() by name: matching names override in-place, new names append, and unmentioned built-in entries survive untouched.

This lets consumers add custom reminders without re-declaring the built-in todo-hygiene, memory-consult, and memory-hygiene entries. The existing pure-replace path stays available (merge: false, the default).

Closes #735