### PR TITLE
refactor(keybindings): migrate key dispatch to bubbles/key

### DIFF
--- a/cmd/keybindings.go
+++ b/cmd/keybindings.go
@@ -100,13 +100,13 @@ func listKeybindings(cmd *cobra.Command, args []string) error {
 		}
 
 		status := icons.CheckMarkStyle.Render(icons.CheckMark)
-		if !action.Enabled {
+		if !action.Binding.Enabled() {
 			status = icons.CrossMarkStyle.Render(icons.CrossMark)
 		}
 
-		keys := strings.Join(action.Keys, ", ")
+		keys := strings.Join(action.Binding.Keys(), ", ")
 		fmt.Printf("  %s %-25s %s\n", status, action.ID, keys)
-		fmt.Printf("     %s\n", action.Description)
+		fmt.Printf("     %s\n", action.Binding.Help().Desc)
 		fmt.Println()
 	}
 

--- a/config/keybindings.go
+++ b/config/keybindings.go
@@ -114,6 +114,12 @@ func addChatBindings(bindings map[string]KeyBindingEntry) {
 		Category:    "chat",
 		Enabled:     &enabled,
 	}
+	bindings[ActionID(NamespaceChat, "tab_key_handler")] = KeyBindingEntry{
+		Keys:        []string{"tab"},
+		Description: "complete autocomplete or cycle history suggestion",
+		Category:    "chat",
+		Enabled:     &enabled,
+	}
 	bindings[ActionID(NamespaceChat, "focus_attachments")] = KeyBindingEntry{
 		Keys:        []string{"ctrl+g"},
 		Description: "focus the attached-snippets tree below the input (↑/↓ move · d remove · c clear · esc done)",
@@ -177,7 +183,7 @@ func addNavigationBindings(bindings map[string]KeyBindingEntry) {
 		Enabled:     &enabled,
 	}
 	bindings[ActionID(NamespaceNavigation, "page_down")] = KeyBindingEntry{
-		Keys:        []string{"pgdn", "page_down"},
+		Keys:        []string{"pgdn", "pgdown", "page_down"},
 		Description: "page down",
 		Category:    "navigation",
 		Enabled:     &enabled,
@@ -443,6 +449,36 @@ func addExplorerBindings(bindings map[string]KeyBindingEntry) {
 	add("halfpage_up", "scroll the preview up half a page", "ctrl+u")
 	add("halfpage_down", "scroll the preview down half a page", "ctrl+d")
 	add("cancel", "close the explorer panel", "esc", "q")
+}
+
+// ResolveKeybindings merges user overrides from cfg onto GetDefaultKeybindings()
+// and returns the effective entry for every default action ID. Overrides replace
+// Keys (when non-empty) and Enabled (when set); Description/Category always come
+// from the defaults. cfg.Enabled==false yields pure defaults. The second return
+// lists override IDs that match no default action, so the caller can warn about
+// typos (this package stays log-free).
+func ResolveKeybindings(cfg KeybindingsConfig) (map[string]KeyBindingEntry, []string) {
+	resolved := GetDefaultKeybindings()
+	if !cfg.Enabled {
+		return resolved, nil
+	}
+
+	var unknown []string
+	for id, ov := range cfg.Bindings {
+		entry, ok := resolved[id]
+		if !ok {
+			unknown = append(unknown, id)
+			continue
+		}
+		if len(ov.Keys) > 0 {
+			entry.Keys = ov.Keys
+		}
+		if ov.Enabled != nil {
+			entry.Enabled = ov.Enabled
+		}
+		resolved[id] = entry
+	}
+	return resolved, unknown
 }
 
 // ResolveNamespaceBindings returns the effective key lists for every default

--- a/config/keybindings_test.go
+++ b/config/keybindings_test.go
@@ -130,3 +130,81 @@ func TestDefaultKeybindingsConfig(t *testing.T) {
 		t.Error("Default config should have bindings")
 	}
 }
+
+func TestResolveKeybindings(t *testing.T) {
+	quitID := config.ActionID(config.NamespaceGlobal, "quit")
+	cancelID := config.ActionID(config.NamespaceGlobal, "cancel")
+	disabled := false
+
+	tests := []struct {
+		name        string
+		cfg         config.KeybindingsConfig
+		wantKeys    map[string][]string
+		wantEnabled map[string]bool
+		wantUnknown []string
+	}{
+		{
+			name:     "no overrides yields defaults",
+			cfg:      config.KeybindingsConfig{Enabled: true},
+			wantKeys: map[string][]string{quitID: {"ctrl+c"}},
+		},
+		{
+			name: "keys override replaces defaults",
+			cfg: config.KeybindingsConfig{Enabled: true, Bindings: map[string]config.KeyBindingEntry{
+				quitID: {Keys: []string{"ctrl+q"}},
+			}},
+			wantKeys: map[string][]string{quitID: {"ctrl+q"}, cancelID: {"esc"}},
+		},
+		{
+			name: "enabled=false override disables action",
+			cfg: config.KeybindingsConfig{Enabled: true, Bindings: map[string]config.KeyBindingEntry{
+				cancelID: {Enabled: &disabled},
+			}},
+			wantEnabled: map[string]bool{cancelID: false, quitID: true},
+		},
+		{
+			name: "disabled config ignores overrides",
+			cfg: config.KeybindingsConfig{Enabled: false, Bindings: map[string]config.KeyBindingEntry{
+				quitID: {Keys: []string{"ctrl+q"}},
+			}},
+			wantKeys: map[string][]string{quitID: {"ctrl+c"}},
+		},
+		{
+			name: "unknown IDs reported",
+			cfg: config.KeybindingsConfig{Enabled: true, Bindings: map[string]config.KeyBindingEntry{
+				"no_such_action": {Keys: []string{"x"}},
+			}},
+			wantUnknown: []string{"no_such_action"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, unknown := config.ResolveKeybindings(tt.cfg)
+			if len(resolved) != len(config.GetDefaultKeybindings()) {
+				t.Errorf("resolved map has %d entries, want all %d defaults", len(resolved), len(config.GetDefaultKeybindings()))
+			}
+			for id, keys := range tt.wantKeys {
+				got := resolved[id].Keys
+				if len(got) != len(keys) {
+					t.Fatalf("action %s keys = %v, want %v", id, got, keys)
+				}
+				for i := range keys {
+					if got[i] != keys[i] {
+						t.Errorf("action %s keys = %v, want %v", id, got, keys)
+					}
+				}
+			}
+			for id, want := range tt.wantEnabled {
+				entry := resolved[id]
+				got := entry.Enabled == nil || *entry.Enabled
+				if got != want {
+					t.Errorf("action %s enabled = %v, want %v", id, got, want)
+				}
+			}
+			if len(unknown) != len(tt.wantUnknown) {
+				t.Errorf("unknown = %v, want %v", unknown, tt.wantUnknown)
+			}
+		})
+	}
+}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
+	key "charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
 	sdk "github.com/inference-gateway/sdk"
@@ -123,9 +123,9 @@ type ChatApplication struct {
 	// Key binding system
 	keyBindingManager *keybinding.KeyBindingManager
 
-	// Resolved chat-namespace keybindings (actionID -> keys), used for the
-	// snippet-attachments focus shim that runs ahead of the key binding manager.
-	chatKeys map[string][]string
+	// Config-backed binding that moves key focus to the snippet attachments
+	// tree; the fixed guard bindings live in the package-level guardKeys.
+	focusAttachments key.Binding
 
 	// Track last key handled by keybinding action to prevent double-handling
 	lastHandledKey string
@@ -273,7 +273,7 @@ func NewChatApplication(
 	app.queueBoxView = components.NewQueueBoxView(styleProvider)
 	app.todoBoxView = components.NewTodoBoxView(styleProvider)
 	app.snippetAttachmentsView = components.NewSnippetAttachmentsView(styleProvider)
-	app.chatKeys = config.ResolveNamespaceBindings(app.config.Chat.Keybindings, config.NamespaceChat)
+	app.focusAttachments = focusAttachmentsBinding(app.config.Chat.Keybindings)
 	app.approvalBoxView = components.NewApprovalBoxView(styleProvider, app.stateManager, toolFormatterService)
 	app.questionFormView = components.NewQuestionFormView(styleProvider, app.stateManager)
 
@@ -761,7 +761,7 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 	// While an AskUserQuestion form is up it captures all keys (like the
 	// tool-approval box). It floats over the chat, so the view stays Chat.
 	// ctrl+c falls through so the user can still cancel the whole turn.
-	if app.stateManager.GetUserQuestionUIState() != nil && keyMsg.String() != "ctrl+c" {
+	if app.stateManager.GetUserQuestionUIState() != nil && !key.Matches(keyMsg, guardKeys.interrupt) {
 		return app.handleUserQuestionKeys(keyMsg)
 	}
 
@@ -769,11 +769,11 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 		return app.handleMessageHistoryKeys(keyMsg)
 	}
 
-	if app.attachmentsFocused && keyMsg.String() != "ctrl+c" {
+	if app.attachmentsFocused && !key.Matches(keyMsg, guardKeys.interrupt) {
 		app.lastHandledKey = keyMsg.String()
 		return app.handleAttachmentsKeys(keyMsg)
 	}
-	if app.statusBarFocused && keyMsg.String() != "ctrl+c" {
+	if app.statusBarFocused && !key.Matches(keyMsg, guardKeys.interrupt) {
 		if cmds, handled := app.handleStatusBarKeys(keyMsg); handled {
 			app.lastHandledKey = keyMsg.String()
 			return cmds
@@ -800,7 +800,7 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 // matchesFocusAttachments reports whether the pressed key is bound to the
 // chat-namespace focus-attachments action.
 func (app *ChatApplication) matchesFocusAttachments(keyMsg tea.KeyPressMsg) bool {
-	return slices.Contains(app.chatKeys[actChatFocusAttachments], keyMsg.String())
+	return key.Matches(keyMsg, app.focusAttachments)
 }
 
 // handleAttachmentsKeys interprets keys while the snippet attachments tree holds
@@ -810,17 +810,18 @@ func (app *ChatApplication) handleAttachmentsKeys(keyMsg tea.KeyPressMsg) []tea.
 		app.attachmentsFocused = false
 		return nil
 	}
-	switch keyMsg.String() {
-	case "up", "k":
+	gk := guardKeys
+	switch {
+	case key.Matches(keyMsg, gk.navUp):
 		app.snippetAttachmentsView.MoveCursor(-1)
-	case "down", "j":
+	case key.Matches(keyMsg, gk.navDown):
 		app.snippetAttachmentsView.MoveCursor(1)
-	case "d", "x", "backspace", "delete":
+	case key.Matches(keyMsg, gk.attachRemove):
 		app.removeFocusedSnippet()
-	case "c":
+	case key.Matches(keyMsg, gk.attachClear):
 		app.pendingSnippets = nil
 		app.attachmentsFocused = false
-	case "esc", "q":
+	case key.Matches(keyMsg, gk.attachExit):
 		app.attachmentsFocused = false
 	}
 	return nil
@@ -843,19 +844,20 @@ func (app *ChatApplication) removeFocusedSnippet() {
 // focus. Unhandled keys blur the row and report handled=false so they flow
 // on to the normal chain - typing lands back in the input.
 func (app *ChatApplication) handleStatusBarKeys(keyMsg tea.KeyPressMsg) ([]tea.Cmd, bool) {
-	switch keyMsg.String() {
-	case "left", "shift+tab":
+	gk := guardKeys
+	switch {
+	case key.Matches(keyMsg, gk.statusPrev):
 		app.inputStatusBar.SelectPrev()
 		return nil, true
-	case "right", "tab":
+	case key.Matches(keyMsg, gk.statusNext):
 		app.inputStatusBar.SelectNext()
 		return nil, true
-	case "down":
+	case key.Matches(keyMsg, gk.statusHold):
 		return nil, true
-	case "up", "esc":
+	case key.Matches(keyMsg, gk.statusBlur):
 		app.blurStatusBar()
 		return nil, true
-	case "enter":
+	case key.Matches(keyMsg, gk.confirm):
 		return app.activateSelectedIndicator(), true
 	default:
 		app.blurStatusBar()
@@ -956,16 +958,17 @@ func (app *ChatApplication) handleUserQuestionKeys(keyMsg tea.KeyPressMsg) []tea
 		return nil
 	}
 
-	switch keyMsg.String() {
-	case "up", "k":
+	gk := guardKeys
+	switch {
+	case key.Matches(keyMsg, gk.navUp):
 		app.moveUserQuestionCursor(-1)
-	case "down", "j":
+	case key.Matches(keyMsg, gk.navDown):
 		app.moveUserQuestionCursor(1)
-	case " ", "space":
+	case key.Matches(keyMsg, gk.questionToggle):
 		app.toggleUserQuestionAtCursor()
-	case "enter":
+	case key.Matches(keyMsg, gk.confirm):
 		app.confirmUserQuestion()
-	case "esc":
+	case key.Matches(keyMsg, gk.cancel):
 		sm.ClearUserQuestionUIState()
 	}
 	return nil
@@ -975,12 +978,13 @@ func (app *ChatApplication) handleUserQuestionKeys(keyMsg tea.KeyPressMsg) []tea
 // question. Enter confirms (and advances/submits); esc leaves text entry.
 func (app *ChatApplication) handleUserQuestionOtherKey(keyMsg tea.KeyPressMsg) {
 	sm := app.stateManager
-	switch keyMsg.String() {
-	case "enter":
+	gk := guardKeys
+	switch {
+	case key.Matches(keyMsg, gk.confirm):
 		app.confirmUserQuestion()
-	case "esc":
+	case key.Matches(keyMsg, gk.cancel):
 		sm.SetUserQuestionOtherActive(false)
-	case "backspace":
+	case key.Matches(keyMsg, gk.questionBackspace):
 		sm.BackspaceUserQuestionOtherText()
 	default:
 		if text := keys.PrintableText(keyMsg); text != "" {
@@ -2130,7 +2134,7 @@ func (app *ChatApplication) syncSnippetAttachmentsView() {
 // focusAttachmentsKeyLabel returns the primary key bound to the focus-attachments
 // action, for display in the attachments tree header ("" when unbound).
 func (app *ChatApplication) focusAttachmentsKeyLabel() string {
-	if ks := app.chatKeys[actChatFocusAttachments]; len(ks) > 0 {
+	if ks := app.focusAttachments.Keys(); len(ks) > 0 {
 		return ks[0]
 	}
 	return ""
@@ -2813,14 +2817,15 @@ func (app *ChatApplication) handleMessageHistoryKeys(keyMsg tea.KeyPressMsg) []t
 		return cmds
 	}
 
-	switch keyMsg.String() {
-	case "up", "k":
+	gk := guardKeys
+	switch {
+	case key.Matches(keyMsg, gk.navUp):
 		cv.NavigateHistoryUp()
-	case "down", "j":
+	case key.Matches(keyMsg, gk.navDown):
 		cv.NavigateHistoryDown()
-	case "enter":
+	case key.Matches(keyMsg, gk.confirm):
 		cmds = app.handleMessageHistoryEnter(cv, iv, cmds)
-	case "esc":
+	case key.Matches(keyMsg, gk.cancel):
 		cv.ExitMessageHistoryMode()
 		iv.ClearCustomHint()
 	}

--- a/internal/app/chat_keymap.go
+++ b/internal/app/chat_keymap.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	key "charm.land/bubbles/v2/key"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+// guardKeys holds the fixed key.Bindings for the chat view's precedence
+// guards — the focus modes (attachments tree, status bar, question form,
+// message history) that capture keys before the keybinding registry runs.
+// These are navigation keys local to their overlay and are not user-remappable;
+// the config-backed focus-attachments binding lives on ChatApplication.
+var guardKeys = struct {
+	// interrupt always falls through the guards so the user can cancel the turn.
+	interrupt key.Binding
+
+	navUp   key.Binding
+	navDown key.Binding
+	confirm key.Binding
+	cancel  key.Binding
+
+	attachRemove key.Binding
+	attachClear  key.Binding
+	attachExit   key.Binding
+
+	statusPrev key.Binding
+	statusNext key.Binding
+	statusHold key.Binding
+	statusBlur key.Binding
+
+	questionToggle    key.Binding
+	questionBackspace key.Binding
+}{
+	interrupt: key.NewBinding(key.WithKeys("ctrl+c")),
+
+	navUp:   key.NewBinding(key.WithKeys("up", "k")),
+	navDown: key.NewBinding(key.WithKeys("down", "j")),
+	confirm: key.NewBinding(key.WithKeys("enter")),
+	cancel:  key.NewBinding(key.WithKeys("esc")),
+
+	attachRemove: key.NewBinding(key.WithKeys("d", "x", "backspace", "delete")),
+	attachClear:  key.NewBinding(key.WithKeys("c")),
+	attachExit:   key.NewBinding(key.WithKeys("esc", "q")),
+
+	statusPrev: key.NewBinding(key.WithKeys("left", "shift+tab")),
+	statusNext: key.NewBinding(key.WithKeys("right", "tab")),
+	statusHold: key.NewBinding(key.WithKeys("down")),
+	statusBlur: key.NewBinding(key.WithKeys("up", "esc")),
+
+	questionToggle:    key.NewBinding(key.WithKeys(" ", "space")),
+	questionBackspace: key.NewBinding(key.WithKeys("backspace")),
+}
+
+// focusAttachmentsBinding resolves the user-remappable focus-attachments keys
+// from the keybindings config (defaults + overrides). A disabled or keyless
+// entry yields a binding that never matches.
+func focusAttachmentsBinding(kb config.KeybindingsConfig) key.Binding {
+	focusKeys := config.ResolveNamespaceBindings(kb, config.NamespaceChat)[actChatFocusAttachments]
+	return key.NewBinding(key.WithKeys(focusKeys...))
+}

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -19,415 +19,26 @@ import (
 	keys "github.com/inference-gateway/cli/internal/ui/keys"
 )
 
-// registerDefaultBindings registers all default key bindings
-func (r *Registry) registerDefaultBindings() {
-	globalActions := r.createGlobalActions()
-	chatActions := r.createChatActions()
-	scrollActions := r.createScrollActions()
-	approvalActions := r.createApprovalActions()
+// defaultActions declares every built-in action: its ID, handler, and the
+// view/condition context it is active in. Keys, descriptions, and categories
+// deliberately do NOT live here — they come from config.GetDefaultKeybindings()
+// (merged with keybindings.yaml overrides) when NewRegistry builds each
+// action's key.Binding, so there is a single source of truth for defaults.
+func defaultActions() []*KeyAction {
+	chatView := func(conds ...ContextCondition) KeyContext {
+		return KeyContext{
+			Views:      []domain.ViewState{domain.ViewStateChat},
+			Conditions: conds,
+		}
+	}
+	planApprovalView := KeyContext{Views: []domain.ViewState{domain.ViewStatePlanApproval}}
 
-	r.registerActionsToLayers(globalActions, chatActions, scrollActions, approvalActions)
-}
-
-// createGlobalActions creates global key actions available in all views
-func (r *Registry) createGlobalActions() []*KeyAction {
-	return []*KeyAction{
-		{
-			ID:          config.ActionID(config.NamespaceGlobal, "quit"),
-			Namespace:   config.NamespaceGlobal,
-			Keys:        []string{"ctrl+c"},
-			Description: "exit application",
-			Category:    "global",
-			Handler:     handleQuit,
-			Priority:    100,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{},
-			},
-		},
-		{
-			ID:          config.ActionID(config.NamespaceGlobal, "cancel"),
-			Namespace:   config.NamespaceGlobal,
-			Keys:        []string{"esc"},
-			Description: "cancel current operation",
-			Category:    "global",
-			Handler:     handleCancel,
-			Priority:    100,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{},
-			},
-		},
-		{
-			ID:          config.ActionID(config.NamespaceGlobal, "new_session"),
-			Namespace:   config.NamespaceGlobal,
-			Keys:        []string{"ctrl+l"},
-			Description: "clear chat and start a new session",
-			Category:    "global",
-			Handler:     handleNewSession,
-			Priority:    100,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{},
-			},
+	inputIsEmpty := ContextCondition{
+		Name: "input_is_empty",
+		Check: func(app KeyHandlerContext) bool {
+			return strings.TrimSpace(app.GetInputView().GetInput()) == ""
 		},
 	}
-}
-
-// createChatActions creates key actions specific to chat view
-func (r *Registry) createChatActions() []*KeyAction {
-	actions := []*KeyAction{
-		{
-			Namespace:   config.NamespaceMode,
-			ID:          config.ActionID(config.NamespaceMode, "cycle_agent_mode"),
-			Keys:        []string{"shift+tab"},
-			Description: "cycle agent mode (Standard/Plan/Auto-Accept)",
-			Category:    "mode",
-			Handler:     handleCycleAgentMode,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTools,
-			ID:          config.ActionID(config.NamespaceTools, "toggle_tool_expansion"),
-			Keys:        []string{"ctrl+o"},
-			Description: "expand/collapse tool results",
-			Category:    "tools",
-			Handler:     handleToggleToolExpansion,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTools,
-			ID:          config.ActionID(config.NamespaceTools, "background_shell"),
-			Keys:        []string{"ctrl+b"},
-			Description: "move running bash command to background",
-			Category:    "tools",
-			Handler:     handleBackgroundShell,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceDisplay,
-			ID:          config.ActionID(config.NamespaceDisplay, "toggle_raw_format"),
-			Keys:        []string{"ctrl+r"},
-			Description: "toggle raw/rendered markdown",
-			Category:    "display",
-			Handler:     handleToggleRawFormat,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceSelection,
-			ID:          config.ActionID(config.NamespaceSelection, "toggle_mouse_mode"),
-			Keys:        []string{"ctrl+s"},
-			Description: "toggle mouse scrolling/text selection",
-			Category:    "selection",
-			Handler:     handleToggleMouseMode,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceChat,
-			ID:          config.ActionID(config.NamespaceChat, "tab_key_handler"),
-			Keys:        []string{"tab"},
-			Description: "complete autocomplete or cycle history suggestion",
-			Category:    "chat",
-			Handler:     handleTabKey,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceChat,
-			ID:          config.ActionID(config.NamespaceChat, "enter_key_handler"),
-			Keys:        []string{"enter"},
-			Description: "send message or insert newline",
-			Category:    "chat",
-			Handler:     handleEnterKey,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceHelp,
-			ID:          config.ActionID(config.NamespaceHelp, "toggle_help"),
-			Keys:        []string{"?"},
-			Description: "toggle help when input is empty",
-			Category:    "help",
-			Handler:     handleToggleHelp,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-				Conditions: []ContextCondition{
-					{
-						Name: "input_is_empty",
-						Check: func(app KeyHandlerContext) bool {
-							input := strings.TrimSpace(app.GetInputView().GetInput())
-							return len(input) == 0
-						},
-					},
-				},
-			},
-		},
-		{
-			Namespace:   config.NamespaceDisplay,
-			ID:          config.ActionID(config.NamespaceDisplay, "toggle_todo_box"),
-			Keys:        []string{"ctrl+t"},
-			Description: "toggle todo list",
-			Category:    "display",
-			Handler:     handleToggleTodoBox,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceDisplay,
-			ID:          config.ActionID(config.NamespaceDisplay, "toggle_thinking"),
-			Keys:        []string{"ctrl+k"},
-			Description: "expand/collapse thinking blocks",
-			Category:    "display",
-			Handler:     handleToggleThinkingExpansion,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-	}
-
-	actions = append(actions, r.createClipboardActions()...)
-	actions = append(actions, r.createTextEditingActions()...)
-	actions = append(actions, r.createWordEditingActions()...)
-	actions = append(actions, r.createHistoryActions()...)
-
-	return actions
-}
-
-// createClipboardActions creates clipboard-related key actions
-func (r *Registry) createClipboardActions() []*KeyAction {
-	return []*KeyAction{
-		{
-			Namespace:   config.NamespaceClipboard,
-			ID:          config.ActionID(config.NamespaceClipboard, "paste_text"),
-			Keys:        []string{"ctrl+v", "super+v"},
-			Description: "paste text",
-			Category:    "clipboard",
-			Handler:     handlePaste,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceClipboard,
-			ID:          config.ActionID(config.NamespaceClipboard, "copy_text"),
-			Keys:        []string{"ctrl+shift+c", "super+c"},
-			Description: "copy text",
-			Category:    "clipboard",
-			Handler:     handleCopy,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-	}
-}
-
-// createTextEditingActions creates text editing key actions
-func (r *Registry) createTextEditingActions() []*KeyAction {
-	return []*KeyAction{
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "insert_newline_alt"),
-			Keys:        []string{"alt+enter"},
-			Description: "insert newline",
-			Category:    "text_editing",
-			Handler:     handleInsertNewline,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "insert_newline_ctrl"),
-			Keys:        []string{"ctrl+j"},
-			Description: "insert newline",
-			Category:    "text_editing",
-			Handler:     handleInsertNewline,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "move_cursor_left"),
-			Keys:        []string{"left"},
-			Description: "move cursor left",
-			Category:    "text_editing",
-			Handler:     handleCursorLeftOrPlanNav,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "move_cursor_right"),
-			Keys:        []string{"right"},
-			Description: "move cursor right",
-			Category:    "text_editing",
-			Handler:     handleCursorRightOrPlanNav,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "backspace"),
-			Keys:        []string{"backspace"},
-			Description: "delete character",
-			Category:    "text_editing",
-			Handler:     handleBackspace,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "delete_to_beginning"),
-			Keys:        []string{"ctrl+u"},
-			Description: "delete to beginning of line",
-			Category:    "text_editing",
-			Handler:     handleDeleteToBeginning,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "delete_word_backward"),
-			Keys:        []string{"ctrl+w", "alt+backspace", "ctrl+backspace"},
-			Description: "delete word backward",
-			Category:    "text_editing",
-			Handler:     handleDeleteWordBackward,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "move_to_beginning"),
-			Keys:        []string{"ctrl+a"},
-			Description: "move cursor to beginning",
-			Category:    "text_editing",
-			Handler:     handleMoveToBeginning,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "move_to_end"),
-			Keys:        []string{"ctrl+e"},
-			Description: "move cursor to end",
-			Category:    "text_editing",
-			Handler:     handleMoveToEnd,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-	}
-}
-
-// createWordEditingActions creates word-wise cursor movement and deletion actions
-func (r *Registry) createWordEditingActions() []*KeyAction {
-	return []*KeyAction{
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "move_cursor_word_left"),
-			Keys:        []string{"alt+left", "ctrl+left", "alt+b"},
-			Description: "move cursor one word left",
-			Category:    "text_editing",
-			Handler:     handleMoveCursorWordLeft,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "move_cursor_word_right"),
-			Keys:        []string{"alt+right", "ctrl+right", "alt+f"},
-			Description: "move cursor one word right",
-			Category:    "text_editing",
-			Handler:     handleMoveCursorWordRight,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "delete_word_forward"),
-			Keys:        []string{"alt+d"},
-			Description: "delete word forward",
-			Category:    "text_editing",
-			Handler:     handleDeleteWordForward,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-	}
-}
-
-// createHistoryActions creates history navigation key actions
-func (r *Registry) createHistoryActions() []*KeyAction {
 	noApprovalPending := ContextCondition{
 		Name: "no_approval_pending",
 		Check: func(app KeyHandlerContext) bool {
@@ -436,248 +47,64 @@ func (r *Registry) createHistoryActions() []*KeyAction {
 				stateManager.GetApprovalUIState() == nil
 		},
 	}
+	chatIdleOrCompleted := ContextCondition{
+		Name: "chat_idle_or_completed",
+		Check: func(app KeyHandlerContext) bool {
+			stateManager := app.GetStateManager()
+			chatSession := stateManager.GetChatSession()
+			return stateManager.GetPlanApprovalUIState() == nil &&
+				stateManager.GetApprovalUIState() == nil &&
+				(chatSession == nil || chatSession.Status == domain.ChatStatusIdle || chatSession.Status == domain.ChatStatusCompleted)
+		},
+	}
 
 	return []*KeyAction{
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "history_up"),
-			Keys:        []string{"up"},
-			Description: "navigate to previous message in history",
-			Category:    "text_editing",
-			Handler:     handleHistoryUp,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views:      []domain.ViewState{domain.ViewStateChat},
-				Conditions: []ContextCondition{noApprovalPending},
-			},
-		},
-		{
-			Namespace:   config.NamespaceTextEditing,
-			ID:          config.ActionID(config.NamespaceTextEditing, "history_down"),
-			Keys:        []string{"down"},
-			Description: "navigate to next message in history / select status indicator",
-			Category:    "text_editing",
-			Handler:     handleHistoryDown,
-			Priority:    200,
-			Enabled:     true,
-			Context: KeyContext{
-				Views:      []domain.ViewState{domain.ViewStateChat},
-				Conditions: []ContextCondition{noApprovalPending},
-			},
-		},
-	}
-}
+		{ID: config.ActionID(config.NamespaceGlobal, "quit"), Handler: handleQuit},
+		{ID: config.ActionID(config.NamespaceGlobal, "cancel"), Handler: handleCancel},
+		{ID: config.ActionID(config.NamespaceGlobal, "new_session"), Handler: handleNewSession},
 
-// createScrollActions creates scroll-related key actions
-func (r *Registry) createScrollActions() []*KeyAction {
-	return []*KeyAction{
-		{
-			Namespace:   config.NamespaceNavigation,
-			ID:          config.ActionID(config.NamespaceNavigation, "go_back_in_time"),
-			Keys:        []string{"esc,esc"},
-			Description: "go back in time to previous message (double esc)",
-			Category:    "navigation",
-			Handler:     handleGoBackInTime,
-			Priority:    120,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-				Conditions: []ContextCondition{
-					{
-						Name: "chat_idle_or_completed",
-						Check: func(app KeyHandlerContext) bool {
-							stateManager := app.GetStateManager()
-							chatSession := stateManager.GetChatSession()
-							planApprovalState := stateManager.GetPlanApprovalUIState()
-							approvalState := stateManager.GetApprovalUIState()
+		{ID: config.ActionID(config.NamespaceMode, "cycle_agent_mode"), Handler: handleCycleAgentMode, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTools, "toggle_tool_expansion"), Handler: handleToggleToolExpansion, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTools, "background_shell"), Handler: handleBackgroundShell, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceDisplay, "toggle_raw_format"), Handler: handleToggleRawFormat, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceDisplay, "toggle_todo_box"), Handler: handleToggleTodoBox, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceDisplay, "toggle_thinking"), Handler: handleToggleThinkingExpansion, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceSelection, "toggle_mouse_mode"), Handler: handleToggleMouseMode, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceChat, "tab_key_handler"), Handler: handleTabKey, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceChat, "enter_key_handler"), Handler: handleEnterKey, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceHelp, "toggle_help"), Handler: handleToggleHelp, Context: chatView(inputIsEmpty)},
 
-							return planApprovalState == nil &&
-								approvalState == nil &&
-								(chatSession == nil || chatSession.Status == domain.ChatStatusIdle || chatSession.Status == domain.ChatStatusCompleted)
-						},
-					},
-				},
-			},
-		},
-		{
-			Namespace:   config.NamespaceNavigation,
-			ID:          config.ActionID(config.NamespaceNavigation, "scroll_to_top"),
-			Keys:        []string{"home"},
-			Description: "scroll to top",
-			Category:    "navigation",
-			Handler:     handleScrollToTop,
-			Priority:    120,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceNavigation,
-			ID:          config.ActionID(config.NamespaceNavigation, "scroll_to_bottom"),
-			Keys:        []string{"end"},
-			Description: "scroll to bottom",
-			Category:    "navigation",
-			Handler:     handleScrollToBottom,
-			Priority:    120,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceNavigation,
-			ID:          config.ActionID(config.NamespaceNavigation, "scroll_up_half_page"),
-			Keys:        []string{"shift+up"},
-			Description: "scroll up half page",
-			Category:    "navigation",
-			Handler:     handleScrollUpHalfPage,
-			Priority:    120,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceNavigation,
-			ID:          config.ActionID(config.NamespaceNavigation, "scroll_down_half_page"),
-			Keys:        []string{"shift+down"},
-			Description: "scroll down half page",
-			Category:    "navigation",
-			Handler:     handleScrollDownHalfPage,
-			Priority:    120,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceNavigation,
-			ID:          config.ActionID(config.NamespaceNavigation, "page_up"),
-			Keys:        []string{"pgup", "page_up"},
-			Description: "page up",
-			Category:    "navigation",
-			Handler:     handlePageUp,
-			Priority:    120,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-		{
-			Namespace:   config.NamespaceNavigation,
-			ID:          config.ActionID(config.NamespaceNavigation, "page_down"),
-			Keys:        []string{"pgdn", "pgdown", "page_down"},
-			Description: "page down",
-			Category:    "navigation",
-			Handler:     handlePageDown,
-			Priority:    120,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStateChat},
-			},
-		},
-	}
-}
+		{ID: config.ActionID(config.NamespaceClipboard, "paste_text"), Handler: handlePaste, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceClipboard, "copy_text"), Handler: handleCopy, Context: chatView()},
 
