### PR TITLE
feat(agent): inject project structure into system prompt to stop path guessing

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -3,9 +3,14 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
+	"unicode/utf8"
 
 	config "github.com/inference-gateway/cli/config"
+	agent "github.com/inference-gateway/cli/internal/agent"
 	container "github.com/inference-gateway/cli/internal/container"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	services "github.com/inference-gateway/cli/internal/services"
 	cobra "github.com/spf13/cobra"
 )
 
@@ -25,26 +30,58 @@ var debugAgentSystemPromptCmd = &cobra.Command{
 	Short: "Print the system prompt a chat session would send to the LLM",
 	Long: "Builds and prints the exact system prompt (base prompt + custom " +
 		"instructions + dynamic context + date) that a fresh `infer chat` " +
-		"session would send to the model.",
+		"session would send to the model. With --tokens, prints size stats " +
+		"(characters, lines, estimated tokens) instead of the prompt itself.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, err := fmt.Fprintln(cmd.OutOrStdout(), renderAgentSystemPrompt(cmd.Context(), Cfg))
+		agentService := syncedAgentService(cmd.Context(), Cfg)
+		prompt := agentService.BuildSystemPrompt()
+
+		showTokens, _ := cmd.Flags().GetBool("tokens")
+		if !showTokens {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), prompt)
+			return err
+		}
+
+		tokenizer := services.NewTokenizerService(services.DefaultTokenizerConfig())
+		out := cmd.OutOrStdout()
+		if sectioned, ok := agentService.(interface{ SystemPromptSections() []agent.PromptSection }); ok {
+			for _, section := range sectioned.SystemPromptSections() {
+				text := strings.TrimSpace(section.Text)
+				_, _ = fmt.Fprintf(out, "%-22s %7d tokens  (%d chars)\n",
+					section.Name, tokenizer.EstimateTokenCount(text), utf8.RuneCountInString(text))
+			}
+			_, _ = fmt.Fprintln(out)
+		}
+		_, err := fmt.Fprintf(out,
+			"Characters: %d\nLines: %d\nEstimated tokens: %d\n",
+			utf8.RuneCountInString(prompt),
+			strings.Count(prompt, "\n")+1,
+			tokenizer.EstimateTokenCount(prompt),
+		)
 		return err
 	},
 }
 
