### PR TITLE
feat(init-github-action): refresh generated workflow template and speed up private-key selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1121,7 +1121,9 @@ actions.
 **Project setup:**
 
 - `/init` - Generate an `AGENTS.md` by analyzing the project
-- `/init-github-action` - Set up a GitHub Action via an interactive wizard
+- `/init-github-action` - Set up a GitHub Action via an interactive wizard. Generates `.github/workflows/infer.yml`
+  pinned to the latest `infer-action` (issue/comment-triggered plus a manual `workflow_dispatch` mode, 15-minute job
+  timeout); pre-scans common locations for your GitHub App `.pem` key so selecting it is instant
 
 **Git Shortcuts** (created by `infer init`):
 

--- a/docs/shortcuts-guide.md
+++ b/docs/shortcuts-guide.md
@@ -68,7 +68,11 @@ These shortcuts are available out of the box:
 **Project setup:**
 
 - `/init` - Set input with project analysis prompt for AGENTS.md generation
-- `/init-github-action` - Set up a GitHub Action via an interactive wizard
+- `/init-github-action` - Set up a GitHub Action via an interactive wizard. Generates
+  `.github/workflows/infer.yml` pinned to the latest `infer-action` (issue/comment-triggered plus a
+  manual `workflow_dispatch` mode, 15-minute job timeout). For org repos it configures the GitHub App
+  org secrets; the private-key step pre-scans common locations (`~/Downloads`, `~/Desktop`, home, cwd)
+  for `.pem` files so you can pick one instantly, with manual entry and a file browser as fallbacks.
 
 ### Project Initialization Shortcut
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -2839,8 +2839,35 @@ func (app *ChatApplication) setOrgSecret(orgName, name, value string) error {
 	return nil
 }
 
-func (app *ChatApplication) generateStandardWorkflowContent() string {
-	return `---
+// Version pins and defaults for the generated .github/workflows/infer.yml.
+// Bumping any of these is a one-line change picked up by both templates.
+const (
+	inferActionVersion     = "v0.28.0"
+	checkoutActionVersion  = "v7.0.0"
+	appTokenActionVersion  = "v3.2.0"
+	workflowDefaultModel   = "ollama_cloud/deepseek-v4-flash"
+	workflowTimeoutMinutes = 15
+)
+
+// workflowHeader is the shared prologue of the generated workflow: header
+// comment, triggers (issue/comment mentions + manual workflow_dispatch),
+// permissions, and the gated job preamble with concurrency and timeout.
+func workflowHeader(extraNote string) string {
+	return fmt.Sprintf(`---
+# Infer Agent CI
+#
+# Runs the Infer agent (inference-gateway/infer-action) in two ways:
+#
+# 1. Issue-driven: mention `+"`@infer`"+` in an issue title, body, or comment and
+#    the agent picks up the task, works on it, and opens a draft PR.
+# 2. Manual (workflow_dispatch): run it from the Actions tab with a free-text
+#    prompt — useful for ad-hoc tasks like "find bugs and report them".
+#    Optionally tick "browser-agent" to spin up the A2A
+#    inference-gateway/browser-agent container so the agent can browse the web.
+#
+# Notes:
+# - Jobs are capped at %d minutes (timeout-minutes).
+# - Runs are deduplicated per issue (or per dispatch run) via concurrency.%s
 name: Infer
 
 on:
@@ -2851,37 +2878,57 @@ on:
   issue_comment:
     types:
       - created
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Free-text task for the agent (e.g. "find bugs and report them")'
+        type: string
+        required: true
+      browser-agent:
+        description: 'Start the A2A browser-agent (inference-gateway/browser-agent) so the agent can browse the web'
+        type: boolean
+        required: false
+        default: false
+      debug:
+        description: 'Enable debug output and mirror agent logs'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   issues: write
   contents: write
   pull-requests: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   infer:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     if: |
-      github.event.sender.type != 'Bot' &&
-      !endsWith(github.actor, '[bot]') &&
+      github.event_name == 'workflow_dispatch' ||
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@infer')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@infer') || contains(github.event.issue.title, '@infer')))
+        github.event.sender.type != 'Bot' &&
+        !endsWith(github.actor, '[bot]') &&
+        (
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@infer')) ||
+          (github.event_name == 'issues' && (contains(github.event.issue.body, '@infer') || contains(github.event.issue.title, '@infer')))
+        )
       )
     runs-on: ubuntu-24.04