-// createApprovalActions creates key actions specific to approval view
-func (r *Registry) createApprovalActions() []*KeyAction {
-	return []*KeyAction{
-		{
-			Namespace:   config.NamespacePlanApproval,
-			ID:          config.ActionID(config.NamespacePlanApproval, "plan_approval_left"),
-			Keys:        []string{"left", "h"},
-			Description: "move selection left",
-			Category:    "plan_approval",
-			Handler:     handlePlanApprovalLeft,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStatePlanApproval},
-			},
-		},
-		{
-			Namespace:   config.NamespacePlanApproval,
-			ID:          config.ActionID(config.NamespacePlanApproval, "plan_approval_right"),
-			Keys:        []string{"right", "l"},
-			Description: "move selection right",
-			Category:    "plan_approval",
-			Handler:     handlePlanApprovalRight,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStatePlanApproval},
-			},
-		},
-		{
-			Namespace:   config.NamespacePlanApproval,
-			ID:          config.ActionID(config.NamespacePlanApproval, "plan_approval_accept"),
-			Keys:        []string{"enter", "y"},
-			Description: "accept plan and enable auto-approve mode",
-			Category:    "plan_approval",
-			Handler:     handlePlanApprovalAccept,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStatePlanApproval},
-			},
-		},
-		{
-			Namespace:   config.NamespacePlanApproval,
-			ID:          config.ActionID(config.NamespacePlanApproval, "plan_approval_reject"),
-			Keys:        []string{"n"},
-			Description: "reject plan",
-			Category:    "plan_approval",
-			Handler:     handlePlanApprovalReject,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStatePlanApproval},
-			},
-		},
-		{
-			Namespace:   config.NamespacePlanApproval,
-			ID:          config.ActionID(config.NamespacePlanApproval, "plan_approval_accept_standard"),
-			Keys:        []string{"s"},
-			Description: "accept plan but approve each step (standard mode)",
-			Category:    "plan_approval",
-			Handler:     handlePlanApprovalAcceptStandard,
-			Priority:    150,
-			Enabled:     true,
-			Context: KeyContext{
-				Views: []domain.ViewState{domain.ViewStatePlanApproval},
-			},
-		},
-	}
-}
+		{ID: config.ActionID(config.NamespaceTextEditing, "insert_newline_alt"), Handler: handleInsertNewline, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "insert_newline_ctrl"), Handler: handleInsertNewline, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "move_cursor_left"), Handler: handleCursorLeftOrPlanNav, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "move_cursor_right"), Handler: handleCursorRightOrPlanNav, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "backspace"), Handler: handleBackspace, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "delete_to_beginning"), Handler: handleDeleteToBeginning, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "delete_word_backward"), Handler: handleDeleteWordBackward, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "delete_word_forward"), Handler: handleDeleteWordForward, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "move_cursor_word_left"), Handler: handleMoveCursorWordLeft, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "move_cursor_word_right"), Handler: handleMoveCursorWordRight, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "move_to_beginning"), Handler: handleMoveToBeginning, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "move_to_end"), Handler: handleMoveToEnd, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceTextEditing, "history_up"), Handler: handleHistoryUp, Context: chatView(noApprovalPending)},
+		{ID: config.ActionID(config.NamespaceTextEditing, "history_down"), Handler: handleHistoryDown, Context: chatView(noApprovalPending)},
 
