### PR TITLE
feat(agent): cap rendered skills list and harden system prompt injection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ const (
 	DefaultLogsPath            = ConfigDirName + "/" + LogsDirName
 	DefaultMemoryMaxChars      = 2000
 	DefaultMemoryMaxEntryChars = 2000
+	DefaultSkillsMaxChars      = 4000
 )
 
 // Config represents the CLI configuration
@@ -440,6 +441,7 @@ type AgentContextConfig struct {
 type AgentSkillsConfig struct {
 	Enabled        bool     `yaml:"enabled" mapstructure:"enabled"`
 	DisabledSkills []string `yaml:"disabled_skills,omitempty" mapstructure:"disabled_skills"`
+	MaxChars       int      `yaml:"max_chars" mapstructure:"max_chars"`
 }
 
 // AgentConfig contains agent command-specific settings.
@@ -863,6 +865,7 @@ func DefaultConfig() *Config { //nolint:funlen
 			Skills: AgentSkillsConfig{
 				Enabled:        true,
 				DisabledSkills: nil,
+				MaxChars:       DefaultSkillsMaxChars,
 			},
 			SystemPromptWithDefaults: true,
 			VerboseTools:             false,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1335,12 +1335,12 @@ func TestAgentServiceImpl_BuildSystemPrompt(t *testing.T) {
 
 	assert.Contains(t, prompt, "You are a helpful assistant.")
 	assert.Contains(t, prompt, "SANDBOX RESTRICTIONS:")
-	assert.Contains(t, prompt, "Current date and time:")
+	assert.Contains(t, prompt, "Current date:")
 
 	systemMsg := agentService.addSystemPrompt(nil)[0]
 	content, err := systemMsg.Content.AsMessageContent0()
 	assert.NoError(t, err)
-	const tsMarker = "Current date and time:"
+	const tsMarker = "Current date:"
 	assert.Equal(t, strings.SplitN(content, tsMarker, 2)[0], strings.SplitN(prompt, tsMarker, 2)[0])
 }
 

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -156,8 +156,8 @@ func (s *AgentServiceImpl) buildSystemPromptText(messages []sdk.Message) string 
 		}
 	}
 
-	currentTime := time.Now().Format("Monday, January 2, 2006 at 3:04 PM MST")
-	parts = append(parts, fmt.Sprintf("Current date and time: %s", currentTime))
+	currentDate := time.Now().Format("Monday, January 2, 2006")
+	parts = append(parts, fmt.Sprintf("Current date: %s", currentDate))
 
 	return strings.Join(parts, "\n\n")
 }
