### PR TITLE
fix(ui): run the whole chat TUI on the alt screen to eliminate flicker

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -1055,11 +1055,7 @@ func (app *ChatApplication) View() tea.View {
 	if app.mouseEnabled {
 		v.MouseMode = tea.MouseModeCellMotion
 	}
-
-	switch app.stateManager.GetCurrentView() {
-	case domain.ViewStateExplorer, domain.ViewStateDiffViewer:
-		v.AltScreen = true
-	}
+	v.AltScreen = true
 	return v
 }
 


### PR DESCRIPTION
Resolves #829

## Summary

The chat view runs inline but composes a full-terminal-height frame on every update, causing visible flicker during streaming. Toggling AltScreen per view also adds a hard flash when entering/leaving Explorer and DiffViewer.

## Changes

- Removes the per-view switch that only set `v.AltScreen = true` for `ViewStateExplorer` and `ViewStateDiffViewer`
- Sets `v.AltScreen = true` unconditionally in `View()`

Terminal-native scrollback UX is preserved by two existing mechanisms:
- The conversation area scrolls via `bubbles/viewport` (delegated scroll + mouse wheel)
- The post-exit transcript print (`PrintConversationHistory`) leaves the conversation in the normal buffer after quit

## Changed files

```
internal/app/chat.go | 6 +-----
 1 file changed, 1 insertion(+), 5 deletions(-)
```

## ponytail

The smallest change that fixes the root cause: one guard removed instead of adding more conditionals. The existing post-exit transcript and viewport scroll already handle scrollback UX, so no new code needed there.