-// registerActionsToLayers registers actions to their appropriate layers
-func (r *Registry) registerActionsToLayers(globalActions, chatActions, scrollActions, approvalActions []*KeyAction) {
-	allActions := append(globalActions, chatActions...)
-	allActions = append(allActions, scrollActions...)
-	allActions = append(allActions, approvalActions...)
+		{ID: config.ActionID(config.NamespaceNavigation, "go_back_in_time"), Handler: handleGoBackInTime, Context: chatView(chatIdleOrCompleted)},
+		{ID: config.ActionID(config.NamespaceNavigation, "scroll_to_top"), Handler: handleScrollToTop, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceNavigation, "scroll_to_bottom"), Handler: handleScrollToBottom, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceNavigation, "scroll_up_half_page"), Handler: handleScrollUpHalfPage, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceNavigation, "scroll_down_half_page"), Handler: handleScrollDownHalfPage, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceNavigation, "page_up"), Handler: handlePageUp, Context: chatView()},
+		{ID: config.ActionID(config.NamespaceNavigation, "page_down"), Handler: handlePageDown, Context: chatView()},
 
-	for _, action := range allActions {
-		if err := r.Register(action); err != nil {
-			continue
-		}
-	}
-
-	for _, action := range globalActions {
-		_ = r.addActionToLayer("global", action)
-	}
-
-	for _, action := range chatActions {
-		_ = r.addActionToLayer("chat_view", action)
-	}
-
-	for _, action := range scrollActions {
-		_ = r.addActionToLayer("chat_view", action)
-	}
-
-	for _, action := range approvalActions {
-		_ = r.addActionToLayer("approval_view", action)
+		{ID: config.ActionID(config.NamespacePlanApproval, "plan_approval_left"), Handler: handlePlanApprovalLeft, Context: planApprovalView},
+		{ID: config.ActionID(config.NamespacePlanApproval, "plan_approval_right"), Handler: handlePlanApprovalRight, Context: planApprovalView},
+		{ID: config.ActionID(config.NamespacePlanApproval, "plan_approval_accept"), Handler: handlePlanApprovalAccept, Context: planApprovalView},
+		{ID: config.ActionID(config.NamespacePlanApproval, "plan_approval_reject"), Handler: handlePlanApprovalReject, Context: planApprovalView},
+		{ID: config.ActionID(config.NamespacePlanApproval, "plan_approval_accept_standard"), Handler: handlePlanApprovalAcceptStandard, Context: planApprovalView},
 	}
 }
 
