### PR TITLE
fix(agent): stop agent loop on tool rejection and exclude approval placeholders from LLM requests

### DIFF
--- a/config/agents.go
+++ b/config/agents.go
@@ -15,8 +15,6 @@ type AgentsConfig struct {
 	path string
 }
 
-var _ CollectionConfig[AgentEntry] = (*AgentsConfig)(nil)
-
 // AgentEntry represents a single A2A agent configuration
 type AgentEntry struct {
 	Name         string            `yaml:"name" mapstructure:"name"`

--- a/config/collection.go
+++ b/config/collection.go
@@ -2,21 +2,6 @@ package config
 
 import "fmt"
 
-// CollectionConfig is implemented by file-backed configs whose payload is a
-// named, mutable collection of entries. MCPConfig (collection of
-// MCPServerEntry) and AgentsConfig (collection of AgentEntry) implement it.
-//
-// Methods mutate the file on disk; the in-memory receiver stays in sync.
-// Implementations must remember the file path they were loaded from so
-// each call can persist back to the same location.
-type CollectionConfig[E any] interface {
-	CreateEntry(entry E) error
-	ReadEntry(name string) (*E, error)
-	UpdateEntry(entry E) error
-	DeleteEntry(name string) error
-	ListEntries() []E
-}
-
 // appendEntry returns slice with entry appended, after rejecting duplicates
 // by name. kind is used in the duplicate-error message (e.g. "MCP server").
 func appendEntry[E any](slice []E, entry E, name string, nameOf func(E) string, kind string) ([]E, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	viper "github.com/spf13/viper"
-	yaml "go.yaml.in/yaml/v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestDefaultConfig(t *testing.T) {

--- a/config/mcp.go
+++ b/config/mcp.go
@@ -20,8 +20,6 @@ type MCPConfig struct {
 	path string
 }
 
-var _ CollectionConfig[MCPServerEntry] = (*MCPConfig)(nil)
-
 // MCPServerEntry represents a single MCP server configuration
 type MCPServerEntry struct {
 	Name           string            `yaml:"name" mapstructure:"name"`

--- a/config/plugins.go
+++ b/config/plugins.go
@@ -27,8 +27,6 @@ type PluginsConfig struct {
 	path string
 }
 
-var _ CollectionConfig[PluginEntry] = (*PluginsConfig)(nil)
-
 // PluginEntry is one installed plugin in the registry.
 type PluginEntry struct {
 	Name         string `yaml:"name" mapstructure:"name"`

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/subosito/gotenv v1.6.0
 	github.com/zeebo/xxh3 v1.1.0
 	go.uber.org/zap v1.28.0
-	go.yaml.in/yaml/v3 v3.0.4
 	golang.design/x/clipboard v0.8.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/image v0.43.0
@@ -136,6 +135,7 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.design/x/x11 v0.2.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect

--- a/internal/agent/states/approving_tools.go
+++ b/internal/agent/states/approving_tools.go
@@ -239,11 +239,19 @@ func (s *ApprovingToolsState) flushLocked(round *toolRound) {
 // remaining results, and signals the state machine. Results are flushed
 // incrementally by completeSlot as they complete; this final drain covers
 // gaps left by cancellation.
+//
+// A user rejection ends the turn: HasToolResults is cleared so canComplete
+// lets PostToolExecution transition to Completing instead of streaming
+// another LLM turn, returning control to the user (same semantics as the
+// non-approval route's "tool was rejected - stopping agent loop", issue #786).
 func (s *ApprovingToolsState) finishApprovals(round *toolRound) {
 	round.wg.Wait()
 	s.flushReady(round)
 
 	s.ctx.AgentCtx.LastToolFailed = domain.AnyToolFailed(*s.ctx.ToolResults)
+	if domain.AnyToolRejected(*s.ctx.ToolResults) {
+		s.ctx.AgentCtx.HasToolResults = false
+	}
 	s.ctx.Events <- domain.AllToolsProcessedEvent{}
 }
 
@@ -262,6 +270,12 @@ func (s *ApprovingToolsState) buildRejectionEntry(tc sdk.ChatCompletionMessageTo
 	return domain.ConversationEntry{
 		Message: rejectionMessage,
 		Time:    time.Now(),
+		ToolExecution: &domain.ToolExecutionResult{
+			ToolName: tc.Function.Name,
+			Success:  false,
+			Error:    "rejected by user",
+			Rejected: true,
+		},
 	}
 }
 

--- a/internal/agent/states/approving_tools_test.go
+++ b/internal/agent/states/approving_tools_test.go
@@ -215,6 +215,59 @@ func TestApprovingToolsState_FlushesResultsIncrementally(t *testing.T) {
 	waitForAllToolsProcessed(t, events)
 }
 
+// TestApprovingToolsState_RejectionStopsTurn is a regression test for issue
+// #786: rejecting a tool must end the turn instead of feeding the rejection
+// back for another LLM turn. The rejection entry must carry
+// ToolExecution.Rejected and HasToolResults must be cleared even when another
+// tool in the batch was approved and executed.
+func TestApprovingToolsState_RejectionStopsTurn(t *testing.T) {
+	execStub := func(tc sdk.ChatCompletionMessageToolCall, _ bool) domain.ConversationEntry {
+		return toolEntry(tc)
+	}
+	approveStub := func(tc sdk.ChatCompletionMessageToolCall) (bool, error) {
+		return tc.ID != "call-0", nil
+	}
+
+	ctx, results, conv, events := newApprovingCtx(makeTools(2), domain.AgentModeStandard, execStub, approveStub)
+	s := &ApprovingToolsState{ctx: ctx}
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+	waitForAllToolsProcessed(t, events)
+
+	require.Len(t, *results, 2)
+	require.Len(t, *conv, 2)
+
+	rejection := (*results)[0]
+	require.NotNil(t, rejection.ToolExecution)
+	assert.True(t, rejection.ToolExecution.Rejected, "rejection entry must be marked Rejected")
+	assert.False(t, rejection.ToolExecution.Success)
+	require.NotNil(t, rejection.Message.ToolCallID)
+	assert.Equal(t, "call-0", *rejection.Message.ToolCallID)
+
+	assert.True(t, ctx.AgentCtx.LastToolFailed, "rejection counts as a failed tool")
+	assert.False(t, ctx.AgentCtx.HasToolResults, "rejection must clear HasToolResults so the turn completes")
+}
+
+// TestApprovingToolsState_ApprovedBatchKeepsToolResults verifies the inverse of
+// the rejection case: a fully approved batch leaves HasToolResults set so the
+// agent streams a follow-up turn responding to the results.
+func TestApprovingToolsState_ApprovedBatchKeepsToolResults(t *testing.T) {
+	execStub := func(tc sdk.ChatCompletionMessageToolCall, _ bool) domain.ConversationEntry {
+		return toolEntry(tc)
+	}
+	approveStub := func(sdk.ChatCompletionMessageToolCall) (bool, error) { return true, nil }
+
+	ctx, results, _, events := newApprovingCtx(makeTools(2), domain.AgentModeStandard, execStub, approveStub)
+	s := &ApprovingToolsState{ctx: ctx}
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+	waitForAllToolsProcessed(t, events)
+
+	require.Len(t, *results, 2)
+	assert.True(t, ctx.AgentCtx.HasToolResults, "approved batch must keep HasToolResults for the follow-up turn")
+	assert.False(t, ctx.AgentCtx.LastToolFailed)
+}
+
 // TestApprovingToolsState_AutoAcceptExecutesAll verifies that in auto-accept
 // mode every tool is executed (concurrently) and results are collected in order.
 func TestApprovingToolsState_AutoAcceptExecutesAll(t *testing.T) {

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -46,6 +46,18 @@ func AnyToolFailed(results []ConversationEntry) bool {
 	return false
 }
 
+// AnyToolRejected reports whether any entry in a completed tool batch was
+// rejected by the user. A rejection ends the agent turn instead of feeding the
+// results back for another LLM response.
+func AnyToolRejected(results []ConversationEntry) bool {
+	for _, entry := range results {
+		if entry.ToolExecution != nil && entry.ToolExecution.Rejected {
+			return true
+		}
+	}
+	return false
+}
+
 // StateGuard is a function that determines if a state transition should occur
 type StateGuard func(ctx *AgentContext) bool
 

--- a/internal/domain/agent_test.go
+++ b/internal/domain/agent_test.go
@@ -24,3 +24,27 @@ func TestAnyToolFailed(t *testing.T) {
 		})
 	}
 }
+
+func TestAnyToolRejected(t *testing.T) {
+	ok := &ToolExecutionResult{Success: true}
+	failed := &ToolExecutionResult{Success: false}
+	rejected := &ToolExecutionResult{Success: false, Rejected: true}
+
+	tests := []struct {
+		name    string
+		results []ConversationEntry
+		want    bool
+	}{
+		{"empty", nil, false},
+		{"no rejection", []ConversationEntry{{ToolExecution: ok}, {ToolExecution: failed}}, false},
+		{"one rejection", []ConversationEntry{{ToolExecution: ok}, {ToolExecution: rejected}}, true},
+		{"nil execution ignored", []ConversationEntry{{ToolExecution: nil}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AnyToolRejected(tt.results); got != tt.want {
+				t.Fatalf("AnyToolRejected = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/services/chatcompletion/runner.go
+++ b/internal/services/chatcompletion/runner.go
@@ -480,7 +480,7 @@ func (r *Runner) addModelRestorationWarning(originalModel string) {
 // BuildAgentMessagesFromEntries converts conversation entries into the flat
 // slice of SDK messages sent to the model.
 //
-// Two classes of entries are filtered:
+// Three classes of entries are filtered:
 //
 //  1. Plan-mode entries (entry.IsPlan): synthesized assistant messages used
 //     for UI rendering only; their content duplicates the args of the
@@ -489,11 +489,18 @@ func (r *Runner) addModelRestorationWarning(originalModel string) {
 //     when the user types `!command` directly in chat. Their assistant
 //     side has tool_calls but no reasoning_content (the user, not the
 //     model, generated them).
+//  3. Pending-approval placeholders (entry.PendingToolCall != nil): UI-only
+//     empty assistant entries added while a tool awaits approval. On
+//     rejection they stay in the repo; serializing one between an assistant
+//     tool_calls message and its tool response breaks the provider's
+//     adjacency requirement ("Messages with role 'tool' must be a response
+//     to a preceding message with 'tool_calls'", issue #786).
+//     SaveConversation applies the same filter for disk persistence.
 //
-// Sending either to a thinking-mode provider (DeepSeek, etc.) produces an
-// assistant turn lacking `reasoning_content`, which is rejected with HTTP
-// 400 ("The reasoning_content in the thinking mode must be passed back to
-// the API.").
+// Sending the first two to a thinking-mode provider (DeepSeek, etc.)
+// produces an assistant turn lacking `reasoning_content`, which is rejected
+// with HTTP 400 ("The reasoning_content in the thinking mode must be passed
+// back to the API.").
 func BuildAgentMessagesFromEntries(entries []domain.ConversationEntry) []sdk.Message {
 	messages := make([]sdk.Message, 0, len(entries))
 	for _, entry := range entries {
@@ -501,6 +508,9 @@ func BuildAgentMessagesFromEntries(entries []domain.ConversationEntry) []sdk.Mes
 			continue
 		}
 		if isUserInitiatedBashEntry(entry) {
+			continue
+		}
+		if entry.PendingToolCall != nil {
 			continue
 		}
 		msg := entry.Message

--- a/internal/services/chatcompletion/runner_test.go
+++ b/internal/services/chatcompletion/runner_test.go
@@ -114,6 +114,59 @@ func TestBuildAgentMessagesFromEntries_FiltersPlanEntries(t *testing.T) {
 	}
 }
 
+// TestBuildAgentMessagesFromEntries_FiltersPendingToolCallEntries is a
+// regression test for issue #786: the UI-only pending-approval placeholder
+// (empty assistant entry) left behind by a rejected tool must not be
+// serialized between the assistant tool_calls message and its tool response.
+func TestBuildAgentMessagesFromEntries_FiltersPendingToolCallEntries(t *testing.T) {
+	entries := []domain.ConversationEntry{
+		{Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("edit the file")}},
+		{
+			Message: sdk.Message{
+				Role:    sdk.Assistant,
+				Content: sdk.NewMessageContent(""),
+				ToolCalls: &[]sdk.ChatCompletionMessageToolCall{
+					{
+						ID:   "call_1",
+						Type: sdk.Function,
+						Function: sdk.ChatCompletionMessageToolCallFunction{
+							Name:      "Edit",
+							Arguments: `{}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Message: sdk.Message{
+				Role:    sdk.Assistant,
+				Content: sdk.NewMessageContent(""),
+			},
+			PendingToolCall:    &sdk.ChatCompletionMessageToolCall{ID: "call_1"},
+			ToolApprovalStatus: domain.ToolApprovalRejected,
+		},
+		{
+			Message: sdk.Message{
+				Role:       sdk.Tool,
+				Content:    sdk.NewMessageContent("Tool execution rejected by user: Edit"),
+				ToolCallID: new("call_1"),
+			},
+		},
+	}
+
+	out := BuildAgentMessagesFromEntries(entries)
+
+	if len(out) != 3 {
+		t.Fatalf("expected 3 messages after filtering placeholder, got %d", len(out))
+	}
+	if out[1].ToolCalls == nil {
+		t.Fatalf("expected message[1] to carry tool_calls")
+	}
+	if out[2].Role != sdk.Tool {
+		t.Fatalf("expected tool response directly after tool_calls message, got role %s", out[2].Role)
+	}
+}
+
 func TestBuildAgentMessagesFromEntries_PreservesNonPlanEntries(t *testing.T) {
 	entries := []domain.ConversationEntry{
 		{Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent("hi")}},

--- a/internal/services/state_manager.go
+++ b/internal/services/state_manager.go
@@ -16,10 +16,6 @@ type StateManager struct {
 	state *domain.ApplicationState
 	mutex sync.RWMutex
 
-	// State change listeners
-	listeners   []StateChangeListener
-	listenersMu sync.RWMutex
-
 	// Event multicast for floating window (optional)
 	eventBridge domain.EventBridge
 
@@ -31,19 +27,6 @@ type StateManager struct {
 
 // Compile-time assertion that StateManager implements domain.StateManager interface
 var _ domain.StateManager = (*StateManager)(nil)
-
-// StateChangeListener interface for components that need to react to state changes
-type StateChangeListener interface {
-	OnStateChanged(oldState, newState domain.StateSnapshot)
-}
-
-// StateChangeEvent represents a state change event
-type StateChangeEvent struct {
-	Type      StateChangeType
-	OldState  domain.StateSnapshot
-	NewState  domain.StateSnapshot
-	Timestamp time.Time
-}
 
 // StateChangeType represents the type of state change
 type StateChangeType int
@@ -74,77 +57,20 @@ func (s StateChangeType) String() string {
 func NewStateManager(debugMode bool) *StateManager {
 	return &StateManager{
 		state:          domain.NewApplicationState(),
-		listeners:      make([]StateChangeListener, 0),
 		debugMode:      debugMode,
 		stateHistory:   make([]domain.StateSnapshot, 0),
 		maxHistorySize: 100,
 	}
 }
 
-// AddListener adds a state change listener
-func (sm *StateManager) AddListener(listener StateChangeListener) {
-	sm.listenersMu.Lock()
-	defer sm.listenersMu.Unlock()
-	sm.listeners = append(sm.listeners, listener)
-}
-
-// RemoveListener removes a state change listener
-func (sm *StateManager) RemoveListener(listener StateChangeListener) {
-	sm.listenersMu.Lock()
-	defer sm.listenersMu.Unlock()
-
-	for i, l := range sm.listeners {
-		if l == listener {
-			sm.listeners = append(sm.listeners[:i], sm.listeners[i+1:]...)
-			break
-		}
-	}
-}
-
-// notifyListeners notifies all listeners of a state change with coordination
-func (sm *StateManager) notifyListeners(oldState, newState domain.StateSnapshot) {
-	sm.listenersMu.RLock()
-	listeners := make([]StateChangeListener, len(sm.listeners))
-	copy(listeners, sm.listeners)
-	sm.listenersMu.RUnlock()
-
-	var wg sync.WaitGroup
-	for _, listener := range listeners {
-		wg.Add(1)
-		go func(l StateChangeListener) {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					logger.Error("listener panicked", "panic", r)
-				}
-			}()
-			l.OnStateChanged(oldState, newState)
-		}(listener)
-	}
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		logger.Warn("some listeners did not respond within timeout")
-	}
-}
-
 // captureStateChange captures a state change for debugging and audit trail
-func (sm *StateManager) captureStateChange(_ /* changeType */ StateChangeType, oldState domain.StateSnapshot) {
+func (sm *StateManager) captureStateChange(_ /* changeType */ StateChangeType, _ domain.StateSnapshot) {
 	newState := sm.state.GetStateSnapshot()
 
 	sm.stateHistory = append(sm.stateHistory, newState)
 	if len(sm.stateHistory) > sm.maxHistorySize {
 		sm.stateHistory = sm.stateHistory[1:]
 	}
-
-	sm.notifyListeners(oldState, newState)
 }
 
 // GetCurrentView returns the current view state

--- a/internal/services/state_manager_test.go
+++ b/internal/services/state_manager_test.go
@@ -43,7 +43,6 @@ func TestNewStateManager(t *testing.T) {
 			assert.NotNil(t, sm.state)
 			assert.Equal(t, tt.expectDebug, sm.debugMode)
 			assert.Equal(t, tt.expectHistory, sm.maxHistorySize)
-			assert.Equal(t, 0, len(sm.listeners))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #786 — rejecting a tool approval (esc) kept the agent generating (a second esc was needed), and the next message failed with HTTP 400: `Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`.

Two root causes:

1. **Loop didn't stop on rejection**: `ApprovingToolsState` treated a rejection as a normal tool result (`HasToolResults=true`), so the state machine looped `PostToolExecution → CheckingQueue → StreamingLLM` into another LLM turn. Rejection entries now carry `ToolExecution.Rejected` and `finishApprovals` clears `HasToolResults`, so the turn completes and control returns to the user — matching the non-approval route's existing "tool was rejected - stopping agent loop" semantics.
2. **Orphaned UI placeholder broke the next request**: the pending-approval placeholder (empty assistant entry) is removed on approve but not on reject, and `BuildAgentMessagesFromEntries` serialized it between the assistant `tool_calls` message and its `tool` response. Placeholders are now filtered there, mirroring the filter `SaveConversation` already applies for disk persistence.

Also includes ponytail-audit cleanups (separate commits):
- remove dead `StateChangeListener` mechanism (zero callers, goroutine fan-out over an always-empty slice on every state change)
- drop the assertion-only `CollectionConfig[E]` interface
- replace the single `go.yaml.in/yaml/v3` test import with the already-direct `gopkg.in/yaml.v3` dep

no docs ticket: internal-only fix/refactor

## Testing

- Regression tests: `TestApprovingToolsState_RejectionStopsTurn`, `TestApprovingToolsState_ApprovedBatchKeepsToolResults`, `TestBuildAgentMessagesFromEntries_FiltersPendingToolCallEntries`, `TestAnyToolRejected`
- `task build`, `task test`, `task lint` all pass