### PR TITLE
fix(flake): add git to nativeCheckInputs for the memory git-backend tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,8 @@
             "-skip=TestIntegration"
           ];
 
+          nativeCheckInputs = [ pkgs.git ];
+
           nativeBuildInputs = [
             pkgs.installShellFiles
           ]


### PR DESCRIPTION
The v0.130.0 git-backed memory tests (`internal/infra/memory/git_test.go`) spawn real `git` processes, but the Nix build sandbox only contains declared inputs, so `nix build` (and any Flox lock refresh building the flake) failed in checkPhase with `exec: "git": executable file not found in $PATH`.

Declare git as a `nativeCheckInputs` so it is on PATH during checkPhase only — it does not become a build or runtime dependency of the output.

Verified locally: `nix build .#` now passes checkPhase (`ok github.com/inference-gateway/cli/internal/infra/memory`).