-// renderAgentSystemPrompt syncs memory in and renders the system prompt a
-// fresh session would send. The sync mirrors the headless agent's pre-session
-// hook: with the git memory backend on a fresh machine, MEMORY.md only exists
-// locally after SyncIn, and without it the render silently omits the
-// PERSISTENT MEMORY INDEX section the real agent would receive. Fail-soft
-// like the agent: a sync failure must never break the debug render.
-func renderAgentSystemPrompt(ctx context.Context, cfg *config.Config) string {
+// syncedAgentService builds the service container and syncs memory in before
+// returning the agent service. The sync mirrors the headless agent's
+// pre-session hook: with the git memory backend on a fresh machine, MEMORY.md
+// only exists locally after SyncIn, and without it the rendered prompt
+// silently omits the PERSISTENT MEMORY INDEX section the real agent would
+// receive. Fail-soft like the agent: a sync failure must never break the
+// debug render.
+func syncedAgentService(ctx context.Context, cfg *config.Config) domain.AgentService {
 	services := container.NewServiceContainer(cfg)
 	_ = services.GetMemoryBackend().SyncIn(ctx)
-	return services.GetAgentService().BuildSystemPrompt()
+	return services.GetAgentService()
+}
+
+// renderAgentSystemPrompt renders the system prompt a fresh session would send.
+func renderAgentSystemPrompt(ctx context.Context, cfg *config.Config) string {
+	return syncedAgentService(ctx, cfg).BuildSystemPrompt()
 }
 
 func init() {
+	debugAgentSystemPromptCmd.Flags().Bool("tokens", false, "print size stats (characters, lines, estimated tokens) instead of the prompt")
 	debugAgentCmd.AddCommand(debugAgentSystemPromptCmd)
 	debugCmd.AddCommand(debugAgentCmd)
 	rootCmd.AddCommand(debugCmd)

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	cobra "github.com/spf13/cobra"
+
 	config "github.com/inference-gateway/cli/config"
 	agent "github.com/inference-gateway/cli/internal/agent"
 	container "github.com/inference-gateway/cli/internal/container"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	services "github.com/inference-gateway/cli/internal/services"
-	cobra "github.com/spf13/cobra"
 )
 
 var debugCmd = &cobra.Command{

--- a/config/config.go
+++ b/config/config.go
@@ -444,6 +444,7 @@ type AgentContextConfig struct {
 	GitContextEnabled      bool `yaml:"git_context_enabled" mapstructure:"git_context_enabled"`
 	WorkingDirEnabled      bool `yaml:"working_dir_enabled" mapstructure:"working_dir_enabled"`
 	GitContextRefreshTurns int  `yaml:"git_context_refresh_turns" mapstructure:"git_context_refresh_turns"`
+	TreeEnabled            bool `yaml:"tree_enabled" mapstructure:"tree_enabled"`
 }
 
 // AgentSkillsConfig controls Agent Skills loading. Skills follow the
@@ -890,6 +891,7 @@ func DefaultConfig() *Config { //nolint:funlen
 				GitContextEnabled:      true,
 				WorkingDirEnabled:      true,
 				GitContextRefreshTurns: 10,
+				TreeEnabled:            true,
 			},
 			Skills: AgentSkillsConfig{
 				Enabled:        true,

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -396,7 +396,7 @@ func defaultPromptsToolsConfig() PromptsToolsConfig { //nolint:funlen
 		},
 		Read: PromptsToolDescription{
 			Description: `Reads a file from the local filesystem. You can access any file directly by using this tool.
-Assume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.
+Assume this tool is able to read all files on the machine. Only read paths you have seen - in the PROJECT STRUCTURE context, Tree/Grep output, a previous tool result, or the user's message. Never guess or invent file paths; if unsure, run the Tree tool on the directory first.
 
 Usage:
 - The file_path parameter can be either an absolute path or a relative path (relative paths will be resolved to absolute paths)
@@ -480,7 +480,7 @@ If you want to create a new file, use:
 			Description: "A powerful search tool with configurable backend (ripgrep or Go implementation)\n\n Usage:\n - ALWAYS use Grep for search tasks. NEVER invoke `grep` or `rg` as a Bash command. The Grep tool has been optimized for correct permissions and access.\n - Supports full regex syntax (e.g., \"log.*Error\", \"function\\s+\\w+\")\n - Filter files with glob parameter (e.g., \"*.js\", \"**/*.tsx\") or type parameter (e.g., \"js\", \"py\", \"rust\")\n - Output modes: \"content\" shows matching lines, \"files_with_matches\" shows only file paths (default), \"count\" shows match counts\n - Use the Agent tool for open-ended searches requiring multiple rounds\n - Pattern syntax: When using ripgrep backend - literal braces need escaping (use `interface\\{\\}` to find `any` in Go code)\n - Multiline matching: By default patterns match within single lines only. For cross-line patterns like `struct \\{[\\s\\S]*?field`, use `multiline: true`\n",
 		},
 		Tree: PromptsToolDescription{
-			Description: `Display directory structure in a tree format, similar to the Unix tree command`,
+			Description: `Display directory structure in a tree format, similar to the Unix tree command. Use format "compact" for a token-efficient one-directory-per-line listing (root-first, git-tracked non-ignored files only) when you just need to see where files live.`,
 		},
 		TodoWrite: PromptsToolDescription{
 			Description: `Use this tool to create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -73,6 +73,8 @@ type AgentServiceImpl struct {
 	// Context caching
 	gitContextCache    string
 	gitContextTurn     int
+	treeContextCache   string
+	treeContextTurn    int
 	memoryContextCache string
 	memoryContextTurn  int
 	contextCacheMux    sync.RWMutex

--- a/internal/agent/agent_utils.go
+++ b/internal/agent/agent_utils.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -16,6 +17,7 @@ import (
 	sdk "github.com/inference-gateway/sdk"
 
 	config "github.com/inference-gateway/cli/config"
+	tools "github.com/inference-gateway/cli/internal/agent/tools"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	formatting "github.com/inference-gateway/cli/internal/formatting"
 	logger "github.com/inference-gateway/cli/internal/logger"
@@ -209,19 +211,64 @@ func (s *AgentServiceImpl) addSystemPrompt(messages []sdk.Message) []sdk.Message
 	return append([]sdk.Message{systemMessage}, messages...)
 }
 
+// PromptSection is one labeled part of the assembled system prompt, exposed
+// for diagnostics (e.g. per-section token estimates in `infer debug`). Text is
+// the raw part as it appears in the prompt, including any separator prefix.
+type PromptSection struct {
+	Name string
+	Text string
+}
+
+// contextSections lists the dynamic context builders in prompt order; it is
+// the single source for both prompt assembly and diagnostics.
+func (s *AgentServiceImpl) contextSections(currentTurn int, messages []sdk.Message) []PromptSection {
+	return []PromptSection{
+		{Name: "sandbox", Text: s.buildSandboxInfo()},
+		{Name: "a2a_agents", Text: s.buildA2AAgentInfo()},
+		{Name: "os", Text: s.buildOSInfo()},
+		{Name: "working_directory", Text: s.buildWorkingDirectoryInfo()},
+		{Name: "git_context", Text: s.buildGitContextInfo(currentTurn)},
+		{Name: "project_structure", Text: s.buildProjectTreeInfo(currentTurn)},
+		{Name: "github_guidance", Text: s.buildGitHubGuidanceInfo()},
+		{Name: "bash_allow_list", Text: s.buildBashAllowInfo()},
+		{Name: "tools", Text: s.buildToolsInfo()},
+		{Name: "skills", Text: s.buildSkillsInfo()},
+		{Name: "active_skill", Text: s.buildActiveSkillInfo(messages)},
+		{Name: "memory", Text: s.buildMemoryInfo(currentTurn)},
+	}
+}
+
 // buildContextInfo assembles dynamic context (sandbox, A2A, OS, working dir, git, GitHub, tools, skills) for the system prompt
 func (s *AgentServiceImpl) buildContextInfo(currentTurn int, messages []sdk.Message) string {
-	return s.buildSandboxInfo() +
-		s.buildA2AAgentInfo() +
-		s.buildOSInfo() +
-		s.buildWorkingDirectoryInfo() +
-		s.buildGitContextInfo(currentTurn) +
-		s.buildGitHubGuidanceInfo() +
-		s.buildBashAllowInfo() +
-		s.buildToolsInfo() +
-		s.buildSkillsInfo() +
-		s.buildActiveSkillInfo(messages) +
-		s.buildMemoryInfo(currentTurn)
+	var b strings.Builder
+	for _, section := range s.contextSections(currentTurn, messages) {
+		b.WriteString(section.Text)
+	}
+	return b.String()
+}
+
+// SystemPromptSections returns the labeled parts of the system prompt a fresh
+// session (turn 0) would send, in prompt order and with empty parts omitted.
+// Exposed for the `infer debug agent system_prompt --tokens` breakdown.
+func (s *AgentServiceImpl) SystemPromptSections() []PromptSection {
+	agentConfig := s.config.GetAgentConfig()
+	sections := []PromptSection{
+		{Name: "base_prompt", Text: s.getSystemPromptForMode()},
+		{Name: "custom_instructions", Text: s.config.Prompts.Agent.CustomInstructions},
+		{Name: "agents_md", Text: s.buildAgentsMDInfo()},
+		{Name: "plugins", Text: plugins.InstructionsBlock(s.config)},
+	}
+	if agentConfig.SystemPromptWithDefaults {
+		sections = append(sections, s.contextSections(0, nil)...)
+	}
+
+	nonEmpty := sections[:0]
+	for _, section := range sections {
+		if section.Text != "" {
+			nonEmpty = append(nonEmpty, section)
+		}
+	}
+	return nonEmpty
 }
 
 // buildGitHubGuidanceInfo steers the model toward the `gh` CLI for GitHub work
@@ -796,6 +843,64 @@ func (s *AgentServiceImpl) buildGitContextInfo(currentTurn int) string {
 	s.contextCacheMux.Unlock()
 
 	return result
+}
+
+// projectTreeMaxLines caps the PROJECT STRUCTURE block in the system prompt.
+const projectTreeMaxLines = 100
+
+// buildProjectTreeInfo injects a root-first, depth-prioritized project listing
+// into the system prompt so the model reads real paths instead of guessing
+// them. It runs the Tree tool in compact format, which in a git repository
+// lists tracked plus untracked non-ignored files one directory per line
+// (shallow directories first, so the root and top-level layout always fit the
+// line budget) and outside a git repo falls back to the ASCII tree. Shares the
+// git-context caching scheme, refreshing every GitContextRefreshTurns turns.
+func (s *AgentServiceImpl) buildProjectTreeInfo(currentTurn int) string {
+	cfg := s.config.GetAgentConfig()
+	if !cfg.Context.TreeEnabled {
+		return ""
+	}
+
+	s.contextCacheMux.RLock()
+	if s.treeContextCache != "" && currentTurn-s.treeContextTurn < cfg.Context.GitContextRefreshTurns {
+		defer s.contextCacheMux.RUnlock()
+		return s.treeContextCache
+	}
+	s.contextCacheMux.RUnlock()
+
+	result := ""
+	if listing := s.compactProjectTree(); listing != "" {
+		result = fmt.Sprintf(
+			"\n\nPROJECT STRUCTURE (one directory per line, root and shallow directories first; hidden dot-files and dot-directories omitted; \"name.go*\" means name.go plus name_test.go; run the Tree or Grep tools for anything omitted):\n%s",
+			listing,
+		)
+	}
+
+	s.contextCacheMux.Lock()
+	s.treeContextCache = result
+	s.treeContextTurn = currentTurn
+	s.contextCacheMux.Unlock()
+
+	return result
+}
+
+// compactProjectTree renders the Tree tool's compact listing for the current
+// directory (falling back to the ASCII tree for non-git directories).
+func (s *AgentServiceImpl) compactProjectTree() string {
+	treeTool := tools.NewTreeTool(s.config)
+	execResult, err := treeTool.Execute(context.Background(), map[string]any{
+		"path":      ".",
+		"format":    "compact",
+		"max_files": float64(projectTreeMaxLines),
+	})
+	if err != nil {
+		logger.Debug("failed to build project tree context", "error", err)
+		return ""
+	}
+	if data, ok := execResult.Data.(*domain.TreeToolResult); ok {
+		return data.Output
+	}
+	return ""
 }
 
 // isGitRepository checks if the current directory is a git repository

--- a/internal/agent/agent_utils_test.go
+++ b/internal/agent/agent_utils_test.go
@@ -591,6 +591,32 @@ func TestBuildAgentsMDInfo(t *testing.T) {
 	})
 }
 
+func TestBuildProjectTreeInfo(t *testing.T) {
+	t.Run("injects tree with real file names when enabled", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("known_file.go", []byte("package x"), 0o644))
+
+		cfg := &config.Config{}
+		cfg.Tools.Enabled = true
+		cfg.Agent.Context.TreeEnabled = true
+		cfg.Agent.Context.GitContextRefreshTurns = 10
+		s := &AgentServiceImpl{config: cfg}
+
+		got := s.buildProjectTreeInfo(0)
+		require.Contains(t, got, "PROJECT STRUCTURE")
+		require.Contains(t, got, "known_file.go")
+	})
+
+	t.Run("empty when disabled", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Tools.Enabled = true
+		cfg.Agent.Context.TreeEnabled = false
+		s := &AgentServiceImpl{config: cfg}
+
+		require.Empty(t, s.buildProjectTreeInfo(0))
+	})
+}
+
 func TestBuildSystemPromptText_AgentsMDAfterCustomInstructions(t *testing.T) {
 	t.Chdir(t.TempDir())
 	require.NoError(t, os.WriteFile("AGENTS.md", []byte("project rules here"), 0o644))

--- a/internal/agent/agent_utils_test.go
+++ b/internal/agent/agent_utils_test.go
@@ -12,9 +12,10 @@ import (
 
 	sdk "github.com/inference-gateway/sdk"
 
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
-	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
 // stubSkillsService implements domain.SkillsService for testing the

--- a/internal/agent/tools/tree.go
+++ b/internal/agent/tools/tree.go
@@ -81,8 +81,8 @@ func (t *TreeTool) Definition() sdk.ChatCompletionTool {
 					},
 					"format": map[string]any{
 						"type":        "string",
-						"description": "Output format (text or json)",
-						"enum":        []string{"text", "json"},
+						"description": "Output format: text (ASCII tree), json, or compact (one directory per line, root-first, git-tracked non-ignored files only)",
+						"enum":        []string{"text", "json", "compact"},
 						"default":     "text",
 					},
 				},
@@ -210,8 +210,8 @@ func (t *TreeTool) Validate(args map[string]any) error {
 		if !isString {
 			return fmt.Errorf("format must be a string")
 		}
-		if formatStr != "text" && formatStr != "json" {
-			return fmt.Errorf("format must be 'text' or 'json'")
+		if formatStr != "text" && formatStr != "json" && formatStr != "compact" {
+			return fmt.Errorf("format must be 'text', 'json', or 'compact'")
 		}
 	}
 
@@ -250,6 +250,15 @@ func (t *TreeTool) executeTree(path string, maxDepth, maxFiles int, showHidden, 
 
 	if err := t.validatePath(path); err != nil {
 		return nil, err
+	}
+
+	if format == "compact" {
+		if listing := compactProjectListing(path, maxFiles); listing != "" {
+			result.Output = listing
+			return result, nil
+		}
+		format = "text"
+		result.Format = format
 	}
 
 	output, files, dirs, truncated, err := t.buildTreeFallback(path, maxDepth, maxFiles, showHidden, respectGitignore, format)

--- a/internal/agent/tools/tree.go
+++ b/internal/agent/tools/tree.go
@@ -11,10 +11,11 @@ import (
 	"sync"
 	"time"
 
+	ignore "github.com/sabhiram/go-gitignore"
+
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	sdk "github.com/inference-gateway/sdk"
-	ignore "github.com/sabhiram/go-gitignore"
 )
 
 // TreeTool handles directory tree visualization operations

--- a/internal/agent/tools/tree_compact.go
+++ b/internal/agent/tools/tree_compact.go
@@ -1,0 +1,111 @@
+package tools
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// compactMaxFilesPerDir caps how many files a single directory line lists in
+// the compact format; the overall line budget comes from the max_files arg.
+const compactMaxFilesPerDir = 25
+
+// compactProjectListing produces the compact one-directory-per-line listing
+// for a git repository rooted at path, or "" when path is not inside a git
+// repository (callers fall back to the text tree).
+func compactProjectListing(path string, maxLines int) string {
+	return formatProjectListing(gitProjectFiles(path), maxLines, compactMaxFilesPerDir)
+}
+
+// gitProjectFiles returns tracked plus untracked non-ignored file paths
+// (relative, slash-separated) or nil when path is not in a git repository.
+func gitProjectFiles(path string) []string {
+	cmd := exec.Command("git", "ls-files", "--cached", "--others", "--exclude-standard")
+	cmd.Dir = path
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	return strings.Split(strings.TrimSpace(string(out)), "\n")
+}
+
+// formatProjectListing groups file paths one directory per line, ordered by
+// directory depth then name so root files come first and shallow structure
+// survives the line budget. Hidden files and directories (any dot-prefixed
+// path component) are omitted to save tokens - the text format still shows
+// them on demand. To save further tokens, a "name.go*" entry means both
+// name.go and name_test.go exist in that directory. Both the per-directory
+// file list and the total line count are capped, with explicit "+N more"
+// markers so truncation is never silent.
+func formatProjectListing(paths []string, maxLines, maxFilesPerDir int) string {
+	byDir := make(map[string][]string)
+	for _, p := range paths {
+		if p == "" || strings.HasPrefix(p, ".") || strings.Contains(p, "/.") {
+			continue
+		}
+		byDir[filepath.Dir(p)] = append(byDir[filepath.Dir(p)], filepath.Base(p))
+	}
+	if len(byDir) == 0 {
+		return ""
+	}
+	for dir, files := range byDir {
+		byDir[dir] = collapseTestSiblings(files)
+	}
+
+	dirs := make([]string, 0, len(byDir))
+	for dir := range byDir {
+		dirs = append(dirs, dir)
+	}
+	sort.Slice(dirs, func(i, j int) bool {
+		di, dj := strings.Count(dirs[i], "/"), strings.Count(dirs[j], "/")
+		if dirs[i] == "." {
+			di = -1
+		}
+		if dirs[j] == "." {
+			dj = -1
+		}
+		if di != dj {
+			return di < dj
+		}
+		return dirs[i] < dirs[j]
+	})
+
+	var b strings.Builder
+	for i, dir := range dirs {
+		if i >= maxLines {
+			fmt.Fprintf(&b, "... +%d more directories\n", len(dirs)-i)
+			break
+		}
+		files := byDir[dir]
+		sort.Strings(files)
+		suffix := ""
+		if len(files) > maxFilesPerDir {
+			suffix = fmt.Sprintf(",+%d more", len(files)-maxFilesPerDir)
+			files = files[:maxFilesPerDir]
+		}
+		fmt.Fprintf(&b, "%s/: %s%s\n", dir, strings.Join(files, ","), suffix)
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+// collapseTestSiblings folds name_test.go into a "name.go*" marker when
+// name.go exists in the same directory; standalone test files stay listed.
+func collapseTestSiblings(files []string) []string {
+	present := make(map[string]bool, len(files))
+	for _, f := range files {
+		present[f] = true
+	}
+	out := files[:0]
+	for _, f := range files {
+		if base, ok := strings.CutSuffix(f, "_test.go"); ok && present[base+".go"] {
+			continue
+		}
+		if present[strings.TrimSuffix(f, ".go")+"_test.go"] && strings.HasSuffix(f, ".go") && !strings.HasSuffix(f, "_test.go") {
+			f += "*"
+		}
+		out = append(out, f)
+	}
+	return out
+}

--- a/internal/agent/tools/tree_compact_test.go
+++ b/internal/agent/tools/tree_compact_test.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatProjectListing(t *testing.T) {
+	t.Run("root files first then shallow directories", func(t *testing.T) {
+		got := formatProjectListing([]string{
+			"internal/agent/agent.go",
+			"cmd/root.go",
+			"main.go",
+			"go.mod",
+		}, 100, 25)
+
+		lines := strings.Split(got, "\n")
+		require.Equal(t, []string{
+			"./: go.mod,main.go",
+			"cmd/: root.go",
+			"internal/agent/: agent.go",
+		}, lines)
+	})
+
+	t.Run("caps lines and files per directory with markers", func(t *testing.T) {
+		paths := []string{"a/one.go", "a/two.go", "a/three.go", "b/x.go", "c/y.go"}
+		got := formatProjectListing(paths, 2, 2)
+
+		require.Contains(t, got, "a/: one.go,three.go,+1 more")
+		require.Contains(t, got, "... +1 more directories")
+		require.NotContains(t, got, "c/:")
+	})
+
+	t.Run("omits hidden files and directories", func(t *testing.T) {
+		got := formatProjectListing([]string{
+			".gitignore",
+			".agents/skills/go/SKILL.md",
+			"internal/.hidden/secret.go",
+			"main.go",
+		}, 100, 25)
+
+		require.Equal(t, "./: main.go", got)
+	})
+
+	t.Run("collapses test siblings into star marker", func(t *testing.T) {
+		got := formatProjectListing([]string{
+			"pkg/agent.go",
+			"pkg/agent_test.go",
+			"pkg/orphan_test.go",
+			"pkg/util.go",
+		}, 100, 25)
+
+		require.Equal(t, "pkg/: agent.go*,orphan_test.go,util.go", got)
+	})
+
+	t.Run("empty input yields empty output", func(t *testing.T) {
+		require.Empty(t, formatProjectListing(nil, 100, 25))
+	})
+}

--- a/internal/agent/tools/tree_compact_test.go
+++ b/internal/agent/tools/tree_compact_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	require "github.com/stretchr/testify/require"
 )
 
 func TestFormatProjectListing(t *testing.T) {


### PR DESCRIPTION
## Problem

Weaker models in headless runs (Infer Action, e.g. `deepseek-v4-flash`) guess file paths and hit `Read: NOT_FOUND` almost every run — e.g. reading `internal/shortcuts/shortcut.go` / `side_effects.go` when the real files are `core.go` / `interfaces.go`. The system prompt carried the git context (repo, branch, recent commits) but **no project layout**, so the model had nothing real to anchor on, and the Read tool description actively invited guessing.

## Fix

Inject a cached, root-first **PROJECT STRUCTURE** block into the system prompt so the model reads real paths without extra tool calls.

- **New Tree tool `format: "compact"`** — one directory per line, root and shallow directories first (fits the 100-line budget), git-tracked plus untracked non-ignored files only (gitignore respected by git itself), dot-files/dot-dirs omitted, and `name.go*` collapses `name.go` + `name_test.go` to save tokens. Falls back to the ASCII text tree outside a git repo. The system prompt calls this format rather than duplicating the listing logic — single implementation.
- `buildProjectTreeInfo` caches the block on the existing git-context refresh cycle (`GitContextRefreshTurns`).
- Config flag `agent.context.tree_enabled` (default `true`).
- Read tool description no longer says "assume the path is valid" — it points the model at PROJECT STRUCTURE / Tree / Grep and says never to guess.
- `debug agent system_prompt --tokens` — per-section token breakdown reusing the existing tokenizer, so prompt size is auditable.

## Verification

- `task test` — passes (agent + tools packages green).
- `task lint` — 0 issues.
- `debug agent system_prompt` — PROJECT STRUCTURE block renders the real repo at ~2667 tokens, complete within the line budget, gitignored paths absent.