### PR TITLE
feat(gateway): hermetic mock gateway with INFER_GATEWAY_MOCK mode, scenario e2e harness, streaming fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,20 @@ jobs:
 
     - name: Run tests with race detector
       run: go test -race ./...
+
+  e2e:
+    needs:
+      - build
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7.0.0
+
+    - name: Setup Go
+      uses: actions/setup-go@v6.5.0
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: Run hermetic end-to-end tests against the mock gateway
+      run: go test -race -tags e2e -timeout 5m ./tests/e2e/...

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 flox.*-linux.*
 /.task
 infer
-mock-gateway
 
 # Nix build artifacts
 result

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 flox.*-linux.*
 /.task
 infer
+mock-gateway
 
 # Nix build artifacts
 result

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,75 @@ The agent is an **event-driven state machine** (`internal/agent/agent_state_mach
 - Prefer table-driven tests where inputs and expected results vary.
 - SA5011 false positives in tests are suppressed in `.golangci.yml` — `t.Fatal` is recognised as no-return.
 
+### Driving the chat TUI via tmux
+
+The chat TUI (Bubble Tea v2) can be exercised end-to-end without a physical
+keyboard by running it inside a detached tmux session and scripting it with
+`send-keys` / `capture-pane`. Combine with the embedded mock gateway
+(`INFER_GATEWAY_MOCK=true`) so no real LLM is called.
+
+**1. Start a dedicated session** (fixed size makes captures deterministic):
+
+```bash
+tmux kill-session -t infer-tui 2>/dev/null || true
+tmux new-session -d -s infer-tui -x 200 -y 50 \
+  'INFER_GATEWAY_MOCK=true go run . chat'
+```
+
+**2. Select a model** — the mock advertises a single model (`openai/gpt-4o`),
+so once the picker renders, Enter selects it:
+
+```bash
+sleep 3   # `go run` compiles first; wait for the TUI to render
+tmux send-keys -t infer-tui Enter
+```
+
+**3. Type and submit a prompt.** Use `-l` for literal text (otherwise tmux
+interprets words like `Enter` or `Space` as key names), then send Enter as a
+separate call:
+
+```bash
+tmux send-keys -t infer-tui -l 'say hello'
+tmux send-keys -t infer-tui Enter
+```
+
+Special keys use tmux key names, not `-l`: `Enter`, `Escape`, `Tab`, `BTab`
+(shift+tab, toggles agent mode), `Up`/`Down`, `C-c`.
+
+**4. Capture and assert.** Always sleep briefly before capturing — the TUI
+repaints asynchronously and an immediate capture shows a stale frame:
+
+```bash
+sleep 1
+tmux capture-pane -t infer-tui -p -S -50
+```
+
+`-S -50` includes scrollback; grep the output for the expected response.
+
+**5. Clean up** when done (also kills the CLI process):
+
+```bash
+tmux kill-session -t infer-tui
+```
+
+**Mock gateway scenarios:** the mock matches the latest real user message
+(injected `<system-reminder>` content is skipped) against the regexes in
+`internal/mockgateway/scenarios.yaml` — e.g. `say hello` → a text reply,
+`please search for X` → a Grep tool call. Unmatched prompts get the `Done.`
+fallback. To test with custom scenarios, build the standalone binary
+(`task build:mockgateway` → `.infer/bin/mock-gateway --scenarios my.yaml`),
+read the listen address from its first stdout line, and point the CLI at it
+with `INFER_GATEWAY_URL` instead of `INFER_GATEWAY_MOCK`.
+
+**Pitfalls:**
+
+- `send-keys` without `-l` treats semicolons as command separators and
+  capitalised words as key names — always use `-l` for message text.
+- Target the session by name (`-t infer-tui`); pane IDs like `%16` are not
+  stable across runs.
+- If a run wedges the TUI, `tmux send-keys -t infer-tui C-c` then
+  `kill-session` — don't leave orphaned sessions behind.
+
 ## Linter Constraints
 
 `.golangci.yml` enforces:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,16 @@ A single test: `flox activate -- go test ./internal/agent/tools -run TestBashToo
 
 Commits use Conventional Commits (`.commitlintrc.json`); release tooling (semantic-release on `main`) maps `feat:` → minor, `fix:` → patch, `feat!:` / `BREAKING CHANGE:` → major.
 
+## Hermetic testing (mock gateway)
+
+`internal/mockgateway/` is an embedded mock inference-gateway serving canned OpenAI-compatible SSE responses. Scenario routing (`internal/mockgateway/scenarios.yaml`) matches the **latest real user message** — injected `<system-reminder>` content is skipped — against each scenario's regex; unmatched prompts get a `Done.` fallback. Three ways in:
+
+- **In-process**: `INFER_GATEWAY_MOCK=true` (config `gateway.mock`) makes the service container start the mock on an ephemeral port and point the CLI at it — no real LLM, no network. Works for interactive `infer chat` too.
+- **Integration tests** (`tests/integration/agent_gateway_test.go`): the agent against the mock over real HTTP — real SDK client, SSE parsing, tool-call accumulation, state machine; no interface fakes on the LLM path.
+- **E2E tests** (`tests/e2e/`, build tag `e2e`): run the built `infer` binary as a subprocess against the mock. `task test:e2e` (= `go test -race -tags e2e -timeout 5m ./tests/e2e/...`); plain `task test` skips them (build tag), CI runs them in a dedicated job.
+
+For manual testing with custom scenarios: `task build:mockgateway` → `.infer/bin/mock-gateway --scenarios my.yaml`, then point the CLI at its printed listen address via `INFER_GATEWAY_URL`. To drive the chat TUI end-to-end (tmux + `send-keys`/`capture-pane`, including pitfalls like `-l` for literal text), follow the recipe in `AGENTS.md` § "Driving the chat TUI via tmux" — don't duplicate it here.
+
 ## Big-picture architecture
 
 The CLI is a Cobra app whose root subcommands all share one dependency-injected service container.

--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ All configuration can be set via environment variables with the `INFER_` prefix:
 
 ```bash
 export INFER_GATEWAY_URL="http://localhost:8080"
+export INFER_GATEWAY_MOCK=true # embedded mock gateway with canned scenario responses, no real LLM
 export INFER_AGENT_MODEL="deepseek/deepseek-v4-pro"
 export INFER_TOOLS_BASH_ENABLED=true
 export INFER_CHAT_THEME="tokyo-night"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,12 +35,13 @@ tasks:
   build:mockgateway:
     desc: Build the mock inference-gateway binary for manual and terminal-automation testing
     cmds:
-      - go build -o mock-gateway ./tests/mockgateway
+      - mkdir -p .infer/bin
+      - go build -o .infer/bin/mock-gateway ./tests/mockgateway
 
   clean:
     desc: Clean build artifacts
     cmds:
-      - rm -f {{.BINARY_NAME}} mock-gateway
+      - rm -f {{.BINARY_NAME}} .infer/bin/mock-gateway
       - go clean
 
   test:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,10 +32,15 @@ tasks:
     cmds:
       - go build -ldflags "-w -s -X github.com/inference-gateway/cli/cmd.version={{.VERSION}}" -o $(go env GOPATH)/bin/{{.BINARY_NAME}} {{.MAIN_PACKAGE}}
 
+  build:mockgateway:
+    desc: Build the mock inference-gateway binary for manual and terminal-automation testing
+    cmds:
+      - go build -o mock-gateway ./tests/mockgateway
+
   clean:
     desc: Clean build artifacts
     cmds:
-      - rm -f {{.BINARY_NAME}}
+      - rm -f {{.BINARY_NAME}} mock-gateway
       - go clean
 
   test:
@@ -57,6 +62,11 @@ tasks:
     desc: Run all tests with the race detector
     cmds:
       - go test -race ./...
+
+  test:e2e:
+    desc: Run hermetic end-to-end tests of the built CLI against the mock gateway
+    cmds:
+      - go test -race -tags e2e -timeout 5m ./tests/e2e/...
 
   lint:
     desc: Run linter (requires golangci-lint)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -100,6 +100,7 @@ func resolveViperEnvironmentVariables(cfg any, keyPrefix string) {
 		if tag == "" {
 			tag = strings.ToLower(fieldType.Name)
 		}
+		tag = strings.SplitN(tag, ",", 2)[0]
 
 		var key string
 		if keyPrefix == "" {

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type GatewayConfig struct {
 	Timeout          int      `yaml:"timeout" mapstructure:"timeout"`
 	OCI              string   `yaml:"oci,omitempty" mapstructure:"oci,omitempty"`
 	Run              bool     `yaml:"run" mapstructure:"run"`
+	Mock             bool     `yaml:"mock,omitempty" mapstructure:"mock,omitempty"`
 	StandaloneBinary bool     `yaml:"standalone_binary" mapstructure:"standalone_binary"`
 	Debug            bool     `yaml:"debug,omitempty" mapstructure:"debug,omitempty"`
 	IncludeModels    []string `yaml:"include_models,omitempty" mapstructure:"include_models,omitempty"`

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -626,6 +626,7 @@ func (s *AgentServiceImpl) RunWithStream(ctx context.Context, req *domain.AgentR
 		cancelChan: make(chan struct{}),
 	}
 	s.registerSession(req.RequestID, sc)
+	context.AfterFunc(sessionCtx, sc.Cancel)
 
 	conversation := s.addSystemPrompt(req.Messages)
 

--- a/internal/agent/agent_streaming.go
+++ b/internal/agent/agent_streaming.go
@@ -89,6 +89,7 @@ func (a *EventDrivenAgent) startStreaming() {
 		if err := a.stateMachine.Transition(a.agentCtx, domain.StateError); err != nil {
 			logger.Error("failed to transition to Error state after stream failure", "error", err)
 		}
+		a.events <- domain.MessageReceivedEvent{}
 		return
 	}
 
@@ -142,6 +143,7 @@ func (a *EventDrivenAgent) handleStreamInterrupted(requestCtx context.Context, p
 		if err := a.stateMachine.Transition(a.agentCtx, domain.StateError); err != nil {
 			logger.Error("failed to transition to Error state after stream failure", "error", err)
 		}
+		a.events <- domain.MessageReceivedEvent{}
 		return
 	}
 
@@ -216,12 +218,12 @@ func (a *EventDrivenAgent) processStreamEvent(
 	}
 
 	var streamUsage *sdk.CompletionUsage
+	if streamResponse.Usage != nil {
+		streamUsage = streamResponse.Usage
+	}
+
 	for _, choice := range streamResponse.Choices {
 		a.processChoiceDelta(choice, message, allToolCallDeltas)
-
-		if streamResponse.Usage != nil {
-			streamUsage = streamResponse.Usage
-		}
 	}
 
 	return streamUsage

--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	sdk "github.com/inference-gateway/sdk"
@@ -39,7 +40,7 @@ type Registry struct {
 	config             *config.Config
 	toolsMu            sync.RWMutex
 	tools              map[string]domain.Tool
-	readToolUsed       bool
+	readToolUsed       atomic.Bool
 	readFiles          map[string]fileReadSnapshot
 	readFilesMu        sync.Mutex
 	taskTracker        domain.A2ATaskTracker
@@ -67,7 +68,6 @@ func NewRegistry(cfg *config.Config, imageService domain.ImageService, mcpManage
 		config:             cfg,
 		tools:              make(map[string]domain.Tool),
 		shellService:       shellService,
-		readToolUsed:       false,
 		readFiles:          make(map[string]fileReadSnapshot),
 		taskTracker:        taskTracker,
 		imageService:       imageService,
@@ -355,14 +355,15 @@ func (r *Registry) SetScreenshotServer(provider domain.ScreenshotProvider) {
 	logger.Info("dynamically registered GetLatestScreenshot tool for streaming mode")
 }
 
-// SetReadToolUsed marks that the Read tool has been used
+// SetReadToolUsed marks that the Read tool has been used. Tool calls in one
+// assistant turn execute concurrently, so this must be safe under parallel use.
 func (r *Registry) SetReadToolUsed() {
-	r.readToolUsed = true
+	r.readToolUsed.Store(true)
 }
 
 // IsReadToolUsed returns whether the Read tool has been used
 func (r *Registry) IsReadToolUsed() bool {
-	return r.readToolUsed
+	return r.readToolUsed.Load()
 }
 
 // fileReadSnapshot captures a file's state the last time the agent read or wrote it, so a later

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -3,6 +3,8 @@ package container
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -21,6 +23,7 @@ import (
 	memory "github.com/inference-gateway/cli/internal/infra/memory"
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
 	logger "github.com/inference-gateway/cli/internal/logger"
+	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
 	services "github.com/inference-gateway/cli/internal/services"
 	a2acoord "github.com/inference-gateway/cli/internal/services/a2acoord"
 	approvalcoord "github.com/inference-gateway/cli/internal/services/approvalcoord"
@@ -72,6 +75,7 @@ type ServiceContainer struct {
 	taskRetentionService   domain.TaskRetentionService
 	backgroundTaskService  domain.BackgroundTaskService
 	gatewayManager         domain.GatewayManager
+	mockGateway            *http.Server
 	agentManager           domain.AgentManager
 
 	// Services
@@ -169,6 +173,10 @@ func NewServiceContainer(cfg *config.Config) *ServiceContainer {
 		logger.Warn("failed to ensure project .infer/.gitignore", "error", err)
 	}
 
+	if cfg.Gateway.Mock {
+		container.startMockGateway()
+	}
+
 	container.initializeGatewayManager()
 	container.initializeStateManager()
 	container.initializeDomainServices()
@@ -193,6 +201,22 @@ func (c *ServiceContainer) SetUINotifier(n domain.UINotifier) {
 // Commands that need the gateway should call gatewayManager.EnsureStarted() explicitly
 func (c *ServiceContainer) initializeGatewayManager() {
 	c.gatewayManager = services.NewGatewayManager(c.sessionID, c.config, c.containerRuntime)
+}
+
+// startMockGateway serves the embedded scenario library (internal/mockgateway) on an
+// ephemeral localhost port, rewriting Gateway.URL to it and forcing Gateway.Run off
+func (c *ServiceContainer) startMockGateway() {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(fmt.Sprintf("mock gateway mode: failed to listen: %v", err))
+	}
+
+	c.mockGateway = &http.Server{Handler: mockgateway.New(mockgateway.Default())}
+	go func() { _ = c.mockGateway.Serve(ln) }()
+
+	c.config.Gateway.URL = "http://" + ln.Addr().String()
+	c.config.Gateway.Run = false
+	logger.Info("mock gateway mode enabled", "url", c.config.Gateway.URL)
 }
 
 // initializeAgentManager creates and starts the agent manager if A2A is enabled
@@ -839,6 +863,10 @@ func (c *ServiceContainer) Shutdown(ctx context.Context) error {
 			logger.Error("failed to stop gateway container", "error", err)
 			return err
 		}
+	}
+
+	if c.mockGateway != nil {
+		_ = c.mockGateway.Close()
 	}
 
 	if c.mcpStartupCancel != nil {

--- a/internal/mockgateway/mockgateway.go
+++ b/internal/mockgateway/mockgateway.go
@@ -1,0 +1,367 @@
+// Package mockgateway implements a hermetic, deterministic stand-in for the
+// inference-gateway HTTP API surface the CLI consumes: GET /v1/models,
+// POST /v1/chat/completions (sync JSON and SSE streaming) and GET /v1/health.
+//
+// Scenario resolution is stateless: every request carries the full message
+// history, so the scenario is chosen by matching each scenario's regex
+// against the first user message, and the turn within the scenario is the
+// count of assistant messages already present in the request. The only
+// mutable state is the error-injection counter and the request recording,
+// both guarded by one mutex, which makes the server safe for concurrent use.
+package mockgateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	sdk "github.com/inference-gateway/sdk"
+)
+
+// DefaultModel is the single model the mock advertises on /v1/models. Model
+// ids carry the provider prefix; request bodies arrive with it stripped.
+const DefaultModel = "openai/gpt-4o"
+
+const defaultChunkSize = 16
+
+// Recorded captures one /v1/chat/completions request for test assertions.
+type Recorded struct {
+	// Provider is the ?provider= query parameter sent by the SDK.
+	Provider string
+	// Model is the request-body model (provider prefix already stripped).
+	Model string
+	// Scenario is the matched scenario name; empty when only the fallback applied.
+	Scenario string
+	// Step is the assistant-message count at the time of the request.
+	Step int
+	// Stream reports whether the request asked for SSE.
+	Stream bool
+	// Body is the full decoded request.
+	Body sdk.CreateChatCompletionRequest
+}
+
+// Server is an http.Handler implementing the inference-gateway API surface
+// the CLI consumes.
+type Server struct {
+	defs *ScenarioFile
+
+	mu    sync.Mutex
+	fails map[string]int
+	reqs  []Recorded
+}
+
+// New returns a Server serving the given scenario definitions.
+func New(defs *ScenarioFile) *Server {
+	return &Server{defs: defs, fails: make(map[string]int)}
+}
+
+// Requests returns a copy of all recorded chat-completion requests.
+func (s *Server) Requests() []Recorded {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.reqs)
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.Method == http.MethodPost && r.URL.Path == "/v1/chat/completions":
+		s.handleCompletions(w, r)
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/models":
+		writeJSON(w, sdk.ListModelsResponse{
+			Object: "list",
+			Data:   []sdk.Model{{ID: DefaultModel, Object: "model", OwnedBy: "openai", ServedBy: "openai"}},
+		})
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/health":
+		writeJSON(w, map[string]string{"status": "ok"})
+	default:
+		http.Error(w, fmt.Sprintf("mockgateway: unexpected %s %s", r.Method, r.URL.Path), http.StatusNotFound)
+	}
+}
+
+func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
+	var req sdk.CreateChatCompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	name, step, turn := s.defs.resolve(&req)
+	stream := req.Stream != nil && *req.Stream
+	w.Header().Set("X-Mockgateway-Scenario", name)
+	w.Header().Set("X-Mockgateway-Step", fmt.Sprintf("%d", step))
+	s.record(Recorded{
+		Provider: r.URL.Query().Get("provider"),
+		Model:    req.Model,
+		Scenario: name,
+		Step:     step,
+		Stream:   stream,
+		Body:     req,
+	})
+
+	if turn.Error != nil && s.consumeFailure(name, step, turn.Error) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(turn.Error.Status)
+		_, _ = fmt.Fprint(w, `{"error":"injected"}`)
+		return
+	}
+
+	if stream {
+		s.renderStream(w, r, req.Model, step, turn)
+		return
+	}
+	s.renderSync(w, r, req.Model, step, turn)
+}
+
+func (s *Server) record(rec Recorded) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reqs = append(s.reqs, rec)
+}
+
+// consumeFailure reports whether this request still receives the injected
+// error and advances the per-scenario/step failure counter.
+func (s *Server) consumeFailure(name string, step int, e *ErrorInject) bool {
+	if e.Times < 0 {
+		return true
+	}
+
+	key := fmt.Sprintf("%s/%d", name, step)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fails[key] >= e.Times {
+		return false
+	}
+	s.fails[key]++
+	return true
+}
+
+func (s *Server) renderSync(w http.ResponseWriter, r *http.Request, model string, step int, turn Turn) {
+	if !wait(r.Context(), turn.DelayMs) {
+		return
+	}
+
+	msg, err := sdk.NewTextMessage(sdk.Assistant, turn.Content)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if turn.Reasoning != "" {
+		reasoning := turn.Reasoning
+		msg.ReasoningContent = &reasoning
+	}
+	if calls := turn.sdkToolCalls(step); len(calls) > 0 {
+		msg.ToolCalls = &calls
+	}
+
+	writeJSON(w, sdk.CreateChatCompletionResponse{
+		ID:      "chatcmpl-mock",
+		Object:  "chat.completion",
+		Model:   model,
+		Choices: []sdk.ChatCompletionChoice{{Index: 0, FinishReason: turn.finishReason(), Message: msg}},
+		Usage:   turn.usage(),
+	})
+}
+
+func (s *Server) renderStream(w http.ResponseWriter, r *http.Request, model string, step int, turn Turn) {
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "mockgateway: streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+
+	sw := &streamWriter{w: w, fl: fl, ctx: r.Context(), model: model, delay: turn.DelayMs}
+	if !sw.delta(sdk.ChatCompletionStreamResponseDelta{Role: sdk.Assistant}, "") {
+		return
+	}
+	if turn.Malformed && !sw.raw("{this is not json") {
+		return
+	}
+	if !streamText(sw, turn) || !streamToolCalls(sw, step, turn) {
+		return
+	}
+	if !sw.delta(sdk.ChatCompletionStreamResponseDelta{}, turn.finishReason()) {
+		return
+	}
+	if !sw.frame([]sdk.ChatCompletionStreamChoice{}, turn.usage()) {
+		return
+	}
+	sw.raw("[DONE]")
+}
+
+// streamText emits reasoning fragments followed by content fragments.
+func streamText(sw *streamWriter, turn Turn) bool {
+	for _, c := range chunks(turn.Reasoning, turn.ChunkSize) {
+		frag := c
+		if !sw.delta(sdk.ChatCompletionStreamResponseDelta{ReasoningContent: &frag}, "") {
+			return false
+		}
+	}
+	for _, c := range chunks(turn.Content, turn.ChunkSize) {
+		if !sw.delta(sdk.ChatCompletionStreamResponseDelta{Content: c}, "") {
+			return false
+		}
+	}
+	return true
+}
+
+// streamToolCalls emits, per tool call, a name fragment followed by at least
+// two argument fragments so the CLI's index-keyed accumulator is always
+// exercised on real multi-fragment input.
+func streamToolCalls(sw *streamWriter, step int, turn Turn) bool {
+	for i, tc := range turn.ToolCalls {
+		id := fmt.Sprintf("call_%d_%d", step, i)
+		typ := string(sdk.Function)
+		head := sdk.ChatCompletionMessageToolCallChunk{
+			Index:    i,
+			ID:       &id,
+			Type:     &typ,
+			Function: &sdk.ChatCompletionMessageToolCallFunction{Name: tc.Name},
+		}
+		if !sw.toolFrame(head) {
+			return false
+		}
+
+		for _, frag := range argFragments(tc.argsJSON, turn.ChunkSize) {
+			part := sdk.ChatCompletionMessageToolCallChunk{
+				Index:    i,
+				Function: &sdk.ChatCompletionMessageToolCallFunction{Arguments: frag},
+			}
+			if !sw.toolFrame(part) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (t Turn) finishReason() sdk.FinishReason {
+	if len(t.ToolCalls) > 0 {
+		return sdk.ToolCalls
+	}
+	return sdk.Stop
+}
+
+func (t Turn) usage() *sdk.CompletionUsage {
+	u := Usage{PromptTokens: 10, CompletionTokens: 5}
+	if t.Usage != nil {
+		u = *t.Usage
+	}
+	return &sdk.CompletionUsage{
+		PromptTokens:     u.PromptTokens,
+		CompletionTokens: u.CompletionTokens,
+		TotalTokens:      u.PromptTokens + u.CompletionTokens,
+	}
+}
+
+func (t Turn) sdkToolCalls(step int) []sdk.ChatCompletionMessageToolCall {
+	calls := make([]sdk.ChatCompletionMessageToolCall, len(t.ToolCalls))
+	for i, tc := range t.ToolCalls {
+		calls[i] = sdk.ChatCompletionMessageToolCall{
+			ID:   fmt.Sprintf("call_%d_%d", step, i),
+			Type: sdk.Function,
+			Function: sdk.ChatCompletionMessageToolCallFunction{
+				Name:      tc.Name,
+				Arguments: tc.argsJSON,
+			},
+		}
+	}
+	return calls
+}
+
+// streamWriter writes SSE frames in the exact format the SDK parses:
+// "data: <json>\n\n" (the space after the colon is required) with a flush
+// per frame, honoring the per-frame delay and client disconnect.
+type streamWriter struct {
+	w     io.Writer
+	fl    http.Flusher
+	ctx   context.Context
+	model string
+	delay int
+}
+
+func (sw *streamWriter) delta(d sdk.ChatCompletionStreamResponseDelta, finish sdk.FinishReason) bool {
+	return sw.frame([]sdk.ChatCompletionStreamChoice{{Index: 0, Delta: d, FinishReason: finish}}, nil)
+}
+
+func (sw *streamWriter) toolFrame(call sdk.ChatCompletionMessageToolCallChunk) bool {
+	calls := []sdk.ChatCompletionMessageToolCallChunk{call}
+	return sw.delta(sdk.ChatCompletionStreamResponseDelta{ToolCalls: &calls}, "")
+}
+
+func (sw *streamWriter) frame(choices []sdk.ChatCompletionStreamChoice, usage *sdk.CompletionUsage) bool {
+	b, err := json.Marshal(sdk.CreateChatCompletionStreamResponse{
+		ID:      "chatcmpl-mock",
+		Object:  "chat.completion.chunk",
+		Model:   sw.model,
+		Choices: choices,
+		Usage:   usage,
+	})
+	if err != nil {
+		return false
+	}
+	return sw.raw(string(b))
+}
+
+func (sw *streamWriter) raw(payload string) bool {
+	if !wait(sw.ctx, sw.delay) {
+		return false
+	}
+	if _, err := fmt.Fprintf(sw.w, "data: %s\n\n", payload); err != nil {
+		return false
+	}
+	sw.fl.Flush()
+	return true
+}
+
+// wait sleeps for ms milliseconds, returning false if ctx finishes first.
+func wait(ctx context.Context, ms int) bool {
+	if ms <= 0 {
+		return true
+	}
+	select {
+	case <-time.After(time.Duration(ms) * time.Millisecond):
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// chunks splits s into size-rune pieces (default 16), never splitting a
+// UTF-8 rune across fragments.
+func chunks(s string, size int) []string {
+	if s == "" {
+		return nil
+	}
+	if size <= 0 {
+		size = defaultChunkSize
+	}
+
+	runes := []rune(s)
+	out := make([]string, 0, len(runes)/size+1)
+	for start := 0; start < len(runes); start += size {
+		out = append(out, string(runes[start:min(start+size, len(runes))]))
+	}
+	return out
+}
+
+// argFragments splits a tool call's arguments JSON into at least two pieces
+// whenever it is long enough, so accumulation is always exercised.
+func argFragments(args string, size int) []string {
+	if size <= 0 {
+		size = defaultChunkSize
+	}
+	half := (len([]rune(args)) + 1) / 2
+	return chunks(args, min(size, max(1, half)))
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/mockgateway/mockgateway_test.go
+++ b/internal/mockgateway/mockgateway_test.go
@@ -1,0 +1,374 @@
+package mockgateway
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sdk "github.com/inference-gateway/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+func mustText(t *testing.T, role sdk.MessageRole, text string) sdk.Message {
+	t.Helper()
+	msg, err := sdk.NewTextMessage(role, text)
+	require.NoError(t, err)
+	return msg
+}
+
+func chatRequest(t *testing.T, prompt string, assistants int, stream bool) *sdk.CreateChatCompletionRequest {
+	t.Helper()
+	msgs := []sdk.Message{
+		mustText(t, sdk.System, "you are a test agent"),
+		mustText(t, sdk.User, prompt),
+	}
+	for range assistants {
+		msgs = append(msgs, mustText(t, sdk.Assistant, "prior answer"))
+	}
+	return &sdk.CreateChatCompletionRequest{Model: "gpt-4o", Messages: msgs, Stream: &stream}
+}
+
+func postCompletion(t *testing.T, baseURL string, req *sdk.CreateChatCompletionRequest) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	resp, err := http.Post(baseURL+"/v1/chat/completions?provider=openai", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	return resp
+}
+
+// readFrames parses an SSE body into decoded chunks, the raw data payloads,
+// and whether the [DONE] sentinel arrived.
+func readFrames(t *testing.T, body io.Reader) ([]sdk.CreateChatCompletionStreamResponse, []string, bool) {
+	t.Helper()
+	var frames []sdk.CreateChatCompletionStreamResponse
+	var raw []string
+	done := false
+
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		payload, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			continue
+		}
+		raw = append(raw, payload)
+		if payload == "[DONE]" {
+			done = true
+			continue
+		}
+		var chunk sdk.CreateChatCompletionStreamResponse
+		if err := json.Unmarshal([]byte(payload), &chunk); err == nil {
+			frames = append(frames, chunk)
+		}
+	}
+	require.NoError(t, scanner.Err())
+	return frames, raw, done
+}
+
+func TestDefaultScenariosAreValid(t *testing.T) {
+	defs := Default()
+	require.Len(t, defs.Scenarios, 13)
+	require.Equal(t, "Done.", defs.Fallback.Content)
+}
+
+func TestResolve(t *testing.T) {
+	defs := Default()
+
+	tests := []struct {
+		name         string
+		prompt       string
+		assistants   int
+		wantScenario string
+		wantContent  string
+	}{
+		{"first matching scenario wins", "say hello to everyone", 0, "text-only", "Hello! How can I help?"},
+		{"case insensitive", "PLEASE SEARCH FOR todo items", 0, "search", ""},
+		{"step selects later turn", "explore the project structure", 2, "sequential-explore", "The project contains a.txt with fixture content."},
+		{"step past end falls back", "say hello", 1, "text-only", "Done."},
+		{"no match falls back", "completely unknown prompt", 0, "", "Done."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, step, turn := defs.resolve(chatRequest(t, tt.prompt, tt.assistants, false))
+			require.Equal(t, tt.wantScenario, name)
+			require.Equal(t, tt.assistants, step)
+			require.Equal(t, tt.wantContent, turn.Content)
+		})
+	}
+}
+
+func TestResolveIgnoresLaterUserMessages(t *testing.T) {
+	defs := Default()
+	req := chatRequest(t, "say hello", 1, false)
+	req.Messages = append(req.Messages, mustText(t, sdk.User, "<system-reminder>automated check</system-reminder>"))
+
+	name, step, _ := defs.resolve(req)
+	require.Equal(t, "text-only", name)
+	require.Equal(t, 1, step)
+}
+
+func TestResolveConcatenatesContentParts(t *testing.T) {
+	defs := Default()
+
+	textPart, err := sdk.NewTextContentPart("say hello")
+	require.NoError(t, err)
+	imagePart, err := sdk.NewImageContentPart("data:image/png;base64,AAAA", nil)
+	require.NoError(t, err)
+	userMsg, err := sdk.NewImageMessage(sdk.User, []sdk.ContentPart{textPart, imagePart})
+	require.NoError(t, err)
+
+	stream := false
+	req := &sdk.CreateChatCompletionRequest{Model: "gpt-4o", Messages: []sdk.Message{userMsg}, Stream: &stream}
+	name, _, _ := defs.resolve(req)
+	require.Equal(t, "text-only", name)
+}
+
+func TestLoadValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{"unknown field", "scenarios:\n  - name: a\n    match: x\n    turns: [{content: hi}]\n    typo: true\n", "field typo not found"},
+		{"missing name", "scenarios:\n  - match: x\n    turns: [{content: hi}]\n", "name is required"},
+		{"duplicate name", "scenarios:\n  - {name: a, match: x, turns: [{content: hi}]}\n  - {name: a, match: y, turns: [{content: hi}]}\n", "duplicate name"},
+		{"bad regex", "scenarios:\n  - {name: a, match: '([', turns: [{content: hi}]}\n", "invalid match"},
+		{"no turns", "scenarios:\n  - {name: a, match: x, turns: []}\n", "at least one turn"},
+		{"retryable 400 rejected", "scenarios:\n  - {name: a, match: x, turns: [{error: {status: 400, times: 1}}]}\n", "error.status"},
+		{"zero times rejected", "scenarios:\n  - {name: a, match: x, turns: [{error: {status: 500, times: 0}}]}\n", "error.times"},
+		{"tool call needs name", "scenarios:\n  - {name: a, match: x, turns: [{tool_calls: [{args: {k: v}}]}]}\n", "name is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Load([]byte(tt.yaml))
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestModelsAndHealthEndpoints(t *testing.T) {
+	ts := httptest.NewServer(New(Default()))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/models")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var models sdk.ListModelsResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&models))
+	require.Len(t, models.Data, 1)
+	require.Equal(t, DefaultModel, models.Data[0].ID)
+
+	health, err := http.Get(ts.URL + "/v1/health")
+	require.NoError(t, err)
+	defer func() { _ = health.Body.Close() }()
+	require.Equal(t, http.StatusOK, health.StatusCode)
+
+	unknown, err := http.Get(ts.URL + "/v1/nope")
+	require.NoError(t, err)
+	defer func() { _ = unknown.Body.Close() }()
+	require.Equal(t, http.StatusNotFound, unknown.StatusCode)
+}
+
+func TestSyncTextResponse(t *testing.T) {
+	ts := httptest.NewServer(New(Default()))
+	defer ts.Close()
+
+	resp := postCompletion(t, ts.URL, chatRequest(t, "say hello", 0, false))
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out sdk.CreateChatCompletionResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	require.Len(t, out.Choices, 1)
+	require.Equal(t, sdk.Stop, out.Choices[0].FinishReason)
+
+	content, err := out.Choices[0].Message.Content.AsMessageContent0()
+	require.NoError(t, err)
+	require.Equal(t, "Hello! How can I help?", content)
+	require.NotNil(t, out.Usage)
+	require.EqualValues(t, 15, out.Usage.TotalTokens)
+}
+
+func TestSyncToolCalls(t *testing.T) {
+	ts := httptest.NewServer(New(Default()))
+	defer ts.Close()
+
+	resp := postCompletion(t, ts.URL, chatRequest(t, "please execute the Read tool 4 times in parallel", 0, false))
+	defer func() { _ = resp.Body.Close() }()
+
+	var out sdk.CreateChatCompletionResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	require.Equal(t, sdk.ToolCalls, out.Choices[0].FinishReason)
+	require.NotNil(t, out.Choices[0].Message.ToolCalls)
+
+	calls := *out.Choices[0].Message.ToolCalls
+	require.Len(t, calls, 4)
+	for i, call := range calls {
+		require.Equal(t, "Read", call.Function.Name)
+		require.NotEmpty(t, call.ID)
+		var args map[string]any
+		require.NoError(t, json.Unmarshal([]byte(call.Function.Arguments), &args), "call %d arguments must be valid JSON", i)
+		require.Contains(t, args, "file_path")
+	}
+}
+
+func TestStreamTextAndReasoningRoundTrip(t *testing.T) {
+	ts := httptest.NewServer(New(Default()))
+	defer ts.Close()
+
+	resp := postCompletion(t, ts.URL, chatRequest(t, "think step by step", 0, true))
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	frames, _, done := readFrames(t, resp.Body)
+	require.True(t, done, "stream must terminate with [DONE]")
+
+	var content, reasoning strings.Builder
+	var usage *sdk.CompletionUsage
+	for _, f := range frames {
+		if f.Usage != nil {
+			usage = f.Usage
+			require.Empty(t, f.Choices, "usage chunk must carry no choices")
+		}
+		for _, c := range f.Choices {
+			content.WriteString(c.Delta.Content)
+			if c.Delta.ReasoningContent != nil {
+				reasoning.WriteString(*c.Delta.ReasoningContent)
+			}
+		}
+	}
+
+	require.Equal(t, "Answer: 42.", content.String())
+	require.Equal(t, "Considering the question carefully before answering.", reasoning.String())
+	require.NotNil(t, usage)
+	require.EqualValues(t, 15, usage.TotalTokens)
+}
+
+func TestStreamToolCallFragments(t *testing.T) {
+	ts := httptest.NewServer(New(Default()))
+	defer ts.Close()
+
+	resp := postCompletion(t, ts.URL, chatRequest(t, "please execute the Read tool 4 times in parallel", 0, true))
+	defer func() { _ = resp.Body.Close() }()
+
+	frames, _, done := readFrames(t, resp.Body)
+	require.True(t, done)
+
+	type acc struct {
+		id, name, args string
+		argFragments   int
+	}
+	byIndex := map[int]*acc{}
+	for _, f := range frames {
+		for _, c := range f.Choices {
+			if c.Delta.ToolCalls == nil {
+				continue
+			}
+			for _, tc := range *c.Delta.ToolCalls {
+				a := byIndex[tc.Index]
+				if a == nil {
+					a = &acc{}
+					byIndex[tc.Index] = a
+				}
+				if tc.ID != nil {
+					a.id = *tc.ID
+				}
+				if tc.Function == nil {
+					continue
+				}
+				if tc.Function.Name != "" {
+					a.name = tc.Function.Name
+				}
+				if tc.Function.Arguments != "" {
+					a.args += tc.Function.Arguments
+					a.argFragments++
+				}
+			}
+		}
+	}
+
+	require.Len(t, byIndex, 4)
+	for i := range 4 {
+		a := byIndex[i]
+		require.NotNil(t, a, "missing tool call index %d", i)
+		require.Equal(t, "Read", a.name)
+		require.NotEmpty(t, a.id)
+		require.GreaterOrEqual(t, a.argFragments, 2, "arguments for index %d must arrive fragmented", i)
+		var args map[string]any
+		require.NoError(t, json.Unmarshal([]byte(a.args), &args), "reassembled arguments for index %d", i)
+		require.Contains(t, args, "file_path")
+	}
+}
+
+func TestStreamMalformedFrameThenRecovers(t *testing.T) {
+	ts := httptest.NewServer(New(Default()))
+	defer ts.Close()
+
+	resp := postCompletion(t, ts.URL, chatRequest(t, "give me a garbled stream", 0, true))
+	defer func() { _ = resp.Body.Close() }()
+
+	frames, raw, done := readFrames(t, resp.Body)
+	require.True(t, done)
+	require.Contains(t, raw, "{this is not json")
+
+	var content strings.Builder
+	for _, f := range frames {
+		for _, c := range f.Choices {
+			content.WriteString(c.Delta.Content)
+		}
+	}
+	require.Equal(t, "Still standing.", content.String())
+}
+
+func TestErrorInjectionCountsThenRecovers(t *testing.T) {
+	srv := New(Default())
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	for _, wantStatus := range []int{429, 429, 200} {
+		resp := postCompletion(t, ts.URL, chatRequest(t, "you are a flaky backend", 0, false))
+		require.Equal(t, wantStatus, resp.StatusCode)
+		_ = resp.Body.Close()
+	}
+
+	require.Len(t, srv.Requests(), 3)
+}
+
+func TestErrorInjectionForever(t *testing.T) {
+	ts := httptest.NewServer(New(Default()))
+	defer ts.Close()
+
+	for range 4 {
+		resp := postCompletion(t, ts.URL, chatRequest(t, "this always fails", 0, false))
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		_ = resp.Body.Close()
+	}
+}
+
+func TestRequestsRecording(t *testing.T) {
+	srv := New(Default())
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postCompletion(t, ts.URL, chatRequest(t, "say hello", 1, true))
+	_ = resp.Body.Close()
+
+	reqs := srv.Requests()
+	require.Len(t, reqs, 1)
+	require.Equal(t, "openai", reqs[0].Provider)
+	require.Equal(t, "gpt-4o", reqs[0].Model)
+	require.Equal(t, "text-only", reqs[0].Scenario)
+	require.Equal(t, 1, reqs[0].Step)
+	require.True(t, reqs[0].Stream)
+	require.Len(t, reqs[0].Body.Messages, 3)
+}

--- a/internal/mockgateway/mockgateway_test.go
+++ b/internal/mockgateway/mockgateway_test.go
@@ -114,6 +114,17 @@ func TestResolveIgnoresLaterUserMessages(t *testing.T) {
 	require.Equal(t, 1, step)
 }
 
+func TestResolveReroutesOnNewChatPrompt(t *testing.T) {
+	defs := Default()
+	req := chatRequest(t, "Hi", 1, false)
+	req.Messages = append(req.Messages, mustText(t, sdk.User, "Say hello"))
+
+	name, step, turn := defs.resolve(req)
+	require.Equal(t, "text-only", name)
+	require.Equal(t, 0, step)
+	require.Equal(t, "Hello! How can I help?", turn.Content)
+}
+
 func TestResolveConcatenatesContentParts(t *testing.T) {
 	defs := Default()
 

--- a/internal/mockgateway/scenario.go
+++ b/internal/mockgateway/scenario.go
@@ -1,0 +1,249 @@
+package mockgateway
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	sdk "github.com/inference-gateway/sdk"
+	yaml "gopkg.in/yaml.v3"
+)
+
+//go:embed scenarios.yaml
+var embeddedScenarios []byte
+
+// injectableStatuses are the HTTP statuses allowed for error injection. 400
+// is deliberately excluded: the CLI's default client.retry configuration
+// treats it as retryable, which would turn an intended hard failure into a
+// surprising retry storm for scenario authors.
+var injectableStatuses = map[int]bool{408: true, 429: true, 500: true, 502: true, 503: true, 504: true}
+
+// ScenarioFile is the root of a scenarios YAML document.
+type ScenarioFile struct {
+	// Fallback is rendered when no scenario matches the prompt or when a
+	// matched scenario has no turn left for the current step.
+	Fallback Turn `yaml:"fallback"`
+	// Scenarios are evaluated in file order; the first regex match wins.
+	Scenarios []Scenario `yaml:"scenarios"`
+}
+
+// Scenario is one scripted conversation, selected by regex.
+type Scenario struct {
+	// Name uniquely identifies the scenario in recordings and logs.
+	Name string `yaml:"name"`
+	// Match is a Go regular expression tested (unanchored) against the first
+	// user message of each request.
+	Match string `yaml:"match"`
+	// Turns are the scripted assistant responses, indexed by the number of
+	// assistant messages already present in the request.
+	Turns []Turn `yaml:"turns"`
+
+	re *regexp.Regexp
+}
+
+// Turn is one scripted assistant response, rendered as SSE or as a sync JSON
+// body depending on the request's stream flag.
+type Turn struct {
+	// Content is the assistant text, streamed in ChunkSize-rune fragments.
+	Content string `yaml:"content"`
+	// Reasoning is streamed as reasoning_content deltas before Content.
+	Reasoning string `yaml:"reasoning"`
+	// ToolCalls all land in this single assistant turn.
+	ToolCalls []ToolCall `yaml:"tool_calls"`
+	// Usage defaults to 10 prompt / 5 completion tokens when nil.
+	Usage *Usage `yaml:"usage"`
+	// ChunkSize is the fragment size in runes for streamed text (default 16).
+	ChunkSize int `yaml:"chunk_size"`
+	// DelayMs sleeps before each SSE frame (streaming) or once before the
+	// body (sync), aborting early when the client disconnects.
+	DelayMs int `yaml:"delay_ms"`
+	// Error, when set, replaces the turn with an HTTP error for the first
+	// Times matching requests (-1 means every request).
+	Error *ErrorInject `yaml:"error"`
+	// Malformed emits one non-JSON data: frame early in the stream.
+	Malformed bool `yaml:"malformed"`
+}
+
+// ToolCall describes one function call the mock model requests.
+type ToolCall struct {
+	// Name is the tool name as registered in the CLI (e.g. Read, Grep, Bash).
+	Name string `yaml:"name"`
+	// Args is marshaled into the tool call's JSON arguments string.
+	Args map[string]any `yaml:"args"`
+
+	argsJSON string
+}
+
+// Usage overrides the token usage reported for a turn.
+type Usage struct {
+	PromptTokens     int64 `yaml:"prompt_tokens"`
+	CompletionTokens int64 `yaml:"completion_tokens"`
+}
+
+// ErrorInject makes a turn answer with HTTP Status for the first Times
+// requests that resolve to it; Times -1 fails forever.
+type ErrorInject struct {
+	Status int `yaml:"status"`
+	Times  int `yaml:"times"`
+}
+
+// Default returns the embedded built-in scenario library.
+func Default() *ScenarioFile {
+	f, err := Load(embeddedScenarios)
+	if err != nil {
+		panic(fmt.Sprintf("mockgateway: embedded scenarios.yaml is invalid: %v", err))
+	}
+	return f
+}
+
+// Load parses and validates a scenarios YAML document. Unknown fields are
+// rejected so typos in scenario files fail fast.
+func Load(b []byte) (*ScenarioFile, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(b))
+	dec.KnownFields(true)
+
+	var f ScenarioFile
+	if err := dec.Decode(&f); err != nil {
+		return nil, fmt.Errorf("parsing scenarios: %w", err)
+	}
+	if err := f.validate(); err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+func (f *ScenarioFile) validate() error {
+	if err := f.Fallback.validate("fallback"); err != nil {
+		return err
+	}
+
+	seen := make(map[string]bool, len(f.Scenarios))
+	for i := range f.Scenarios {
+		if err := f.Scenarios[i].validate(seen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Scenario) validate(seen map[string]bool) error {
+	if s.Name == "" {
+		return fmt.Errorf("scenario with match %q: name is required", s.Match)
+	}
+	if seen[s.Name] {
+		return fmt.Errorf("scenario %q: duplicate name", s.Name)
+	}
+	seen[s.Name] = true
+
+	if s.Match == "" {
+		return fmt.Errorf("scenario %q: match is required", s.Name)
+	}
+	re, err := regexp.Compile(s.Match)
+	if err != nil {
+		return fmt.Errorf("scenario %q: invalid match: %w", s.Name, err)
+	}
+	s.re = re
+
+	if len(s.Turns) == 0 {
+		return fmt.Errorf("scenario %q: at least one turn is required", s.Name)
+	}
+	for i := range s.Turns {
+		if err := s.Turns[i].validate(fmt.Sprintf("scenario %q turn %d", s.Name, i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Turn) validate(where string) error {
+	if t.ChunkSize < 0 || t.DelayMs < 0 {
+		return fmt.Errorf("%s: chunk_size and delay_ms must be >= 0", where)
+	}
+	if t.Error != nil {
+		if !injectableStatuses[t.Error.Status] {
+			return fmt.Errorf("%s: error.status must be one of 408, 429, 500, 502, 503, 504", where)
+		}
+		if t.Error.Times == 0 || t.Error.Times < -1 {
+			return fmt.Errorf("%s: error.times must be positive or -1", where)
+		}
+	}
+
+	for i := range t.ToolCalls {
+		tc := &t.ToolCalls[i]
+		if tc.Name == "" {
+			return fmt.Errorf("%s: tool_calls[%d].name is required", where, i)
+		}
+		if tc.Args == nil {
+			tc.argsJSON = "{}"
+			continue
+		}
+		args, err := json.Marshal(tc.Args)
+		if err != nil {
+			return fmt.Errorf("%s: tool_calls[%d].args: %w", where, i, err)
+		}
+		tc.argsJSON = string(args)
+	}
+	return nil
+}
+
+// resolve picks the scenario and turn for a request. It returns the matched
+// scenario name ("" when only the fallback applies), the step derived from
+// the request's assistant-message count, and the turn to render.
+func (f *ScenarioFile) resolve(req *sdk.CreateChatCompletionRequest) (string, int, Turn) {
+	prompt := firstUserPrompt(req.Messages)
+
+	step := 0
+	for _, m := range req.Messages {
+		if m.Role == sdk.Assistant {
+			step++
+		}
+	}
+
+	for i := range f.Scenarios {
+		sc := &f.Scenarios[i]
+		if !sc.re.MatchString(prompt) {
+			continue
+		}
+		if step < len(sc.Turns) {
+			return sc.Name, step, sc.Turns[step]
+		}
+		return sc.Name, step, f.Fallback
+	}
+	return "", step, f.Fallback
+}
+
+// firstUserPrompt returns the text of the first user message. Later user
+// messages (e.g. the CLI's injected automated-check reminder) must never
+// re-route a conversation to a different scenario.
+func firstUserPrompt(messages []sdk.Message) string {
+	for _, m := range messages {
+		if m.Role == sdk.User {
+			return textContent(m.Content)
+		}
+	}
+	return ""
+}
+
+// textContent extracts plain text from either content form: a bare string or
+// a multimodal content-part array (text parts concatenated).
+func textContent(c sdk.MessageContent) string {
+	if s, err := c.AsMessageContent0(); err == nil {
+		return s
+	}
+
+	parts, err := c.AsMessageContent1()
+	if err != nil {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, p := range parts {
+		if tp, err := p.AsTextContentPart(); err == nil && tp.Type == sdk.TextContentPartTypeText {
+			b.WriteString(tp.Text)
+		}
+	}
+	return b.String()
+}

--- a/internal/mockgateway/scenario.go
+++ b/internal/mockgateway/scenario.go
@@ -34,11 +34,11 @@ type ScenarioFile struct {
 type Scenario struct {
 	// Name uniquely identifies the scenario in recordings and logs.
 	Name string `yaml:"name"`
-	// Match is a Go regular expression tested (unanchored) against the first
-	// user message of each request.
+	// Match is a Go regular expression tested (unanchored) against the latest
+	// user message of each request that is not an injected <system-reminder>.
 	Match string `yaml:"match"`
 	// Turns are the scripted assistant responses, indexed by the number of
-	// assistant messages already present in the request.
+	// assistant messages following the matched user message.
 	Turns []Turn `yaml:"turns"`
 
 	re *regexp.Regexp
@@ -191,12 +191,12 @@ func (t *Turn) validate(where string) error {
 
 // resolve picks the scenario and turn for a request. It returns the matched
 // scenario name ("" when only the fallback applies), the step derived from
-// the request's assistant-message count, and the turn to render.
+// the assistant-message count after the anchor, and the turn to render.
 func (f *ScenarioFile) resolve(req *sdk.CreateChatCompletionRequest) (string, int, Turn) {
-	prompt := firstUserPrompt(req.Messages)
+	prompt, anchor := anchorUserMessage(req.Messages)
 
 	step := 0
-	for _, m := range req.Messages {
+	for _, m := range req.Messages[anchor+1:] {
 		if m.Role == sdk.Assistant {
 			step++
 		}
@@ -215,16 +215,24 @@ func (f *ScenarioFile) resolve(req *sdk.CreateChatCompletionRequest) (string, in
 	return "", step, f.Fallback
 }
 
-// firstUserPrompt returns the text of the first user message. Later user
-// messages (e.g. the CLI's injected automated-check reminder) must never
-// re-route a conversation to a different scenario.
-func firstUserPrompt(messages []sdk.Message) string {
-	for _, m := range messages {
-		if m.Role == sdk.User {
-			return textContent(m.Content)
+// anchorUserMessage returns the text and index of the latest user message that
+// is not injected CLI content (<system-reminder>). Anchoring on the latest real
+// prompt lets an interactive chat session re-route to a new scenario on every
+// message, while the headless loop's automated-check reminder never re-routes
+// a run mid-loop. Steps count the assistant messages after the anchor, so each
+// new prompt restarts its scenario at turn 0.
+func anchorUserMessage(messages []sdk.Message) (string, int) {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role != sdk.User {
+			continue
 		}
+		text := textContent(messages[i].Content)
+		if strings.Contains(text, "<system-reminder>") {
+			continue
+		}
+		return text, i
 	}
-	return ""
+	return "", -1
 }
 
 // textContent extracts plain text from either content form: a bare string or

--- a/internal/mockgateway/scenarios.yaml
+++ b/internal/mockgateway/scenarios.yaml
@@ -1,0 +1,100 @@
+# Built-in scenario library for the mock inference-gateway.
+#
+# A scenario is selected by matching `match` (a Go regular expression,
+# unanchored, first match in file order wins) against the FIRST user message
+# of the request. The turn within a scenario is the number of assistant
+# messages already present in the request; past the last turn the top-level
+# fallback is served, which lets the headless agent's completion check
+# (two consecutive turns without tool calls) terminate naturally.
+
+fallback:
+  content: "Done."
+
+scenarios:
+  - name: text-only
+    match: '(?i)^say hello'
+    turns:
+      - content: "Hello! How can I help?"
+
+  - name: parallel-reads
+    match: '(?i)execute (the )?Read tool 4 times in parallel'
+    turns:
+      - tool_calls:
+          - { name: Read, args: { file_path: "a.txt" } }
+          - { name: Read, args: { file_path: "b.txt" } }
+          - { name: Read, args: { file_path: "c.txt" } }
+          - { name: Read, args: { file_path: "d.txt" } }
+      - content: "All four files read."
+
+  - name: search
+    match: '(?i)^please search for (.+)'
+    turns:
+      - tool_calls:
+          - { name: Grep, args: { pattern: "TODO", path: "." } }
+      - content: "Search finished: found matches for TODO."
+
+  - name: sequential-explore
+    match: '(?i)explore the project structure'
+    turns:
+      - tool_calls:
+          - { name: Tree, args: { path: "." } }
+      - tool_calls:
+          - { name: Read, args: { file_path: "a.txt" } }
+      - content: "The project contains a.txt with fixture content."
+
+  - name: write-blocked
+    match: '(?i)create a file named blocked\.txt'
+    turns:
+      - tool_calls:
+          - { name: Write, args: { file_path: "blocked.txt", content: "hi" } }
+      - content: "Understood, the write was not permitted."
+
+  - name: bash-allowed
+    match: '(?i)run the echo command'
+    turns:
+      - tool_calls:
+          - { name: Bash, args: { command: "echo hello-from-bash" } }
+      - content: "The echo command ran."
+
+  - name: bash-blocked
+    match: '(?i)run the forbidden command'
+    turns:
+      - tool_calls:
+          - { name: Bash, args: { command: "curl http://example.com" } }
+      - content: "Understood, the command was not permitted."
+
+  - name: error-retry
+    match: '(?i)flaky backend'
+    turns:
+      - error: { status: 429, times: 2 }
+        content: "Recovered after retries."
+
+  - name: error-hard
+    match: '(?i)always fails'
+    turns:
+      - error: { status: 500, times: -1 }
+
+  - name: malformed-sse
+    match: '(?i)garbled stream'
+    turns:
+      - malformed: true
+        content: "Still standing."
+
+  - name: slow-stream
+    match: '(?i)stream slowly'
+    turns:
+      - content: "This response is intentionally streamed in very small fragments with a per-frame delay so that progressive rendering, spinner behaviour and mid-stream cancellation can be observed and asserted deterministically by tests."
+        chunk_size: 4
+        delay_ms: 50
+
+  - name: usage-report
+    match: '(?i)report your usage'
+    turns:
+      - content: "Usage reported."
+        usage: { prompt_tokens: 100, completion_tokens: 42 }
+
+  - name: reasoning
+    match: '(?i)think step by step'
+    turns:
+      - reasoning: "Considering the question carefully before answering."
+        content: "Answer: 42."

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -1,0 +1,282 @@
+//go:build e2e
+
+// Package e2e runs the real `infer` binary as a subprocess against an
+// in-test mock inference-gateway (internal/mockgateway), asserting on the
+// headless JSON output contract, the piped-chat streaming path, tool side
+// effects on disk, and the exact requests received by the gateway.
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	sdk "github.com/inference-gateway/sdk"
+	"github.com/stretchr/testify/require"
+
+	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
+)
+
+var binPath string
+
+// TestMain builds the CLI once for all tests. Set INFER_E2E_BINARY to reuse
+// an already-built binary (e.g. the Taskfile output) and skip the build.
+func TestMain(m *testing.M) {
+	if p := os.Getenv("INFER_E2E_BINARY"); p != "" {
+		binPath = p
+		os.Exit(m.Run())
+	}
+
+	dir, err := os.MkdirTemp("", "infer-e2e-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	binPath = filepath.Join(dir, "infer")
+
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Dir = repoRoot()
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "building infer: %v\n%s", err, out)
+		_ = os.RemoveAll(dir)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+func repoRoot() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(filepath.Dir(filepath.Dir(file)))
+}
+
+func startMock(t *testing.T) (*mockgateway.Server, string) {
+	t.Helper()
+	gw := mockgateway.New(mockgateway.Default())
+	ts := httptest.NewServer(gw)
+	t.Cleanup(ts.Close)
+	return gw, ts.URL
+}
+
+// runCLI executes the built binary with a hermetic environment: gateway URL
+// pointed at the mock, gateway auto-start off, storage off, retry backoff
+// zeroed, and HOME moved to a temp dir so ~/.infer never leaks in. Note
+// INFER_AGENT_MODEL resolves through the resolveViperEnvironmentVariables
+// backstop in cmd/config.go (agent.model has a zero default, so it is not a
+// registered viper default).
+func runCLI(t *testing.T, gatewayURL, dir, stdin string, args ...string) (string, string, int) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"INFER_GATEWAY_URL="+gatewayURL,
+		"INFER_GATEWAY_RUN=false",
+		"INFER_AGENT_MODEL="+mockgateway.DefaultModel,
+		"INFER_STORAGE_ENABLED=false",
+		"INFER_CLIENT_RETRY_INITIAL_BACKOFF_SEC=0",
+		"HOME="+t.TempDir(),
+	)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	require.NoError(t, ctx.Err(), "CLI run exceeded the test timeout; stdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr, "unexpected non-exit error: %v; stderr:\n%s", err, stderr.String())
+		exitCode = exitErr.ExitCode()
+	}
+	return stdout.String(), stderr.String(), exitCode
+}
+
+func runAgent(t *testing.T, gatewayURL, dir, prompt string) (string, int) {
+	t.Helper()
+	stdout, _, code := runCLI(t, gatewayURL, dir, "", "agent", prompt)
+	return stdout, code
+}
+
+// jsonLines parses every stdout line into a generic map; the headless agent
+// emits newline-delimited JSON only.
+func jsonLines(t *testing.T, stdout string) []map[string]any {
+	t.Helper()
+	var lines []map[string]any
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var obj map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &obj), "non-JSON stdout line: %q", line)
+		lines = append(lines, obj)
+	}
+	return lines
+}
+
+func contentsByRole(lines []map[string]any, role string) []string {
+	var out []string
+	for _, l := range lines {
+		if l["role"] == role {
+			content, _ := l["content"].(string)
+			out = append(out, content)
+		}
+	}
+	return out
+}
+
+func statusOfType(lines []map[string]any, typ string) map[string]any {
+	for _, l := range lines {
+		if l["type"] == typ {
+			return l
+		}
+	}
+	return nil
+}
+
+func writeFixtures(t *testing.T, dir string, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("fixture content\n"), 0o600))
+	}
+}
+
+func toolMessages(body sdk.CreateChatCompletionRequest) []sdk.Message {
+	var out []sdk.Message
+	for _, m := range body.Messages {
+		if m.Role == sdk.Tool {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func TestAgentTextOnlyTerminatesAfterTwoTurns(t *testing.T) {
+	gw, url := startMock(t)
+
+	stdout, code := runAgent(t, url, t.TempDir(), "say hello")
+	require.Zero(t, code)
+
+	lines := jsonLines(t, stdout)
+	assistants := contentsByRole(lines, "assistant")
+	require.Contains(t, assistants, "Hello! How can I help?")
+
+	stats := statusOfType(lines, "session_stats")
+	require.NotNil(t, stats, "a session_stats line must be emitted")
+	require.EqualValues(t, 2, stats["requests"], "two consecutive no-tool-call turns end the run")
+	require.EqualValues(t, 30, stats["total_tokens"], "usage must accumulate across both turns")
+
+	reqs := gw.Requests()
+	require.Len(t, reqs, 2)
+	for _, r := range reqs {
+		require.Equal(t, "text-only", r.Scenario, "the injected automated-check reminder must not re-route the scenario")
+		require.False(t, r.Stream, "headless agent uses the non-streaming path")
+	}
+}
+
+func TestAgentParallelReadsExecuteAndReturnInOrder(t *testing.T) {
+	gw, url := startMock(t)
+	dir := t.TempDir()
+	writeFixtures(t, dir, "a.txt", "b.txt", "c.txt", "d.txt")
+
+	stdout, code := runAgent(t, url, dir, "please execute the Read tool 4 times in parallel")
+	require.Zero(t, code)
+
+	lines := jsonLines(t, stdout)
+	toolResults := contentsByRole(lines, "tool")
+	require.Len(t, toolResults, 4, "all four Read executions must be reported")
+	for _, content := range toolResults {
+		require.Contains(t, content, "Result of tool call", "Read is auto-approved and must succeed")
+	}
+	require.Contains(t, contentsByRole(lines, "assistant"), "All four files read.")
+
+	reqs := gw.Requests()
+	require.Len(t, reqs, 3, "tool turn, answer turn, then the automated-check turn")
+
+	tools := toolMessages(reqs[1].Body)
+	require.Len(t, tools, 4)
+	for i, m := range tools {
+		require.Equal(t, fmt.Sprintf("call_0_%d", i), *m.ToolCallID, "tool results must keep the original call order")
+	}
+}
+
+func TestAgentWriteIsBlockedWithoutApprover(t *testing.T) {
+	gw, url := startMock(t)
+	dir := t.TempDir()
+
+	stdout, code := runAgent(t, url, dir, "create a file named blocked.txt")
+	require.Zero(t, code)
+
+	require.NoFileExists(t, filepath.Join(dir, "blocked.txt"),
+		"Write requires approval and headless runs have no approver")
+
+	lines := jsonLines(t, stdout)
+	toolResults := contentsByRole(lines, "tool")
+	require.Len(t, toolResults, 1)
+	require.Contains(t, toolResults[0], "Blocked:", "the rejection must carry an actionable reason")
+
+	tools := toolMessages(gw.Requests()[1].Body)
+	require.Len(t, tools, 1, "the rejection must flow back to the gateway as a tool result")
+}
+
+func TestAgentBashAllowlistedCommandRuns(t *testing.T) {
+	_, url := startMock(t)
+
+	stdout, code := runAgent(t, url, t.TempDir(), "run the echo command")
+	require.Zero(t, code)
+
+	toolResults := contentsByRole(jsonLines(t, stdout), "tool")
+	require.Len(t, toolResults, 1)
+	require.Contains(t, toolResults[0], "hello-from-bash", "allow-listed echo must actually execute")
+}
+
+func TestAgentBashOffListCommandIsBlocked(t *testing.T) {
+	_, url := startMock(t)
+
+	stdout, code := runAgent(t, url, t.TempDir(), "run the forbidden command")
+	require.Zero(t, code)
+
+	toolResults := contentsByRole(jsonLines(t, stdout), "tool")
+	require.Len(t, toolResults, 1)
+	require.Contains(t, toolResults[0], "Blocked:", "off-allowlist Bash must not execute headless")
+}
+
+func TestAgentHardErrorSurfacesAndExitsNonZero(t *testing.T) {
+	gw, url := startMock(t)
+
+	stdout, code := runAgent(t, url, t.TempDir(), "this always fails")
+	require.NotZero(t, code, "a run that cannot reach the model must fail loudly")
+
+	require.NotNil(t, statusOfType(jsonLines(t, stdout), "agent_error"), "an agent_error line must be emitted")
+	require.Len(t, gw.Requests(), 3, "initial request plus two retries before giving up")
+}
+
+func TestChatPipedInputStreamsPlainText(t *testing.T) {
+	gw, url := startMock(t)
+
+	stdout, _, code := runCLI(t, url, t.TempDir(), "say hello\n", "chat")
+	require.Zero(t, code)
+	require.Contains(t, stdout, "Hello! How can I help?", "piped chat must print the streamed content")
+
+	reqs := gw.Requests()
+	require.Len(t, reqs, 1)
+	require.True(t, reqs[0].Stream, "chat uses the SSE streaming path")
+}

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -192,6 +192,26 @@ func TestAgentTextOnlyTerminatesAfterTwoTurns(t *testing.T) {
 	}
 }
 
+func TestAgentMockModeNeedsOnlyOneEnvVar(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binPath, "agent", "-m", mockgateway.DefaultModel, "say hello")
+	cmd.Dir = t.TempDir()
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"INFER_GATEWAY_MOCK=true",
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Run(), "stderr:\n%s", stderr.String())
+
+	assistants := contentsByRole(jsonLines(t, stdout.String()), "assistant")
+	require.Contains(t, assistants, "Hello! How can I help?")
+}
+
 func TestAgentParallelReadsExecuteAndReturnInOrder(t *testing.T) {
 	gw, url := startMock(t)
 	dir := t.TempDir()

--- a/tests/integration/agent_gateway_test.go
+++ b/tests/integration/agent_gateway_test.go
@@ -1,0 +1,347 @@
+// Package integration exercises the agent end-to-end against a mock
+// inference-gateway over real HTTP: real SDK client, real SSE parsing and
+// tool-call accumulation, real state machine and tool execution - no
+// interface fakes on the LLM path (issue #815).
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	sdk "github.com/inference-gateway/sdk"
+	"github.com/stretchr/testify/require"
+
+	config "github.com/inference-gateway/cli/config"
+	container "github.com/inference-gateway/cli/internal/container"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
+	streamevent "github.com/inference-gateway/cli/internal/streamevent"
+)
+
+const runTimeout = 30 * time.Second
+
+type env struct {
+	container *container.ServiceContainer
+	gateway   *mockgateway.Server
+}
+
+// newEnv builds a real service container pointed at an in-process mock
+// gateway, with the working directory moved to a fresh temp dir so tool
+// executions (Read, Grep, ...) stay sandboxed to fixtures.
+func newEnv(t *testing.T) *env {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	restore := streamevent.SetWriter(io.Discard)
+	t.Cleanup(func() { restore() })
+
+	gw := mockgateway.New(mockgateway.Default())
+	ts := httptest.NewServer(gw)
+	t.Cleanup(ts.Close)
+
+	cfg := config.DefaultConfig()
+	cfg.Gateway.URL = ts.URL
+	cfg.Gateway.Run = false
+	cfg.Storage.Enabled = false
+	cfg.Agent.Model = mockgateway.DefaultModel
+	cfg.Client.Retry.InitialBackoffSec = 0
+	cfg.Client.Retry.MaxAttempts = 3
+
+	c := container.NewServiceContainer(cfg)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = c.Shutdown(ctx)
+	})
+
+	models, err := c.GetModelService().ListModels(context.Background())
+	require.NoError(t, err, "mock /v1/models must serve the real ModelService")
+	require.Equal(t, []string{mockgateway.DefaultModel}, models)
+	require.NoError(t, c.GetModelService().SelectModel(mockgateway.DefaultModel))
+
+	return &env{container: c, gateway: gw}
+}
+
+func (e *env) writeFixtures(t *testing.T, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		require.NoError(t, os.WriteFile(filepath.Join(".", name), []byte("fixture content with a TODO marker\n"), 0o600))
+	}
+}
+
+func userMessage(t *testing.T, text string) sdk.Message {
+	t.Helper()
+	msg, err := sdk.NewTextMessage(sdk.User, text)
+	require.NoError(t, err)
+	return msg
+}
+
+type result struct {
+	chunks    []domain.ChatChunkEvent
+	completes []domain.ChatCompleteEvent
+	errs      []domain.ChatErrorEvent
+}
+
+// content concatenates all streamed content deltas.
+func (r result) content() string {
+	var b strings.Builder
+	for _, c := range r.chunks {
+		b.WriteString(c.Content)
+	}
+	return b.String()
+}
+
+// reasoning concatenates all streamed reasoning deltas.
+func (r result) reasoning() string {
+	var b strings.Builder
+	for _, c := range r.chunks {
+		b.WriteString(c.ReasoningContent)
+	}
+	return b.String()
+}
+
+// final returns the last ChatCompleteEvent of the run.
+func (r result) final(t *testing.T) domain.ChatCompleteEvent {
+	t.Helper()
+	require.NotEmpty(t, r.completes, "no ChatCompleteEvent received")
+	return r.completes[len(r.completes)-1]
+}
+
+// runStream drives one full RunWithStream session (the state machine loops
+// through tool execution internally) and drains events until the agent
+// closes the channel.
+func (e *env) runStream(ctx context.Context, t *testing.T, prompt string) result {
+	t.Helper()
+	req := &domain.AgentRequest{
+		RequestID: fmt.Sprintf("req-%s", strings.ReplaceAll(t.Name(), "/", "-")),
+		Model:     mockgateway.DefaultModel,
+		Messages:  []sdk.Message{userMessage(t, prompt)},
+	}
+
+	events, err := e.container.GetAgentService().RunWithStream(ctx, req)
+	require.NoError(t, err)
+	return drain(t, events)
+}
+
+func drain(t *testing.T, events <-chan domain.ChatEvent) result {
+	t.Helper()
+	var res result
+	deadline := time.After(runTimeout)
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				return res
+			}
+			switch e := ev.(type) {
+			case domain.ChatChunkEvent:
+				res.chunks = append(res.chunks, e)
+			case domain.ChatCompleteEvent:
+				res.completes = append(res.completes, e)
+			case domain.ChatErrorEvent:
+				res.errs = append(res.errs, e)
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the agent event channel to close")
+		}
+	}
+}
+
+// completionBodies returns the recorded chat-completion request bodies.
+func (e *env) completionBodies() []sdk.CreateChatCompletionRequest {
+	reqs := e.gateway.Requests()
+	bodies := make([]sdk.CreateChatCompletionRequest, len(reqs))
+	for i, r := range reqs {
+		bodies[i] = r.Body
+	}
+	return bodies
+}
+
+func toolMessages(body sdk.CreateChatCompletionRequest) []sdk.Message {
+	var out []sdk.Message
+	for _, m := range body.Messages {
+		if m.Role == sdk.Tool {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func lastAssistant(t *testing.T, body sdk.CreateChatCompletionRequest) sdk.Message {
+	t.Helper()
+	for i := len(body.Messages) - 1; i >= 0; i-- {
+		if body.Messages[i].Role == sdk.Assistant {
+			return body.Messages[i]
+		}
+	}
+	t.Fatal("no assistant message in request body")
+	return sdk.Message{}
+}
+
+func TestStreamTextOnlyCompletesInOneRequest(t *testing.T) {
+	e := newEnv(t)
+
+	res := e.runStream(context.Background(), t, "say hello")
+
+	require.Empty(t, res.errs)
+	require.Equal(t, "Hello! How can I help?", res.content())
+	require.Empty(t, res.final(t).ToolCalls)
+	require.Len(t, e.gateway.Requests(), 1, "a text-only streaming turn must not loop")
+}
+
+func TestStreamToolCallArgumentsAreReassembled(t *testing.T) {
+	e := newEnv(t)
+	e.writeFixtures(t, "haystack.txt")
+
+	res := e.runStream(context.Background(), t, "please search for TODO")
+
+	require.Empty(t, res.errs)
+	require.Equal(t, "Search finished: found matches for TODO.", res.content())
+
+	bodies := e.completionBodies()
+	require.Len(t, bodies, 2, "tool round-trip must trigger exactly one follow-up request")
+
+	assistant := lastAssistant(t, bodies[1])
+	require.NotNil(t, assistant.ToolCalls)
+	calls := *assistant.ToolCalls
+	require.Len(t, calls, 1)
+	require.Equal(t, "Grep", calls[0].Function.Name)
+	require.JSONEq(t, `{"pattern":"TODO","path":"."}`, calls[0].Function.Arguments,
+		"fragmented SSE arguments must reassemble into the full JSON")
+
+	tools := toolMessages(bodies[1])
+	require.Len(t, tools, 1)
+	require.Equal(t, calls[0].ID, *tools[0].ToolCallID)
+}
+
+func TestStreamParallelReadsExecuteAllFourInOrder(t *testing.T) {
+	e := newEnv(t)
+	e.writeFixtures(t, "a.txt", "b.txt", "c.txt", "d.txt")
+
+	res := e.runStream(context.Background(), t, "please execute the Read tool 4 times in parallel")
+
+	require.Empty(t, res.errs)
+	require.Equal(t, "All four files read.", res.content())
+
+	bodies := e.completionBodies()
+	require.Len(t, bodies, 2)
+
+	assistant := lastAssistant(t, bodies[1])
+	require.NotNil(t, assistant.ToolCalls)
+	require.Len(t, *assistant.ToolCalls, 4)
+
+	tools := toolMessages(bodies[1])
+	require.Len(t, tools, 4, "all four tool results must return to the gateway")
+	for i, call := range *assistant.ToolCalls {
+		require.Equal(t, call.ID, *tools[i].ToolCallID, "tool results must keep call order")
+	}
+}
+
+func TestStreamSequentialToolTurns(t *testing.T) {
+	e := newEnv(t)
+	e.writeFixtures(t, "a.txt")
+
+	res := e.runStream(context.Background(), t, "explore the project structure")
+
+	require.Empty(t, res.errs)
+	require.Equal(t, "The project contains a.txt with fixture content.", res.content())
+	require.Len(t, e.gateway.Requests(), 3, "Tree turn, Read turn, then the final answer")
+}
+
+func TestStreamReasoningAccumulatesSeparately(t *testing.T) {
+	e := newEnv(t)
+
+	res := e.runStream(context.Background(), t, "think step by step")
+
+	require.Empty(t, res.errs)
+	require.Equal(t, "Answer: 42.", res.content())
+	require.Equal(t, "Considering the question carefully before answering.", res.reasoning())
+}
+
+func TestStreamUsageIsCaptured(t *testing.T) {
+	e := newEnv(t)
+
+	res := e.runStream(context.Background(), t, "report your usage")
+
+	require.Empty(t, res.errs)
+	final := res.final(t)
+	require.NotNil(t, final.Metrics)
+	require.NotNil(t, final.Metrics.Usage)
+	require.EqualValues(t, 142, final.Metrics.Usage.TotalTokens)
+}
+
+func TestStreamRetriesOn429ThenRecovers(t *testing.T) {
+	e := newEnv(t)
+
+	res := e.runStream(context.Background(), t, "you are a flaky backend")
+
+	require.Empty(t, res.errs)
+	require.Equal(t, "Recovered after retries.", res.content())
+	require.Len(t, e.gateway.Requests(), 3, "two injected 429s then success")
+}
+
+func TestStreamSurfacesHardErrorAfterRetryExhaustion(t *testing.T) {
+	e := newEnv(t)
+
+	res := e.runStream(context.Background(), t, "this always fails")
+
+	require.NotEmpty(t, res.errs, "persistent 500s must surface as a ChatErrorEvent")
+	require.Len(t, e.gateway.Requests(), 3, "initial request plus two retries")
+}
+
+func TestStreamMalformedFrameIsSkipped(t *testing.T) {
+	e := newEnv(t)
+
+	res := e.runStream(context.Background(), t, "give me a garbled stream")
+
+	require.Empty(t, res.errs)
+	require.Equal(t, "Still standing.", res.content(),
+		"a malformed SSE frame is skipped and the stream continues")
+}
+
+func TestStreamCancelMidStreamReturnsPromptly(t *testing.T) {
+	e := newEnv(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	res := e.runStream(ctx, t, "please stream slowly")
+
+	require.Less(t, time.Since(start), 10*time.Second, "cancel must not wait for the full slow stream")
+	if len(res.completes) > 0 {
+		require.True(t, res.final(t).Cancelled, "a cancelled run must be marked Cancelled")
+	}
+}
+
+func TestSyncRunParsesNonStreamingResponse(t *testing.T) {
+	e := newEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	defer cancel()
+
+	resp, err := e.container.GetAgentService().Run(ctx, &domain.AgentRequest{
+		RequestID: "req-sync",
+		Model:     mockgateway.DefaultModel,
+		Messages:  []sdk.Message{userMessage(t, "say hello")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Hello! How can I help?", resp.Content)
+	require.NotNil(t, resp.Usage)
+	require.EqualValues(t, 15, resp.Usage.TotalTokens)
+
+	reqs := e.gateway.Requests()
+	require.Len(t, reqs, 1)
+	require.False(t, reqs[0].Stream, "AgentService.Run must use the non-streaming path")
+	require.Equal(t, "gpt-4o", reqs[0].Model, "provider prefix must be stripped from the wire model")
+	require.Equal(t, "openai", reqs[0].Provider)
+}

--- a/tests/mockgateway/main.go
+++ b/tests/mockgateway/main.go
@@ -1,0 +1,67 @@
+// Command mock-gateway serves the internal/mockgateway scenario server as a
+// standalone binary for manual testing and terminal-automation harnesses.
+// Go tests use the internal/mockgateway package in-process instead.
+//
+// The first stdout line is the readiness protocol for harnesses:
+//
+//	mock-gateway listening on http://127.0.0.1:<port>
+//
+// One line per request is logged to stderr, including the resolved scenario
+// and step from the X-Mockgateway-* response headers.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/inference-gateway/cli/internal/mockgateway"
+)
+
+func main() {
+	port := flag.Int("port", 0, "port to listen on (0 picks a free port)")
+	scenarios := flag.String("scenarios", "", "path to a scenarios YAML file (default: built-in library)")
+	flag.Parse()
+
+	defs, err := loadScenarios(*scenarios)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", *port))
+	if err != nil {
+		log.Fatalf("listening: %v", err)
+	}
+
+	fmt.Printf("mock-gateway listening on http://%s\n", ln.Addr())
+	if err := http.Serve(ln, logRequests(mockgateway.New(defs))); err != nil {
+		log.Fatalf("serving: %v", err)
+	}
+}
+
+func loadScenarios(path string) (*mockgateway.ScenarioFile, error) {
+	if path == "" {
+		return mockgateway.Default(), nil
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading scenarios: %w", err)
+	}
+	return mockgateway.Load(b)
+}
+
+// logRequests prints one line per request to stderr so harnesses can follow
+// which scenario and step each call resolved to.
+func logRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s scenario=%q step=%s",
+			r.Method, r.URL.Path,
+			w.Header().Get("X-Mockgateway-Scenario"),
+			w.Header().Get("X-Mockgateway-Step"))
+	})
+}


### PR DESCRIPTION
Closes #815.

## What

A hermetic end-to-end test harness for the agent: a **mock inference-gateway** that serves the exact API surface the CLI consumes, selecting canned **scenarios via regex on the user prompt** — no real LLM, no API key, deterministic and fast (the full binary e2e suite runs in ~6s). Plus a zero-config way to use it:

```bash
INFER_GATEWAY_MOCK=true infer chat
```

One env var: the container serves the embedded scenario library in-process on an ephemeral localhost port, rewrites `gateway.url` to it and forces `gateway.run` off. Chat lands in the model-selection view with the mock model; every scenario works interactively. Same for `infer agent -m openai/gpt-4o "..."`.

### Design (stateless by construction)

Every request carries the full message history, so the mock needs no session state:

- **Scenario** = first regex (file order) matching the **latest user message that is not an injected `<system-reminder>`** — each interactive chat prompt re-routes to its scenario, while the headless loop's automated-check reminder never re-routes a run.
- **Turn** = count of assistant messages after that anchor → `turns[step]`, so every new prompt restarts its scenario at turn 0; past the end, a `fallback` turn is served, which lets the headless "two consecutive no-tool-call turns" termination happen naturally.
- Responses marshal the SDK's own types (`CreateChatCompletionResponse` / `...StreamResponse`) for wire fidelity; the only mutable state is the error-injection counter and request recording. Zero new dependencies.

### Pieces

| Path | What |
| --- | --- |
| `internal/mockgateway` | `http.Handler`: `/v1/models`, `/v1/chat/completions` (sync JSON + SSE), `/v1/health`; YAML scenario schema (strict decode); embedded library of 13 scenarios; `Requests()` recording for assertions |
| `config` / `internal/container` | `gateway.mock` (`INFER_GATEWAY_MOCK`): boots the mock in-process and points the SDK client at it |
| `tests/mockgateway` | standalone `mock-gateway` binary (`-port`, `-scenarios`) for custom scenario files and the future tmux TUI harness; first stdout line is the readiness protocol |
| `tests/integration` | in-process e2e: real container + real SDK client + real SSE parsing via `RunWithStream`/`Run` — fragment accumulation, parallel tool dispatch, multi-turn loops, retry, hard errors, malformed frames, cancel mid-stream, usage capture. Runs in plain `go test ./...` |
| `tests/e2e` (`-tags e2e`) | the built `infer` binary as a subprocess: headless JSON output contract, termination rule, parallel reads, write blocked without approver, bash allow-list gate, `agent_error` + non-zero exit, piped-chat streaming, one-env-var mock mode |
| `Taskfile` / CI | `task test:e2e`, `task build:mockgateway`; new `e2e` CI job |

Streaming tool-call arguments are deliberately emitted in **≥2 fragments** per call so the CLI's index-keyed accumulator is always exercised; content chunks split on runes (UTF-8-safe).

### Bugs the harness caught immediately (fixed here)

1. **Stream-failure hang + goroutine leak**: a failed `GenerateContentStream` (or stream timeout) transitioned the state machine to `Error` from the streaming goroutine without waking the event loop — the chat event channel never closed. Fixed with an event nudge after the transition.
2. **Context cancellation ignored**: cancelling the ctx passed to `RunWithStream` aborted the HTTP stream but nothing closed the session cancel channel, parking the machine in `StreamingLLM` forever (also hit non-interactive chat on gateway timeout). Fixed with `context.AfterFunc(sessionCtx, sc.Cancel)`.
3. **Usage-only chunks dropped**: usage was read inside the per-choice loop, so the OpenAI-style final usage chunk (`stream_options.include_usage`, `choices: []`) was discarded and stats fell back to the tokenizer polyfill. Fixed by hoisting the capture.
4. **Data race**: `Registry.SetReadToolUsed` raced under parallel tool execution (e.g. four `Read` calls in one turn). Now an `atomic.Bool`.
5. **`INFER_*` env vars dead for optioned mapstructure tags**: `resolveViperEnvironmentVariables` built viper keys from the raw tag, so fields tagged `debug,omitempty` looked up `gateway.debug,omitempty` — `INFER_GATEWAY_DEBUG`/`INFER_GATEWAY_OCI` never resolved. Tag options are stripped before building the key.

### Try it

```bash
INFER_GATEWAY_MOCK=true infer chat
```

Prompts that trigger scenarios (`internal/mockgateway/scenarios.yaml` is the reference): `say hello`, `please search for TODO`, `run the echo command`, `explore the project structure`, `create a file named blocked.txt` (approval prompt), `stream slowly`, `think step by step`, `report your usage`; `please execute the Read tool 4 times in parallel` reads `a.txt`–`d.txt` from the cwd. Anything else answers with the fallback (`Done.`).

Custom scenario files use the standalone binary: `task build:mockgateway && .infer/bin/mock-gateway -port 0 -scenarios my.yaml` + `INFER_GATEWAY_URL`.

### Out of scope

TUI automation (tmux screen-capture harness) — follow-up in #818; the mock gateway here is its prerequisite.