@@ -1381,7 +808,7 @@ func handleToggleMouseMode(app KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cm
 
 // KeyBindingManager manages the key binding system for ChatApplication
 type KeyBindingManager struct {
-	registry            KeyRegistry
+	registry            *Registry
 	app                 KeyHandlerContext
 	keySequenceBuffer   []string
 	lastKeyTime         time.Time
@@ -1473,7 +900,7 @@ func (m *KeyBindingManager) handleSequenceTimeout(now time.Time, keyMsg tea.KeyP
 		pendingKey := m.keySequenceBuffer[0]
 		m.keySequenceBuffer = m.keySequenceBuffer[:0]
 
-		action := m.registry.Resolve(pendingKey, m.app)
+		action := m.registry.ResolveKey(pendingKey, m.app)
 		if action != nil {
 			pendingCmd := action.Handler(m.app, tea.KeyPressMsg{})
 			newKeyCmd := m.ProcessKey(keyMsg)
@@ -1489,7 +916,7 @@ func (m *KeyBindingManager) handleMultiKeySequence(sequenceKey string, keyMsg te
 		return nil
 	}
 
-	sequenceAction := m.registry.Resolve(sequenceKey, m.app)
+	sequenceAction := m.registry.ResolveKey(sequenceKey, m.app)
 	if sequenceAction != nil {
 		m.keySequenceBuffer = m.keySequenceBuffer[:0]
 		m.sequenceConsumedKey = keyMsg.String()
@@ -1508,7 +935,7 @@ func (m *KeyBindingManager) handleSingleKey(keyStr string, keyMsg tea.KeyPressMs
 		return m.batchCmds(append(cmds, statusCmds...))
 	}
 
-	action := m.registry.Resolve(keyStr, m.app)
+	action := m.registry.Resolve(keyMsg, m.app)
 	if action != nil {
 		m.keySequenceBuffer = m.keySequenceBuffer[:0]
 		actionCmd := action.Handler(m.app, keyMsg)
@@ -1521,19 +948,14 @@ func (m *KeyBindingManager) handleSingleKey(keyStr string, keyMsg tea.KeyPressMs
 }
 
 func (m *KeyBindingManager) showSequenceHint(keyStr string) []tea.Cmd {
-	registry, ok := m.registry.(*Registry)
-	if !ok {
-		return nil
-	}
-
-	sequenceAction := registry.GetSequenceActionForPrefix(keyStr, m.app)
+	sequenceAction := m.registry.GetSequenceActionForPrefix(keyStr, m.app)
 	if sequenceAction == nil {
 		return nil
 	}
 
 	statusCmd := func() tea.Msg {
 		return domain.SetStatusEvent{
-			Message: sequenceAction.Description,
+			Message: sequenceAction.Binding.Help().Desc,
 			Spinner: false,
 		}
 	}
@@ -1583,9 +1005,7 @@ func (m *KeyBindingManager) joinSequence(keys []string) string {
 
 // IsKeyHandledByAction returns true if the key would be handled by a keybinding action
 func (m *KeyBindingManager) IsKeyHandledByAction(keyMsg tea.KeyPressMsg) bool {
-	keyStr := keyMsg.String()
-	action := m.registry.Resolve(keyStr, m.app)
-	return action != nil
+	return m.registry.Resolve(keyMsg, m.app) != nil
 }
 
 // ShouldSkipInputUpdate reports whether a keybinding action fully consumed the
@@ -1596,7 +1016,7 @@ func (m *KeyBindingManager) ShouldSkipInputUpdate(keyMsg tea.KeyPressMsg) bool {
 		m.sequenceConsumedKey = ""
 		return true
 	}
-	action := m.registry.Resolve(keyStr, m.app)
+	action := m.registry.Resolve(keyMsg, m.app)
 	if action == nil {
 		return false
 	}
@@ -1609,22 +1029,14 @@ func (m *KeyBindingManager) GetHelpShortcuts() []HelpShortcut {
 	return m.registry.GetHelpShortcuts(m.app)
 }
 
-// RegisterCustomAction registers a new custom key action
-func (m *KeyBindingManager) RegisterCustomAction(action *KeyAction) error {
-	return m.registry.Register(action)
-}
-
 // GetRegistry returns the underlying registry (for advanced usage)
-func (m *KeyBindingManager) GetRegistry() KeyRegistry {
+func (m *KeyBindingManager) GetRegistry() *Registry {
 	return m.registry
 }
 
 // GetHintFormatter returns a hint formatter for displaying keybinding hints in UI
 func (m *KeyBindingManager) GetHintFormatter() *hints.Formatter {
-	if registry, ok := m.registry.(*Registry); ok {
-		return NewHintFormatterFromRegistry(registry)
-	}
-	return nil
+	return NewHintFormatterFromRegistry(m.registry)
 }
 
 // debugKeyBinding logs key binding events when debug mode is enabled

--- a/internal/ui/keybinding/config_test.go
+++ b/internal/ui/keybinding/config_test.go
@@ -28,11 +28,11 @@ func TestConfigOverrides(t *testing.T) {
 		t.Fatal("Expected mode_cycle_agent_mode action to exist")
 	}
 
-	if len(action.Keys) != 1 || action.Keys[0] != "ctrl+m" {
-		t.Errorf("Expected keys to be [ctrl+m], got %v", action.Keys)
+	if len(action.Binding.Keys()) != 1 || action.Binding.Keys()[0] != "ctrl+m" {
+		t.Errorf("Expected keys to be [ctrl+m], got %v", action.Binding.Keys())
 	}
 
-	if !action.Enabled {
+	if !action.Binding.Enabled() {
 		t.Error("Expected action to be enabled")
 	}
 }
@@ -57,7 +57,7 @@ func TestConfigDisableAction(t *testing.T) {
 		t.Fatal("Expected tools_toggle_tool_expansion action to exist")
 	}
 
-	if action.Enabled {
+	if action.Binding.Enabled() {
 		t.Error("Expected action to be disabled")
 	}
 }
@@ -82,12 +82,12 @@ func TestConfigMultipleKeys(t *testing.T) {
 		t.Fatal("Expected chat_enter_key_handler action to exist")
 	}
 
-	if len(action.Keys) != 2 {
-		t.Errorf("Expected 2 keys, got %d", len(action.Keys))
+	if len(action.Binding.Keys()) != 2 {
+		t.Errorf("Expected 2 keys, got %d", len(action.Binding.Keys()))
 	}
 
 	expectedKeys := map[string]bool{"ctrl+enter": true, "enter": true}
-	for _, key := range action.Keys {
+	for _, key := range action.Binding.Keys() {
 		if !expectedKeys[key] {
 			t.Errorf("Unexpected key: %s", key)
 		}
@@ -106,7 +106,7 @@ func TestConfigWithoutOverrides(t *testing.T) {
 		t.Fatal("Expected global_quit action to exist even without custom bindings")
 	}
 
-	if len(action.Keys) == 0 {
+	if len(action.Binding.Keys()) == 0 {
 		t.Error("Expected default keys to be present")
 	}
 }
@@ -204,7 +204,7 @@ func TestConfigNoRuntimeValidation(t *testing.T) {
 	}
 
 	hasConfigKey := false
-	for _, key := range action.Keys {
+	for _, key := range action.Binding.Keys() {
 		if key == "ctrl+c" {
 			hasConfigKey = true
 			break

--- a/internal/ui/keybinding/hints_adapter.go
+++ b/internal/ui/keybinding/hints_adapter.go
@@ -10,11 +10,11 @@ type keyActionAdapter struct {
 }
 
 func (a *keyActionAdapter) GetKeys() []string {
-	return a.Keys
+	return a.Binding.Keys()
 }
 
 func (a *keyActionAdapter) IsEnabled() bool {
-	return a.Enabled
+	return a.Binding.Enabled()
 }
 
 // registryAdapter adapts Registry to hints.KeyRegistry interface

--- a/internal/ui/keybinding/registry.go
+++ b/internal/ui/keybinding/registry.go
@@ -7,41 +7,83 @@ import (
 	"strings"
 	"sync"
 
+	key "charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
 	config "github.com/inference-gateway/cli/config"
-	domain "github.com/inference-gateway/cli/internal/domain"
 	logger "github.com/inference-gateway/cli/internal/logger"
 )
 
-// Registry implements the KeyRegistry interface
+// Registry holds all key binding actions and resolves key presses against
+// their bubbles/key Bindings. View-scoped actions win over global ones;
+// within a scope, registration order breaks ties.
 type Registry struct {
 	actions map[string]*KeyAction
-	keyMap  map[string]*KeyAction
-	layers  []*KeyLayer
+	ordered []*KeyAction
 	mutex   sync.RWMutex
 }
 
-// NewRegistry creates a new key binding registry
+// NewRegistry creates a registry whose action Bindings are resolved from the
+// keybindings config: built-in defaults merged with any keybindings.yaml
+// overrides. Dispatch and help both read these same Bindings.
 func NewRegistry(cfg *config.Config) *Registry {
 	registry := &Registry{
 		actions: make(map[string]*KeyAction),
-		keyMap:  make(map[string]*KeyAction),
-		layers:  make([]*KeyLayer, 0),
 	}
 
-	registry.initializeLayers()
-	registry.registerDefaultBindings()
+	var kbCfg config.KeybindingsConfig
+	if cfg != nil {
+		kbCfg = cfg.Chat.Keybindings
+	}
 
-	if cfg != nil && cfg.Chat.Keybindings.Enabled {
-		if err := registry.ApplyConfigOverrides(cfg.Chat.Keybindings); err != nil {
-			logger.Warn("failed to apply keybinding overrides", "error", err)
+	resolved, unknown := config.ResolveKeybindings(kbCfg)
+	for _, id := range unknown {
+		logger.Warn("unknown keybinding action in config, ignoring", "action", id)
+	}
+
+	for _, action := range defaultActions() {
+		entry, ok := resolved[action.ID]
+		if !ok {
+			logger.Warn("keybinding action has no default config entry, skipping", "action", action.ID)
+			continue
+		}
+		action.Category = entry.Category
+		action.Binding = newBindingFromEntry(entry)
+		if err := registry.Register(action); err != nil {
+			logger.Warn("failed to register keybinding action", "action", action.ID, "error", err)
 		}
 	}
 
 	return registry
 }
 
-// Register adds a new key binding action to the registry
-// Multiple actions can share the same key - the layer system resolves conflicts based on context
+// newBindingFromEntry builds the dispatch/help binding for a resolved config
+// entry. Key tokens are normalized to the tea.KeyPressMsg.String() vocabulary
+// for matching ("space" → " "), while help keeps the human-readable token.
+func newBindingFromEntry(entry config.KeyBindingEntry) key.Binding {
+	matchKeys := make([]string, len(entry.Keys))
+	for i, k := range entry.Keys {
+		if k == "space" {
+			k = " "
+		}
+		matchKeys[i] = k
+	}
+
+	displayKey := ""
+	if len(entry.Keys) > 0 {
+		sorted := slices.Clone(entry.Keys)
+		slices.Sort(sorted)
+		displayKey = sorted[0]
+	}
+
+	b := key.NewBinding(key.WithKeys(matchKeys...), key.WithHelp(displayKey, entry.Description))
+	if entry.Enabled != nil && !*entry.Enabled {
+		b.SetEnabled(false)
+	}
+	return b
+}
+
+// Register adds a key binding action to the registry.
+// Multiple actions can share the same key - view context resolves conflicts.
 func (r *Registry) Register(action *KeyAction) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
@@ -50,57 +92,59 @@ func (r *Registry) Register(action *KeyAction) error {
 		return fmt.Errorf("key action ID cannot be empty")
 	}
 
-	if len(action.Keys) == 0 {
+	if len(action.Binding.Keys()) == 0 {
 		return fmt.Errorf("key action must have at least one key")
 	}
 
-	for _, key := range action.Keys {
-		keyCount := strings.Count(key, ",") + 1
+	for _, k := range action.Binding.Keys() {
+		keyCount := strings.Count(k, ",") + 1
 		if keyCount > 2 {
-			return fmt.Errorf("key sequence '%s' exceeds maximum length of 2 keys (has %d keys)", key, keyCount)
+			return fmt.Errorf("key sequence '%s' exceeds maximum length of 2 keys (has %d keys)", k, keyCount)
 		}
 	}
 
+	if _, exists := r.actions[action.ID]; !exists {
+		r.ordered = append(r.ordered, action)
+	}
 	r.actions[action.ID] = action
 
-	for _, key := range action.Keys {
-		r.keyMap[key] = action
-	}
-
-	r.addActionToAppropriateLayer(action)
-
 	return nil
 }
 
-// Unregister removes a key binding action from the registry
-func (r *Registry) Unregister(id string) error {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	action, exists := r.actions[id]
-	if !exists {
-		return fmt.Errorf("action '%s' not found", id)
-	}
-
-	for _, key := range action.Keys {
-		delete(r.keyMap, key)
-	}
-
-	delete(r.actions, id)
-
-	return nil
-}
-
-// Resolve finds the appropriate key action for a key press
-func (r *Registry) Resolve(key string, app KeyHandlerContext) *KeyAction {
+// Resolve finds the action bound to a pressed key via key.Matches.
+// View-scoped actions are consulted before global ones, mirroring the old
+// layer priorities.
+func (r *Registry) Resolve(msg tea.KeyPressMsg, app KeyHandlerContext) *KeyAction {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	activeLayers := r.getActiveLayers(app)
+	for _, viewScoped := range []bool{true, false} {
+		for _, action := range r.ordered {
+			if (len(action.Context.Views) > 0) != viewScoped {
+				continue
+			}
+			if key.Matches(msg, action.Binding) && r.canExecuteAction(action, app) {
+				return action
+			}
+		}
+	}
 
-	for _, layer := range activeLayers {
-		if action, exists := layer.Bindings[key]; exists {
-			if r.canExecuteAction(action, app) {
+	return nil
+}
+
+// ResolveKey resolves a raw key string, used for comma-joined sequences
+// ("esc,esc") that never arrive as a single tea.KeyPressMsg — bubbles/key has
+// no chord support, so sequences stay string-matched.
+func (r *Registry) ResolveKey(keyStr string, app KeyHandlerContext) *KeyAction {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	for _, viewScoped := range []bool{true, false} {
+		for _, action := range r.ordered {
+			if (len(action.Context.Views) > 0) != viewScoped {
+				continue
+			}
+			if action.Binding.Enabled() && slices.Contains(action.Binding.Keys(), keyStr) && r.canExecuteAction(action, app) {
 				return action
 			}
 		}
@@ -123,14 +167,9 @@ func (r *Registry) GetActiveActions(app KeyHandlerContext) []*KeyAction {
 	defer r.mutex.RUnlock()
 
 	var actions []*KeyAction
-	seen := make(map[string]bool)
-
-	for _, layer := range r.getActiveLayers(app) {
-		for _, action := range layer.Bindings {
-			if !seen[action.ID] && r.canExecuteAction(action, app) {
-				actions = append(actions, action)
-				seen[action.ID] = true
-			}
+	for _, action := range r.ordered {
+		if action.Binding.Enabled() && r.canExecuteAction(action, app) {
+			actions = append(actions, action)
 		}
 	}
 
@@ -138,7 +177,7 @@ func (r *Registry) GetActiveActions(app KeyHandlerContext) []*KeyAction {
 		if c := cmp.Compare(a.Category, b.Category); c != 0 {
 			return c
 		}
-		return cmp.Compare(a.Description, b.Description)
+		return cmp.Compare(a.Binding.Help().Desc, b.Binding.Help().Desc)
 	})
 
 	return actions
@@ -150,17 +189,14 @@ func (r *Registry) GetHelpShortcuts(app KeyHandlerContext) []HelpShortcut {
 
 	shortcuts := make([]HelpShortcut, 0, len(actions))
 	for _, action := range actions {
-		if len(action.Keys) == 0 {
+		help := action.Binding.Help()
+		if help.Key == "" {
 			continue
 		}
 
-		sortedKeys := make([]string, len(action.Keys))
-		copy(sortedKeys, action.Keys)
-		slices.Sort(sortedKeys)
-
 		shortcuts = append(shortcuts, HelpShortcut{
-			Key:         sortedKeys[0],
-			Description: action.Description,
+			Key:         help.Key,
+			Description: help.Desc,
 			Category:    action.Category,
 		})
 	}
@@ -168,67 +204,19 @@ func (r *Registry) GetHelpShortcuts(app KeyHandlerContext) []HelpShortcut {
 	return shortcuts
 }
 
-// AddLayer adds a new key layer to the registry
-func (r *Registry) AddLayer(layer *KeyLayer) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	r.layers = append(r.layers, layer)
-
-	slices.SortFunc(r.layers, func(a, b *KeyLayer) int {
-		return cmp.Compare(b.Priority, a.Priority)
-	})
-}
-
-// GetLayers returns all registered layers
-func (r *Registry) GetLayers() []*KeyLayer {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-
-	layers := make([]*KeyLayer, len(r.layers))
-	copy(layers, r.layers)
-	return layers
-}
-
-// getActiveLayers returns layers that are currently active
-func (r *Registry) getActiveLayers(app KeyHandlerContext) []*KeyLayer {
-	var activeLayers []*KeyLayer
-
-	for _, layer := range r.layers {
-		if layer.Matcher == nil || layer.Matcher(app) {
-			activeLayers = append(activeLayers, layer)
-		}
-	}
-
-	return activeLayers
-}
-
 // canExecuteAction checks if an action can be executed in current context
 func (r *Registry) canExecuteAction(action *KeyAction, app KeyHandlerContext) bool {
-	if !action.Enabled {
-		return false
-	}
-
 	if len(action.Context.Views) > 0 {
 		currentView := app.GetStateManager().GetCurrentView()
-		found := false
-		for _, view := range action.Context.Views {
-			if view == currentView {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(action.Context.Views, currentView) {
 			return false
 		}
 	}
 
 	if len(action.Context.ExcludeViews) > 0 {
 		currentView := app.GetStateManager().GetCurrentView()
-		for _, view := range action.Context.ExcludeViews {
-			if view == currentView {
-				return false
-			}
+		if slices.Contains(action.Context.ExcludeViews, currentView) {
+			return false
 		}
 	}
 
@@ -241,195 +229,9 @@ func (r *Registry) canExecuteAction(action *KeyAction, app KeyHandlerContext) bo
 	return true
 }
 
-// initializeLayers sets up the default key binding layers
-func (r *Registry) initializeLayers() {
-	r.AddLayer(&KeyLayer{
-		Name:     "component",
-		Priority: 300,
-		Bindings: make(map[string]*KeyAction),
-		Matcher: func(app KeyHandlerContext) bool {
-			return false
-		},
-	})
-
-	r.AddLayer(&KeyLayer{
-		Name:     "file_selection",
-		Priority: 200,
-		Bindings: make(map[string]*KeyAction),
-		Matcher: func(app KeyHandlerContext) bool {
-			return app.GetStateManager().GetCurrentView() == domain.ViewStateFileSelection
-		},
-	})
-
-	r.AddLayer(&KeyLayer{
-		Name:     "chat_view",
-		Priority: 150,
-		Bindings: make(map[string]*KeyAction),
-		Matcher: func(app KeyHandlerContext) bool {
-			return app.GetStateManager().GetCurrentView() == domain.ViewStateChat
-		},
-	})
-
-	r.AddLayer(&KeyLayer{
-		Name:     "model_selection",
-		Priority: 150,
-		Bindings: make(map[string]*KeyAction),
-		Matcher: func(app KeyHandlerContext) bool {
-			return app.GetStateManager().GetCurrentView() == domain.ViewStateModelSelection
-		},
-	})
-
-	r.AddLayer(&KeyLayer{
-		Name:     "plan_approval_view",
-		Priority: 150,
-		Bindings: make(map[string]*KeyAction),
-		Matcher: func(app KeyHandlerContext) bool {
-			return app.GetStateManager().GetCurrentView() == domain.ViewStatePlanApproval
-		},
-	})
-
-	r.AddLayer(&KeyLayer{
-		Name:     "global",
-		Priority: 100,
-		Bindings: make(map[string]*KeyAction),
-		Matcher: func(app KeyHandlerContext) bool {
-			return true
-		},
-	})
-}
-
-// addActionToLayer adds an action to a specific layer
-func (r *Registry) addActionToLayer(layerName string, action *KeyAction) error {
-	for _, layer := range r.layers {
-		if layer.Name == layerName {
-			for _, key := range action.Keys {
-				layer.Bindings[key] = action
-			}
-			return nil
-		}
-	}
-	return fmt.Errorf("layer '%s' not found", layerName)
-}
-
-// addActionToAppropriateLayer adds an action to the most appropriate layer based on its context
-func (r *Registry) addActionToAppropriateLayer(action *KeyAction) {
-	var targetLayer string
-
-	if len(action.Context.Views) == 0 {
-		targetLayer = "global"
-	} else {
-		targetLayer = r.determineTargetLayer(action.Context.Views)
-	}
-
-	if targetLayer == "" {
-		targetLayer = "global"
-	}
-
-	_ = r.addActionToLayer(targetLayer, action)
-}
-
-// determineTargetLayer determines the appropriate layer for the given views
-func (r *Registry) determineTargetLayer(views []domain.ViewState) string {
-	for _, view := range views {
-		switch view {
-		case domain.ViewStateFileSelection:
-			return "file_selection"
-		case domain.ViewStateModelSelection:
-			return "model_selection"
-		case domain.ViewStateConversationSelection:
-			return "conversation_selection"
-		case domain.ViewStateChat:
-			return "chat_view"
-		default:
-			return "global"
-		}
-	}
-	return "global"
-}
-
-// ApplyConfigOverrides applies keybinding configuration from config
-// Only processes config bindings. Missing entries automatically use defaults already registered.
-func (r *Registry) ApplyConfigOverrides(cfg config.KeybindingsConfig) error {
-	if !cfg.Enabled {
-		logger.Debug("keybindings disabled in config, using defaults only")
-		return nil
-	}
-
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	knownDefaults := config.DefaultKeybindingActionIDs()
-
-	for actionID, configBinding := range cfg.Bindings {
-		action, exists := r.actions[actionID]
-		if !exists {
-			if _, ok := knownDefaults[actionID]; ok {
-				continue
-			}
-			logger.Warn("unknown keybinding action in config, ignoring", "action", actionID)
-			continue
-		}
-
-		if configBinding.Enabled != nil {
-			action.Enabled = *configBinding.Enabled
-		}
-
-		if len(configBinding.Keys) > 0 {
-			r.updateActionKeysUnsafe(action, configBinding.Keys)
-		}
-	}
-
-	return nil
-}
-
-// updateActionKeysUnsafe updates the keys for an action without validation
-// Used at runtime to apply config without blocking on conflicts
-func (r *Registry) updateActionKeysUnsafe(action *KeyAction, newKeys []string) {
-	for _, oldKey := range action.Keys {
-		delete(r.keyMap, oldKey)
-		r.removeKeyFromLayers(oldKey, action)
-	}
-
-	action.Keys = newKeys
-
-	for _, newKey := range newKeys {
-		r.keyMap[newKey] = action
-	}
-
-	r.addActionToAppropriateLayer(action)
-}
-
-// removeKeyFromLayers removes a key from all layers
-func (r *Registry) removeKeyFromLayers(key string, action *KeyAction) {
-	for _, layer := range r.layers {
-		if layerAction, exists := layer.Bindings[key]; exists && layerAction.ID == action.ID {
-			delete(layer.Bindings, key)
-		}
-	}
-}
-
 // HasSequenceWithPrefix checks if any registered action has a key sequence that starts with the given prefix
 func (r *Registry) HasSequenceWithPrefix(prefix string, app KeyHandlerContext) bool {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-
-	for _, action := range r.actions {
-		if !r.canExecuteAction(action, app) {
-			continue
-		}
-
-		for _, key := range action.Keys {
-			if !strings.Contains(key, ",") {
-				continue
-			}
-
-			if strings.HasPrefix(key, prefix+",") || key == prefix {
-				return true
-			}
-		}
-	}
-
-	return false
+	return r.GetSequenceActionForPrefix(prefix, app) != nil
 }
 
 // GetSequenceActionForPrefix returns the action that matches a sequence starting with the given prefix
@@ -437,17 +239,17 @@ func (r *Registry) GetSequenceActionForPrefix(prefix string, app KeyHandlerConte
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	for _, action := range r.actions {
-		if !r.canExecuteAction(action, app) {
+	for _, action := range r.ordered {
+		if !action.Binding.Enabled() || !r.canExecuteAction(action, app) {
 			continue
 		}
 
-		for _, key := range action.Keys {
-			if !strings.Contains(key, ",") {
+		for _, k := range action.Binding.Keys() {
+			if !strings.Contains(k, ",") {
 				continue
 			}
 
-			if strings.HasPrefix(key, prefix+",") || key == prefix {
+			if strings.HasPrefix(k, prefix+",") || k == prefix {
 				return action
 			}
 		}
@@ -459,8 +261,8 @@ func (r *Registry) GetSequenceActionForPrefix(prefix string, app KeyHandlerConte
 // KnownActionIDs returns every action ID the application recognises: the runtime
 // registry actions unioned with the default keybindings config IDs (which include
 // the namespace-path actions consumed directly via config.ResolveNamespaceBindings).
-// The CLI validator and ApplyConfigOverrides share this notion of "valid" so they
-// agree on what is a genuine typo.
+// The CLI validator shares this notion of "valid" so they agree on what is a
+// genuine typo.
 func (r *Registry) KnownActionIDs() []string {
 	ids := make(map[string]struct{})
 
@@ -487,10 +289,7 @@ func (r *Registry) ListAllActions() []*KeyAction {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	actions := make([]*KeyAction, 0, len(r.actions))
-	for _, action := range r.actions {
-		actions = append(actions, action)
-	}
+	actions := slices.Clone(r.ordered)
 
 	slices.SortFunc(actions, func(a, b *KeyAction) int {
 		if c := cmp.Compare(a.Category, b.Category); c != 0 {

--- a/internal/ui/keybinding/registry_test.go
+++ b/internal/ui/keybinding/registry_test.go
@@ -3,6 +3,7 @@ package keybinding_test
 import (
 	"testing"
 
+	key "charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -81,28 +82,28 @@ func TestKeyResolution(t *testing.T) {
 	registry := keybinding.NewRegistry(nil)
 	mockContext := newTestContext(domain.ViewStateChat, "test message")
 
-	action := registry.Resolve("ctrl+c", mockContext)
+	action := registry.ResolveKey("ctrl+c", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+c to resolve to an action")
 	} else if action.ID != "global_quit" {
 		t.Errorf("Expected ctrl+c to resolve to 'global_quit', got %s", action.ID)
 	}
 
-	action = registry.Resolve("ctrl+o", mockContext)
+	action = registry.ResolveKey("ctrl+o", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+o to resolve to an action")
 	} else if action.ID != "tools_toggle_tool_expansion" {
 		t.Errorf("Expected ctrl+o to resolve to 'tools_toggle_tool_expansion', got %s", action.ID)
 	}
 
-	action = registry.Resolve("ctrl+r", mockContext)
+	action = registry.ResolveKey("ctrl+r", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+r to resolve to an action")
 	} else if action.ID != "display_toggle_raw_format" {
 		t.Errorf("Expected ctrl+r to resolve to 'display_toggle_raw_format', got %s", action.ID)
 	}
 
-	action = registry.Resolve("ctrl+z", mockContext)
+	action = registry.ResolveKey("ctrl+z", mockContext)
 	if action != nil {
 		t.Errorf("Expected ctrl+z to not resolve to any action, got %s", action.ID)
 	}
@@ -144,7 +145,7 @@ func TestActionHandlers(t *testing.T) {
 	registry := keybinding.NewRegistry(nil)
 	mockContext := newTestContext(domain.ViewStateChat, "")
 
-	action := registry.Resolve("ctrl+c", mockContext)
+	action := registry.ResolveKey("ctrl+c", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+c to resolve to quit action")
 	} else {
@@ -154,7 +155,7 @@ func TestActionHandlers(t *testing.T) {
 		}
 	}
 
-	action = registry.Resolve("ctrl+o", mockContext)
+	action = registry.ResolveKey("ctrl+o", mockContext)
 	if action == nil {
 		t.Fatal("Expected ctrl+o to resolve to toggle action")
 	} else {
@@ -206,7 +207,7 @@ func TestConditionalKeyBindings(t *testing.T) {
 	registry := keybinding.NewRegistry(nil)
 
 	emptyInputContext := newTestContext(domain.ViewStateChat, "")
-	action := registry.Resolve("enter", emptyInputContext)
+	action := registry.ResolveKey("enter", emptyInputContext)
 	if action == nil {
 		t.Fatal("Expected enter key to resolve to chat_enter_key_handler even when input is empty")
 	} else if action.ID != "chat_enter_key_handler" {
@@ -214,7 +215,7 @@ func TestConditionalKeyBindings(t *testing.T) {
 	}
 
 	nonEmptyInputContext := newTestContext(domain.ViewStateChat, "hello")
-	action = registry.Resolve("enter", nonEmptyInputContext)
+	action = registry.ResolveKey("enter", nonEmptyInputContext)
 	if action == nil {
 		t.Fatal("Expected enter key to resolve to chat_enter_key_handler when input has content")
 	} else if action.ID != "chat_enter_key_handler" {
@@ -222,18 +223,62 @@ func TestConditionalKeyBindings(t *testing.T) {
 	}
 }
 
-func TestLayerPriority(t *testing.T) {
+// TestResolveKeyPressMsg exercises the key.Matches dispatch path with a real
+// tea.KeyPressMsg, complementing the string-based ResolveKey tests.
+func TestResolveKeyPressMsg(t *testing.T) {
 	registry := keybinding.NewRegistry(nil)
+	mockContext := newTestContext(domain.ViewStateChat, "test message")
 
-	layers := registry.GetLayers()
-	if len(layers) == 0 {
-		t.Fatal("Expected layers to be initialized")
+	msg := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+	if got := msg.String(); got != "ctrl+c" {
+		t.Fatalf("test setup: msg.String() = %q, want ctrl+c", got)
 	}
 
-	for i := 1; i < len(layers); i++ {
-		if layers[i-1].Priority < layers[i].Priority {
-			t.Errorf("Layers not sorted by priority: layer %d has priority %d, layer %d has priority %d",
-				i-1, layers[i-1].Priority, i, layers[i].Priority)
+	action := registry.Resolve(msg, mockContext)
+	if action == nil {
+		t.Fatal("Expected ctrl+c key press to resolve to an action")
+	}
+	if action.ID != "global_quit" {
+		t.Errorf("Expected ctrl+c to resolve to 'global_quit', got %s", action.ID)
+	}
+}
+
+// TestDefaultsSingleSourceOfTruth is the drift guard: every runtime action must
+// have its keys defined in config.GetDefaultKeybindings() (the single source of
+// truth), and no two actions active in the same view may share a key.
+func TestDefaultsSingleSourceOfTruth(t *testing.T) {
+	registry := keybinding.NewRegistry(nil)
+	defaults := config.GetDefaultKeybindings()
+
+	type claim struct {
+		actionID string
+		global   bool
+	}
+	claimed := make(map[string][]claim)
+
+	for _, action := range registry.ListAllActions() {
+		def, ok := defaults[action.ID]
+		if !ok {
+			t.Errorf("action %s has no entry in config.GetDefaultKeybindings()", action.ID)
+			continue
+		}
+		if len(def.Keys) == 0 {
+			t.Errorf("action %s has an empty default key list", action.ID)
+		}
+
+		for _, k := range action.Binding.Keys() {
+			for _, view := range action.Context.Views {
+				claimed[string(rune(view))+"|"+k] = append(claimed[string(rune(view))+"|"+k], claim{action.ID, false})
+			}
+			if len(action.Context.Views) == 0 {
+				claimed["global|"+k] = append(claimed["global|"+k], claim{action.ID, true})
+			}
+		}
+	}
+
+	for key, claims := range claimed {
+		if len(claims) > 1 {
+			t.Errorf("key %q is bound by multiple actions in the same view scope: %v", key, claims)
 		}
 	}
 }
@@ -242,15 +287,12 @@ func TestActionRegistration(t *testing.T) {
 	registry := keybinding.NewRegistry(nil)
 
 	customAction := &keybinding.KeyAction{
-		ID:          "test_action",
-		Keys:        []string{"ctrl+shift+t"},
-		Description: "test action",
-		Category:    "test",
+		ID:       "test_action",
+		Category: "test",
+		Binding:  key.NewBinding(key.WithKeys("ctrl+shift+t"), key.WithHelp("ctrl+shift+t", "test action")),
 		Handler: func(app keybinding.KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cmd {
 			return nil
 		},
-		Priority: 100,
-		Enabled:  true,
 		Context: keybinding.KeyContext{
 			Views: []domain.ViewState{domain.ViewStateChat},
 		},
@@ -269,7 +311,7 @@ func TestActionRegistration(t *testing.T) {
 	}
 
 	mockContext := newTestContext(domain.ViewStateChat, "")
-	resolvedAction := registry.Resolve("ctrl+shift+t", mockContext)
+	resolvedAction := registry.ResolveKey("ctrl+shift+t", mockContext)
 	if resolvedAction == nil {
 		t.Fatal("Expected custom action to be resolved")
 	} else if resolvedAction.ID != "test_action" {
@@ -281,15 +323,12 @@ func TestActionConflictDetection(t *testing.T) {
 	registry := keybinding.NewRegistry(nil)
 
 	conflictingAction := &keybinding.KeyAction{
-		ID:          "test_conflicting_action",
-		Keys:        []string{"ctrl+c"},
-		Description: "conflicting action",
-		Category:    "test",
+		ID:       "test_conflicting_action",
+		Category: "test",
+		Binding:  key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "conflicting action")),
 		Handler: func(app keybinding.KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cmd {
 			return nil
 		},
-		Priority: 100,
-		Enabled:  true,
 		Context: keybinding.KeyContext{
 			Views: []domain.ViewState{domain.ViewStateChat},
 		},
@@ -309,7 +348,7 @@ func TestDeleteWordBackwardBindings(t *testing.T) {
 		t.Helper()
 		ctx := newTestContext(domain.ViewStateChat, "hello world")
 		for _, key := range wordDeleteKeys {
-			action := registry.Resolve(key, ctx)
+			action := registry.ResolveKey(key, ctx)
 			if action == nil {
 				t.Fatalf("expected %q to resolve to an action", key)
 			}

--- a/internal/ui/keybinding/types.go
+++ b/internal/ui/keybinding/types.go
@@ -1,6 +1,7 @@
 package keybinding
 
 import (
+	key "charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -43,17 +44,16 @@ type KeyHandlerContext interface {
 // Theme is an alias to the ui Theme interface
 type Theme = ui.Theme
 
-// KeyAction represents a key binding action with metadata
+// KeyAction represents a key binding action. Keys, description, and enabled
+// state live in the Binding, which is constructed at registry init from the
+// resolved keybindings config (defaults + keybindings.yaml overrides) — the
+// single source of truth shared by dispatch and help rendering.
 type KeyAction struct {
-	ID          string
-	Namespace   config.KeyNamespace
-	Keys        []string
-	Description string
-	Category    string
-	Handler     KeyHandler
-	Context     KeyContext
-	Priority    int
-	Enabled     bool
+	ID       string
+	Category string
+	Binding  key.Binding
+	Handler  KeyHandler
+	Context  KeyContext
 }
 
 // KeyContext defines when and where a key binding is active
@@ -67,29 +67,6 @@ type KeyContext struct {
 type ContextCondition struct {
 	Name  string
 	Check func(app KeyHandlerContext) bool
-}
-
-// KeyLayer represents a layer of key bindings with specific priority
-type KeyLayer struct {
-	Name     string
-	Priority int
-	Bindings map[string]*KeyAction
-	Matcher  LayerMatcher
-}
-
-// LayerMatcher determines if a layer is currently active
-type LayerMatcher func(app KeyHandlerContext) bool
-
-// KeyRegistry manages all key bindings and their resolution
-type KeyRegistry interface {
-	Register(action *KeyAction) error
-	Unregister(id string) error
-	Resolve(key string, app KeyHandlerContext) *KeyAction
-	GetAction(id string) *KeyAction
-	GetActiveActions(app KeyHandlerContext) []*KeyAction
-	GetHelpShortcuts(app KeyHandlerContext) []HelpShortcut
-	AddLayer(layer *KeyLayer)
-	GetLayers() []*KeyLayer
 }
 
 // HelpShortcut represents a key shortcut for help display


### PR DESCRIPTION
Closes #831

## What

- **Single source of truth for defaults**: keys, descriptions, and categories now live only in `config.GetDefaultKeybindings()`. The new `config.ResolveKeybindings` merges `keybindings.yaml` overrides once at load, and `NewRegistry` materializes each action as a `key.Binding`. The ~640 lines of duplicated action literals in `actions.go` collapse to a spec list of ID + handler + view context.
- **Dispatch via `key.Matches`**: the 6-layer priority system, `keyMap`, `ApplyConfigOverrides` mutation plumbing, and the single-implementation `KeyRegistry` interface are deleted. Resolution is a flat two-pass scan (view-scoped actions before global). Comma-joined sequences (`esc,esc`) stay string-matched since bubbles/key has no chord support; the sequence buffer, 300ms timeout, and textarea pass-through contract are preserved verbatim.
- **Help = dispatch**: the help bar, hints, and `infer keybindings list` read the same `Binding` objects dispatch uses.
- **chat.go precedence guards**: the attachments-tree, status-bar, question-form, and message-history focus handlers now dispatch via `key.Matches` against binding sets in `internal/app/chat_keymap.go`; the config-backed `focus_attachments` binding replaces the `chatKeys` string map.
- **Fixes two real drifts** the old duplication had already produced: `chat_tab_key_handler` was missing from the config defaults, and `page_down` lacked the `pgdown` token.
- A drift-guard test now asserts every runtime action has a config default entry and no two actions share a key within the same view scope.

## Acceptance criteria

- [x] chat.go key switches replaced by `key.Matches` dispatch
- [x] `keybindings.yaml` remapping still works; the help bar reflects actual bindings from the same source of truth
- [x] `internal/ui/keybinding` shrinks substantially: 3518 → 2745 LOC; dispatch core registry.go 503→302, types.go 100→77, actions.go 1817→1229. This lands at ~35% rather than the issue's "half" — the remaining bulk is the 44 handler functions (behavior, not dispatch plumbing); relocating them would be churn, not deletion.

## Out of scope (follow-up)

Per-view raw `switch keyMsg.String()` handlers (task_management_view, model_selection_view, file_explorer, conversation_selection_view, help_view, a2a_agents_view, tools_view, theme_selection_view, autocomplete, input_view) — each is a mechanical follow-up using the same pattern.

## Verification

- `task test` (50 packages), `task test:e2e`, `task lint` all green
- Live TUI smoke against the mock gateway: help bar (`?`), shift+tab mode cycle, message send, `esc,esc` history chord, history navigation, `ctrl+r`/`ctrl+s` toggles
- Remap check: `global_new_session: ctrl+n` override — dispatch and `keybindings list`/`validate` both honor it, `ctrl+l` goes inert; per-action `enabled: false` disables and marks in list

no docs ticket: internal-only refactor