@@ -395,8 +395,28 @@ func (s *AgentServiceImpl) buildSkillsInfo() string {
 	b.WriteString("Skills are reusable instructions for specific tasks. ")
 	b.WriteString("When a task matches a skill's description, read the SKILL.md file at the listed path using the Read tool, then follow its instructions. ")
 	b.WriteString("To deterministically load a skill's full instructions, invoke it explicitly with /<name> or \"use the <name> skill\".\n\n")
-	for _, sk := range skills {
-		fmt.Fprintf(&b, "- %s (%s): %s\n  Path: %s\n", sk.Name, sk.Scope, sk.Description, sk.Path)
+
+	// Cap the rendered block so many skills with long descriptions can't grow
+	// the system prompt unbounded; skills past the budget stay discoverable as
+	// a names-only list. Whole entries only - never a truncated description.
+	var maxChars int
+	if s.config != nil {
+		maxChars = s.config.GetAgentConfig().Skills.MaxChars
+	}
+	var omitted []string
+	for i, sk := range skills {
+		entry := fmt.Sprintf("- %s (%s): %s\n  Path: %s\n", sk.Name, sk.Scope, sk.Description, sk.Path)
+		if maxChars > 0 && b.Len()+len(entry) > maxChars {
+			for _, rest := range skills[i:] {
+				omitted = append(omitted, rest.Name)
+			}
+			break
+		}
+		b.WriteString(entry)
+	}
+	if len(omitted) > 0 {
+		fmt.Fprintf(&b, "... (%d more skills not expanded: %s - read their SKILL.md under the skills directories)\n",
+			len(omitted), strings.Join(omitted, ", "))
 	}
 	return b.String()
 }
@@ -494,7 +514,11 @@ func (s *AgentServiceImpl) buildMemoryInfo(currentTurn int) string {
 	}
 	index = filterMemoryIndex(index, project.Detect().Slug)
 	if maxChars := s.config.Memory.MaxChars; maxChars > 0 && len(index) > maxChars {
-		index = index[:maxChars] + "\n... (memory index truncated; use the Memory tool 'read' with a name for full facts)"
+		cut := index[:maxChars]
+		if nl := strings.LastIndexByte(cut, '\n'); nl > 0 {
+			cut = cut[:nl]
+		}
+		index = cut + "\n... (memory index truncated; use the Memory tool 'read' with a name for full facts)"
 	}
 
 	var b strings.Builder

--- a/internal/agent/agent_utils_test.go
+++ b/internal/agent/agent_utils_test.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,6 +12,7 @@ import (
 
 	sdk "github.com/inference-gateway/sdk"
 
+	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
@@ -493,5 +497,54 @@ func TestFilterMemoryIndex(t *testing.T) {
 	onlyGlobal := "# Memory Index\n\n- [a](a.md) - a\n"
 	if got := filterMemoryIndex(onlyGlobal, "p"); strings.Contains(got, "other projects") {
 		t.Errorf("no foreign projects must mean no summary line:\n%s", got)
+	}
+}
+
+func TestBuildSkillsInfo_CapsRenderedList(t *testing.T) {
+	var skills []domain.Skill
+	for _, name := range []string{"alpha", "beta", "gamma", "delta"} {
+		skills = append(skills, domain.Skill{
+			Name:        name,
+			Description: strings.Repeat("x", 200),
+			Path:        "/abs/.infer/skills/" + name + "/SKILL.md",
+			Scope:       domain.SkillScopeProject,
+		})
+	}
+	cfg := &config.Config{Agent: config.AgentConfig{Skills: config.AgentSkillsConfig{Enabled: true, MaxChars: 700}}}
+	s := &AgentServiceImpl{config: cfg, skillsService: &stubSkillsService{skills: skills}}
+
+	got := s.buildSkillsInfo()
+
+	require.Contains(t, got, "/abs/.infer/skills/alpha/SKILL.md")
+	require.Contains(t, got, "more skills not expanded")
+	require.Contains(t, got, "delta")
+	require.NotContains(t, got, "/abs/.infer/skills/delta/SKILL.md")
+	require.Equal(t, 1, strings.Count(got, "Path: "))
+
+	cfg.Agent.Skills.MaxChars = 0
+	got = s.buildSkillsInfo()
+	require.NotContains(t, got, "more skills not expanded")
+	require.Equal(t, 4, strings.Count(got, "Path: "))
+}
+
+func TestBuildMemoryInfo_TruncatesAtLineBoundary(t *testing.T) {
+	dir := t.TempDir()
+	var src strings.Builder
+	src.WriteString("# Memory Index\n\n")
+	for i := range 30 {
+		fmt.Fprintf(&src, "- [fact-%02d](fact-%02d.md) - description of fact number %02d\n", i, i, i)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, config.MemoryIndexFileName), []byte(src.String()), 0o600))
+
+	cfg := &config.Config{Memory: config.MemoryConfig{Enabled: true, Dir: dir, MaxChars: 500}}
+	s := &AgentServiceImpl{config: cfg}
+
+	got := s.buildMemoryInfo(1)
+
+	require.Contains(t, got, "memory index truncated")
+	for line := range strings.SplitSeq(got, "\n") {
+		if strings.HasPrefix(line, "- [") {
+			require.Contains(t, src.String(), line+"\n", "truncation left a partial entry: %q", line)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Audit of the memory/skills context-injection path confirmed the design is sound (index/frontmatter-only, one ephemeral system message per request, no history accumulation). This PR closes the three small gaps it surfaced:

- **Cap the rendered skills list** — new `agent.skills.max_chars` (default 4000, `0` disables, env `INFER_AGENT_SKILLS_MAX_CHARS`). Skills past the budget are listed by name only instead of growing the system prompt unbounded; whole entries only, never a truncated description, so every skill stays discoverable.
- **Truncate the memory index at a line boundary** — the `memory.max_chars` cut previously left a broken half-entry in the prompt.
- **Date-only system-prompt timestamp** — the minute-resolution `Current date and time:` line changed the system prompt every turn, invalidating provider-side prompt-prefix caching for the whole conversation. Now `Current date:` at day resolution; the model can run `date` when it needs the time.

## Testing

- New tests: `TestBuildSkillsInfo_CapsRenderedList`, `TestBuildMemoryInfo_TruncatesAtLineBoundary`; updated the timestamp assertions.
- `task test` and `task lint` pass.
- Verified with `infer debug agent system_prompt`: capped skills block, clean memory-index tail, date-only line.

## Cross-repo impact

New user-facing config key `agent.skills.max_chars` → needs a `[DOCS]` issue for `inference-gateway/docs` (configuration reference).