+    timeout-minutes: %d
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+`, workflowTimeoutMinutes, extraNote, workflowTimeoutMinutes)
+}
 
-      - name: Run Infer Agent
-        uses: inference-gateway/infer-action@v0.11.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          trigger-phrase: "@infer"
-          model: deepseek/deepseek-v4-flash
-          max-turns: 50
+// workflowAgentInputs is the shared tail of the "Run Infer Agent" step: the
+// agent defaults and the provider API key pass-throughs.
+const workflowAgentInputs = `          trigger-phrase: '@infer'
+          model: ` + workflowDefaultModel + `
+          direct-prompt: ${{ inputs.prompt }}
+          agents: ${{ inputs.browser-agent && 'browser-agent' || '' }}
+          debug: ${{ inputs.debug }}
+          mirror-agent-logs: ${{ inputs.debug }}
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           google-api-key: ${{ secrets.GOOGLE_API_KEY }}
@@ -2892,75 +2939,60 @@ jobs:
           cohere-api-key: ${{ secrets.COHERE_API_KEY }}
           ollama-api-key: ${{ secrets.OLLAMA_API_KEY }}
           ollama-cloud-api-key: ${{ secrets.OLLAMA_CLOUD_API_KEY }}
+          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          minimax-api-key: ${{ secrets.MINIMAX_API_KEY }}
+          nvidia-api-key: ${{ secrets.NVIDIA_API_KEY }}
 `
+
+func (app *ChatApplication) generateStandardWorkflowContent() string {
+	return workflowHeader("") + fmt.Sprintf(`      - name: Checkout repository
+        uses: actions/checkout@%s
+
+      - name: Run Infer Agent
+        uses: inference-gateway/infer-action@%s
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+`, checkoutActionVersion, inferActionVersion) + workflowAgentInputs
 }
 
 func (app *ChatApplication) generateGithubActionWorkflowContent() string {
-	return `---
-name: Infer
-
-on:
-  issues:
-    types:
-      - opened
-      - edited
-  issue_comment:
-    types:
-      - created
-
-permissions:
-  issues: write
-  contents: write
-  pull-requests: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
-jobs:
-  infer:
-    if: |
-      github.event.sender.type != 'Bot' &&
-      !endsWith(github.actor, '[bot]') &&
-      (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@infer')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@infer') || contains(github.event.issue.title, '@infer')))
-      )
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Generate GitHub App Token
-        uses: actions/create-github-app-token@v3.0.0
-        id: app_token
+	extraNote := `
+# - The GitHub App used for the token needs the "Workflows" (read & write)
+#   repository permission so the agent can push changes to .github/workflows.`
+	return workflowHeader(extraNote) + fmt.Sprintf(`      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@%s
         with:
-          app-id: ${{ secrets.INFER_APP_ID }}
+          client-id: ${{ secrets.INFER_APP_ID }}
           private-key: ${{ secrets.INFER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
             ${{ github.event.repository.name }}
 
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Git
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git config --global commit.gpgsign false
+          git config --global commit.signoff true
+
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@%s
         with:
-          token: ${{ steps.app_token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run Infer Agent
-        uses: inference-gateway/infer-action@v0.11.2
+        uses: inference-gateway/infer-action@%s
         with:
-          github-token: ${{ steps.app_token.outputs.token }}
-          trigger-phrase: "@infer"
-          model: deepseek/deepseek-v4-flash
-          max-turns: 50
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          google-api-key: ${{ secrets.GOOGLE_API_KEY }}
-          deepseek-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
-          groq-api-key: ${{ secrets.GROQ_API_KEY }}
-          mistral-api-key: ${{ secrets.MISTRAL_API_KEY }}
-          cloudflare-api-key: ${{ secrets.CLOUDFLARE_API_KEY }}
-          cohere-api-key: ${{ secrets.COHERE_API_KEY }}
-          ollama-api-key: ${{ secrets.OLLAMA_API_KEY }}
-          ollama-cloud-api-key: ${{ secrets.OLLAMA_CLOUD_API_KEY }}
-`
+          github-token: ${{ steps.app-token.outputs.token }}
+          github-app-slug: ${{ steps.app-token.outputs.app-slug }}
+`, appTokenActionVersion, checkoutActionVersion, inferActionVersion) + workflowAgentInputs
 }
 
 func (app *ChatApplication) preparePRCreation(repo, workflowPath string) (string, error) {

--- a/internal/app/chat_workflow_template_test.go
+++ b/internal/app/chat_workflow_template_test.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func assertWorkflowCommon(t *testing.T, content string) {
+	t.Helper()
+
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(content), &doc); err != nil {
+		t.Fatalf("generated workflow is not valid YAML: %v", err)
+	}
+
+	for _, want := range []string{
+		"inference-gateway/infer-action@" + inferActionVersion,
+		"actions/checkout@" + checkoutActionVersion,
+		"timeout-minutes: 15",
+		"model: " + workflowDefaultModel,
+		"workflow_dispatch:",
+		"browser-agent:",
+		"debug:",
+		"direct-prompt: ${{ inputs.prompt }}",
+		"github.event.issue.number || github.run_id",
+		"moonshot-api-key:",
+		"minimax-api-key:",
+		"nvidia-api-key:",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("workflow missing %q", want)
+		}
+	}
+
+	for _, unwanted := range []string{
+		"max-turns",
+		"memory-repo",
+		"plugins:",
+		"skills:",
+		"bash-allow-append",
+	} {
+		if strings.Contains(content, unwanted) {
+			t.Errorf("workflow should not contain %q", unwanted)
+		}
+	}
+}
+
+func TestGenerateStandardWorkflowContent(t *testing.T) {
+	content := (&ChatApplication{}).generateStandardWorkflowContent()
+	assertWorkflowCommon(t, content)
+
+	if !strings.Contains(content, "github-token: ${{ secrets.GITHUB_TOKEN }}") {
+		t.Error("standard workflow must use GITHUB_TOKEN")
+	}
+	if strings.Contains(content, "create-github-app-token") {
+		t.Error("standard workflow must not mint an app token")
+	}
+}
+
+func TestGenerateGithubActionWorkflowContent(t *testing.T) {
+	content := (&ChatApplication{}).generateGithubActionWorkflowContent()
+	assertWorkflowCommon(t, content)
+
+	for _, want := range []string{
+		"actions/create-github-app-token@" + appTokenActionVersion,
+		"client-id: ${{ secrets.INFER_APP_ID }}",
+		"private-key: ${{ secrets.INFER_APP_PRIVATE_KEY }}",
+		"github-token: ${{ steps.app-token.outputs.token }}",
+		"github-app-slug: ${{ steps.app-token.outputs.app-slug }}",
+		"Get GitHub App User ID",
+		"Set up Git",
+		"commit.signoff true",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("org workflow missing %q", want)
+		}
+	}
+}

--- a/internal/ui/components/init_github_action_view.go
+++ b/internal/ui/components/init_github_action_view.go
@@ -3,7 +3,9 @@ package components
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -43,6 +45,14 @@ type InitGithubActionView struct {
 	privateKeyPath string
 	err            error
 
+	// Private-key selection state: pre-scanned candidates plus the select
+	// choice (a candidate path or one of the sentinels below) and the two
+	// fallback inputs it can route to.
+	pemCandidates  []pemCandidate
+	keyChoice      string
+	manualKeyPath  string
+	browsedKeyPath string
+
 	// Repository information.
 	repoOwner string
 	isOrgRepo bool
@@ -77,6 +87,12 @@ func (v *InitGithubActionView) buildConfirmForm() *huh.Form {
 	).WithShowHelp(true).WithWidth(v.width)
 }
 
+// Sentinel values for the private-key select's fallback entries.
+const (
+	keyChoiceManual = "__manual__"
+	keyChoiceBrowse = "__browse__"
+)
+
 func (v *InitGithubActionView) buildDetailsForm() *huh.Form {
 	appIDInput := huh.NewInput().
 		Key("appID").
@@ -85,22 +101,114 @@ func (v *InitGithubActionView) buildDetailsForm() *huh.Form {
 		Validate(validateAppID).
 		Value(&v.appID)
 
+	options := make([]huh.Option[string], 0, len(v.pemCandidates)+2)
+	for _, c := range v.pemCandidates {
+		options = append(options, huh.NewOption(pemCandidateLabel(c), c.Path))
+	}
+	options = append(options,
+		huh.NewOption("Enter path manually…", keyChoiceManual),
+		huh.NewOption("Browse files…", keyChoiceBrowse),
+	)
+
+	keySelect := huh.NewSelect[string]().
+		Key("privateKeySource").
+		Title("Private key (.pem)").
+		Description("Generate one under your app's 'Private keys' section. Recently found keys are listed first.").
+		Options(options...).
+		Value(&v.keyChoice)
+
+	manualInput := huh.NewInput().
+		Key("privateKeyManual").
+		Title("Private key path").
+		Description("Absolute or ~-relative path to the .pem file.").
+		Validate(validatePemPath).
+		Value(&v.manualKeyPath)
+
 	keyPicker := huh.NewFilePicker().
 		Key("privateKey").
 		Title("Private key (.pem)").
-		Description("Generate one under your app's 'Private keys' section, then pick the file.").
-		CurrentDirectory(".").
+		Description("Pick the private key file.").
+		CurrentDirectory(defaultBrowseDir()).
 		AllowedTypes([]string{".pem"}).
 		ShowHidden(false).
 		Height(10).
-		Value(&v.privateKeyPath)
+		Value(&v.browsedKeyPath)
+
+	secretsExist := func() bool {
+		return v.checkSecretsExist != nil && v.checkSecretsExist(v.appID)
+	}
 
 	return huh.NewForm(
 		huh.NewGroup(appIDInput),
+		huh.NewGroup(keySelect).WithHideFunc(secretsExist),
+		huh.NewGroup(manualInput).WithHideFunc(func() bool {
+			return secretsExist() || v.keyChoice != keyChoiceManual
+		}),
 		huh.NewGroup(keyPicker).WithHideFunc(func() bool {
-			return v.checkSecretsExist != nil && v.checkSecretsExist(v.appID)
+			return secretsExist() || v.keyChoice != keyChoiceBrowse
 		}),
 	).WithShowHelp(true).WithWidth(v.width)
+}
+
+// resolvePrivateKeyPath maps the completed details form onto privateKeyPath,
+// depending on whether the user picked a scanned candidate, typed a path, or
+// browsed for the file.
+func (v *InitGithubActionView) resolvePrivateKeyPath() {
+	switch v.keyChoice {
+	case keyChoiceManual:
+		v.privateKeyPath = expandHomePath(v.manualKeyPath)
+	case keyChoiceBrowse:
+		v.privateKeyPath = v.browsedKeyPath
+	default:
+		v.privateKeyPath = v.keyChoice
+	}
+}
+
+// defaultBrowseDir anchors the fallback file picker where GitHub App keys
+// usually download to.
+func defaultBrowseDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+	if downloads := filepath.Join(home, "Downloads"); dirExists(downloads) {
+		return downloads
+	}
+	return home
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// expandHomePath expands a leading ~ to the user's home directory.
+func expandHomePath(path string) string {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(path, "~"), "/"))
+		}
+	}
+	return path
+}
+
+// validatePemPath requires an existing regular .pem file.
+func validatePemPath(s string) error {
+	if s == "" {
+		return fmt.Errorf("path is required")
+	}
+	path := expandHomePath(s)
+	if !strings.EqualFold(filepath.Ext(path), ".pem") {
+		return fmt.Errorf("file must have a .pem extension")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("file not found: %s", path)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("path is a directory")
+	}
+	return nil
 }
 
 func (v *InitGithubActionView) Init() tea.Cmd {
@@ -141,10 +249,12 @@ func (v *InitGithubActionView) advance() tea.Cmd {
 			v.browserOpened = true
 		}
 		v.phase = phaseDetails
+		v.pemCandidates = scanPemFiles()
 		v.form = v.buildDetailsForm()
 		return v.form.Init()
 	}
 
+	v.resolvePrivateKeyPath()
 	v.done = true
 	return nil
 }
@@ -230,6 +340,10 @@ func (v *InitGithubActionView) Reset() {
 	v.hasExisting = false
 	v.appID = ""
 	v.privateKeyPath = ""
+	v.pemCandidates = nil
+	v.keyChoice = ""
+	v.manualKeyPath = ""
+	v.browsedKeyPath = ""
 	v.browserOpened = false
 	v.err = nil
 	v.form = v.buildConfirmForm()

--- a/internal/ui/components/init_github_action_view_test.go
+++ b/internal/ui/components/init_github_action_view_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -37,6 +38,10 @@ func TestInitWizard_ResetClearsState(t *testing.T) {
 	v.phase = phaseDetails
 	v.appID = "12345"
 	v.privateKeyPath = "/tmp/key.pem"
+	v.pemCandidates = []pemCandidate{{Path: "/tmp/key.pem"}}
+	v.keyChoice = keyChoiceManual
+	v.manualKeyPath = "/tmp/key.pem"
+	v.browsedKeyPath = "/tmp/key.pem"
 	v.browserOpened = true
 
 	v.Reset()
@@ -49,6 +54,9 @@ func TestInitWizard_ResetClearsState(t *testing.T) {
 	}
 	if v.appID != "" || v.privateKeyPath != "" || v.browserOpened {
 		t.Fatalf("expected results cleared after Reset, got appID=%q key=%q browser=%v", v.appID, v.privateKeyPath, v.browserOpened)
+	}
+	if v.pemCandidates != nil || v.keyChoice != "" || v.manualKeyPath != "" || v.browsedKeyPath != "" {
+		t.Fatalf("expected key-selection state cleared after Reset")
 	}
 	if v.form == nil {
 		t.Fatal("expected a rebuilt form after Reset")
@@ -70,6 +78,51 @@ func TestInitWizard_GithubURLs(t *testing.T) {
 	install := v.GetInstallationURL("acme", "infra")
 	if !strings.Contains(install, "acme") || !strings.Contains(install, "infra") {
 		t.Fatalf("expected installation URL to include owner and repo, got %q", install)
+	}
+}
+
+func TestResolvePrivateKeyPath(t *testing.T) {
+	v := NewInitGithubActionView(createMockStyleProviderForHelpBar())
+
+	v.keyChoice = "/tmp/scanned.pem"
+	v.resolvePrivateKeyPath()
+	if v.privateKeyPath != "/tmp/scanned.pem" {
+		t.Errorf("candidate choice: got %q", v.privateKeyPath)
+	}
+
+	v.keyChoice = keyChoiceManual
+	v.manualKeyPath = "/tmp/manual.pem"
+	v.resolvePrivateKeyPath()
+	if v.privateKeyPath != "/tmp/manual.pem" {
+		t.Errorf("manual choice: got %q", v.privateKeyPath)
+	}
+
+	v.keyChoice = keyChoiceBrowse
+	v.browsedKeyPath = "/tmp/browsed.pem"
+	v.resolvePrivateKeyPath()
+	if v.privateKeyPath != "/tmp/browsed.pem" {
+		t.Errorf("browse choice: got %q", v.privateKeyPath)
+	}
+}
+
+func TestValidatePemPath(t *testing.T) {
+	dir := t.TempDir()
+	pem := dir + "/key.pem"
+	if err := os.WriteFile(pem, []byte("key"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validatePemPath(pem); err != nil {
+		t.Errorf("existing .pem: unexpected error %v", err)
+	}
+	if err := validatePemPath(""); err == nil {
+		t.Error("empty path: expected error")
+	}
+	if err := validatePemPath(dir + "/missing.pem"); err == nil {
+		t.Error("missing file: expected error")
+	}
+	if err := validatePemPath(pem + ".txt"); err == nil {
+		t.Error("wrong extension: expected error")
 	}
 }
 

--- a/internal/ui/components/pem_scan.go
+++ b/internal/ui/components/pem_scan.go
@@ -1,0 +1,136 @@
+package components
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// pemCandidate is a discovered private-key file offered in the setup wizard.
+type pemCandidate struct {
+	Path    string
+	ModTime time.Time
+}
+
+// pemScanLimits bound the filesystem scan so it can run synchronously in the
+// TUI without a noticeable stall, even on large home directories.
+const (
+	pemScanMaxEntries = 5000
+	pemScanMaxResults = 15
+)
+
+// pemScanSkipDirs are directory names never descended into during the scan.
+var pemScanSkipDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+}
+
+// scanPemFiles searches the places a GitHub App private key typically lives
+// (~/Downloads, ~/Desktop, the home directory, and the working directory) for
+// .pem files, newest first.
+func scanPemFiles() []pemCandidate {
+	type root struct {
+		dir   string
+		depth int
+	}
+
+	var roots []root
+	if home, err := os.UserHomeDir(); err == nil {
+		roots = append(roots,
+			root{filepath.Join(home, "Downloads"), 2},
+			root{filepath.Join(home, "Desktop"), 2},
+			root{home, 1},
+		)
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		roots = append(roots, root{cwd, 2})
+	}
+
+	seen := make(map[string]bool)
+	var candidates []pemCandidate
+	budget := pemScanMaxEntries
+	for _, r := range roots {
+		scanPemDir(r.dir, r.depth, &budget, seen, &candidates)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ModTime.After(candidates[j].ModTime)
+	})
+	if len(candidates) > pemScanMaxResults {
+		candidates = candidates[:pemScanMaxResults]
+	}
+	return candidates
+}
+
+func scanPemDir(dir string, depth int, budget *int, seen map[string]bool, out *[]pemCandidate) {
+	if depth < 0 || *budget <= 0 {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if *budget <= 0 {
+			return
+		}
+		*budget--
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if entry.IsDir() {
+			if !pemScanSkipDirs[name] {
+				scanPemDir(filepath.Join(dir, name), depth-1, budget, seen, out)
+			}
+			continue
+		}
+		if !strings.EqualFold(filepath.Ext(name), ".pem") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			abs = path
+		}
+		if seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		*out = append(*out, pemCandidate{Path: abs, ModTime: info.ModTime()})
+	}
+}
+
+// pemCandidateLabel renders a candidate for the wizard select: the file name,
+// its ~-relative directory, and a humanized age.
+func pemCandidateLabel(c pemCandidate) string {
+	dir := filepath.Dir(c.Path)
+	if home, err := os.UserHomeDir(); err == nil && strings.HasPrefix(dir, home) {
+		dir = "~" + strings.TrimPrefix(dir, home)
+	}
+	return fmt.Sprintf("%s  (%s, %s)", filepath.Base(c.Path), dir, humanizeAge(time.Since(c.ModTime)))
+}
+
+func humanizeAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	case d < 365*24*time.Hour:
+		return fmt.Sprintf("%dmo ago", int(d.Hours()/(24*30)))
+	default:
+		return fmt.Sprintf("%dy ago", int(d.Hours()/(24*365)))
+	}
+}

--- a/internal/ui/components/pem_scan_test.go
+++ b/internal/ui/components/pem_scan_test.go
@@ -1,0 +1,74 @@
+package components
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writePem(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("key"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanPemDir_FindsAndSortsByModTime(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	writePem(t, filepath.Join(dir, "old.pem"), now.Add(-48*time.Hour))
+	writePem(t, filepath.Join(dir, "new.pem"), now)
+	writePem(t, filepath.Join(dir, "sub", "mid.pem"), now.Add(-24*time.Hour))
+	writePem(t, filepath.Join(dir, "not-a-key.txt"), now)
+	writePem(t, filepath.Join(dir, ".hidden", "secret.pem"), now)
+	writePem(t, filepath.Join(dir, "node_modules", "dep.pem"), now)
+	writePem(t, filepath.Join(dir, "sub", "deep", "toodeep.pem"), now)
+
+	budget := pemScanMaxEntries
+	seen := map[string]bool{}
+	var out []pemCandidate
+	scanPemDir(dir, 1, &budget, seen, &out)
+
+	if len(out) != 3 {
+		t.Fatalf("expected 3 candidates, got %d: %v", len(out), out)
+	}
+	// scanPemFiles sorts; here verify contents only.
+	found := map[string]bool{}
+	for _, c := range out {
+		found[filepath.Base(c.Path)] = true
+	}
+	for _, want := range []string{"old.pem", "new.pem", "mid.pem"} {
+		if !found[want] {
+			t.Errorf("missing %s in %v", want, out)
+		}
+	}
+}
+
+func TestScanPemDir_RespectsBudget(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 10; i++ {
+		writePem(t, filepath.Join(dir, string(rune('a'+i))+".pem"), time.Now())
+	}
+	budget := 5
+	var out []pemCandidate
+	scanPemDir(dir, 0, &budget, map[string]bool{}, &out)
+	if len(out) > 5 {
+		t.Errorf("budget not respected: got %d results", len(out))
+	}
+}
+
+func TestPemCandidateLabel(t *testing.T) {
+	c := pemCandidate{Path: "/tmp/infer-bot.pem", ModTime: time.Now().Add(-49 * time.Hour)}
+	label := pemCandidateLabel(c)
+	if !strings.Contains(label, "infer-bot.pem") || !strings.Contains(label, "2d ago") {
+		t.Errorf("unexpected label: %q", label)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #775.

- Updates both `/init-github-action` workflow templates to the current `infer-action@v0.28.0` shape (modeled on the [openeditor reference](https://github.com/edenreich/openeditor/blob/main/.github/workflows/infer.yml), minus its repo-specific inputs):
  - `workflow_dispatch` manual-run mode (`prompt`, `browser-agent`, `debug` inputs)
  - default job timeout `timeout-minutes: 15`, job-level concurrency dedup (`issue.number || run_id`)
  - default model `ollama_cloud/deepseek-v4-flash`; `max-turns` dropped (action default)
  - org template: `actions/create-github-app-token@v3.2.0` with `client-id`, app-slug bot git identity setup, checkout with the app token, `github-app-slug` passthrough
  - new provider key passthroughs: moonshot, minimax, nvidia
  - version pins extracted to consts so future bumps are one-line
- Faster, more intuitive private-key selection: the wizard now pre-scans `~/Downloads`, `~/Desktop`, home, and cwd (bounded depth/entries) for `.pem` files and offers them in a select sorted newest-first, with 'Enter path manually…' (validated) and 'Browse files…' (picker anchored at `~/Downloads`) fallbacks.
- Tests for both template generators (YAML validity + pins), the pem scanner, and the new wizard resolution; docs one-liners expanded in README and docs/shortcuts-guide.md.

## Impacted repos

- `inference-gateway/docs` — `github-action.md` quick-start pins `infer-action@v0.23.6`; follow-up [DOCS] issue filed alongside this PR.

## Verification

- `task build`, `task test`, `task lint` all pass.