### PR TITLE
fix(ui): make git branch resolution injectable so PR-cache tests are hermetic

### DIFF
--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -55,6 +55,19 @@ type InputView struct {
 	gitBranchCacheTime   time.Time
 	gitBranchCacheTTL    time.Duration
 	gitPRCache           string
+	resolveGitBranch     func() (string, error)
+}
+
+// gitCurrentBranch returns the current git branch by shelling out to git. It is
+// the default resolver wired into getCurrentGitBranch; tests inject a stub via
+// the resolveGitBranch field so branch resolution is deterministic without a
+// real repository.
+func gitCurrentBranch() (string, error) {
+	output, err := exec.Command("git", "branch", "--show-current").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }
 
 func NewInputView(modelService domain.ModelService) *InputView {
@@ -87,6 +100,7 @@ func NewInputViewWithName(modelService domain.ModelService, configDir, name stri
 		imageAttachments:  []domain.ImageAttachment{},
 		focused:           true,
 		gitBranchCacheTTL: 5 * time.Second,
+		resolveGitBranch:  gitCurrentBranch,
 	}
 }
 
@@ -234,8 +248,11 @@ func (iv *InputView) getCurrentGitBranch() (string, bool) {
 		return iv.gitBranchCache, true
 	}
 
-	cmd := exec.Command("git", "branch", "--show-current")
-	output, err := cmd.Output()
+	resolve := iv.resolveGitBranch
+	if resolve == nil {
+		resolve = gitCurrentBranch
+	}
+	branch, err := resolve()
 
 	iv.gitBranchCacheTime = time.Now()
 
@@ -244,7 +261,6 @@ func (iv *InputView) getCurrentGitBranch() (string, bool) {
 		return "", false
 	}
 
-	branch := strings.TrimSpace(string(output))
 	if iv.gitBranchCache != "" && branch != iv.gitBranchCache {
 		iv.gitPRCache = ""
 	}

--- a/internal/ui/components/input_view_test.go
+++ b/internal/ui/components/input_view_test.go
@@ -731,6 +731,7 @@ func TestInputView_InitFetchesPR(t *testing.T) {
 func TestInputView_BranchChangeClearsPRCache(t *testing.T) {
 	iv := newInputViewWithPR(t, "definitely-not-the-real-branch", "123")
 	iv.gitBranchCacheTime = time.Now().Add(-10 * time.Second)
+	iv.resolveGitBranch = func() (string, error) { return "main", nil }
 
 	_, _ = iv.getCurrentGitBranch()
 
@@ -740,6 +741,7 @@ func TestInputView_BranchChangeClearsPRCache(t *testing.T) {
 func TestInputView_BranchRefreshAfterInvalidationKeepsPRCache(t *testing.T) {
 	iv := newInputViewWithPR(t, "main", "123")
 	iv.InvalidateGitBranchCache()
+	iv.resolveGitBranch = func() (string, error) { return "main", nil }
 
 	_, _ = iv.getCurrentGitBranch()
 


### PR DESCRIPTION
## Problem

`nix build` / `flox install` of `infer` **0.140.0** fails in the check phase:

```
--- FAIL: TestInputView_BranchChangeClearsPRCache (0.01s)
    input_view_test.go:737: Should be empty, but was 123
    Messages: a branch switch must drop the old branch's PR number
```

The PR-status-bar cache added in #806 introduced `TestInputView_BranchChangeClearsPRCache`, which shells out to real `git` and relies on the ambient repository returning a branch name **different** from a fabricated one. `flake.nix` strips `.git` from `src` (but keeps the `git` binary via `nativeCheckInputs`), so in the hermetic sandbox `git branch --show-current` **errors**. In `getCurrentGitBranch()` the PR-clearing logic lived only on the git-**success** path, so on error the stale PR number `123` survived and the assertion failed. It only passed locally because the dev's real repo returns a branch that differs from the fake one.

## Fix

Extract the git call into a package-level `gitCurrentBranch` default and wire it through a new `resolveGitBranch func() (string, error)` field on `InputView`. The two cache-expiring tests inject a stub returning a fixed branch, so branch resolution is deterministic **with or without** a real repository. Production behavior is unchanged (default resolver = the current real `git` call); a nil-guard falls back to the real call for struct-literal-built test views.

## Verification

- `go test ./internal/ui/components/...` and `go vet` pass.
- The two targeted tests pass both **in a repo** and from a **`.git`-free directory** (where `git branch --show-current` errors) - the exact sandbox condition.
- `nix build .#infer` succeeds end-to-end through the check phase (previously red here).