### PR TITLE
feat: scope memory entries by project

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -735,6 +735,11 @@ func applyMemoryEnvOverrides(cfg *config.Config) {
 			cfg.Memory.MaxChars = n
 		}
 	}
+	if v, ok := os.LookupEnv("INFER_MEMORY_MAX_ENTRY_CHARS"); ok {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			cfg.Memory.MaxEntryChars = n
+		}
+	}
 	if v, ok := os.LookupEnv("INFER_MEMORY_BACKEND_TYPE"); ok {
 		cfg.Memory.Backend.Type = v
 	}

--- a/cmd/config_memory_test.go
+++ b/cmd/config_memory_test.go
@@ -39,6 +39,21 @@ func TestApplyMemoryEnvOverrides_Backend(t *testing.T) {
 	}
 }
 
+func TestApplyMemoryEnvOverrides_Caps(t *testing.T) {
+	t.Setenv("INFER_MEMORY_MAX_CHARS", "1500")
+	t.Setenv("INFER_MEMORY_MAX_ENTRY_CHARS", "6000")
+
+	cfg := &config.Config{}
+	applyMemoryEnvOverrides(cfg)
+
+	if cfg.Memory.MaxChars != 1500 {
+		t.Errorf("MaxChars = %d, want 1500", cfg.Memory.MaxChars)
+	}
+	if cfg.Memory.MaxEntryChars != 6000 {
+		t.Errorf("MaxEntryChars = %d, want 6000", cfg.Memory.MaxEntryChars)
+	}
+}
+
 func TestPruneMemoryRemindersIfDisabled(t *testing.T) {
 	countMemory := func(rs []config.ReminderConfig) int {
 		n := 0

--- a/config/config.go
+++ b/config/config.go
@@ -18,9 +18,10 @@ const (
 	MemoryDirName       = "memory"
 	MemoryIndexFileName = "MEMORY.md"
 
-	DefaultConfigPath     = ConfigDirName + "/" + ConfigFileName
-	DefaultLogsPath       = ConfigDirName + "/" + LogsDirName
-	DefaultMemoryMaxChars = 4000
+	DefaultConfigPath          = ConfigDirName + "/" + ConfigFileName
+	DefaultLogsPath            = ConfigDirName + "/" + LogsDirName
+	DefaultMemoryMaxChars      = 2000
+	DefaultMemoryMaxEntryChars = 4000
 )
 
 // Config represents the CLI configuration
@@ -1164,10 +1165,10 @@ func (c *Config) GetSandboxDirectories() []string {
 }
 
 // ResolveMemoryDir resolves the directory that holds the memory index
-// (MEMORY.md) and the individual fact-files. It honors an explicit Memory.Dir
-// override and otherwise defaults to the global userspace ~/.infer/memory. The
-// store is intentionally global (shared across all projects), so there is no
-// project-local branch.
+// (MEMORY.md) and the fact-files. It honors an explicit Memory.Dir override
+// and otherwise defaults to the global userspace ~/.infer/memory. The store is
+// shared across all projects: global facts live at the root and project facts
+// under a per-project subdirectory (<project-slug>/<slug>.md).
 func (c *Config) ResolveMemoryDir() (string, error) {
 	if strings.TrimSpace(c.Memory.Dir) != "" {
 		return c.Memory.Dir, nil

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ const (
 	DefaultConfigPath          = ConfigDirName + "/" + ConfigFileName
 	DefaultLogsPath            = ConfigDirName + "/" + LogsDirName
 	DefaultMemoryMaxChars      = 2000
-	DefaultMemoryMaxEntryChars = 4000
+	DefaultMemoryMaxEntryChars = 2000
 )
 
 // Config represents the CLI configuration

--- a/config/memory.go
+++ b/config/memory.go
@@ -46,10 +46,11 @@ const (
 // session reminder lives in reminders.yaml - keeping each concern in its own
 // file, like Heartbeat/ComputerUse/Channels.
 type MemoryConfig struct {
-	Enabled  bool                `yaml:"enabled" mapstructure:"enabled"`
-	Dir      string              `yaml:"dir" mapstructure:"dir"`             // "" => ~/.infer/memory
-	MaxChars int                 `yaml:"max_chars" mapstructure:"max_chars"` // cap on the injected MEMORY.md index
-	Backend  MemoryBackendConfig `yaml:"backend" mapstructure:"backend"`
+	Enabled       bool                `yaml:"enabled" mapstructure:"enabled"`
+	Dir           string              `yaml:"dir" mapstructure:"dir"`                         // "" => ~/.infer/memory
+	MaxChars      int                 `yaml:"max_chars" mapstructure:"max_chars"`             // cap on the injected MEMORY.md index
+	MaxEntryChars int                 `yaml:"max_entry_chars" mapstructure:"max_entry_chars"` // cap on a single fact's content at write time; 0 => default
+	Backend       MemoryBackendConfig `yaml:"backend" mapstructure:"backend"`
 }
 
 // MemoryBackendConfig selects how the memory directory is synced. type: local
@@ -86,9 +87,10 @@ type MemoryGitSyncConfig struct {
 // opts into git.
 func DefaultMemoryConfig() *MemoryConfig {
 	return &MemoryConfig{
-		Enabled:  true,
-		Dir:      "",
-		MaxChars: DefaultMemoryMaxChars,
+		Enabled:       true,
+		Dir:           "",
+		MaxChars:      DefaultMemoryMaxChars,
+		MaxEntryChars: DefaultMemoryMaxEntryChars,
 		Backend: MemoryBackendConfig{
 			Type: MemoryBackendLocal,
 			Git: MemoryGitConfig{
@@ -124,7 +126,20 @@ func (m MemoryConfig) Validate() error {
 	if m.Enabled && m.MaxChars <= 0 {
 		return fmt.Errorf("invalid memory.max_chars %d: must be > 0 when memory is enabled", m.MaxChars)
 	}
+	if m.MaxEntryChars < 0 {
+		return fmt.Errorf("invalid memory.max_entry_chars %d: must be >= 0 (0 means default %d)", m.MaxEntryChars, DefaultMemoryMaxEntryChars)
+	}
 	return m.Backend.validate(m.Enabled)
+}
+
+// EffectiveMaxEntryChars returns the per-entry content cap, defaulting when
+// unset. A pre-existing memory.yaml without the key unmarshals to 0 (LoadMemory
+// does not merge defaults), so 0 means "use the default" rather than invalid.
+func (m MemoryConfig) EffectiveMaxEntryChars() int {
+	if m.MaxEntryChars > 0 {
+		return m.MaxEntryChars
+	}
+	return DefaultMemoryMaxEntryChars
 }
 
 func (b MemoryBackendConfig) validate(memoryEnabled bool) error {

--- a/config/memory_test.go
+++ b/config/memory_test.go
@@ -31,6 +31,8 @@ func TestMemoryConfig_Validate(t *testing.T) {
 		{"unknown on_finish", git(config.MemoryGitConfig{Repo: "r", Sync: config.MemoryGitSyncConfig{OnFinish: "commit"}}), true},
 		{"off sync values are valid", git(config.MemoryGitConfig{Repo: "r", Sync: config.MemoryGitSyncConfig{OnStart: config.MemorySyncOff, OnFinish: config.MemorySyncOff}}), false},
 		{"git without repo but disabled is valid", config.MemoryConfig{Enabled: false, Backend: config.MemoryBackendConfig{Type: config.MemoryBackendGit}}, false},
+		{"zero max_entry_chars is valid (means default)", config.MemoryConfig{Enabled: true, MaxChars: 100, MaxEntryChars: 0}, false},
+		{"negative max_entry_chars is invalid", config.MemoryConfig{Enabled: true, MaxChars: 100, MaxEntryChars: -1}, true},
 	}
 
 	for _, tt := range tests {
@@ -40,6 +42,21 @@ func TestMemoryConfig_Validate(t *testing.T) {
 				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestMemoryConfig_EffectiveMaxEntryChars(t *testing.T) {
+	if got := (config.MemoryConfig{}).EffectiveMaxEntryChars(); got != config.DefaultMemoryMaxEntryChars {
+		t.Errorf("EffectiveMaxEntryChars() zero = %d, want default %d", got, config.DefaultMemoryMaxEntryChars)
+	}
+	if got := (config.MemoryConfig{MaxEntryChars: 123}).EffectiveMaxEntryChars(); got != 123 {
+		t.Errorf("EffectiveMaxEntryChars() = %d, want 123", got)
+	}
+	if config.DefaultMemoryConfig().MaxEntryChars != config.DefaultMemoryMaxEntryChars {
+		t.Error("DefaultMemoryConfig must set max_entry_chars")
+	}
+	if config.DefaultMemoryMaxChars != 2000 {
+		t.Errorf("DefaultMemoryMaxChars = %d, want 2000", config.DefaultMemoryMaxChars)
 	}
 }
 

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -666,12 +666,12 @@ Each subagent is independent and cannot itself spawn further subagents. Prefer n
 			Description: `Retrieves the latest screenshot from the buffer. This is a read-only operation that does NOT require approval. Use this tool to see the current state of the screen. Screenshots are automatically captured every few seconds when streaming is enabled.`,
 		},
 		Memory: PromptsToolDescription{
-			Description: `Persistent, cross-session memory stored as individual fact-files in a global memory directory. Each fact is one Markdown file (<slug>.md) with YAML frontmatter (name, description, metadata.type); MEMORY.md is the index (one line per fact) and is injected into your context at the start of every session. Use this to remember durable facts: user preferences, project conventions, recurring gotchas, and decisions that should outlive the current conversation.
+			Description: `Persistent, cross-session memory stored as fact-files in a global memory directory, organized by project. Global facts live at the root (<name>.md); project facts live in a per-project subdirectory (<project>/<name>.md, e.g. inference-gateway-cli/build-commands.md). Each fact is one Markdown file with YAML frontmatter (name, description, metadata.type, metadata.project, metadata.session - the session that last wrote it); MEMORY.md is the index (one line per fact, linking to its path). At session start you are given the index entries for the current project and for global facts; other projects are listed by name only - read the full index (read with no name) to see them.
 
 Operations:
-- read: With no name, return the MEMORY.md index. With a name, return that fact-file's full content. Use this to load a specific fact in full before relying on it.
-- write: Create or update a fact. Required: name (a short slug), description (a one-line summary shown in the index), type (one of user, feedback, project, reference), and content (the fact body). This writes <slug>.md and keeps the MEMORY.md index in sync automatically.
-- delete: Remove a fact and its index entry. Required: name.
+- read: With no name, return the full MEMORY.md index (all projects). With a name, return that fact-file's full content. Use the exact name shown in the index: "build-commands" for a global fact, "inference-gateway-cli/build-commands" for a project fact.
+- write: Create or update a fact. Required: name (a short slug), description (a one-line summary shown in the index), type (one of user, feedback, project, reference), and content (the fact body in Markdown; writes over the per-entry size cap are rejected, so keep it tight). Optional: project - where the fact belongs. Defaults: "user" facts are global (they describe the user, not a project); feedback/project/reference facts go under the current project (detected from the git remote). Pass project "global" to force a global fact, or an org/repo name to file it under another project.
+- delete: Remove a fact and its index entry. Required: name (the exact name from the index, including the project prefix for project facts).
 
 Guidelines: record one fact per memory; keep description to a single line; before writing, check the index for an existing entry and update it rather than creating a duplicate; delete facts that turn out to be wrong. Never edit MEMORY.md by hand - the tool maintains it.`,
 		},

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -976,6 +976,12 @@ func (s *AgentServiceImpl) executeToolInternal(
 	if s.stateManager != nil {
 		execCtx = domain.WithAgentMode(execCtx, s.stateManager.GetAgentMode())
 	}
+
+	if domain.GetSessionID(execCtx) == "" && s.conversationRepo != nil {
+		if convID := s.conversationRepo.GetCurrentConversationID(); convID != "" {
+			execCtx = domain.WithSessionID(execCtx, convID)
+		}
+	}
 	if wasApproved {
 		execCtx = domain.WithToolApproved(execCtx)
 	}
@@ -997,9 +1003,6 @@ func (s *AgentServiceImpl) executeToolInternal(
 		execCtx = domain.WithBashDetachChannel(execCtx, detachChan)
 	}
 
-	// AskUserQuestion blocks on an interactive form. Only hand it the broker
-	// when a chat UI/event loop is present (GetChatHandler is set only on the
-	// chat path); headless runs see a nil broker and degrade gracefully.
 	if tc.Function.Name == "AskUserQuestion" && domain.GetChatHandler(ctx) != nil {
 		execCtx = domain.WithUserQuestionBroker(execCtx, &chatQuestionBroker{publisher: eventPublisher})
 	}

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	domain "github.com/inference-gateway/cli/internal/domain"
 	formatting "github.com/inference-gateway/cli/internal/formatting"
 	logger "github.com/inference-gateway/cli/internal/logger"
+	project "github.com/inference-gateway/cli/internal/project"
 	streamevent "github.com/inference-gateway/cli/internal/streamevent"
 )
 
@@ -490,12 +492,13 @@ func (s *AgentServiceImpl) buildMemoryInfo(currentTurn int) string {
 	if index == "" {
 		return ""
 	}
+	index = filterMemoryIndex(index, project.Detect().Slug)
 	if maxChars := s.config.Memory.MaxChars; maxChars > 0 && len(index) > maxChars {
 		index = index[:maxChars] + "\n... (memory index truncated; use the Memory tool 'read' with a name for full facts)"
 	}
 
 	var b strings.Builder
-	b.WriteString("\n\nPERSISTENT MEMORY INDEX (durable facts from past sessions; use the Memory tool 'read' with a name to load one in full):\n")
+	b.WriteString("\n\nPERSISTENT MEMORY INDEX (global facts plus facts for the current project, from past sessions; use the Memory tool 'read' with a name to load one in full):\n")
 	b.WriteString(index)
 	b.WriteString("\n")
 
@@ -507,6 +510,55 @@ func (s *AgentServiceImpl) buildMemoryInfo(currentTurn int) string {
 	s.contextCacheMux.Unlock()
 
 	return result
+}
+
+// memoryIndexLink extracts the link target from a MEMORY.md entry line.
+var memoryIndexLink = regexp.MustCompile(`\]\(([^)]+)\.md\)`)
+
+// filterMemoryIndex keeps index entry lines that are global (root-level link)
+// or belong to projectSlug, and collapses every other project into one summary
+// line so the injected index stays small while other projects remain
+// discoverable. Non-entry lines (header, blanks) and unparsable entry lines
+// are kept as-is (fail open).
+func filterMemoryIndex(index, projectSlug string) string {
+	var b strings.Builder
+	others := make(map[string]struct{})
+
+	for line := range strings.SplitSeq(index, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "- ") {
+			b.WriteString(line)
+			b.WriteString("\n")
+			continue
+		}
+		m := memoryIndexLink.FindStringSubmatch(trimmed)
+		if m == nil {
+			b.WriteString(line)
+			b.WriteString("\n")
+			continue
+		}
+		lineProject := ""
+		if i := strings.IndexByte(m[1], '/'); i >= 0 {
+			lineProject = m[1][:i]
+		}
+		if lineProject == "" || lineProject == projectSlug {
+			b.WriteString(line)
+			b.WriteString("\n")
+			continue
+		}
+		others[lineProject] = struct{}{}
+	}
+
+	out := strings.TrimRight(b.String(), "\n")
+	if len(others) > 0 {
+		names := make([]string, 0, len(others))
+		for p := range others {
+			names = append(names, p)
+		}
+		sort.Strings(names)
+		out += fmt.Sprintf("\n- other projects with memories (not shown; read with \"<project>/<name>\"): %s", strings.Join(names, ", "))
+	}
+	return out
 }
 
 // matchSkillTriggers scans user-role messages for explicit skill invocations
@@ -692,27 +744,7 @@ func isGitRepository() bool {
 
 // getGitRepositoryName extracts the repository name from the git remote URL
 func getGitRepositoryName() string {
-	cmd := exec.Command("git", "remote", "get-url", "origin")
-	output, err := cmd.Output()
-	if err != nil {
-		logger.Debug("failed to get git remote URL", "error", err)
-		return ""
-	}
-
-	remoteURL := strings.TrimSpace(string(output))
-
-	httpsPattern := regexp.MustCompile(`^https?://[^/]+/([^/]+/[^/]+?)(?:\.git)?$`)
-	if matches := httpsPattern.FindStringSubmatch(remoteURL); len(matches) > 1 {
-		return matches[1]
-	}
-
-	sshPattern := regexp.MustCompile(`^git@[^:]+:([^/]+/[^/]+?)(?:\.git)?$`)
-	if matches := sshPattern.FindStringSubmatch(remoteURL); len(matches) > 1 {
-		return matches[1]
-	}
-
-	logger.Debug("could not parse git repository name from URL", "url", remoteURL)
-	return ""
+	return project.RemoteName()
 }
 
 // getGitBranch returns the current git branch name

--- a/internal/agent/agent_utils_test.go
+++ b/internal/agent/agent_utils_test.go
@@ -457,3 +457,41 @@ func TestBuildActiveSkillInfo_AdjacentSlashTokens(t *testing.T) {
 	require.Contains(t, got, "FOO_DESC")
 	require.Contains(t, got, "BAR_DESC")
 }
+
+func TestFilterMemoryIndex(t *testing.T) {
+	index := "# Memory Index\n\n" +
+		"- [global-fact](global-fact.md) - a global fact\n" +
+		"- [inference-gateway-cli/build](inference-gateway-cli/build.md) - build steps\n" +
+		"- [other-proj/x](other-proj/x.md) - other\n" +
+		"- [zeta/y](zeta/y.md) - another\n" +
+		"- unparsable entry line\n"
+
+	got := filterMemoryIndex(index, "inference-gateway-cli")
+	for _, want := range []string{
+		"](global-fact.md)",
+		"](inference-gateway-cli/build.md)",
+		"- unparsable entry line",
+		"other projects with memories",
+		"other-proj, zeta",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("filtered index missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "](other-proj/x.md)") || strings.Contains(got, "](zeta/y.md)") {
+		t.Errorf("foreign entries must be collapsed:\n%s", got)
+	}
+
+	got = filterMemoryIndex(index, "")
+	if strings.Contains(got, "](inference-gateway-cli/build.md)") {
+		t.Errorf("empty project slug must keep only globals:\n%s", got)
+	}
+	if !strings.Contains(got, "inference-gateway-cli, other-proj, zeta") {
+		t.Errorf("all projects must be summarized (sorted):\n%s", got)
+	}
+
+	onlyGlobal := "# Memory Index\n\n- [a](a.md) - a\n"
+	if got := filterMemoryIndex(onlyGlobal, "p"); strings.Contains(got, "other projects") {
+		t.Errorf("no foreign projects must mean no summary line:\n%s", got)
+	}
+}

--- a/internal/agent/tools/agent.go
+++ b/internal/agent/tools/agent.go
@@ -17,6 +17,7 @@ import (
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	logger "github.com/inference-gateway/cli/internal/logger"
+	project "github.com/inference-gateway/cli/internal/project"
 	agentrunner "github.com/inference-gateway/cli/internal/services/agentrunner"
 	sdk "github.com/inference-gateway/sdk"
 )
@@ -444,7 +445,7 @@ func (t *AgentTool) buildChatPaneCommand(spec AgentTaskSpec, sessionID string) s
 		parts = append(parts, "INFER_AGENT_MODEL="+shellQuote(spec.Model))
 	}
 
-	historyName := sanitizeSlug(spec.Label)
+	historyName := project.Slugify(spec.Label)
 	if historyName == "" {
 		historyName = domain.SubagentHistoryMemoryOnly
 	}

--- a/internal/agent/tools/memory.go
+++ b/internal/agent/tools/memory.go
@@ -6,15 +6,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
 
-	config "github.com/inference-gateway/cli/config"
-	domain "github.com/inference-gateway/cli/internal/domain"
 	sdk "github.com/inference-gateway/sdk"
 	yaml "gopkg.in/yaml.v3"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	project "github.com/inference-gateway/cli/internal/project"
 )
 
 const (
@@ -30,7 +31,6 @@ const (
 	MemoryTypeReference = "reference"
 
 	memoryIndexHeader = "# Memory Index"
-	maxSlugLen        = 64
 )
 
 // MemoryTool implements persistent, cross-session agent memory as a directory of
@@ -41,16 +41,20 @@ type MemoryTool struct {
 	enabled   bool
 	formatter domain.CustomFormatter
 	backend   domain.MemoryBackend
+	project   project.Identity
 }
 
 // NewMemoryTool creates a new memory tool. backend syncs the memory directory to
 // a remote after a write/delete (nil-safe: a nil backend, or the local no-op
 // backend, means no remote sync). This is the chat push path - post_session
 // would push after every message, so the tool triggers the push instead.
-func NewMemoryTool(cfg *config.Config, backend domain.MemoryBackend) *MemoryTool {
+// proj is the detected project the process runs in (zero value = global scope);
+// it decides where project-scoped facts are filed.
+func NewMemoryTool(cfg *config.Config, backend domain.MemoryBackend, proj project.Identity) *MemoryTool {
 	return &MemoryTool{
 		config:  cfg,
 		enabled: cfg.Memory.Enabled,
+		project: proj,
 		formatter: domain.NewCustomFormatter(ToolNameMemory, func(key string) bool {
 			return key == "content"
 		}),
@@ -79,8 +83,15 @@ func (t *MemoryTool) Definition() sdk.ChatCompletionTool {
 					},
 					"name": map[string]any{
 						"type": "string",
-						"description": "Short slug identifying the memory (e.g. \"build-commands\"). " +
+						"description": "Name identifying the memory: \"<slug>\" for a global fact (e.g. \"build-commands\") or " +
+							"\"<project>/<slug>\" for a project fact (e.g. \"inference-gateway-cli/build-commands\"), exactly as shown in the index. " +
 							"Required for write and delete; optional for read.",
+					},
+					"project": map[string]any{
+						"type": "string",
+						"description": "Optional, write only. Where the fact belongs: omit to use the default " +
+							"(user facts are global; feedback/project/reference facts go under the current project), " +
+							"pass \"global\" to force a global fact, or an org/repo name to file it under another project.",
 					},
 					"description": map[string]any{
 						"type":        "string",
@@ -147,27 +158,28 @@ func (t *MemoryTool) execRead(args map[string]any, start time.Time) (*domain.Too
 		return t.readIndex(args, start, dir)
 	}
 
-	slug := sanitizeSlug(name)
-	if slug == "" {
+	projectSlug, slug, ok := sanitizeName(name)
+	if !ok {
 		return t.errResult(args, start, fmt.Sprintf("invalid memory name: %q", name)), nil
 	}
+	relKey := joinKey(projectSlug, slug)
 
-	filePath := filepath.Join(dir, slug+".md")
+	filePath := filepath.Join(dir, projectSlug, slug+".md")
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return t.okResult(args, start, &MemoryToolResult{
 				Operation: OperationRead,
-				Name:      slug,
-				Message:   fmt.Sprintf("No memory named %q.", slug),
+				Name:      relKey,
+				Message:   fmt.Sprintf("No memory named %q (project facts are read as \"<project>/<name>\" - see the index).", relKey),
 			}), nil
 		}
-		return t.errResult(args, start, fmt.Sprintf("failed to read memory %q: %v", slug, err)), nil
+		return t.errResult(args, start, fmt.Sprintf("failed to read memory %q: %v", relKey, err)), nil
 	}
 
 	return t.okResult(args, start, &MemoryToolResult{
 		Operation: OperationRead,
-		Name:      slug,
+		Name:      relKey,
 		Path:      filePath,
 		Content:   string(content),
 		Size:      int64(len(content)),
@@ -200,10 +212,18 @@ func (t *MemoryTool) execWrite(ctx context.Context, args map[string]any, start t
 	description, _ := args["description"].(string)
 	memType, _ := args["type"].(string)
 	content, _ := args["content"].(string)
+	projectArg, _ := args["project"].(string)
 
-	slug := sanitizeSlug(name)
-	if slug == "" {
-		return t.errResult(args, start, fmt.Sprintf("invalid memory name: %q", name)), nil
+	projectSlug, slug, err := resolveWriteTarget(name, projectArg, memType, t.project)
+	if err != nil {
+		return t.errResult(args, start, err.Error()), nil
+	}
+	relKey := joinKey(projectSlug, slug)
+
+	if maxChars := t.config.Memory.EffectiveMaxEntryChars(); len(content) > maxChars {
+		return t.errResult(args, start, fmt.Sprintf(
+			"memory content is %d chars, over the per-entry cap of %d; store a tighter summary or split into multiple facts (memory.max_entry_chars raises the cap)",
+			len(content), maxChars)), nil
 	}
 
 	dir, err := t.config.ResolveMemoryDir()
@@ -211,17 +231,17 @@ func (t *MemoryTool) execWrite(ctx context.Context, args map[string]any, start t
 		return t.errResult(args, start, fmt.Sprintf("failed to resolve memory dir: %v", err)), nil
 	}
 
-	fileBody, err := buildMemoryFile(slug, description, memType, content)
+	fileBody, err := buildMemoryFile(slug, description, memType, t.projectDisplayName(projectSlug, projectArg), domain.GetSessionID(ctx), content)
 	if err != nil {
 		return t.errResult(args, start, fmt.Sprintf("failed to render memory file: %v", err)), nil
 	}
 
-	filePath := filepath.Join(dir, slug+".md")
+	filePath := filepath.Join(dir, projectSlug, slug+".md")
 	if err := writeFileAtomic(filePath, fileBody); err != nil {
 		return t.errResult(args, start, fmt.Sprintf("failed to write memory file: %v", err)), nil
 	}
 
-	if err := upsertIndexEntry(dir, slug, description); err != nil {
+	if err := upsertIndexEntry(dir, relKey, description); err != nil {
 		return t.errResult(args, start, fmt.Sprintf("failed to update memory index: %v", err)), nil
 	}
 
@@ -229,8 +249,9 @@ func (t *MemoryTool) execWrite(ctx context.Context, args map[string]any, start t
 
 	return t.okResult(args, start, &MemoryToolResult{
 		Operation:   OperationWrite,
-		Name:        slug,
+		Name:        relKey,
 		Type:        memType,
+		Project:     projectSlug,
 		Description: description,
 		Path:        filePath,
 		Size:        int64(len(fileBody)),
@@ -238,20 +259,76 @@ func (t *MemoryTool) execWrite(ctx context.Context, args map[string]any, start t
 	}), nil
 }
 
+// projectDisplayName returns the human-readable project name recorded in the
+// fact's frontmatter: the detected project's name when the fact is filed under
+// it, otherwise the explicit project argument as given; empty for global.
+func (t *MemoryTool) projectDisplayName(projectSlug, projectArg string) string {
+	if projectSlug == "" {
+		return ""
+	}
+	if projectSlug == t.project.Slug && t.project.Name != "" {
+		return t.project.Name
+	}
+	if arg := strings.TrimSpace(projectArg); arg != "" && !strings.EqualFold(arg, projectGlobal) {
+		return arg
+	}
+	return projectSlug
+}
+
+// projectGlobal is the sentinel project argument that forces a global fact.
+const projectGlobal = "global"
+
+// resolveWriteTarget decides where a write lands: a project subdirectory or the
+// global root. Precedence: a project embedded in the name ("p/s"), then the
+// explicit project argument ("global" forces the root), then a type-based
+// default - user facts are global, everything else goes under the detected
+// project (global when no project was detected).
+func resolveWriteTarget(name, projectArg, memType string, detected project.Identity) (projectSlug, slug string, err error) {
+	nameProject, slug, ok := sanitizeName(name)
+	if !ok {
+		return "", "", fmt.Errorf("invalid memory name: %q", name)
+	}
+
+	argSlug := ""
+	if arg := strings.TrimSpace(projectArg); arg != "" {
+		if !strings.EqualFold(arg, projectGlobal) {
+			argSlug = project.Slugify(arg)
+			if argSlug == "" {
+				return "", "", fmt.Errorf("invalid project: %q", projectArg)
+			}
+		}
+	}
+
+	if nameProject != "" {
+		if strings.TrimSpace(projectArg) != "" && argSlug != nameProject {
+			return "", "", fmt.Errorf("conflicting project: name says %q, project says %q", nameProject, projectArg)
+		}
+		return nameProject, slug, nil
+	}
+	if strings.TrimSpace(projectArg) != "" {
+		return argSlug, slug, nil
+	}
+	if memType == MemoryTypeUser {
+		return "", slug, nil
+	}
+	return detected.Slug, slug, nil
+}
+
 // execDelete removes a fact-file and its index entry (idempotent).
 func (t *MemoryTool) execDelete(ctx context.Context, args map[string]any, start time.Time) (*domain.ToolExecutionResult, error) {
 	name, _ := args["name"].(string)
-	slug := sanitizeSlug(name)
-	if slug == "" {
+	projectSlug, slug, ok := sanitizeName(name)
+	if !ok {
 		return t.errResult(args, start, fmt.Sprintf("invalid memory name: %q", name)), nil
 	}
+	relKey := joinKey(projectSlug, slug)
 
 	dir, err := t.config.ResolveMemoryDir()
 	if err != nil {
 		return t.errResult(args, start, fmt.Sprintf("failed to resolve memory dir: %v", err)), nil
 	}
 
-	filePath := filepath.Join(dir, slug+".md")
+	filePath := filepath.Join(dir, projectSlug, slug+".md")
 	existed := true
 	if err := os.Remove(filePath); err != nil {
 		if !os.IsNotExist(err) {
@@ -260,19 +337,19 @@ func (t *MemoryTool) execDelete(ctx context.Context, args map[string]any, start 
 		existed = false
 	}
 
-	if err := removeIndexEntry(dir, slug); err != nil {
+	if err := removeIndexEntry(dir, relKey); err != nil {
 		return t.errResult(args, start, fmt.Sprintf("failed to update memory index: %v", err)), nil
 	}
 
 	t.syncOut(ctx)
 
-	message := fmt.Sprintf("Deleted memory %q.", slug)
+	message := fmt.Sprintf("Deleted memory %q.", relKey)
 	if !existed {
-		message = fmt.Sprintf("No memory named %q; nothing to delete.", slug)
+		message = fmt.Sprintf("No memory named %q; nothing to delete.", relKey)
 	}
 	return t.okResult(args, start, &MemoryToolResult{
 		Operation: OperationDelete,
-		Name:      slug,
+		Name:      relKey,
 		Path:      filePath,
 		Message:   message,
 	}), nil
@@ -332,6 +409,11 @@ func validateWriteArgs(args map[string]any) error {
 	if !validMemoryType(memType) {
 		return fmt.Errorf("type must be one of: user, feedback, project, reference")
 	}
+	if v, ok := args["project"]; ok {
+		if _, ok := v.(string); !ok {
+			return fmt.Errorf("project must be a string")
+		}
+	}
 	return nil
 }
 
@@ -340,6 +422,7 @@ type MemoryToolResult struct {
 	Operation   string `json:"operation"`
 	Name        string `json:"name,omitempty"`
 	Type        string `json:"type,omitempty"`
+	Project     string `json:"project,omitempty"`
 	Description string `json:"description,omitempty"`
 	Path        string `json:"path,omitempty"`
 	Content     string `json:"content,omitempty"`
@@ -353,24 +436,43 @@ type memoryFrontmatter struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
 	Metadata    struct {
-		Type string `yaml:"type"`
+		Type    string `yaml:"type"`
+		Project string `yaml:"project,omitempty"` // human-readable, e.g. "inference-gateway/cli"; absent for global
+		Session string `yaml:"session,omitempty"` // session that last wrote the fact (chat conversation ID or headless session ID)
 	} `yaml:"metadata"`
 }
 
-var slugInvalidChars = regexp.MustCompile(`[^a-z0-9]+`)
-
-// sanitizeSlug normalizes a memory name into a safe, flat filename stem:
-// lowercased, non-alphanumeric runs collapsed to single hyphens, trimmed, and
-// length-capped. The result contains no path separators or dots, so it always
-// resolves to a single file inside the memory dir (no traversal).
-func sanitizeSlug(name string) string {
-	s := strings.ToLower(strings.TrimSpace(name))
-	s = slugInvalidChars.ReplaceAllString(s, "-")
-	s = strings.Trim(s, "-")
-	if len(s) > maxSlugLen {
-		s = strings.Trim(s[:maxSlugLen], "-")
+// sanitizeName parses a memory name into (projectSlug, slug): "p/s" ->
+// ("p", "s"), "s" -> ("", "s"). Each segment is independently slugified
+// (lowercased, non-alphanumeric runs collapsed to single hyphens, trimmed,
+// length-capped), so no dots or separators survive and the joined path always
+// stays inside the memory dir (no traversal). More than one "/" or any empty
+// sanitized segment yields ok=false.
+func sanitizeName(name string) (projectSlug, slug string, ok bool) {
+	parts := strings.Split(strings.TrimSpace(name), "/")
+	switch len(parts) {
+	case 1:
+		slug = project.Slugify(parts[0])
+		return "", slug, slug != ""
+	case 2:
+		projectSlug = project.Slugify(parts[0])
+		slug = project.Slugify(parts[1])
+		if projectSlug == "" || slug == "" {
+			return "", "", false
+		}
+		return projectSlug, slug, true
+	default:
+		return "", "", false
 	}
-	return s
+}
+
+// joinKey renders the index key for a fact: "p/s" or bare "s". Always a
+// forward slash - the key doubles as a Markdown link target.
+func joinKey(projectSlug, slug string) string {
+	if projectSlug == "" {
+		return slug
+	}
+	return projectSlug + "/" + slug
 }
 
 func validMemoryType(memType string) bool {
@@ -403,10 +505,14 @@ func requireStringArgValue(args map[string]any, key string) (string, error) {
 }
 
 // buildMemoryFile renders a fact-file: YAML frontmatter (name/description/
-// metadata.type) followed by the body.
-func buildMemoryFile(slug, description, memType, content string) (string, error) {
+// metadata.type/metadata.project/metadata.session) followed by the body.
+// projectName is the human-readable project (empty for a global fact);
+// sessionID tracks provenance - the session that last wrote the fact.
+func buildMemoryFile(slug, description, memType, projectName, sessionID, content string) (string, error) {
 	fm := memoryFrontmatter{Name: slug, Description: description}
 	fm.Metadata.Type = memType
+	fm.Metadata.Project = projectName
+	fm.Metadata.Session = sessionID
 
 	var fmBuf bytes.Buffer
 	enc := yaml.NewEncoder(&fmBuf)
@@ -425,18 +531,21 @@ func buildMemoryFile(slug, description, memType, content string) (string, error)
 	return b.String(), nil
 }
 
-// indexEntryLine renders the one-line catalog entry for a memory.
-func indexEntryLine(slug, description string) string {
+// indexEntryLine renders the one-line catalog entry for a memory. relKey is
+// "slug" for a global fact or "project/slug" for a project fact.
+func indexEntryLine(relKey, description string) string {
 	desc := strings.TrimSpace(description)
 	if desc == "" {
-		return fmt.Sprintf("- [%s](%s.md)", slug, slug)
+		return fmt.Sprintf("- [%s](%s.md)", relKey, relKey)
 	}
-	return fmt.Sprintf("- [%s](%s.md) - %s", slug, slug, desc)
+	return fmt.Sprintf("- [%s](%s.md) - %s", relKey, relKey, desc)
 }
 
-// indexEntryMatches reports whether an index line points at slug's fact-file.
-func indexEntryMatches(line, slug string) bool {
-	return strings.Contains(line, fmt.Sprintf("](%s.md)", slug))
+// indexEntryMatches reports whether an index line points at relKey's fact-file.
+// The "](<relKey>.md)" needle is unambiguous across the global and project
+// forms: "](s.md)" never occurs inside "](p/s.md)".
+func indexEntryMatches(line, relKey string) bool {
+	return strings.Contains(line, fmt.Sprintf("](%s.md)", relKey))
 }
 
 // readIndexEntries returns the catalog entry lines (those beginning with "- ")
@@ -478,7 +587,7 @@ func writeIndexEntries(indexPath string, entries []string) error {
 // can't see because it is a file, not shared memory).
 var indexMu sync.Mutex
 
-func upsertIndexEntry(dir, slug, description string) error {
+func upsertIndexEntry(dir, relKey, description string) error {
 	indexMu.Lock()
 	defer indexMu.Unlock()
 	indexPath := filepath.Join(dir, config.MemoryIndexFileName)
@@ -486,10 +595,10 @@ func upsertIndexEntry(dir, slug, description string) error {
 	if err != nil {
 		return err
 	}
-	newEntry := indexEntryLine(slug, description)
+	newEntry := indexEntryLine(relKey, description)
 	found := false
 	for i, e := range entries {
-		if indexEntryMatches(e, slug) {
+		if indexEntryMatches(e, relKey) {
 			entries[i] = newEntry
 			found = true
 			break
@@ -501,7 +610,7 @@ func upsertIndexEntry(dir, slug, description string) error {
 	return writeIndexEntries(indexPath, entries)
 }
 
-func removeIndexEntry(dir, slug string) error {
+func removeIndexEntry(dir, relKey string) error {
 	indexMu.Lock()
 	defer indexMu.Unlock()
 	indexPath := filepath.Join(dir, config.MemoryIndexFileName)
@@ -511,7 +620,7 @@ func removeIndexEntry(dir, slug string) error {
 	}
 	kept := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if indexEntryMatches(e, slug) {
+		if indexEntryMatches(e, relKey) {
 			continue
 		}
 		kept = append(kept, e)

--- a/internal/agent/tools/memory_test.go
+++ b/internal/agent/tools/memory_test.go
@@ -14,16 +14,29 @@ import (
 	yaml "gopkg.in/yaml.v3"
 
 	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	project "github.com/inference-gateway/cli/internal/project"
 )
 
+// testProjectIdentity is the zero identity (global scope): the pre-existing
+// tests assert root-level fact files, which is exactly the no-project case.
+func testProjectIdentity() project.Identity {
+	return project.Identity{}
+}
+
 func newTestMemoryTool(t *testing.T) (*MemoryTool, string) {
+	t.Helper()
+	return newTestMemoryToolWithProject(t, testProjectIdentity())
+}
+
+func newTestMemoryToolWithProject(t *testing.T, proj project.Identity) (*MemoryTool, string) {
 	t.Helper()
 	cfg := config.DefaultConfig()
 	cfg.Memory.Enabled = true
 	cfg.Memory.Dir = t.TempDir()
 	cfg.Memory.MaxChars = config.DefaultMemoryMaxChars
 	cfg.Prompts = *config.DefaultPromptsConfig()
-	return NewMemoryTool(cfg, nil), cfg.Memory.Dir
+	return NewMemoryTool(cfg, nil, proj), cfg.Memory.Dir
 }
 
 func TestMemoryTool_SyncOutOnMutation(t *testing.T) {
@@ -34,7 +47,7 @@ func TestMemoryTool_SyncOutOnMutation(t *testing.T) {
 	cfg.Prompts = *config.DefaultPromptsConfig()
 
 	fake := &mocks.FakeMemoryBackend{}
-	tool := NewMemoryTool(cfg, fake)
+	tool := NewMemoryTool(cfg, fake, testProjectIdentity())
 
 	if _, err := tool.Execute(context.Background(), map[string]any{"operation": "read"}); err != nil {
 		t.Fatalf("read: %v", err)
@@ -132,12 +145,12 @@ func TestMemoryTool_Definition(t *testing.T) {
 
 func TestMemoryTool_IsEnabled(t *testing.T) {
 	cfg := config.DefaultConfig()
-	if NewMemoryTool(cfg, nil).IsEnabled() {
+	if NewMemoryTool(cfg, nil, testProjectIdentity()).IsEnabled() {
 		t.Error("Memory tool should be disabled by default")
 	}
 
 	cfg.Memory.Enabled = true
-	if !NewMemoryTool(cfg, nil).IsEnabled() {
+	if !NewMemoryTool(cfg, nil, testProjectIdentity()).IsEnabled() {
 		t.Error("Memory tool should be enabled when memory.enabled is true")
 	}
 }
@@ -189,7 +202,7 @@ func TestMemoryTool_Validate(t *testing.T) {
 func TestMemoryTool_Validate_Disabled(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Memory.Enabled = false
-	tool := NewMemoryTool(cfg, nil)
+	tool := NewMemoryTool(cfg, nil, testProjectIdentity())
 	if err := tool.Validate(map[string]any{"operation": "read"}); err == nil {
 		t.Error("Expected validation error when memory is disabled")
 	}
@@ -272,18 +285,18 @@ func TestMemoryTool_Write_SanitizesSlug(t *testing.T) {
 		t.Errorf("expected flat fact-file my-fact-v2.md: %v", err)
 	}
 
-	res = execOK(t, tool, map[string]any{
+	execRes, err := tool.Execute(context.Background(), map[string]any{
 		"operation":   "write",
 		"name":        "../evil",
 		"description": "d",
 		"type":        "reference",
 		"content":     "b",
 	})
-	if strings.ContainsAny(res.Name, "/.") {
-		t.Errorf("slug must not contain path separators or dots, got %q", res.Name)
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, res.Name+".md")); err != nil {
-		t.Errorf("expected flat fact-file inside dir: %v", err)
+	if execRes.Success {
+		t.Error("a traversal name must be rejected")
 	}
 	if _, err := os.Stat(filepath.Join(dir, "..", "evil.md")); err == nil {
 		t.Error("a file escaped the memory dir")
@@ -408,5 +421,210 @@ func TestMemoryTool_NoTempLeftovers(t *testing.T) {
 		if strings.HasPrefix(e.Name(), ".tmp-memory") {
 			t.Errorf("leftover temp file: %s", e.Name())
 		}
+	}
+}
+
+func TestMemoryTool_Write_ProjectScoping(t *testing.T) {
+	detected := project.Identity{Name: "inference-gateway/cli", Slug: "inference-gateway-cli"}
+	tool, dir := newTestMemoryToolWithProject(t, detected)
+
+	res := execOK(t, tool, map[string]any{
+		"operation": "write", "name": "build-commands", "description": "d", "type": "project", "content": "b",
+	})
+	if res.Name != "inference-gateway-cli/build-commands" {
+		t.Errorf("expected project-prefixed name, got %q", res.Name)
+	}
+	path := filepath.Join(dir, "inference-gateway-cli", "build-commands.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected project fact-file: %v", err)
+	}
+	fm := parseFrontmatter(t, string(data))
+	if fm.Metadata.Project != "inference-gateway/cli" {
+		t.Errorf("frontmatter project = %q, want inference-gateway/cli", fm.Metadata.Project)
+	}
+	if !strings.Contains(readIndexFile(t, dir), "](inference-gateway-cli/build-commands.md)") {
+		t.Errorf("index missing project entry:\n%s", readIndexFile(t, dir))
+	}
+}
+
+func TestMemoryTool_Write_UserTypeDefaultsGlobal(t *testing.T) {
+	detected := project.Identity{Name: "inference-gateway/cli", Slug: "inference-gateway-cli"}
+	tool, dir := newTestMemoryToolWithProject(t, detected)
+
+	res := execOK(t, tool, map[string]any{
+		"operation": "write", "name": "prefers-tabs", "description": "d", "type": "user", "content": "b",
+	})
+	if res.Name != "prefers-tabs" {
+		t.Errorf("user fact must be global, got %q", res.Name)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "prefers-tabs.md"))
+	if err != nil {
+		t.Fatalf("expected root fact-file: %v", err)
+	}
+	if fm := parseFrontmatter(t, string(data)); fm.Metadata.Project != "" {
+		t.Errorf("global fact must have no frontmatter project, got %q", fm.Metadata.Project)
+	}
+}
+
+func TestMemoryTool_Write_ExplicitProject(t *testing.T) {
+	detected := project.Identity{Name: "inference-gateway/cli", Slug: "inference-gateway-cli"}
+	tool, dir := newTestMemoryToolWithProject(t, detected)
+
+	res := execOK(t, tool, map[string]any{
+		"operation": "write", "name": "x", "description": "d", "type": "project", "content": "b", "project": "GLOBAL",
+	})
+	if res.Name != "x" {
+		t.Errorf("project=global must force root, got %q", res.Name)
+	}
+
+	res = execOK(t, tool, map[string]any{
+		"operation": "write", "name": "y", "description": "d", "type": "reference", "content": "b", "project": "other-org/other",
+	})
+	if res.Name != "other-org-other/y" {
+		t.Errorf("explicit project must be slugified, got %q", res.Name)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "other-org-other", "y.md"))
+	if err != nil {
+		t.Fatalf("expected other-project fact-file: %v", err)
+	}
+	if fm := parseFrontmatter(t, string(data)); fm.Metadata.Project != "other-org/other" {
+		t.Errorf("frontmatter project = %q, want other-org/other", fm.Metadata.Project)
+	}
+}
+
+func TestMemoryTool_Write_NameEmbeddedProject(t *testing.T) {
+	tool, dir := newTestMemoryToolWithProject(t, project.Identity{})
+
+	res := execOK(t, tool, map[string]any{
+		"operation": "write", "name": "p/s", "description": "d", "type": "project", "content": "b",
+	})
+	if res.Name != "p/s" {
+		t.Errorf("expected p/s, got %q", res.Name)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "p", "s.md")); err != nil {
+		t.Fatalf("expected fact under p/: %v", err)
+	}
+
+	execRes, err := tool.Execute(context.Background(), map[string]any{
+		"operation": "write", "name": "p/s", "description": "d", "type": "project", "content": "b", "project": "q",
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if execRes.Success || !strings.Contains(execRes.Error, "conflicting project") {
+		t.Errorf("conflicting name/project must error, got success=%v err=%q", execRes.Success, execRes.Error)
+	}
+}
+
+func TestMemoryTool_ReadDelete_ProjectAndLegacy(t *testing.T) {
+	tool, dir := newTestMemoryToolWithProject(t, project.Identity{Name: "o/r", Slug: "o-r"})
+
+	execOK(t, tool, map[string]any{
+		"operation": "write", "name": "x", "description": "global x", "type": "user", "content": "gx",
+	})
+	execOK(t, tool, map[string]any{
+		"operation": "write", "name": "x", "description": "project x", "type": "project", "content": "px",
+	})
+
+	res := execOK(t, tool, map[string]any{"operation": "read", "name": "x"})
+	if !strings.Contains(res.Content, "gx") {
+		t.Errorf("bare read must hit the global fact:\n%s", res.Content)
+	}
+	res = execOK(t, tool, map[string]any{"operation": "read", "name": "o-r/x"})
+	if !strings.Contains(res.Content, "px") {
+		t.Errorf("prefixed read must hit the project fact:\n%s", res.Content)
+	}
+
+	res = execOK(t, tool, map[string]any{"operation": "read", "name": "o-r/missing"})
+	if !strings.Contains(res.Message, "o-r/missing") {
+		t.Errorf("miss message must include the full name, got %q", res.Message)
+	}
+
+	execOK(t, tool, map[string]any{"operation": "delete", "name": "o-r/x"})
+	if _, err := os.Stat(filepath.Join(dir, "o-r", "x.md")); err == nil {
+		t.Error("project fact must be deleted")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "x.md")); err != nil {
+		t.Error("global fact must survive the project delete")
+	}
+	index := readIndexFile(t, dir)
+	if strings.Contains(index, "](o-r/x.md)") || !strings.Contains(index, "](x.md)") {
+		t.Errorf("index must drop only the project entry:\n%s", index)
+	}
+}
+
+func TestMemoryTool_Write_EntryCap(t *testing.T) {
+	tool, _ := newTestMemoryTool(t)
+	maxChars := tool.config.Memory.EffectiveMaxEntryChars()
+
+	execOK(t, tool, map[string]any{
+		"operation": "write", "name": "at-cap", "description": "d", "type": "reference",
+		"content": strings.Repeat("a", maxChars),
+	})
+
+	res, err := tool.Execute(context.Background(), map[string]any{
+		"operation": "write", "name": "over-cap", "description": "d", "type": "reference",
+		"content": strings.Repeat("a", maxChars+1),
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if res.Success || !strings.Contains(res.Error, "max_entry_chars") {
+		t.Errorf("over-cap write must be rejected with an actionable error, got success=%v err=%q", res.Success, res.Error)
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		in          string
+		wantProject string
+		wantSlug    string
+		wantOK      bool
+	}{
+		{"build-commands", "", "build-commands", true},
+		{"A B/C d", "a-b", "c-d", true},
+		{"p/s", "p", "s", true},
+		{"../evil", "", "", false},
+		{"a/b/c", "", "", false},
+		{"", "", "", false},
+		{"/s", "", "", false},
+		{"p/", "", "", false},
+	}
+	for _, tt := range tests {
+		p, s, ok := sanitizeName(tt.in)
+		if p != tt.wantProject || s != tt.wantSlug || ok != tt.wantOK {
+			t.Errorf("sanitizeName(%q) = (%q, %q, %v), want (%q, %q, %v)", tt.in, p, s, ok, tt.wantProject, tt.wantSlug, tt.wantOK)
+		}
+	}
+}
+
+func TestMemoryTool_Write_RecordsSessionID(t *testing.T) {
+	tool, dir := newTestMemoryTool(t)
+
+	ctx := domain.WithSessionID(context.Background(), "channel-telegram-12345")
+	res, err := tool.Execute(ctx, map[string]any{
+		"operation": "write", "name": "with-session", "description": "d", "type": "reference", "content": "b",
+	})
+	if err != nil || !res.Success {
+		t.Fatalf("write failed: err=%v res=%+v", err, res)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "with-session.md"))
+	if err != nil {
+		t.Fatalf("read fact: %v", err)
+	}
+	if fm := parseFrontmatter(t, string(data)); fm.Metadata.Session != "channel-telegram-12345" {
+		t.Errorf("frontmatter session = %q, want channel-telegram-12345", fm.Metadata.Session)
+	}
+
+	execOK(t, tool, map[string]any{
+		"operation": "write", "name": "no-session", "description": "d", "type": "reference", "content": "b",
+	})
+	data, err = os.ReadFile(filepath.Join(dir, "no-session.md"))
+	if err != nil {
+		t.Fatalf("read fact: %v", err)
+	}
+	if fm := parseFrontmatter(t, string(data)); fm.Metadata.Session != "" {
+		t.Errorf("session must be omitted without a session context, got %q", fm.Metadata.Session)
 	}
 }

--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -7,12 +7,14 @@ import (
 	"sync"
 	"time"
 
+	sdk "github.com/inference-gateway/sdk"
+
 	config "github.com/inference-gateway/cli/config"
 	display "github.com/inference-gateway/cli/internal/display"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	logger "github.com/inference-gateway/cli/internal/logger"
+	project "github.com/inference-gateway/cli/internal/project"
 	utils "github.com/inference-gateway/cli/internal/utils"
-	sdk "github.com/inference-gateway/sdk"
 
 	_ "github.com/inference-gateway/cli/internal/display/macos"
 	_ "github.com/inference-gateway/cli/internal/display/wayland"
@@ -177,7 +179,7 @@ func (r *Registry) registerTools() {
 	}
 
 	if cfg.Memory.Enabled {
-		r.tools["Memory"] = NewMemoryTool(cfg, r.memoryBackend)
+		r.tools["Memory"] = NewMemoryTool(cfg, r.memoryBackend, project.Detect())
 	}
 }
 
@@ -190,7 +192,7 @@ func (r *Registry) SetMemoryBackend(backend domain.MemoryBackend) {
 	r.memoryBackend = backend
 	if r.config.Memory.Enabled {
 		r.toolsMu.Lock()
-		r.tools["Memory"] = NewMemoryTool(r.config, backend)
+		r.tools["Memory"] = NewMemoryTool(r.config, backend, project.Detect())
 		r.toolsMu.Unlock()
 	}
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,89 @@
+// Package project derives the identity of the project the process runs in.
+// It is a leaf package so both the agent and its tools can share it without
+// import cycles.
+package project
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Identity is the detected project the process is running in. The zero value
+// means global scope (no project).
+type Identity struct {
+	Name string
+	Slug string
+}
+
+// maxSlugLen caps a slug segment, mirroring the memory tool's historical cap.
+const maxSlugLen = 64
+
+var (
+	detectOnce sync.Once
+	detected   Identity
+
+	slugInvalidChars = regexp.MustCompile(`[^a-z0-9]+`)
+	httpsPattern     = regexp.MustCompile(`^https?://[^/]+/([^/]+/[^/]+?)(?:\.git)?$`)
+	sshPattern       = regexp.MustCompile(`^git@[^:]+:([^/]+/[^/]+?)(?:\.git)?$`)
+)
+
+// Detect returns the current project, cached for the process lifetime (chat
+// sessions and `infer agent` subprocesses run with a fixed cwd). Detection
+// order: git remote origin -> org/repo; else the cwd basename; else global
+// (the zero Identity).
+func Detect() Identity {
+	detectOnce.Do(func() { detected = detect() })
+	return detected
+}
+
+func detect() Identity {
+	if name := RemoteName(); name != "" {
+		return Identity{Name: name, Slug: Slugify(name)}
+	}
+	if wd, err := os.Getwd(); err == nil {
+		base := filepath.Base(wd)
+		if slug := Slugify(base); slug != "" && base != string(filepath.Separator) {
+			return Identity{Name: base, Slug: slug}
+		}
+	}
+	return Identity{}
+}
+
+// RemoteName returns the "org/repo" name parsed from the origin remote URL,
+// or "" when there is no repo/remote or the URL is unparsable.
+func RemoteName() string {
+	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return ParseRemoteURL(strings.TrimSpace(string(out)))
+}
+
+// ParseRemoteURL extracts "org/repo" from an https or scp-style ssh git remote
+// URL, returning "" when it does not match either form.
+func ParseRemoteURL(url string) string {
+	if m := httpsPattern.FindStringSubmatch(url); len(m) > 1 {
+		return m[1]
+	}
+	if m := sshPattern.FindStringSubmatch(url); len(m) > 1 {
+		return m[1]
+	}
+	return ""
+}
+
+// Slugify normalizes a name into a safe, flat filename segment: lowercased,
+// non-alphanumeric runs collapsed to single hyphens, trimmed, and
+// length-capped. Notably Slugify("org/repo") == "org-repo".
+func Slugify(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = slugInvalidChars.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > maxSlugLen {
+		s = strings.Trim(s[:maxSlugLen], "-")
+	}
+	return s
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,49 @@
+package project
+
+import "testing"
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"inference-gateway/cli", "inference-gateway-cli"},
+		{"My Fact! v2", "my-fact-v2"},
+		{"  Hello  ", "hello"},
+		{"---", ""},
+		{"", ""},
+		{"UPPER_case.name", "upper-case-name"},
+	}
+	for _, tt := range tests {
+		if got := Slugify(tt.in); got != tt.want {
+			t.Errorf("Slugify(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+
+	long := make([]byte, 100)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if got := Slugify(string(long)); len(got) != maxSlugLen {
+		t.Errorf("Slugify long input length = %d, want %d", len(got), maxSlugLen)
+	}
+}
+
+func TestParseRemoteURL(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"https://github.com/org/repo", "org/repo"},
+		{"https://github.com/org/repo.git", "org/repo"},
+		{"http://gitlab.example.com/org/repo.git", "org/repo"},
+		{"git@github.com:org/repo.git", "org/repo"},
+		{"git@github.com:org/repo", "org/repo"},
+		{"not a url", ""},
+		{"", ""},
+		{"https://github.com/onlyorg", ""},
+	}
+	for _, tt := range tests {
+		if got := ParseRemoteURL(tt.in); got != tt.want {
+			t.Errorf("ParseRemoteURL(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #758. Memory fact-files lived in one flat global directory with no way to tell which project a fact belonged to; cross-project slugs could collide, and the whole index was injected into every session.

- **Per-project subdirectories**: project facts live at `<project-slug>/<slug>.md` (e.g. `inference-gateway-cli/build-commands.md`); global facts stay at the root. Legacy flat files keep working as global — **no migration needed**.
- **Project detection**: new `internal/project` package — git remote origin → `org/repo`, fallback cwd basename, else global; cached per process.
- **Frontmatter provenance**: `metadata.project` (human-readable `org/repo`) and `metadata.session` (the session that last wrote the fact; chat now injects the conversation ID into the tool context, headless already had one).
- **Write semantics**: optional `project` arg; defaults by type — `user` facts are global, `feedback`/`project`/`reference` go under the detected project; `"global"` forces the root; `name` accepts `slug` or `project/slug` exactly as shown in the index (traversal names are now rejected outright).
- **Token-efficient recall**: the injected MEMORY.md index is filtered to current-project + global entries plus one line naming other projects; the injection cap default drops **4000 → 2000 chars** (`memory.max_chars`, `INFER_MEMORY_MAX_CHARS`). The Memory tool's index `read` still returns the full index.
- **Per-entry cap**: new `memory.max_entry_chars` (default 2000, `INFER_MEMORY_MAX_ENTRY_CHARS`); over-cap writes are rejected with an actionable error. Zero/missing means default, so existing `memory.yaml` files keep loading.

## Acceptance criteria (#758)

- [x] Easier to sort memory files by project (directory layout)
- [x] Easier to look up memory files by project (index paths carry the project; `read` by `project/slug`)
- [x] Recall optimized for relevant info (project-filtered injection)
- [x] No vectorization — plain files + flat index
- [x] Token-efficient entries with caps (`max_chars` 2000 default, new `max_entry_chars` 2000 default)

## Cross-repo impact

- **infer-action**: references the built-in memory reminders by name; names and texts are unchanged → no change required.
- **Shared `.memory` git remotes**: subdirectories sync via the existing `git add -A`; mixed old/new CLI versions against one remote are safe (both index-line forms share one grammar; old CLIs treat everything as flat/global).
- **docs**: needs a `[DOCS]` follow-up for the new layout, `project` arg, `max_entry_chars`, and the 2000-char default (see docs ticket).
- Stale user `prompts.yaml` keeps the old Memory tool description until `infer init --overwrite`; bare names remain valid, so behavior degrades to "no project awareness", never breaks.

## Testing

- `task test` green, `task lint` 0 issues.
- New tests: project scoping (auto-prefix, user-type global default, explicit/conflicting `project` arg, name-embedded project), read/delete by `project/slug` and legacy bare slug, index isolation of `x` vs `p/x`, `sanitizeName` table incl. traversal rejection, entry-cap boundaries, session-ID frontmatter, `filterMemoryIndex` table, `Slugify`/remote-URL parsing, config validation and env overrides.
