### PR TITLE
fix(debug): sync memory in before rendering the agent system prompt

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
+	config "github.com/inference-gateway/cli/config"
 	container "github.com/inference-gateway/cli/internal/container"
 	cobra "github.com/spf13/cobra"
 )
@@ -25,10 +27,21 @@ var debugAgentSystemPromptCmd = &cobra.Command{
 		"instructions + dynamic context + date) that a fresh `infer chat` " +
 		"session would send to the model.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		services := container.NewServiceContainer(Cfg)
-		_, err := fmt.Fprintln(cmd.OutOrStdout(), services.GetAgentService().BuildSystemPrompt())
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), renderAgentSystemPrompt(cmd.Context(), Cfg))
 		return err
 	},
+}
+
+// renderAgentSystemPrompt syncs memory in and renders the system prompt a
+// fresh session would send. The sync mirrors the headless agent's pre-session
+// hook: with the git memory backend on a fresh machine, MEMORY.md only exists
+// locally after SyncIn, and without it the render silently omits the
+// PERSISTENT MEMORY INDEX section the real agent would receive. Fail-soft
+// like the agent: a sync failure must never break the debug render.
+func renderAgentSystemPrompt(ctx context.Context, cfg *config.Config) string {
+	services := container.NewServiceContainer(cfg)
+	_ = services.GetMemoryBackend().SyncIn(ctx)
+	return services.GetAgentService().BuildSystemPrompt()
 }
 
 func init() {

--- a/cmd/debug_test.go
+++ b/cmd/debug_test.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	config "github.com/inference-gateway/cli/config"
 	require "github.com/stretchr/testify/require"
+
+	config "github.com/inference-gateway/cli/config"
 )
 
 // The fresh-CI-runner case: the git memory backend is configured but nothing

--- a/cmd/debug_test.go
+++ b/cmd/debug_test.go
@@ -15,7 +15,6 @@ import (
 // has cloned the memory repo yet. renderAgentSystemPrompt must SyncIn before
 // building the prompt so the PERSISTENT MEMORY INDEX section renders.
 func TestRenderAgentSystemPrompt_SyncsGitMemoryIn(t *testing.T) {
-	// Isolate git from the developer's config (identity, signing).
 	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "no-such-gitconfig"))
 	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
 	t.Setenv("GIT_AUTHOR_NAME", "infer-test")
@@ -34,8 +33,6 @@ func TestRenderAgentSystemPrompt_SyncsGitMemoryIn(t *testing.T) {
 		require.NoError(t, err, "git %v: %s", args, out)
 	}
 
-	// Bare remote seeded with a MEMORY.md global fact (no project prefix, so
-	// filterMemoryIndex keeps it regardless of the detected project slug).
 	bare := filepath.Join(t.TempDir(), "remote.git")
 	mustGit("", "init", "--bare", "-b", "main", bare)
 	work := t.TempDir()
@@ -47,7 +44,6 @@ func TestRenderAgentSystemPrompt_SyncsGitMemoryIn(t *testing.T) {
 	mustGit(work, "commit", "-m", "seed memory")
 	mustGit(work, "push", "-u", "origin", "main")
 
-	// Memory dir does NOT exist yet.
 	memDir := filepath.Join(t.TempDir(), "memory")
 
 	cfg := config.DefaultConfig()

--- a/cmd/debug_test.go
+++ b/cmd/debug_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+	require "github.com/stretchr/testify/require"
+)
+
+// The fresh-CI-runner case: the git memory backend is configured but nothing
+// has cloned the memory repo yet. renderAgentSystemPrompt must SyncIn before
+// building the prompt so the PERSISTENT MEMORY INDEX section renders.
+func TestRenderAgentSystemPrompt_SyncsGitMemoryIn(t *testing.T) {
+	// Isolate git from the developer's config (identity, signing).
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "no-such-gitconfig"))
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	t.Setenv("GIT_AUTHOR_NAME", "infer-test")
+	t.Setenv("GIT_AUTHOR_EMAIL", "infer-test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "infer-test")
+	t.Setenv("GIT_COMMITTER_EMAIL", "infer-test@example.com")
+	t.Setenv("GIT_TERMINAL_PROMPT", "0")
+
+	mustGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	// Bare remote seeded with a MEMORY.md global fact (no project prefix, so
+	// filterMemoryIndex keeps it regardless of the detected project slug).
+	bare := filepath.Join(t.TempDir(), "remote.git")
+	mustGit("", "init", "--bare", "-b", "main", bare)
+	work := t.TempDir()
+	mustGit("", "clone", bare, work)
+	mustGit(work, "checkout", "-B", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(work, "MEMORY.md"),
+		[]byte("# Memory Index\n\n- [ci-fact](ci-fact.md) - proves debug sync-in ran\n"), 0o600))
+	mustGit(work, "add", "-A")
+	mustGit(work, "commit", "-m", "seed memory")
+	mustGit(work, "push", "-u", "origin", "main")
+
+	// Memory dir does NOT exist yet.
+	memDir := filepath.Join(t.TempDir(), "memory")
+
+	cfg := config.DefaultConfig()
+	cfg.Gateway.Run = false
+	cfg.Storage.Enabled = false
+	cfg.Prompts.Agent.SystemPrompt = "You are a test agent."
+	cfg.Memory.Enabled = true
+	cfg.Memory.Dir = memDir
+	cfg.Memory.Backend.Type = config.MemoryBackendGit
+	cfg.Memory.Backend.Git.Repo = bare
+	cfg.Memory.Backend.Git.Branch = "main"
+
+	got := renderAgentSystemPrompt(context.Background(), cfg)
+
+	require.Contains(t, got, "PERSISTENT MEMORY INDEX")
+	require.Contains(t, got, "ci-fact")
+}


### PR DESCRIPTION
## Summary

`infer debug agent system_prompt` renders the prompt straight from disk without syncing memory in, so on a fresh machine with the git memory backend configured (e.g. a CI runner probing the prompt before the agent starts) the `PERSISTENT MEMORY INDEX` section is silently omitted — while the real agent, which runs `SyncIn` in its pre-session hook before building the prompt, does receive it. The debug render under-reports the agent's reality.

Observed via infer-action, which probes the merged prompt before spawning `infer agent`: [docs run 28809013238](https://github.com/inference-gateway/docs/actions/runs/28809013238/job/85431796214) shows the full context block but no memory index despite the git backend being fully configured.

## Change

The debug command now calls `SyncIn` on the container's memory backend before `BuildSystemPrompt()`, mirroring the headless agent's pre-session hook. Fail-soft like the agent (the backend warns and continues); the local backend is a no-op, and the git backend self-gates on `sync.on_start` and is `sync.Once`-idempotent — so behavior is unchanged except when a configured git memory repo hasn't been pulled yet.

## Test

`cmd/debug_test.go` reproduces the fresh-runner case: a seeded local bare repo as the memory remote, a non-existent memory dir, and asserts the rendered prompt contains `PERSISTENT MEMORY INDEX` and the seeded fact.
