### PR TITLE
fix(config): correct GLM 5.2 context window to 1M tokens

### DIFF
--- a/config/model_context.go
+++ b/config/model_context.go
@@ -43,6 +43,7 @@ var ContextMatchers = []ModelMatcher{
 	{Patterns: []string{"mistral", "mixtral"}, ContextWindow: 32768},
 	{Patterns: []string{"minimax-m2"}, ContextWindow: 204800},
 	{Patterns: []string{"minimax-m3"}, ContextWindow: 1000000},
+	{Patterns: []string{"glm-5.2"}, ContextWindow: 1000000},
 	{Patterns: []string{"glm-4", "glm-5"}, ContextWindow: 200000},
 	{Patterns: []string{"nemotron-3"}, ContextWindow: 262144},
 	{Patterns: []string{"kimi-k2", "kimi-latest"}, ContextWindow: 262144},

--- a/internal/models/context_test.go
+++ b/internal/models/context_test.go
@@ -242,6 +242,7 @@ func TestMiscOpenWeightContextWindow(t *testing.T) {
 		{"ollama_cloud/glm-4.7", 200000},
 		{"ollama_cloud/glm-5", 200000},
 		{"ollama_cloud/glm-5.1", 200000},
+		{"ollama_cloud/glm-5.2", 1000000},
 		{"ollama_cloud/nemotron-3-super", 262144},
 		{"ollama_cloud/nemotron-3-nano:30b", 262144},
 	}


### PR DESCRIPTION
## Summary

Fixes #745

Ollama Cloud GLM 5.2 has a 1M token context window, but the context window estimator reported 200k because the single `glm-4`/`glm-5` matcher grouped all GLM 4/5 variants under 200k.

## Changes

- **`config/model_context.go`** — Added a dedicated `glm-5.2` matcher with a 1M context window, placed **before** the general `glm-4`/`glm-5` matcher. This is required because `LookupContextWindow` evaluates matchers in priority order using `strings.Contains` (first match wins), so the more specific pattern must come first — the same convention already used for `minimax-m2` vs `minimax-m3`, `deepseek-v3` vs `deepseek-v4`, etc.
- **`internal/models/context_test.go`** — Added a test case for `ollama_cloud/glm-5.2` expecting 1M, alongside the existing GLM 4.6/4.7/5/5.1 cases that remain at 200k.

## Verification

All tests in the `internal/models` package pass:

```
=== RUN   TestMiscOpenWeightContextWindow
--- PASS: TestMiscOpenWeightContextWindow (0.00s)
PASS
ok      github.com/inference-gateway/cli/internal/models
```

GLM 4.x and GLM 5/5.1 remain at 200k; only GLM 5.2 resolves to 1M.

## Affected repos

- `cli` only — no cross-repo impact (no schema/gateway/docs changes needed).