### PR TITLE
refactor: consolidate interactive forms on huh/v2, unify spinners, author the huh-v2 skill

### DIFF
--- a/.agents/skills/huh-v2/SKILL.md
+++ b/.agents/skills/huh-v2/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: huh-v2
+description: >
+  Build interactive terminal forms and prompts with huh v2 (charm.land/huh/v2):
+  Form/Group/Field composition, Select/MultiSelect/Input/Confirm/Text/FilePicker,
+  embedding forms inside a Bubble Tea v2 model, standalone Run() prompts, theming,
+  and filtering. Use when adding or reviewing any interactive form, picker, wizard,
+  confirm, or approval prompt with this stack. v2's Theme became an interface and
+  forms complete via internal command messages, so lead with the contract and the
+  v1->v2 table - never write from v1 memory.
+license: Apache-2.0
+---
+
+# Huh v2
+
+Terminal forms for Bubble Tea v2. Import `charm.land/huh/v2`; pinned to v2.0.3.
+A `Form` is a sequence of `Group`s (one visible at a time); a `Group` holds
+`Field`s. Values bind to your variables via `.Value(&x)`.
+
+## The contract: embedding a form in a Bubble Tea model
+
+The canonical in-repo example is
+`internal/ui/components/init_github_action_view.go`. Hold a `*huh.Form`,
+delegate `Update`, type-assert the returned model, switch on `form.State`,
+and rebuild + `Init()` a fresh form per phase:
+
+```go
+type wizard struct {
+    form *huh.Form
+    name string
+}
+
+func (w *wizard) buildForm() *huh.Form {
+    return huh.NewForm(
+        huh.NewGroup(
+            huh.NewInput().Title("Name").Validate(notEmpty).Value(&w.name),
+        ),
+    ).WithWidth(w.width).WithTheme(huhTheme(w.styleProvider))
+}
+
+func (w *wizard) Init() tea.Cmd { return w.form.Init() }
+
+func (w *wizard) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    form, cmd := w.form.Update(msg)
+    if f, ok := form.(*huh.Form); ok {
+        w.form = f
+    }
+    switch w.form.State {
+    case huh.StateCompleted: // bound values are now set
+        return w, w.advance() // next phase: rebuild form, return form.Init()
+    case huh.StateAborted:   // quit key pressed (ctrl+c by default)
+        return w, tea.Quit
+    }
+    return w, cmd
+}
+
+func (w *wizard) View() tea.View { return tea.NewView(w.form.View()) }
+```
+
+**Every message must reach the form.** Enter/next/submit work through huh's
+internal command messages (`nextFieldMsg`, `nextGroupMsg`): the field returns
+a cmd, the runtime executes it, and the resulting message must be routed back
+into `form.Update` or the form stalls one step before completion. This is
+automatic when the form's owner is the top-level model; when the form floats
+inside a larger app (see `question_form_view.go` + `forwardToOverlayForms` in
+`internal/app/chat.go`), forward non-key messages explicitly. The same applies
+to tests: pump returned cmds back through the form instead of asserting after
+a single `Update` call.
+
+## v2 vs the v1 you remember
+
+| Topic | v1 | v2 |
+| --- | --- | --- |
+| Import | `github.com/charmbracelet/huh` | `charm.land/huh/v2` |
+| `Theme` | struct | **interface** `Theme(isDark bool) *Styles`; adapt funcs with `huh.ThemeFunc` |
+| Built-in themes | `huh.ThemeCharm()` returns `*Theme` | `huh.ThemeCharm(isDark bool) *Styles` (same for Dracula/Catppuccin/Base/Base16) |
+| Accessible mode | per-field `WithAccessible` | form-level only: `Form.WithAccessible(true)`; field methods removed |
+| Bubble Tea types | v1 `tea.Cmd`/`tea.Msg` | `charm.land/bubbletea/v2` throughout |
+| Styling types | Lip Gloss v1 | Lip Gloss v2 (see **lipgloss-v2**) |
+| Button alignment | v1 `lipgloss.Position` | v2 `lipgloss.Position` |
+| Form model | unexported | `huh.Model` exported; `Form.View()` returns `string` |
+
+## Fields you'll reach for
+
+| Field | Purpose | Must-know |
+| --- | --- | --- |
+| `Input` | one-line text | `.Validate(func(string) error)`, `.Placeholder` |
+| `Text` | multi-line text | `.Lines(n)` |
+| `Select[T]` | pick one | generic over the value type; `.Height(n)` viewport; `/` filter built in; `.Inline(true)` = one-line ←/→ carousel; `.OptionsFunc` for dynamic options; `.GetFiltering()` |
+| `MultiSelect[T]` | pick many | toggle with space/x; `.Validate` for "at least one" |
+| `Confirm` | yes/no | `.Affirmative("Yes")` / `.Negative("No")` |
+| `FilePicker` | pick a file | `.CurrentDirectory`, `.AllowedTypes([]string{".pem"})`, `.Height` |
+| `Note` | static text | display-only card |
+
+Options carry a display key and a typed value: `huh.NewOption("label", value)`.
+`huh.NewOptions("a", "b")` when key == value.
+
+## Best practices & gotchas
+
+- **Forms are one-shot.** After `StateCompleted`/`StateAborted` a form is
+  done; build a new one (and run its `Init()`) to show it again. Reset bound
+  variables when rebuilding - they keep their last values.
+- **Quit is ctrl+c only by default; esc does NOT abort.** Rebind when needed:
+  `km := huh.NewDefaultKeyMap(); km.Quit = key.NewBinding(key.WithKeys("esc"))`
+  then `.WithKeyMap(km)`. Beware: form-level Quit wins over field keys, so
+  binding esc to Quit breaks Select's esc-clears-filter.
+- **Enter is both next-field and submit** in the default keymap; the last
+  group's completion submits the form.
+- **Select's `/` filter is substring, not fuzzy**, and matches `option.Key` -
+  including any suffix text you baked into the label.
+- **Conditional groups**: `huh.NewGroup(...).WithHideFunc(func() bool)` -
+  evaluated live, the standard trick for "show this input only when X chosen"
+  (see the private-key fallbacks in `init_github_action_view.go`).
+- **Theming**: this repo maps the active style-provider palette via
+  `huhTheme(styleProvider)` in `internal/ui/components/huh_theme.go` - use it
+  on every form (`.WithTheme(huhTheme(p))`). The theme is captured at build
+  time; the rebuild-per-phase pattern picks up theme switches for free.
+- **Plain-terminal prompts** (outside any Bubble Tea program): call `Run()`
+  directly - `huh.NewConfirm().Title("Proceed?").Value(&ok).Run()` runs its
+  own mini program (see `confirmInstall` in `cmd/plugins.go`). Guard for
+  non-interactive stdin first.
+- **Sizing**: overlay forms never see `tea.WindowSizeMsg`; set `.WithWidth`
+  from your component's own width at build time.
+
+Pairs with **bubbletea-v2** (the runtime), **bubbles-v2** (components), and
+**lipgloss-v2** (styling). Pinned to huh v2.0.3.

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	huh "charm.land/huh/v2"
 	cobra "github.com/spf13/cobra"
 
 	config "github.com/inference-gateway/cli/config"
@@ -257,14 +257,11 @@ func confirmInstall(yes bool) error {
 	if err != nil || (stat.Mode()&os.ModeCharDevice) == 0 {
 		return fmt.Errorf("confirmation required on non-interactive stdin - pass --yes to proceed")
 	}
-	fmt.Print("Proceed? [y/N]: ")
-	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
-	switch strings.ToLower(strings.TrimSpace(line)) {
-	case "y", "yes":
-		return nil
-	default:
+	var ok bool
+	if err := huh.NewConfirm().Title("Proceed with installation?").Value(&ok).Run(); err != nil || !ok {
 		return fmt.Errorf("installation aborted")
 	}
+	return nil
 }
 
 func printPostInstallNotes() {

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -443,9 +443,6 @@ func (app *ChatApplication) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	viewBefore := app.stateManager.GetCurrentView()
 
-	// View transitions can happen inside commands, between Updates - detect
-	// re-entry into the model selector here and clear its done flag from the
-	// previous selection, or the view bounces straight back to chat.
 	if viewBefore == domain.ViewStateModelSelection && app.lastView != domain.ViewStateModelSelection {
 		app.modelSelector.Reset()
 	}
@@ -716,8 +713,6 @@ func (app *ChatApplication) isInputBlocked(currentView domain.ViewState) bool {
 func (app *ChatApplication) handleModelSelectionView(msg tea.Msg) []tea.Cmd {
 	var cmds []tea.Cmd
 
-	// Always reassign and check selection state: huh-driven completion can
-	// return a nil cmd on the final keypress.
 	model, cmd := app.modelSelector.Update(msg)
 	app.modelSelector = model.(*components.ModelSelectorImpl)
 	if cmd != nil {
@@ -796,8 +791,6 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 	var cmds []tea.Cmd
 
 	// While an AskUserQuestion form is up it captures all keys (like the
-	// tool-approval box). It floats over the chat, so the view stays Chat.
-	// ctrl+c falls through so the user can still cancel the whole turn.
 	if app.stateManager.GetUserQuestionUIState() != nil && !key.Matches(keyMsg, guardKeys.interrupt) {
 		if cmd := app.questionFormView.Forward(keyMsg); cmd != nil {
 			return []tea.Cmd{cmd}
@@ -805,8 +798,6 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 		return nil
 	}
 
-	// The tool-approval inline select takes left/right/enter; everything else
-	// (esc reject, ctrl+c interrupt, typing) keeps its existing binding.
 	if app.stateManager.GetApprovalUIState() != nil {
 		switch keyMsg.Code {
 		case tea.KeyLeft, tea.KeyRight, tea.KeyEnter:

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -454,9 +454,7 @@ func (app *ChatApplication) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if cmd := app.forwardToQuestionForm(msg); cmd != nil {
-		cmds = append(cmds, cmd)
-	}
+	cmds = append(cmds, app.forwardToOverlayForms(msg)...)
 
 	cmds = append(cmds, app.handleViewSpecificMessages(msg)...)
 
@@ -486,21 +484,29 @@ func logSlowUpdate(start time.Time, msg tea.Msg) {
 	}
 }
 
-// forwardToQuestionForm starts the AskUserQuestion huh form when its event
-// arrives and routes non-key messages to it while it is up - huh's internal
-// group/field navigation rides on those messages, so without this the form
-// stalls. Key presses reach it via handleChatViewKeyPress instead.
-func (app *ChatApplication) forwardToQuestionForm(msg tea.Msg) tea.Cmd {
-	if _, ok := msg.(domain.UserQuestionRequestedEvent); ok {
-		return app.questionFormView.Begin()
-	}
-	if app.stateManager.GetUserQuestionUIState() == nil {
+// forwardToOverlayForms starts the AskUserQuestion / tool-approval huh forms
+// when their events arrive and routes non-key messages to them while they are
+// up - huh's internal group/field navigation rides on those messages, so
+// without this the forms stall. Key presses reach them via
+// handleChatViewKeyPress instead.
+func (app *ChatApplication) forwardToOverlayForms(msg tea.Msg) []tea.Cmd {
+	switch msg.(type) {
+	case domain.UserQuestionRequestedEvent:
+		return []tea.Cmd{app.questionFormView.Begin()}
+	case domain.ToolApprovalRequestedEvent:
+		return []tea.Cmd{app.approvalBoxView.Begin()}
+	case tea.KeyPressMsg:
 		return nil
 	}
-	if _, isKey := msg.(tea.KeyPressMsg); isKey {
-		return nil
+
+	var cmds []tea.Cmd
+	if app.stateManager.GetUserQuestionUIState() != nil {
+		cmds = append(cmds, app.questionFormView.Forward(msg))
 	}
-	return app.questionFormView.Forward(msg)
+	if app.stateManager.GetApprovalUIState() != nil {
+		cmds = append(cmds, app.approvalBoxView.Forward(msg))
+	}
+	return cmds
 }
 
 // isDomainEvent checks if an event should be handled by ChatHandler (positive filtering).
@@ -786,6 +792,18 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 			return []tea.Cmd{cmd}
 		}
 		return nil
+	}
+
+	// The tool-approval inline select takes left/right/enter; everything else
+	// (esc reject, ctrl+c interrupt, typing) keeps its existing binding.
+	if app.stateManager.GetApprovalUIState() != nil {
+		switch keyMsg.Code {
+		case tea.KeyLeft, tea.KeyRight, tea.KeyEnter:
+			if cmd := app.approvalBoxView.Forward(keyMsg); cmd != nil {
+				return []tea.Cmd{cmd}
+			}
+			return nil
+		}
 	}
 
 	if cv, ok := app.conversationView.(*components.ConversationView); ok && cv.IsInMessageHistoryMode() {

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -128,6 +128,7 @@ type ChatApplication struct {
 
 	// Track last key handled by keybinding action to prevent double-handling
 	lastHandledKey string
+	lastView       domain.ViewState
 
 	// Available models
 	availableModels []string
@@ -442,6 +443,13 @@ func (app *ChatApplication) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	viewBefore := app.stateManager.GetCurrentView()
 
+	// View transitions can happen inside commands, between Updates - detect
+	// re-entry into the model selector here and clear its done flag from the
+	// previous selection, or the view bounces straight back to chat.
+	if viewBefore == domain.ViewStateModelSelection && app.lastView != domain.ViewStateModelSelection {
+		app.modelSelector.Reset()
+	}
+
 	var cmds []tea.Cmd
 
 	if cmd := app.handleAppEvents(msg); cmd != nil {
@@ -471,6 +479,8 @@ func (app *ChatApplication) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		!app.messageQueue.IsEmpty() {
 		cmds = append(cmds, func() tea.Msg { return domain.DrainQueueEvent{} })
 	}
+
+	app.lastView = viewBefore
 
 	return app, tea.Batch(cmds...)
 }

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -213,6 +213,7 @@ func NewChatApplication(
 	styleProvider := styles.NewProvider(app.themeService)
 
 	app.toolCallRenderer = components.NewToolCallRenderer(styleProvider)
+	app.toolCallRenderer.SetStateManager(app.stateManager)
 	app.conversationView = factory.CreateConversationView(app.themeService)
 	toolFormatterService := services.NewToolFormatterService(app.toolRegistry, styleProvider)
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -779,6 +779,13 @@ func (app *ChatApplication) handleChatView(msg tea.Msg) []tea.Cmd {
 		return cmds
 	}
 
+	if pasteMsg, ok := msg.(tea.PasteMsg); ok {
+		if cmd := keybinding.HandlePasteEvent(app, pasteMsg.Content); cmd != nil {
+			return []tea.Cmd{cmd}
+		}
+		return nil
+	}
+
 	keyMsg, ok := msg.(tea.KeyPressMsg)
 	if !ok {
 		return cmds

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -706,14 +706,15 @@ func (app *ChatApplication) isInputBlocked(currentView domain.ViewState) bool {
 func (app *ChatApplication) handleModelSelectionView(msg tea.Msg) []tea.Cmd {
 	var cmds []tea.Cmd
 
-	if model, cmd := app.modelSelector.Update(msg); cmd != nil {
+	// Always reassign and check selection state: huh-driven completion can
+	// return a nil cmd on the final keypress.
+	model, cmd := app.modelSelector.Update(msg)
+	app.modelSelector = model.(*components.ModelSelectorImpl)
+	if cmd != nil {
 		cmds = append(cmds, cmd)
-		app.modelSelector = model.(*components.ModelSelectorImpl)
-
-		return app.handleModelSelection(cmds)
 	}
 
-	return cmds
+	return app.handleModelSelection(cmds)
 }
 
 func (app *ChatApplication) handleModelSelection(cmds []tea.Cmd) []tea.Cmd {

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -30,7 +30,6 @@ import (
 	components "github.com/inference-gateway/cli/internal/ui/components"
 	factory "github.com/inference-gateway/cli/internal/ui/components/factory"
 	keybinding "github.com/inference-gateway/cli/internal/ui/keybinding"
-	keys "github.com/inference-gateway/cli/internal/ui/keys"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
@@ -455,6 +454,10 @@ func (app *ChatApplication) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	if cmd := app.forwardToQuestionForm(msg); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+
 	cmds = append(cmds, app.handleViewSpecificMessages(msg)...)
 
 	cmds = append(cmds, app.updateUIComponentsForUIMessages(msg, viewBefore)...)
@@ -481,6 +484,23 @@ func logSlowUpdate(start time.Time, msg tea.Msg) {
 	if d := time.Since(start); d > constants.SlowUpdateThreshold {
 		logger.Warn("slow update", "event", fmt.Sprintf("%T", msg), "ms", d.Milliseconds())
 	}
+}
+
+// forwardToQuestionForm starts the AskUserQuestion huh form when its event
+// arrives and routes non-key messages to it while it is up - huh's internal
+// group/field navigation rides on those messages, so without this the form
+// stalls. Key presses reach it via handleChatViewKeyPress instead.
+func (app *ChatApplication) forwardToQuestionForm(msg tea.Msg) tea.Cmd {
+	if _, ok := msg.(domain.UserQuestionRequestedEvent); ok {
+		return app.questionFormView.Begin()
+	}
+	if app.stateManager.GetUserQuestionUIState() == nil {
+		return nil
+	}
+	if _, isKey := msg.(tea.KeyPressMsg); isKey {
+		return nil
+	}
+	return app.questionFormView.Forward(msg)
 }
 
 // isDomainEvent checks if an event should be handled by ChatHandler (positive filtering).
@@ -762,7 +782,10 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 	// tool-approval box). It floats over the chat, so the view stays Chat.
 	// ctrl+c falls through so the user can still cancel the whole turn.
 	if app.stateManager.GetUserQuestionUIState() != nil && !key.Matches(keyMsg, guardKeys.interrupt) {
-		return app.handleUserQuestionKeys(keyMsg)
+		if cmd := app.questionFormView.Forward(keyMsg); cmd != nil {
+			return []tea.Cmd{cmd}
+		}
+		return nil
 	}
 
 	if cv, ok := app.conversationView.(*components.ConversationView); ok && cv.IsInMessageHistoryMode() {
@@ -938,127 +961,6 @@ func (app *ChatApplication) activateSelectedIndicator() []tea.Cmd {
 	default:
 		return nil
 	}
-}
-
-// handleUserQuestionKeys drives the AskUserQuestion floating form. It mutates
-// the form state in place; Bubble Tea re-renders after each key, so no command
-// is needed. On the final question's confirm it sends the answers on the
-// response channel (unblocking the tool); esc cancels (closing the channel
-// without a value, which the tool reads as "dismissed").
-func (app *ChatApplication) handleUserQuestionKeys(keyMsg tea.KeyPressMsg) []tea.Cmd {
-	sm := app.stateManager
-	q := sm.GetUserQuestionUIState()
-	if q == nil {
-		return nil
-	}
-
-	// Free-text entry on the "Other" row consumes most keys as input.
-	if q.OtherActive[q.CurrentIndex] {
-		app.handleUserQuestionOtherKey(keyMsg)
-		return nil
-	}
-
-	gk := guardKeys
-	switch {
-	case key.Matches(keyMsg, gk.navUp):
-		app.moveUserQuestionCursor(-1)
-	case key.Matches(keyMsg, gk.navDown):
-		app.moveUserQuestionCursor(1)
-	case key.Matches(keyMsg, gk.questionToggle):
-		app.toggleUserQuestionAtCursor()
-	case key.Matches(keyMsg, gk.confirm):
-		app.confirmUserQuestion()
-	case key.Matches(keyMsg, gk.cancel):
-		sm.ClearUserQuestionUIState()
-	}
-	return nil
-}
-
-// handleUserQuestionOtherKey edits the free-text "Other" buffer for the current
-// question. Enter confirms (and advances/submits); esc leaves text entry.
-func (app *ChatApplication) handleUserQuestionOtherKey(keyMsg tea.KeyPressMsg) {
-	sm := app.stateManager
-	gk := guardKeys
-	switch {
-	case key.Matches(keyMsg, gk.confirm):
-		app.confirmUserQuestion()
-	case key.Matches(keyMsg, gk.cancel):
-		sm.SetUserQuestionOtherActive(false)
-	case key.Matches(keyMsg, gk.questionBackspace):
-		sm.BackspaceUserQuestionOtherText()
-	default:
-		if text := keys.PrintableText(keyMsg); text != "" {
-			sm.AppendUserQuestionOtherText(text)
-		}
-	}
-}
-
-// moveUserQuestionCursor moves the option highlight with wrap-around over the
-// real options plus the trailing "Other" row.
-func (app *ChatApplication) moveUserQuestionCursor(delta int) {
-	q := app.stateManager.GetUserQuestionUIState()
-	if q == nil {
-		return
-	}
-	rows := q.OtherRowIndex() + 1
-	app.stateManager.SetUserQuestionOptionCursor(((q.OptionCursor+delta)%rows + rows) % rows)
-}
-
-// toggleUserQuestionAtCursor toggles the highlighted option, or starts free-text
-// entry when the cursor is on the "Other" row.
-func (app *ChatApplication) toggleUserQuestionAtCursor() {
-	q := app.stateManager.GetUserQuestionUIState()
-	if q == nil {
-		return
-	}
-	if q.OnOtherRow() {
-		app.stateManager.SetUserQuestionOtherActive(true)
-		return
-	}
-
-	if q.Questions[q.CurrentIndex].MultiSelect {
-		app.stateManager.ToggleUserQuestionOption(q.OptionCursor)
-	}
-}
-
-// confirmUserQuestion advances to the next question or, on the last one, submits
-// all answers (the current single-select choice already follows the cursor).
-func (app *ChatApplication) confirmUserQuestion() {
-	sm := app.stateManager
-	q := sm.GetUserQuestionUIState()
-	if q == nil {
-		return
-	}
-
-	// Enter on the "Other" row starts free-text entry rather than advancing.
-	if q.OnOtherRow() && !q.OtherActive[q.CurrentIndex] {
-		sm.SetUserQuestionOtherActive(true)
-		return
-	}
-
-	if !userQuestionAnswered(q) {
-		return
-	}
-
-	if !sm.AdvanceUserQuestion() {
-		return // more questions remain; the next one renders
-	}
-
-	answers := sm.BuildUserQuestionAnswers()
-	if q.ResponseChan != nil {
-		q.ResponseChan <- answers
-	}
-	sm.ClearUserQuestionUIState()
-}
-
-// userQuestionAnswered reports whether the current question has a selection or
-// non-empty Other text.
-func userQuestionAnswered(q *domain.UserQuestionUIState) bool {
-	i := q.CurrentIndex
-	if i < 0 || i >= len(q.Questions) {
-		return false
-	}
-	return len(q.Selected[i]) > 0 || strings.TrimSpace(q.OtherText[i]) != ""
 }
 
 func (app *ChatApplication) handleFileSelectionView(msg tea.Msg) []tea.Cmd {

--- a/internal/app/chat_input_routing_test.go
+++ b/internal/app/chat_input_routing_test.go
@@ -138,7 +138,7 @@ func TestModelSelectionSearchDoesNotLeakIntoInput(t *testing.T) {
 		t.Fatalf("selector search keys leaked into disabled input, got %q", got)
 	}
 
-	_, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	pumpApp(app, tea.KeyPressMsg{Code: tea.KeyEnter}, 10)
 	_, _ = app.Update(tea.FocusMsg{})
 
 	if got := inputView.GetInput(); got != "draft prompt" {

--- a/internal/app/question_form_repro_test.go
+++ b/internal/app/question_form_repro_test.go
@@ -38,9 +38,35 @@ func TestQuestionFormReproChain(t *testing.T) {
 
 	fv := components.NewQuestionFormView(styles.NewProvider(domain.NewThemeProvider()), sm)
 	fv.SetWidth(80)
+	_ = fv.Begin()
 	if out := fv.Render(); !strings.Contains(out, "Backend") || !strings.Contains(out, "sqlite") {
 		t.Fatalf("form did not render from shared StateManager:\n%q", out)
 	}
+}
+
+// pumpApp executes the commands returned by app.Update and feeds their
+// messages back in, like the Bubble Tea runtime would. Depth is bounded so
+// self-rearming commands (spinner ticks) can't loop forever.
+func pumpApp(app *ChatApplication, msg tea.Msg, depth int) {
+	_, cmd := app.Update(msg)
+	drainAppCmd(app, cmd, depth)
+}
+
+func drainAppCmd(app *ChatApplication, cmd tea.Cmd, depth int) {
+	if cmd == nil || depth <= 0 {
+		return
+	}
+	msg := cmd()
+	if msg == nil {
+		return
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			drainAppCmd(app, c, depth-1)
+		}
+		return
+	}
+	pumpApp(app, msg, depth-1)
 }
 
 // TestChatApplication_QuestionFormRendersOnEvent reproduces the FULL live path:
@@ -122,7 +148,7 @@ func TestChatApplication_QuestionFormRendersOnEvent(t *testing.T) {
 		t.Fatalf("form disappeared after a tool progress tick; got:\n%s", out2)
 	}
 
-	_, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	pumpApp(app, tea.KeyPressMsg{Code: tea.KeyEnter}, 10)
 
 	if c.GetStateManager().GetUserQuestionUIState() != nil {
 		t.Fatal("form was not cleared after Enter/submit")

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -381,13 +381,6 @@ type PlanApprovalUIManager interface {
 type UserQuestionUIManager interface {
 	SetupUserQuestionUIState(questions []UserQuestion, responseChan chan []UserQuestionAnswer)
 	GetUserQuestionUIState() *UserQuestionUIState
-	SetUserQuestionOptionCursor(idx int)
-	ToggleUserQuestionOption(optIdx int)
-	AdvanceUserQuestion() bool
-	SetUserQuestionOtherActive(active bool)
-	AppendUserQuestionOtherText(text string)
-	BackspaceUserQuestionOtherText()
-	BuildUserQuestionAnswers() []UserQuestionAnswer
 	ClearUserQuestionUIState()
 }
 

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -365,7 +365,6 @@ type FileSelectionManager interface {
 type ApprovalUIManager interface {
 	SetupApprovalUIState(toolCall *sdk.ChatCompletionMessageToolCall, responseChan chan ApprovalAction)
 	GetApprovalUIState() *ApprovalUIState
-	SetApprovalSelectedIndex(index int)
 	ClearApprovalUIState()
 }
 

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -412,33 +412,13 @@ type PlanApprovalUIState struct {
 }
 
 // UserQuestionUIState drives the interactive AskUserQuestion form. The agent
-// loop is blocked in the tool goroutine while this holds the UI's working copy
-// of the in-progress answers. The slices are sized len(Questions): Selected is
-// the set of chosen option indices per question, OtherText/OtherActive back the
-// synthesized free-text "Other" row per question. ResponseChan delivers the
-// final answers slice back to the blocked tool.
+// loop is blocked in the tool goroutine while the form is up; the
+// answer-in-progress state lives in the QuestionFormView's huh form.
+// ResponseChan delivers the final answers slice back to the blocked tool;
+// closing it without a send signals cancellation.
 type UserQuestionUIState struct {
 	Questions    []UserQuestion            `json:"questions"`
-	CurrentIndex int                       `json:"current_index"`
-	OptionCursor int                       `json:"option_cursor"`
-	Selected     []map[int]bool            `json:"selected"`
-	OtherText    []string                  `json:"other_text"`
-	OtherActive  []bool                    `json:"other_active"`
 	ResponseChan chan []UserQuestionAnswer `json:"-"`
-}
-
-// OtherRowIndex returns the option-cursor index of the synthesized "Other" row
-// for the current question (it sits just past the last real option).
-func (q *UserQuestionUIState) OtherRowIndex() int {
-	if q.CurrentIndex < 0 || q.CurrentIndex >= len(q.Questions) {
-		return 0
-	}
-	return len(q.Questions[q.CurrentIndex].Options)
-}
-
-// OnOtherRow reports whether the option cursor is on the "Other" free-text row.
-func (q *UserQuestionUIState) OnOtherRow() bool {
-	return q.OptionCursor == q.OtherRowIndex()
 }
 
 // MessageEditState represents the state when editing a message
@@ -981,196 +961,17 @@ func (s *ApplicationState) ClearPlanApprovalUIState() {
 // User Question State Management
 
 // SetupUserQuestionUIState initializes the AskUserQuestion form state for the
-// given questions, pre-sizing the per-question working slices.
+// given questions.
 func (s *ApplicationState) SetupUserQuestionUIState(questions []UserQuestion, responseChan chan []UserQuestionAnswer) {
-	n := len(questions)
-	selected := make([]map[int]bool, n)
-	for i := range selected {
-		selected[i] = make(map[int]bool)
-	}
 	s.userQuestionUIState = &UserQuestionUIState{
 		Questions:    questions,
-		CurrentIndex: 0,
-		OptionCursor: 0,
-		Selected:     selected,
-		OtherText:    make([]string, n),
-		OtherActive:  make([]bool, n),
 		ResponseChan: responseChan,
 	}
-	s.userQuestionUIState.applyCurrentQuestionDefault()
-}
-
-// defaultUserQuestionOption returns the option index to pre-select for a
-// single-select question: the first option whose label is marked "(Recommended)"
-// (case-insensitive), otherwise the first option.
-func defaultUserQuestionOption(q UserQuestion) int {
-	for i, opt := range q.Options {
-		if strings.Contains(strings.ToLower(opt.Label), "(recommended)") {
-			return i
-		}
-	}
-	return 0
-}
-
-// applyCurrentQuestionDefault pre-selects the default option for the current
-// question when it is single-select, so the radio always shows a choice and the
-// cursor starts on it. Multi-select questions start with nothing selected.
-func (q *UserQuestionUIState) applyCurrentQuestionDefault() {
-	if q.CurrentIndex >= len(q.Questions) {
-		return
-	}
-	question := q.Questions[q.CurrentIndex]
-	if question.MultiSelect || len(question.Options) == 0 {
-		return
-	}
-	idx := defaultUserQuestionOption(question)
-	q.OptionCursor = idx
-	sel := q.Selected[q.CurrentIndex]
-	for k := range sel {
-		delete(sel, k)
-	}
-	sel[idx] = true
 }
 
 // GetUserQuestionUIState returns the current AskUserQuestion form state, or nil.
 func (s *ApplicationState) GetUserQuestionUIState() *UserQuestionUIState {
 	return s.userQuestionUIState
-}
-
-// SetUserQuestionOptionCursor sets the highlighted option row for the current
-// question, clamped to [0, OtherRowIndex].
-func (s *ApplicationState) SetUserQuestionOptionCursor(idx int) {
-	q := s.userQuestionUIState
-	if q == nil {
-		return
-	}
-	maxIdx := q.OtherRowIndex()
-	if idx < 0 {
-		idx = 0
-	}
-	if idx > maxIdx {
-		idx = maxIdx
-	}
-	q.OptionCursor = idx
-
-	if q.CurrentIndex < len(q.Questions) && !q.Questions[q.CurrentIndex].MultiSelect {
-		sel := q.Selected[q.CurrentIndex]
-		for k := range sel {
-			delete(sel, k)
-		}
-		if idx < len(q.Questions[q.CurrentIndex].Options) {
-			sel[idx] = true
-			q.OtherActive[q.CurrentIndex] = false
-		}
-	}
-}
-
-// ToggleUserQuestionOption toggles the option at optIdx for the current
-// question. For single-select questions, selecting an option clears any other
-// selection first. Selecting any real option clears the "Other" free-text.
-func (s *ApplicationState) ToggleUserQuestionOption(optIdx int) {
-	q := s.userQuestionUIState
-	if q == nil || q.CurrentIndex >= len(q.Questions) {
-		return
-	}
-	sel := q.Selected[q.CurrentIndex]
-	if q.Questions[q.CurrentIndex].MultiSelect {
-		if sel[optIdx] {
-			delete(sel, optIdx)
-		} else {
-			sel[optIdx] = true
-		}
-		return
-	}
-	// Single-select: replace the selection.
-	wasSelected := sel[optIdx]
-	for k := range sel {
-		delete(sel, k)
-	}
-	if !wasSelected {
-		sel[optIdx] = true
-	}
-	q.OtherActive[q.CurrentIndex] = false
-}
-
-// AdvanceUserQuestion moves to the next question (resetting the option cursor)
-// and reports whether all questions have now been answered.
-func (s *ApplicationState) AdvanceUserQuestion() bool {
-	q := s.userQuestionUIState
-	if q == nil {
-		return true
-	}
-	q.CurrentIndex++
-	q.OptionCursor = 0
-	if q.CurrentIndex >= len(q.Questions) {
-		return true
-	}
-	q.applyCurrentQuestionDefault()
-	return false
-}
-
-// SetUserQuestionOtherActive toggles free-text entry on the "Other" row of the
-// current question. Activating it (single-select) clears the option selection.
-func (s *ApplicationState) SetUserQuestionOtherActive(active bool) {
-	q := s.userQuestionUIState
-	if q == nil || q.CurrentIndex >= len(q.Questions) {
-		return
-	}
-	q.OtherActive[q.CurrentIndex] = active
-	if active && !q.Questions[q.CurrentIndex].MultiSelect {
-		for k := range q.Selected[q.CurrentIndex] {
-			delete(q.Selected[q.CurrentIndex], k)
-		}
-	}
-}
-
-// AppendUserQuestionOtherText appends typed text to the current question's
-// "Other" buffer.
-func (s *ApplicationState) AppendUserQuestionOtherText(text string) {
-	q := s.userQuestionUIState
-	if q == nil || q.CurrentIndex >= len(q.Questions) {
-		return
-	}
-	q.OtherText[q.CurrentIndex] += text
-}
-
-// BackspaceUserQuestionOtherText removes the last rune from the current
-// question's "Other" buffer.
-func (s *ApplicationState) BackspaceUserQuestionOtherText() {
-	q := s.userQuestionUIState
-	if q == nil || q.CurrentIndex >= len(q.Questions) {
-		return
-	}
-	buf := q.OtherText[q.CurrentIndex]
-	if buf == "" {
-		return
-	}
-	r := []rune(buf)
-	q.OtherText[q.CurrentIndex] = string(r[:len(r)-1])
-}
-
-// BuildUserQuestionAnswers materializes the answers from the working state.
-func (s *ApplicationState) BuildUserQuestionAnswers() []UserQuestionAnswer {
-	q := s.userQuestionUIState
-	if q == nil {
-		return nil
-	}
-	answers := make([]UserQuestionAnswer, 0, len(q.Questions))
-	for i, question := range q.Questions {
-		labels := make([]string, 0, len(question.Options))
-		for optIdx := range question.Options {
-			if q.Selected[i][optIdx] {
-				labels = append(labels, question.Options[optIdx].Label)
-			}
-		}
-		answers = append(answers, UserQuestionAnswer{
-			Header:         question.Header,
-			Question:       question.Question,
-			SelectedLabels: labels,
-			OtherText:      strings.TrimSpace(q.OtherText[i]),
-		})
-	}
-	return answers
 }
 
 // ClearUserQuestionUIState clears the AskUserQuestion form state and closes the

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -637,18 +637,21 @@ func (s *ApplicationState) isValidChatStatusTransition(from, to ChatStatus) bool
 		ChatStatusStarting: {
 			ChatStatusThinking,
 			ChatStatusGenerating,
+			ChatStatusWaitingTools,
 			ChatStatusError,
 			ChatStatusCancelled,
 		},
 		ChatStatusThinking: {
 			ChatStatusGenerating,
 			ChatStatusReceivingTools,
+			ChatStatusWaitingTools,
 			ChatStatusCompleted,
 			ChatStatusError,
 			ChatStatusCancelled,
 		},
 		ChatStatusGenerating: {
 			ChatStatusReceivingTools,
+			ChatStatusWaitingTools,
 			ChatStatusCompleted,
 			ChatStatusError,
 			ChatStatusCancelled,

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -398,7 +398,6 @@ type FileSelectionState struct {
 
 // ApprovalUIState represents the state of approval UI
 type ApprovalUIState struct {
-	SelectedIndex   int                                `json:"selected_index"`
 	PendingToolCall *sdk.ChatCompletionMessageToolCall `json:"pending_tool_call"`
 	ResponseChan    chan ApprovalAction                `json:"-"`
 }
@@ -900,7 +899,6 @@ func (s *ApplicationState) ClearFileSelectionState() {
 // SetupApprovalUIState initializes approval UI state with the pending tool call
 func (s *ApplicationState) SetupApprovalUIState(toolCall *sdk.ChatCompletionMessageToolCall, responseChan chan ApprovalAction) {
 	s.approvalUIState = &ApprovalUIState{
-		SelectedIndex:   int(ApprovalApprove),
 		PendingToolCall: toolCall,
 		ResponseChan:    responseChan,
 	}
@@ -909,13 +907,6 @@ func (s *ApplicationState) SetupApprovalUIState(toolCall *sdk.ChatCompletionMess
 // GetApprovalUIState returns the current approval UI state
 func (s *ApplicationState) GetApprovalUIState() *ApprovalUIState {
 	return s.approvalUIState
-}
-
-// SetApprovalSelectedIndex sets the approval selection index
-func (s *ApplicationState) SetApprovalSelectedIndex(index int) {
-	if s.approvalUIState != nil {
-		s.approvalUIState.SelectedIndex = index
-	}
 }
 
 // ClearApprovalUIState clears the approval UI state

--- a/internal/domain/ui_events.go
+++ b/internal/domain/ui_events.go
@@ -285,12 +285,6 @@ type TriggerGithubActionSetupEvent struct{}
 // lists every slash command and keybinding in two tables.
 type TriggerHelpViewEvent struct{}
 
-// ApprovalSelectionChangedEvent signals that the approval selection index has changed
-// and the UI needs to refresh to show the new selection
-type ApprovalSelectionChangedEvent struct {
-	NewIndex int
-}
-
 // PlanApprovalSelectionChangedEvent signals that the plan-approval button
 // selection has moved and the conversation viewport needs to re-render so
 // the highlighted button reflects the new index.

--- a/internal/domain/user_question_test.go
+++ b/internal/domain/user_question_test.go
@@ -36,94 +36,13 @@ func sampleQuestions() []UserQuestion {
 	}
 }
 
-func TestUserQuestionUIState_SingleSelectDefaultAndFollowsCursor(t *testing.T) {
+func TestUserQuestionUIState_SetupAndGet(t *testing.T) {
 	s := NewApplicationState()
 	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
 
 	st := s.GetUserQuestionUIState()
-	if !st.Selected[0][0] {
-		t.Error("expected the first option to be pre-selected by default")
-	}
-
-	s.SetUserQuestionOptionCursor(1)
-	if st.Selected[0][0] || !st.Selected[0][1] {
-		t.Errorf("expected selection to follow the cursor to option 1, got %v", st.Selected[0])
-	}
-}
-
-func TestUserQuestionUIState_RecommendedDefault(t *testing.T) {
-	s := NewApplicationState()
-	s.SetupUserQuestionUIState([]UserQuestion{
-		{Header: "Fmt", Question: "q", MultiSelect: false, Options: []UserQuestionOption{
-			{Label: "JSON"}, {Label: "YAML (Recommended)"},
-		}},
-	}, make(chan []UserQuestionAnswer, 1))
-
-	st := s.GetUserQuestionUIState()
-	if st.Selected[0][0] || !st.Selected[0][1] {
-		t.Errorf("expected the (Recommended) option pre-selected, got %v", st.Selected[0])
-	}
-	if st.OptionCursor != 1 {
-		t.Errorf("expected the cursor on the recommended option, got %d", st.OptionCursor)
-	}
-}
-
-func TestUserQuestionUIState_MultiSelectAccumulates(t *testing.T) {
-	s := NewApplicationState()
-	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
-
-	if s.AdvanceUserQuestion() {
-		t.Fatal("did not expect to be done after advancing from q0")
-	}
-	s.ToggleUserQuestionOption(0)
-	s.ToggleUserQuestionOption(2)
-
-	st := s.GetUserQuestionUIState()
-	if !st.Selected[1][0] || !st.Selected[1][2] {
-		t.Errorf("expected options 0 and 2 selected, got %v", st.Selected[1])
-	}
-
-	s.ToggleUserQuestionOption(0)
-	if st.Selected[1][0] {
-		t.Error("expected option 0 toggled off")
-	}
-}
-
-func TestUserQuestionUIState_BuildAnswersAndAdvance(t *testing.T) {
-	s := NewApplicationState()
-	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
-
-	if s.AdvanceUserQuestion() {
-		t.Fatal("expected not done after q0")
-	}
-	s.ToggleUserQuestionOption(1)
-	s.SetUserQuestionOtherActive(true)
-	s.AppendUserQuestionOtherText("custom")
-	if !s.AdvanceUserQuestion() {
-		t.Fatal("expected done after the last question")
-	}
-
-	answers := s.BuildUserQuestionAnswers()
-	if len(answers) != 2 {
-		t.Fatalf("expected 2 answers, got %d", len(answers))
-	}
-	if len(answers[0].SelectedLabels) != 1 || answers[0].SelectedLabels[0] != "JSON" {
-		t.Errorf("q0 expected [JSON] (default), got %v", answers[0].SelectedLabels)
-	}
-	if answers[1].OtherText != "custom" {
-		t.Errorf("q1 expected OtherText=custom, got %q", answers[1].OtherText)
-	}
-}
-
-func TestUserQuestionUIState_BackspaceOtherText(t *testing.T) {
-	s := NewApplicationState()
-	s.SetupUserQuestionUIState(sampleQuestions(), make(chan []UserQuestionAnswer, 1))
-
-	s.SetUserQuestionOtherActive(true)
-	s.AppendUserQuestionOtherText("ab")
-	s.BackspaceUserQuestionOtherText()
-	if got := s.GetUserQuestionUIState().OtherText[0]; got != "a" {
-		t.Errorf("expected Other text 'a', got %q", got)
+	if st == nil || len(st.Questions) != 2 {
+		t.Fatalf("expected state with 2 questions, got %+v", st)
 	}
 }
 

--- a/internal/services/chatcompletion/runner.go
+++ b/internal/services/chatcompletion/runner.go
@@ -183,6 +183,8 @@ func (r *Runner) HandleChatComplete(msg domain.ChatCompleteEvent) tea.Cmd {
 	} else if len(msg.ToolCalls) == 0 {
 		_ = r.stateManager.UpdateChatStatus(domain.ChatStatusCompleted)
 		r.stateManager.EndToolExecution()
+	} else {
+		_ = r.stateManager.UpdateChatStatus(domain.ChatStatusWaitingTools)
 	}
 
 	cmds := []tea.Cmd{

--- a/internal/services/chatcompletion/runner_test.go
+++ b/internal/services/chatcompletion/runner_test.go
@@ -362,7 +362,7 @@ func TestRunner_HandleChatComplete(t *testing.T) {
 		}
 	})
 
-	t.Run("with tool calls: does not update status to Completed (waits for tool round-trip)", func(t *testing.T) {
+	t.Run("with tool calls: transitions to WaitingTools to prevent false stall detection", func(t *testing.T) {
 		runner, _, state, _, _ := newRunnerForTest()
 		state.GetChatSessionReturns(nil)
 
@@ -377,11 +377,11 @@ func TestRunner_HandleChatComplete(t *testing.T) {
 			}},
 		})
 
-		// Should NOT have called UpdateChatStatus on a non-cancelled
-		// completion with tool calls - the tool round-trip will end the
-		// status update later.
-		if state.UpdateChatStatusCallCount() != 0 {
-			t.Errorf("expected no UpdateChatStatus call when tool calls present, got %d", state.UpdateChatStatusCallCount())
+		if state.UpdateChatStatusCallCount() != 1 {
+			t.Errorf("expected 1 UpdateChatStatus call with WaitingTools, got %d", state.UpdateChatStatusCallCount())
+		}
+		if status := state.UpdateChatStatusArgsForCall(0); status != domain.ChatStatusWaitingTools {
+			t.Errorf("expected ChatStatusWaitingTools, got %v", status)
 		}
 	})
 }

--- a/internal/services/state_manager.go
+++ b/internal/services/state_manager.go
@@ -623,62 +623,6 @@ func (sm *StateManager) GetUserQuestionUIState() *domain.UserQuestionUIState {
 	return sm.state.GetUserQuestionUIState()
 }
 
-// SetUserQuestionOptionCursor sets the highlighted option row
-func (sm *StateManager) SetUserQuestionOptionCursor(idx int) {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-
-	sm.state.SetUserQuestionOptionCursor(idx)
-}
-
-// ToggleUserQuestionOption toggles the option at optIdx for the current question
-func (sm *StateManager) ToggleUserQuestionOption(optIdx int) {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-
-	sm.state.ToggleUserQuestionOption(optIdx)
-}
-
-// AdvanceUserQuestion moves to the next question and reports whether done
-func (sm *StateManager) AdvanceUserQuestion() bool {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-
-	return sm.state.AdvanceUserQuestion()
-}
-
-// SetUserQuestionOtherActive toggles free-text entry on the "Other" row
-func (sm *StateManager) SetUserQuestionOtherActive(active bool) {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-
-	sm.state.SetUserQuestionOtherActive(active)
-}
-
-// AppendUserQuestionOtherText appends typed text to the current "Other" buffer
-func (sm *StateManager) AppendUserQuestionOtherText(text string) {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-
-	sm.state.AppendUserQuestionOtherText(text)
-}
-
-// BackspaceUserQuestionOtherText removes the last rune from the "Other" buffer
-func (sm *StateManager) BackspaceUserQuestionOtherText() {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-
-	sm.state.BackspaceUserQuestionOtherText()
-}
-
-// BuildUserQuestionAnswers materializes the answers from the working state
-func (sm *StateManager) BuildUserQuestionAnswers() []domain.UserQuestionAnswer {
-	sm.mutex.RLock()
-	defer sm.mutex.RUnlock()
-
-	return sm.state.BuildUserQuestionAnswers()
-}
-
 // ClearUserQuestionUIState clears the AskUserQuestion form state
 func (sm *StateManager) ClearUserQuestionUIState() {
 	sm.mutex.Lock()

--- a/internal/services/state_manager.go
+++ b/internal/services/state_manager.go
@@ -550,14 +550,6 @@ func (sm *StateManager) GetApprovalUIState() *domain.ApprovalUIState {
 	return sm.state.GetApprovalUIState()
 }
 
-// SetApprovalSelectedIndex sets the approval selection index
-func (sm *StateManager) SetApprovalSelectedIndex(index int) {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-
-	sm.state.SetApprovalSelectedIndex(index)
-}
-
 // ClearApprovalUIState clears the approval UI state
 func (sm *StateManager) ClearApprovalUIState() {
 	sm.mutex.Lock()

--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	huh "charm.land/huh/v2"
 
 	sdk "github.com/inference-gateway/sdk"
 
@@ -41,6 +42,12 @@ type ApprovalBoxView struct {
 	styleProvider *styles.Provider
 	stateManager  domain.StateManager
 	toolFormatter domain.ToolFormatter
+
+	// active is the approval state the form was built for; a mismatch with
+	// the StateManager (cleared externally) marks the form stale.
+	active *domain.ApprovalUIState
+	form   *huh.Form
+	choice domain.ApprovalAction
 }
 
 func NewApprovalBoxView(styleProvider *styles.Provider, stateManager domain.StateManager, toolFormatter domain.ToolFormatter) *ApprovalBoxView {
@@ -66,11 +73,66 @@ func (av *ApprovalBoxView) Render() string {
 	}
 
 	approvalState := av.stateManager.GetApprovalUIState()
-	if approvalState == nil || approvalState.PendingToolCall == nil {
+	if approvalState == nil || approvalState.PendingToolCall == nil ||
+		approvalState != av.active || av.form == nil {
 		return ""
 	}
 
 	return av.renderApprovalBox(approvalState)
+}
+
+// Begin builds the action select for the approval currently in the
+// StateManager. Call it when a ToolApprovalRequestedEvent has set up the state.
+func (av *ApprovalBoxView) Begin() tea.Cmd {
+	state := av.stateManager.GetApprovalUIState()
+	if state == nil || state.PendingToolCall == nil {
+		return nil
+	}
+	av.active = state
+	av.choice = domain.ApprovalApprove
+	av.form = huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[domain.ApprovalAction]().
+				Options(
+					huh.NewOption("Approve", domain.ApprovalApprove),
+					huh.NewOption("Reject", domain.ApprovalReject),
+					huh.NewOption("Auto-Approve", domain.ApprovalAutoAccept),
+				).
+				Inline(true).
+				Value(&av.choice),
+		),
+	).
+		WithShowHelp(false).
+		WithWidth(av.summaryBudget()).
+		WithTheme(huhTheme(av.styleProvider))
+	return av.form.Init()
+}
+
+// Forward delegates a message to the action select. On completion it emits the
+// ToolApprovalResponseEvent that the approval coordinator consumes.
+func (av *ApprovalBoxView) Forward(msg tea.Msg) tea.Cmd {
+	state := av.stateManager.GetApprovalUIState()
+	if state == nil || state != av.active || av.form == nil {
+		av.active = nil
+		av.form = nil
+		return nil
+	}
+
+	model, cmd := av.form.Update(msg)
+	if f, ok := model.(*huh.Form); ok {
+		av.form = f
+	}
+
+	if av.form.State == huh.StateCompleted {
+		action := av.choice
+		toolCall := *state.PendingToolCall
+		av.active = nil
+		av.form = nil
+		return func() tea.Msg {
+			return domain.ToolApprovalResponseEvent{Action: action, ToolCall: toolCall}
+		}
+	}
+	return cmd
 }
 
 // renderApprovalBox frames the pending tool call and the action buttons in a
@@ -82,9 +144,8 @@ func (av *ApprovalBoxView) renderApprovalBox(state *domain.ApprovalUIState) stri
 
 	title := av.styleProvider.RenderWithColorAndBold("Approval required", accentColor)
 	body := av.renderBody(state.PendingToolCall)
-	buttons := av.renderApprovalButtons(state.SelectedIndex)
 
-	content := strings.Join([]string{title, body, buttons}, "\n")
+	content := strings.Join([]string{title, body, av.form.View()}, "\n")
 	return av.styleProvider.RenderBorderedBox(content, accentColor, 0, 1)
 }
 
@@ -208,50 +269,6 @@ func (av *ApprovalBoxView) summaryBudget() int {
 		return minApprovalSummaryWidth
 	}
 	return budget
-}
-
-func (av *ApprovalBoxView) renderApprovalButtons(selectedIndex int) string {
-	approveText := "Approve"
-	rejectText := "Reject"
-	autoApproveText := "Auto-Approve"
-
-	successColor := av.styleProvider.GetThemeColor("success")
-	errorColor := av.styleProvider.GetThemeColor("error")
-	accentColor := av.styleProvider.GetThemeColor("accent")
-	highlightBg := av.styleProvider.GetThemeColor("selection_bg")
-
-	var approveStyled, rejectStyled, autoApproveStyled string
-	if selectedIndex == int(domain.ApprovalApprove) {
-		approveStyled = av.styleProvider.RenderStyledText("[ "+approveText+" ]", styles.StyleOptions{
-			Foreground: successColor,
-			Background: highlightBg,
-			Bold:       true,
-		})
-	} else {
-		approveStyled = av.styleProvider.RenderWithColor("[ "+approveText+" ]", successColor)
-	}
-
-	if selectedIndex == int(domain.ApprovalReject) {
-		rejectStyled = av.styleProvider.RenderStyledText("[ "+rejectText+" ]", styles.StyleOptions{
-			Foreground: errorColor,
-			Background: highlightBg,
-			Bold:       true,
-		})
-	} else {
-		rejectStyled = av.styleProvider.RenderWithColor("[ "+rejectText+" ]", errorColor)
-	}
-
-	if selectedIndex == int(domain.ApprovalAutoAccept) {
-		autoApproveStyled = av.styleProvider.RenderStyledText("[ "+autoApproveText+" ]", styles.StyleOptions{
-			Foreground: accentColor,
-			Background: highlightBg,
-			Bold:       true,
-		})
-	} else {
-		autoApproveStyled = av.styleProvider.RenderWithColor("[ "+autoApproveText+" ]", accentColor)
-	}
-
-	return fmt.Sprintf("%s  %s  %s", approveStyled, rejectStyled, autoApproveStyled)
 }
 
 func (av *ApprovalBoxView) Init() tea.Cmd {

--- a/internal/ui/components/approval_box_view_test.go
+++ b/internal/ui/components/approval_box_view_test.go
@@ -245,7 +245,7 @@ func TestApprovalBox_EditDiffUsesTwoContextLines(t *testing.T) {
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(120)
-	av.SetHeight(60) // previewLineLimit -> 30; the small diff is not capped
+	av.SetHeight(60)
 	_ = av.Begin()
 	out := stripANSI(av.Render())
 

--- a/internal/ui/components/approval_box_view_test.go
+++ b/internal/ui/components/approval_box_view_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	sdk "github.com/inference-gateway/sdk"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -34,9 +36,8 @@ func (argsAwareToolFormatter) FormatToolResultExpanded(*domain.ToolExecutionResu
 func (argsAwareToolFormatter) FormatToolResultForLLM(*domain.ToolExecutionResult) string { return "" }
 func (argsAwareToolFormatter) ShouldAlwaysExpandTool(string) bool                        { return false }
 
-func approvalStateWith(toolName, arguments string, selected domain.ApprovalAction) *domain.ApprovalUIState {
+func approvalStateWith(toolName, arguments string) *domain.ApprovalUIState {
 	return &domain.ApprovalUIState{
-		SelectedIndex: int(selected),
 		PendingToolCall: &sdk.ChatCompletionMessageToolCall{
 			ID: "call_1",
 			Function: sdk.ChatCompletionMessageToolCallFunction{
@@ -59,16 +60,18 @@ func TestApprovalBox_EmptyWhenNoPendingCall(t *testing.T) {
 
 func TestApprovalBox_FramesSummaryAndButtons(t *testing.T) {
 	sm := &domainmocks.FakeStateManager{}
-	sm.GetApprovalUIStateReturns(approvalStateWith("Read", `{"file_path":"/x/y.txt"}`, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Read", `{"file_path":"/x/y.txt"}`))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(80)
+	_ = av.Begin()
 	out := av.Render()
 
+	// The inline select shows only the focused option (← Approve →).
 	for _, want := range []string{
 		"Approval required",
 		"Read(file_path=/x/y.txt)",
-		"Approve", "Reject", "Auto-Approve",
+		"Approve",
 		"╭", "╰",
 	} {
 		if !strings.Contains(out, want) {
@@ -77,12 +80,39 @@ func TestApprovalBox_FramesSummaryAndButtons(t *testing.T) {
 	}
 }
 
+func TestApprovalBox_SelectEmitsResponseEvent(t *testing.T) {
+	sm := &domainmocks.FakeStateManager{}
+	sm.GetApprovalUIStateReturns(approvalStateWith("Read", `{"file_path":"/x/y.txt"}`))
+
+	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
+	av.SetWidth(80)
+	_ = av.Begin()
+
+	_ = av.Forward(tea.KeyPressMsg{Code: tea.KeyRight})
+	cmd := av.Forward(tea.KeyPressMsg{Code: tea.KeyEnter})
+	for cmd != nil {
+		msg := cmd()
+		if ev, ok := msg.(domain.ToolApprovalResponseEvent); ok {
+			if ev.Action != domain.ApprovalReject {
+				t.Errorf("expected Reject after one right arrow, got %v", ev.Action)
+			}
+			if ev.ToolCall.ID != "call_1" {
+				t.Errorf("expected the pending tool call echoed, got %+v", ev.ToolCall)
+			}
+			return
+		}
+		cmd = av.Forward(msg)
+	}
+	t.Fatal("expected a ToolApprovalResponseEvent after enter")
+}
+
 func TestApprovalBox_NilFormatterFallsBackToName(t *testing.T) {
 	sm := &domainmocks.FakeStateManager{}
-	sm.GetApprovalUIStateReturns(approvalStateWith("Read", `{"file_path":"/x/y.txt"}`, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Read", `{"file_path":"/x/y.txt"}`))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, nil)
 	av.SetWidth(80)
+	_ = av.Begin()
 	out := av.Render()
 
 	if !strings.Contains(out, "Read(...)") {
@@ -92,10 +122,11 @@ func TestApprovalBox_NilFormatterFallsBackToName(t *testing.T) {
 
 func TestApprovalBox_UnparseableArgsFallBack(t *testing.T) {
 	sm := &domainmocks.FakeStateManager{}
-	sm.GetApprovalUIStateReturns(approvalStateWith("Bash", `not json`, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Bash", `not json`))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(80)
+	_ = av.Begin()
 	out := av.Render()
 
 	if !strings.Contains(out, "Bash(...)") {
@@ -106,10 +137,11 @@ func TestApprovalBox_UnparseableArgsFallBack(t *testing.T) {
 func TestApprovalBox_TruncatesLongSummaryOnNarrowWidth(t *testing.T) {
 	longPath := "/very/long/path/to/some/deeply/nested/file/name/that/keeps/going.txt"
 	sm := &domainmocks.FakeStateManager{}
-	sm.GetApprovalUIStateReturns(approvalStateWith("Read", fmt.Sprintf(`{"file_path":%q}`, longPath), domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Read", fmt.Sprintf(`{"file_path":%q}`, longPath)))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(34)
+	_ = av.Begin()
 	out := av.Render()
 
 	if strings.Contains(out, longPath) {
@@ -126,10 +158,11 @@ func TestApprovalBox_TruncatesLongSummaryOnNarrowWidth(t *testing.T) {
 func TestApprovalBox_RendersEditDiff(t *testing.T) {
 	sm := &domainmocks.FakeStateManager{}
 	args := `{"file_path":"/x/y.txt","old_string":"OLD_CONTENT","new_string":"NEW_CONTENT"}`
-	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(80)
+	_ = av.Begin()
 	out := stripANSI(av.Render())
 
 	if !strings.Contains(out, "/x/y.txt") {
@@ -154,12 +187,13 @@ func TestApprovalBox_CapsLongDiffWithHint(t *testing.T) {
 	args := fmt.Sprintf(`{"file_path":"/x/y.txt","old_string":"","new_string":%q}`, b.String())
 
 	sm := &domainmocks.FakeStateManager{}
-	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(80)
 	av.SetHeight(24) // previewLineLimit -> 12
 
+	_ = av.Begin()
 	out := stripANSI(av.Render())
 
 	if !strings.Contains(out, "more lines") {
@@ -175,10 +209,11 @@ func TestApprovalBox_CapsLongDiffWithHint(t *testing.T) {
 func TestApprovalBox_DiffToolIgnoresFormatter(t *testing.T) {
 	sm := &domainmocks.FakeStateManager{}
 	args := `{"file_path":"/x/y.txt","old_string":"OLD","new_string":"NEW"}`
-	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, nil)
 	av.SetWidth(80)
+	_ = av.Begin()
 	out := stripANSI(av.Render())
 
 	if strings.Contains(out, "Edit(") {
@@ -206,11 +241,12 @@ func TestApprovalBox_EditDiffUsesTwoContextLines(t *testing.T) {
 	args := fmt.Sprintf(`{"file_path":"/x/y.txt","old_string":%q,"new_string":%q}`, oldContextSnippet, newContextSnippet)
 
 	sm := &domainmocks.FakeStateManager{}
-	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(120)
 	av.SetHeight(60) // previewLineLimit -> 30; the small diff is not capped
+	_ = av.Begin()
 	out := stripANSI(av.Render())
 
 	for _, want := range []string{"charlie", "delta", "foxtrot", "golf", "echo_NEW"} {
@@ -232,11 +268,12 @@ func TestApprovalBox_MultiEditKeepsThreeContext(t *testing.T) {
 	args := fmt.Sprintf(`{"file_path":"/x/y.txt","edits":[{"old_string":%q,"new_string":%q}]}`, oldContextSnippet, newContextSnippet)
 
 	sm := &domainmocks.FakeStateManager{}
-	sm.GetApprovalUIStateReturns(approvalStateWith("MultiEdit", args, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("MultiEdit", args))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(120)
 	av.SetHeight(60)
+	_ = av.Begin()
 	out := stripANSI(av.Render())
 
 	for _, want := range []string{"bravo", "hotel", "echo_NEW"} {
@@ -259,11 +296,12 @@ func TestApprovalBox_EditDiffShowsFileContext(t *testing.T) {
 	args := fmt.Sprintf(`{"file_path":%q,"old_string":"TARGET","new_string":"CHANGED"}`, path)
 
 	sm := &domainmocks.FakeStateManager{}
-	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args, domain.ApprovalApprove))
+	sm.GetApprovalUIStateReturns(approvalStateWith("Edit", args))
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(120)
 	av.SetHeight(60)
+	_ = av.Begin()
 	out := stripANSI(av.Render())
 
 	for _, want := range []string{"line2", "line3", "CHANGED", "line5", "line6"} {

--- a/internal/ui/components/conversation_selection_view.go
+++ b/internal/ui/components/conversation_selection_view.go
@@ -9,7 +9,7 @@ import (
 	spinner "charm.land/bubbles/v2/spinner"
 	table "charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
+	lipgloss "charm.land/lipgloss/v2"
 
 	constants "github.com/inference-gateway/cli/internal/constants"
 	domain "github.com/inference-gateway/cli/internal/domain"

--- a/internal/ui/components/conversation_selection_view.go
+++ b/internal/ui/components/conversation_selection_view.go
@@ -54,9 +54,7 @@ func NewConversationSelector(repo shortcuts.PersistentConversationRepository, st
 		loadError:             nil,
 	}
 
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	c.spinner = s
+	c.spinner = newModernSpinner()
 
 	return c
 }

--- a/internal/ui/components/conversation_selection_view.go
+++ b/internal/ui/components/conversation_selection_view.go
@@ -68,6 +68,7 @@ func NewConversationSelector(repo shortcuts.PersistentConversationRepository, st
 		}),
 		table.WithFocused(true),
 		table.WithHeight(c.tableHeight()),
+		table.WithWidth(c.width),
 		table.WithStyles(c.tableStyles()),
 	)
 
@@ -204,6 +205,7 @@ func (c *ConversationSelectorImpl) handleConversationsLoaded(msg domain.Conversa
 func (c *ConversationSelectorImpl) handleWindowResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	c.width = msg.Width
 	c.height = msg.Height
+	c.table.SetWidth(c.width)
 	c.table.SetHeight(c.tableHeight())
 	return c, nil
 }
@@ -424,11 +426,13 @@ func (c *ConversationSelectorImpl) GetSelected() shortcuts.ConversationSummary {
 // SetWidth sets the width of the conversation selector
 func (c *ConversationSelectorImpl) SetWidth(width int) {
 	c.width = width
+	c.table.SetWidth(width)
 }
 
 // SetHeight sets the height of the conversation selector
 func (c *ConversationSelectorImpl) SetHeight(height int) {
 	c.height = height
+	c.table.SetHeight(c.tableHeight())
 }
 
 // Reset resets the conversation selector state for reuse

--- a/internal/ui/components/conversation_selection_view.go
+++ b/internal/ui/components/conversation_selection_view.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	spinner "charm.land/bubbles/v2/spinner"
+	table "charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	constants "github.com/inference-gateway/cli/internal/constants"
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -21,7 +23,6 @@ import (
 type ConversationSelectorImpl struct {
 	conversations         []shortcuts.ConversationSummary
 	filteredConversations []shortcuts.ConversationSummary
-	selected              int
 	width                 int
 	height                int
 	styleProvider         *styles.Provider
@@ -36,6 +37,7 @@ type ConversationSelectorImpl struct {
 	deleteError           error
 	dataLoaded            bool
 	spinner               spinner.Model
+	table                 table.Model
 }
 
 // NewConversationSelector creates a new conversation selector
@@ -43,7 +45,6 @@ func NewConversationSelector(repo shortcuts.PersistentConversationRepository, st
 	c := &ConversationSelectorImpl{
 		conversations:         make([]shortcuts.ConversationSummary, 0),
 		filteredConversations: make([]shortcuts.ConversationSummary, 0),
-		selected:              0,
 		width:                 80,
 		height:                24,
 		styleProvider:         styleProvider,
@@ -55,8 +56,76 @@ func NewConversationSelector(repo shortcuts.PersistentConversationRepository, st
 	}
 
 	c.spinner = newModernSpinner()
+	c.table = table.New(
+		table.WithColumns([]table.Column{
+			{Title: "ID", Width: 38},
+			{Title: "Summary", Width: 25},
+			{Title: "Messages", Width: 10},
+			{Title: "Requests", Width: 8},
+			{Title: "Input Tokens", Width: 12},
+			{Title: "Output Tokens", Width: 13},
+			{Title: "Cost", Width: 10},
+		}),
+		table.WithFocused(true),
+		table.WithHeight(c.tableHeight()),
+		table.WithStyles(c.tableStyles()),
+	)
 
 	return c
+}
+
+func (c *ConversationSelectorImpl) tableStyles() table.Styles {
+	s := table.DefaultStyles()
+	if c.styleProvider != nil {
+		s.Header = s.Header.Foreground(lipgloss.Color(c.styleProvider.GetThemeColor("dim")))
+		s.Selected = s.Selected.Foreground(lipgloss.Color(c.styleProvider.GetThemeColor("accent"))).Bold(true)
+	}
+	return s
+}
+
+func (c *ConversationSelectorImpl) tableHeight() int {
+	h := c.height - 15
+	if h < 3 {
+		h = 3
+	}
+	return h
+}
+
+// syncTable refreshes the table rows from the filtered conversations, keeping
+// the cursor in range.
+func (c *ConversationSelectorImpl) syncTable() {
+	rows := make([]table.Row, 0, len(c.filteredConversations))
+	for _, conv := range c.filteredConversations {
+		rows = append(rows, conversationRow(conv))
+	}
+	c.table.SetRows(rows)
+	if c.table.Cursor() >= len(rows) {
+		c.table.SetCursor(max(len(rows)-1, 0))
+	}
+}
+
+// conversationRow renders one conversation as table cells, keeping the
+// cost-tier precision of the previous hand-built table.
+func conversationRow(conv shortcuts.ConversationSummary) table.Row {
+	costStr := "-"
+	switch cost := conv.CostStats.TotalCost; {
+	case cost > 0 && cost < 0.01:
+		costStr = fmt.Sprintf("$%.4f", cost)
+	case cost > 0 && cost < 1.0:
+		costStr = fmt.Sprintf("$%.3f", cost)
+	case cost > 0:
+		costStr = fmt.Sprintf("$%.2f", cost)
+	}
+
+	return table.Row{
+		conv.ID,
+		formatting.TruncateText(conv.Title, 25),
+		fmt.Sprintf("%d", conv.MessageCount),
+		fmt.Sprintf("%d", conv.TokenStats.RequestCount),
+		fmt.Sprintf("%d", conv.TokenStats.TotalInputTokens),
+		fmt.Sprintf("%d", conv.TokenStats.TotalOutputTokens),
+		costStr,
+	}
 }
 
 func (c *ConversationSelectorImpl) Init() tea.Cmd {
@@ -123,10 +192,8 @@ func (c *ConversationSelectorImpl) handleConversationsLoaded(msg domain.Conversa
 		c.conversations = conversations
 		c.filteredConversations = make([]shortcuts.ConversationSummary, len(conversations))
 		copy(c.filteredConversations, conversations)
-
-		if len(c.filteredConversations) > 0 {
-			c.selected = 0
-		}
+		c.syncTable()
+		c.table.GotoTop()
 	} else {
 		logger.Error("conversationSelector failed to load conversations", "error", msg.Error)
 	}
@@ -137,6 +204,7 @@ func (c *ConversationSelectorImpl) handleConversationsLoaded(msg domain.Conversa
 func (c *ConversationSelectorImpl) handleWindowResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	c.width = msg.Width
 	c.height = msg.Height
+	c.table.SetHeight(c.tableHeight())
 	return c, nil
 }
 
@@ -151,10 +219,6 @@ func (c *ConversationSelectorImpl) handleKeyInput(msg tea.KeyPressMsg) (tea.Mode
 			return c.handleSearchClear()
 		}
 		return c.handleCancel()
-	case "up":
-		return c.handleNavigationUp()
-	case "down":
-		return c.handleNavigationDown()
 	case "enter", " ":
 		return c.handleSelection()
 	case "d", "delete":
@@ -170,7 +234,12 @@ func (c *ConversationSelectorImpl) handleKeyInput(msg tea.KeyPressMsg) (tea.Mode
 	case "backspace":
 		return c.handleBackspace()
 	default:
-		return c.handleCharacterInput(msg)
+		if c.searchMode {
+			return c.handleCharacterInput(msg)
+		}
+		var cmd tea.Cmd
+		c.table, cmd = c.table.Update(msg)
+		return c, cmd
 	}
 }
 
@@ -180,22 +249,8 @@ func (c *ConversationSelectorImpl) handleCancel() (tea.Model, tea.Cmd) {
 	return c, nil
 }
 
-func (c *ConversationSelectorImpl) handleNavigationUp() (tea.Model, tea.Cmd) {
-	if c.selected > 0 {
-		c.selected--
-	}
-	return c, nil
-}
-
-func (c *ConversationSelectorImpl) handleNavigationDown() (tea.Model, tea.Cmd) {
-	if c.selected < len(c.filteredConversations)-1 {
-		c.selected++
-	}
-	return c, nil
-}
-
 func (c *ConversationSelectorImpl) handleSelection() (tea.Model, tea.Cmd) {
-	if len(c.filteredConversations) > 0 && c.selected >= 0 && c.selected < len(c.filteredConversations) {
+	if len(c.filteredConversations) > 0 && c.table.Cursor() < len(c.filteredConversations) {
 		c.done = true
 	}
 	return c, nil
@@ -231,7 +286,8 @@ func (c *ConversationSelectorImpl) handleCharacterInput(msg tea.KeyPressMsg) (te
 
 func (c *ConversationSelectorImpl) updateSearch() {
 	c.filterConversations()
-	c.selected = 0
+	c.syncTable()
+	c.table.GotoTop()
 }
 
 func (c *ConversationSelectorImpl) View() tea.View {
@@ -291,7 +347,7 @@ func (c *ConversationSelectorImpl) filterConversations() {
 }
 
 func (c *ConversationSelectorImpl) handleDeleteRequest() (tea.Model, tea.Cmd) {
-	if len(c.filteredConversations) == 0 || c.selected >= len(c.filteredConversations) {
+	if len(c.filteredConversations) == 0 || c.table.Cursor() >= len(c.filteredConversations) {
 		return c, nil
 	}
 
@@ -314,12 +370,13 @@ func (c *ConversationSelectorImpl) handleDeleteConfirmation(msg tea.KeyPressMsg)
 }
 
 func (c *ConversationSelectorImpl) performDelete() (tea.Model, tea.Cmd) {
-	if c.selected >= len(c.filteredConversations) {
+	cursor := c.table.Cursor()
+	if cursor >= len(c.filteredConversations) {
 		c.confirmDelete = false
 		return c, nil
 	}
 
-	conv := c.filteredConversations[c.selected]
+	conv := c.filteredConversations[cursor]
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -338,11 +395,8 @@ func (c *ConversationSelectorImpl) performDelete() (tea.Model, tea.Cmd) {
 		}
 	}
 
-	c.filteredConversations = append(c.filteredConversations[:c.selected], c.filteredConversations[c.selected+1:]...)
-
-	if c.selected >= len(c.filteredConversations) && c.selected > 0 {
-		c.selected--
-	}
+	c.filteredConversations = append(c.filteredConversations[:cursor], c.filteredConversations[cursor+1:]...)
+	c.syncTable()
 
 	c.confirmDelete = false
 	c.deleteError = nil
@@ -361,8 +415,8 @@ func (c *ConversationSelectorImpl) IsCancelled() bool {
 
 // GetSelected returns the selected conversation
 func (c *ConversationSelectorImpl) GetSelected() shortcuts.ConversationSummary {
-	if c.IsSelected() && len(c.filteredConversations) > 0 && c.selected < len(c.filteredConversations) {
-		return c.filteredConversations[c.selected]
+	if c.IsSelected() && c.table.Cursor() < len(c.filteredConversations) {
+		return c.filteredConversations[c.table.Cursor()]
 	}
 	return shortcuts.ConversationSummary{}
 }
@@ -381,7 +435,6 @@ func (c *ConversationSelectorImpl) SetHeight(height int) {
 func (c *ConversationSelectorImpl) Reset() {
 	c.done = false
 	c.cancelled = false
-	c.selected = 0
 	c.searchQuery = ""
 	c.searchMode = false
 	c.loading = true
@@ -389,6 +442,8 @@ func (c *ConversationSelectorImpl) Reset() {
 	c.conversations = make([]shortcuts.ConversationSummary, 0)
 	c.filteredConversations = make([]shortcuts.ConversationSummary, 0)
 	c.dataLoaded = false
+	c.syncTable()
+	c.table.GotoTop()
 }
 
 // NeedsInitialization returns true if the component needs to load data
@@ -439,93 +494,9 @@ func (c *ConversationSelectorImpl) writeEmptyView(b *strings.Builder) string {
 	return b.String()
 }
 
-// writeConversationList writes the main conversation list
+// writeConversationList writes the main conversation table
 func (c *ConversationSelectorImpl) writeConversationList(b *strings.Builder) {
-	c.writeTableHeader(b)
-
-	pagination := c.calculatePagination()
-
-	for i := pagination.start; i < pagination.start+pagination.maxVisible && i < len(c.filteredConversations); i++ {
-		conv := c.filteredConversations[i]
-		c.writeConversationRow(b, conv, i)
-	}
-
-	if len(c.filteredConversations) > pagination.maxVisible {
-		paginationText := fmt.Sprintf("Showing %d-%d of %d conversations",
-			pagination.start+1, pagination.start+pagination.maxVisible, len(c.filteredConversations))
-		fmt.Fprintf(b, "%s\n", c.styleProvider.RenderDimText(paginationText))
-	}
-}
-
-// writeTableHeader writes the table header
-func (c *ConversationSelectorImpl) writeTableHeader(b *strings.Builder) {
-	headerLine := fmt.Sprintf("%-38s │ %-25s │ %-10s │ %-8s │ %-12s │ %-13s │ %-10s",
-		"ID", "Summary", "Messages", "Requests", "Input Tokens", "Output Tokens", "Cost")
-	fmt.Fprintf(b, "%s\n", c.styleProvider.RenderDimText(headerLine))
-
-	separator := strings.Repeat("─", c.width-4)
-	fmt.Fprintf(b, "%s\n", c.styleProvider.RenderDimText(separator))
-}
-
-// paginationInfo holds pagination calculation results
-type paginationInfo struct {
-	start      int
-	maxVisible int
-}
-
-// calculatePagination calculates pagination parameters
-func (c *ConversationSelectorImpl) calculatePagination() paginationInfo {
-	maxVisible := c.height - 15
-	if maxVisible > len(c.filteredConversations) {
-		maxVisible = len(c.filteredConversations)
-	}
-	if maxVisible < 1 {
-		maxVisible = 1
-	}
-
-	start := 0
-	if c.selected >= maxVisible {
-		start = c.selected - maxVisible + 1
-	}
-	if start < 0 {
-		start = 0
-	}
-	if start > len(c.filteredConversations)-maxVisible && len(c.filteredConversations) > maxVisible {
-		start = len(c.filteredConversations) - maxVisible
-	}
-
-	return paginationInfo{start: start, maxVisible: maxVisible}
-}
-
-// writeConversationRow writes a single conversation row
-func (c *ConversationSelectorImpl) writeConversationRow(b *strings.Builder, conv shortcuts.ConversationSummary, index int) {
-	fullID := conv.ID
-	summary := formatting.TruncateText(conv.Title, 25)
-	msgCount := fmt.Sprintf("%d", conv.MessageCount)
-	requestCount := fmt.Sprintf("%d", conv.TokenStats.RequestCount)
-	inputTokens := fmt.Sprintf("%d", conv.TokenStats.TotalInputTokens)
-	outputTokens := fmt.Sprintf("%d", conv.TokenStats.TotalOutputTokens)
-
-	costStr := "-"
-	if conv.CostStats.TotalCost > 0 {
-		if conv.CostStats.TotalCost < 0.01 {
-			costStr = fmt.Sprintf("$%.4f", conv.CostStats.TotalCost)
-		} else if conv.CostStats.TotalCost < 1.0 {
-			costStr = fmt.Sprintf("$%.3f", conv.CostStats.TotalCost)
-		} else {
-			costStr = fmt.Sprintf("$%.2f", conv.CostStats.TotalCost)
-		}
-	}
-
-	if index == c.selected {
-		accentColor := c.styleProvider.GetThemeColor("accent")
-		rowText := fmt.Sprintf("▶ %-36s │ %-25s │ %-10s │ %-8s │ %-12s │ %-13s │ %-10s",
-			fullID, summary, msgCount, requestCount, inputTokens, outputTokens, costStr)
-		fmt.Fprintf(b, "%s\n", c.styleProvider.RenderWithColor(rowText, accentColor))
-	} else {
-		fmt.Fprintf(b, "  %-36s │ %-25s │ %-10s │ %-8s │ %-12s │ %-13s │ %-10s\n",
-			fullID, summary, msgCount, requestCount, inputTokens, outputTokens, costStr)
-	}
+	fmt.Fprintf(b, "%s\n", c.table.View())
 }
 
 // writeFooter writes the footer section
@@ -545,11 +516,11 @@ func (c *ConversationSelectorImpl) writeFooter(b *strings.Builder) {
 
 // writeDeleteConfirmation writes the delete confirmation dialog
 func (c *ConversationSelectorImpl) writeDeleteConfirmation(b *strings.Builder) string {
-	if c.selected >= len(c.filteredConversations) {
+	if c.table.Cursor() >= len(c.filteredConversations) {
 		return b.String()
 	}
 
-	conv := c.filteredConversations[c.selected]
+	conv := c.filteredConversations[c.table.Cursor()]
 
 	c.writeSearchInfo(b)
 	c.writeConversationList(b)

--- a/internal/ui/components/conversation_selection_view_test.go
+++ b/internal/ui/components/conversation_selection_view_test.go
@@ -43,7 +43,6 @@ func TestConversationSelectorImpl_Reset(t *testing.T) {
 	if selector.cancelled {
 		t.Error("Expected cancelled to be false after reset")
 	}
-	// An empty bubbles table parks its cursor at -1.
 	if selector.table.Cursor() > 0 {
 		t.Errorf("Expected cursor at the top after reset, got %d", selector.table.Cursor())
 	}

--- a/internal/ui/components/conversation_selection_view_test.go
+++ b/internal/ui/components/conversation_selection_view_test.go
@@ -25,7 +25,7 @@ func TestConversationSelectorImpl_Reset(t *testing.T) {
 
 	selector.done = true
 	selector.cancelled = true
-	selector.selected = 5
+	selector.table.SetCursor(5)
 	selector.searchQuery = "test query"
 	selector.searchMode = true
 	selector.loading = true
@@ -43,8 +43,9 @@ func TestConversationSelectorImpl_Reset(t *testing.T) {
 	if selector.cancelled {
 		t.Error("Expected cancelled to be false after reset")
 	}
-	if selector.selected != 0 {
-		t.Errorf("Expected selected to be 0 after reset, got %d", selector.selected)
+	// An empty bubbles table parks its cursor at -1.
+	if selector.table.Cursor() > 0 {
+		t.Errorf("Expected cursor at the top after reset, got %d", selector.table.Cursor())
 	}
 	if selector.searchQuery != "" {
 		t.Errorf("Expected searchQuery to be empty after reset, got %q", selector.searchQuery)

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -1160,8 +1160,6 @@ func (cv *ConversationView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	switch msg := msg.(type) {
-	case domain.ApprovalSelectionChangedEvent:
-		return cv.handleApprovalSelectionChanged(msg, cmd)
 	case domain.PlanApprovalSelectionChangedEvent:
 		return cv.handlePlanApprovalSelectionChanged(msg, cmd)
 	case domain.UpdateHistoryEvent:
@@ -1226,14 +1224,6 @@ func (cv *ConversationView) handleWindowSizeEvents(msg tea.Msg) tea.Cmd {
 		}
 	}
 	return nil
-}
-
-// handleApprovalSelectionChanged processes approval selection change events
-func (cv *ConversationView) handleApprovalSelectionChanged(_ domain.ApprovalSelectionChangedEvent, cmd tea.Cmd) (tea.Model, tea.Cmd) {
-	if cv.navigationMode != NavigationModeMessageHistory {
-		cv.updateViewportContent()
-	}
-	return cv, cmd
 }
 
 // handlePlanApprovalSelectionChanged refreshes the conversation viewport so

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -129,10 +129,9 @@ type ConversationView struct {
 	// Keyed by remote task ID. Entries are inserted on
 	// A2ATaskSubmittedEvent, updated on status/complete/fail events, and
 	// removed by BackgroundTaskRemovalTickMsg ~5s after a terminal state.
-	backgroundTasks    map[string]*BackgroundTaskDisplay
-	subagentTasks      map[string]*subagentDisplay
-	backgroundSpinStep int
-	backgroundSpinner  spinner.Model
+	backgroundTasks   map[string]*BackgroundTaskDisplay
+	subagentTasks     map[string]*subagentDisplay
+	backgroundSpinner spinner.Model
 	// agentNameResolver maps an agent URL to its configured friendly name
 	// from ~/.infer/agents.yaml. Optional; falls back to the URL when nil
 	// or when the URL has no matching entry.
@@ -154,10 +153,7 @@ func NewConversationView(styleProvider *styles.Provider) *ConversationView {
 		mdRenderer = markdown.NewRenderer(themeService, 80)
 	}
 
-	bgSpin := spinner.New()
-	bgSpinStyle := spinner.Dot
-	bgSpinStyle.FPS = 100 * time.Millisecond
-	bgSpin.Spinner = bgSpinStyle
+	bgSpin := newModernSpinner()
 
 	return &ConversationView{
 		conversation:           []domain.ConversationEntry{},
@@ -1313,7 +1309,6 @@ func (cv *ConversationView) handleSpinnerTick(msg spinner.TickMsg, cmd tea.Cmd) 
 	var bgCmd tea.Cmd
 	cv.backgroundSpinner, bgCmd = cv.backgroundSpinner.Update(msg)
 	if bgCmd != nil && cv.hasActiveBackgroundTasks() {
-		cv.backgroundSpinStep++
 		cmd = tea.Batch(cmd, bgCmd)
 	}
 
@@ -1649,7 +1644,7 @@ func (cv *ConversationView) renderSubagentTree() string {
 		case "failed":
 			icon, iconColor, bodyColor = icons.CrossMark, "error", "error"
 		default:
-			icon, iconColor, bodyColor = icons.GetSpinnerFrame(cv.backgroundSpinStep), "accent", "accent"
+			icon, iconColor, bodyColor = cv.backgroundSpinner.View(), "accent", "accent"
 		}
 
 		statusText := d.Status
@@ -1948,7 +1943,7 @@ func (cv *ConversationView) renderBackgroundTaskLine(display *BackgroundTaskDisp
 		stateColor = "dim"
 		body = cv.formatTerminalHeader(name, "cancelled", display)
 	default:
-		icon = icons.GetSpinnerFrame(cv.backgroundSpinStep)
+		icon = cv.backgroundSpinner.View()
 		iconColor = "accent"
 		stateColor = "accent"
 		body = cv.formatNonTerminalBody(name, state, display, width)

--- a/internal/ui/components/huh_theme.go
+++ b/internal/ui/components/huh_theme.go
@@ -2,7 +2,7 @@ package components
 
 import (
 	huh "charm.land/huh/v2"
-	"charm.land/lipgloss/v2"
+	lipgloss "charm.land/lipgloss/v2"
 
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )

--- a/internal/ui/components/huh_theme.go
+++ b/internal/ui/components/huh_theme.go
@@ -12,6 +12,9 @@ import (
 // rebuild the form (the standard per-phase pattern) after a theme switch.
 func huhTheme(p *styles.Provider) huh.Theme {
 	return huh.ThemeFunc(func(isDark bool) *huh.Styles {
+		if p == nil {
+			return huh.ThemeBase(isDark)
+		}
 		accent := lipgloss.Color(p.GetThemeColor("accent"))
 		errColor := lipgloss.Color(p.GetThemeColor("error"))
 		dim := lipgloss.Color(p.GetThemeColor("dim"))

--- a/internal/ui/components/huh_theme.go
+++ b/internal/ui/components/huh_theme.go
@@ -1,0 +1,52 @@
+package components
+
+import (
+	huh "charm.land/huh/v2"
+	"charm.land/lipgloss/v2"
+
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+)
+
+// huhTheme maps the active style-provider colors onto a huh theme so huh
+// forms match the rest of the TUI. Forms capture the theme at build time, so
+// rebuild the form (the standard per-phase pattern) after a theme switch.
+func huhTheme(p *styles.Provider) huh.Theme {
+	return huh.ThemeFunc(func(isDark bool) *huh.Styles {
+		accent := lipgloss.Color(p.GetThemeColor("accent"))
+		errColor := lipgloss.Color(p.GetThemeColor("error"))
+		dim := lipgloss.Color(p.GetThemeColor("dim"))
+		success := lipgloss.Color(p.GetThemeColor("success"))
+
+		t := huh.ThemeBase(isDark)
+
+		t.Focused.Title = t.Focused.Title.Foreground(accent).Bold(true)
+		t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(accent).Bold(true)
+		t.Focused.Description = t.Focused.Description.Foreground(dim)
+		t.Focused.ErrorIndicator = t.Focused.ErrorIndicator.Foreground(errColor)
+		t.Focused.ErrorMessage = t.Focused.ErrorMessage.Foreground(errColor)
+		t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(accent)
+		t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(accent)
+		t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(accent)
+		t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(accent)
+		t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(accent)
+		t.Focused.SelectedPrefix = t.Focused.SelectedPrefix.Foreground(success)
+		t.Focused.FocusedButton = t.Focused.FocusedButton.Foreground(lipgloss.Color("0")).Background(accent).Bold(true)
+		t.Focused.BlurredButton = t.Focused.BlurredButton.Foreground(dim)
+		t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(accent)
+		t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(accent)
+		t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(dim)
+		t.Focused.Directory = t.Focused.Directory.Foreground(accent)
+		t.Focused.File = t.Focused.File.Foreground(lipgloss.NoColor{})
+
+		t.Blurred = t.Focused
+		t.Blurred.Base = t.Blurred.Base.BorderStyle(lipgloss.HiddenBorder())
+		t.Blurred.Title = t.Blurred.Title.Bold(false).Foreground(dim)
+
+		t.Help.ShortKey = t.Help.ShortKey.Foreground(dim)
+		t.Help.ShortDesc = t.Help.ShortDesc.Foreground(dim)
+		t.Help.FullKey = t.Help.FullKey.Foreground(dim)
+		t.Help.FullDesc = t.Help.FullDesc.Foreground(dim)
+
+		return t
+	})
+}

--- a/internal/ui/components/init_github_action_view.go
+++ b/internal/ui/components/init_github_action_view.go
@@ -84,7 +84,7 @@ func (v *InitGithubActionView) buildConfirmForm() *huh.Form {
 				Negative("No, create a new one").
 				Value(&v.hasExisting),
 		),
-	).WithShowHelp(true).WithWidth(v.width)
+	).WithShowHelp(true).WithWidth(v.width).WithTheme(huhTheme(v.styleProvider))
 }
 
 // Sentinel values for the private-key select's fallback entries.
@@ -147,7 +147,7 @@ func (v *InitGithubActionView) buildDetailsForm() *huh.Form {
 		huh.NewGroup(keyPicker).WithHideFunc(func() bool {
 			return secretsExist() || v.keyChoice != keyChoiceBrowse
 		}),
-	).WithShowHelp(true).WithWidth(v.width)
+	).WithShowHelp(true).WithWidth(v.width).WithTheme(huhTheme(v.styleProvider))
 }
 
 // resolvePrivateKeyPath maps the completed details form onto privateKeyPath,

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -694,13 +694,13 @@ func (isb *InputStatusBar) buildCostIndicator() string {
 		return ""
 	}
 
-	// Format: 💰 $0.0234
+	// Format: $0.0234
 	if costStats.TotalCost < 0.01 {
-		return fmt.Sprintf("💰 $%.4f", costStats.TotalCost)
+		return fmt.Sprintf("$%.4f", costStats.TotalCost)
 	} else if costStats.TotalCost < 1.0 {
-		return fmt.Sprintf("💰 $%.3f", costStats.TotalCost)
+		return fmt.Sprintf("$%.3f", costStats.TotalCost)
 	} else {
-		return fmt.Sprintf("💰 $%.2f", costStats.TotalCost)
+		return fmt.Sprintf("$%.2f", costStats.TotalCost)
 	}
 }
 

--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -359,7 +359,7 @@ func (iv *InputView) Render() string {
 }
 
 // buildGitBranchLabel returns the "⎇ <branch>" label embedded in the input box
-// top border, or "⎇ <branch> #<pr>" when a PR exists for the current branch
+// top border, or "⎇ <branch>  #<pr>" when a PR exists for the current branch
 // and git_pr is enabled. Returns "" when the git_branch indicator is disabled
 // or there is no branch to show (not a repo / detached HEAD). Truncation to
 // fit the border is handled by the style provider, so no length cap is applied
@@ -378,7 +378,7 @@ func (iv *InputView) buildGitBranchLabel() string {
 
 	if iv.config == nil || iv.config.Chat.StatusBar.Indicators.GitPR {
 		if iv.gitPRCache != "" {
-			label += " #" + iv.gitPRCache
+			label += "  #" + iv.gitPRCache
 		}
 	}
 

--- a/internal/ui/components/input_view_test.go
+++ b/internal/ui/components/input_view_test.go
@@ -754,7 +754,7 @@ func newInputViewWithPR(t *testing.T, branch, pr string) *InputView {
 
 func TestInputView_BuildGitBranchLabel_WithPR(t *testing.T) {
 	iv := newInputViewWithPR(t, "fix/issue-785", "792")
-	require.Equal(t, "⎇ fix/issue-785 #792", iv.buildGitBranchLabel())
+	require.Equal(t, "⎇ fix/issue-785  #792", iv.buildGitBranchLabel())
 }
 
 func TestInputView_BuildGitBranchLabel_WithPR_DisabledByConfig(t *testing.T) {

--- a/internal/ui/components/model_selection_view.go
+++ b/internal/ui/components/model_selection_view.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	huh "charm.land/huh/v2"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -22,11 +23,15 @@ const (
 	ModelViewSubscription
 )
 
-// ModelSelectorImpl implements model selection UI
+// modelSelectChromeLines is the vertical space around the huh select: title,
+// tabs, separator, blank lines, and the help row.
+const modelSelectChromeLines = 8
+
+// ModelSelectorImpl implements model selection UI as a huh select with the
+// pricing tabs (keys 1-4) layered on top: switching a tab rebuilds the form
+// with that tab's option set. Search is huh's built-in `/` filter.
 type ModelSelectorImpl struct {
 	models         []string
-	filteredModels []string
-	selected       int
 	width          int
 	height         int
 	styleProvider  *styles.Provider
@@ -35,29 +40,65 @@ type ModelSelectorImpl struct {
 	modelService   domain.ModelService
 	pricingService domain.PricingService
 	config         *config.Config
-	searchQuery    string
-	searchMode     bool
 	currentView    ModelViewMode
+
+	form   *huh.Form
+	sel    *huh.Select[string]
+	choice string
 }
 
 // NewModelSelector creates a new model selector
 func NewModelSelector(models []string, modelService domain.ModelService, pricingService domain.PricingService, cfg *config.Config, styleProvider *styles.Provider) *ModelSelectorImpl {
 	m := &ModelSelectorImpl{
 		models:         models,
-		filteredModels: make([]string, len(models)),
-		selected:       0,
 		width:          80,
 		height:         24,
 		styleProvider:  styleProvider,
 		modelService:   modelService,
 		pricingService: pricingService,
 		config:         cfg,
-		searchQuery:    "",
-		searchMode:     false,
 		currentView:    ModelViewAll,
 	}
-	copy(m.filteredModels, models)
+	m.buildForm()
 	return m
+}
+
+// buildForm (re)builds the huh select over the current tab's models. The
+// form's Init cmd is discarded on purpose: the selector is routed every
+// message while its view is active, so only cursor-blink cosmetics are lost.
+func (m *ModelSelectorImpl) buildForm() {
+	tabModels := m.tabModels()
+	options := make([]huh.Option[string], 0, len(tabModels))
+	for _, model := range tabModels {
+		label := model
+		if suffix := m.formatModelSuffix(model); suffix != "" {
+			label = model + " " + suffix
+		}
+		options = append(options, huh.NewOption(label, model))
+	}
+
+	m.choice = ""
+	m.sel = huh.NewSelect[string]().
+		Options(options...).
+		Height(m.selectHeight(len(tabModels))).
+		Value(&m.choice)
+
+	m.form = huh.NewForm(huh.NewGroup(m.sel)).
+		WithShowHelp(false).
+		WithWidth(m.width).
+		WithTheme(huhTheme(m.styleProvider))
+	_ = m.form.Init()
+}
+
+func (m *ModelSelectorImpl) selectHeight(optionCount int) int {
+	h := m.height - modelSelectChromeLines
+	if h > optionCount {
+		h = optionCount
+	}
+	if h < 3 {
+		h = 3
+	}
+	return h
 }
 
 func (m *ModelSelectorImpl) Init() tea.Cmd {
@@ -67,102 +108,50 @@ func (m *ModelSelectorImpl) Init() tea.Cmd {
 func (m *ModelSelectorImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		return m.handleWindowResize(msg)
-	case tea.KeyPressMsg:
-		return m.handleKeyInput(msg)
-	}
-
-	return m, nil
-}
-
-func (m *ModelSelectorImpl) handleWindowResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
-	m.width = msg.Width
-	m.height = msg.Height
-	return m, nil
-}
-
-func (m *ModelSelectorImpl) handleKeyInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "ctrl+c":
-		return m.handleCancel()
-	case "up":
-		return m.handleNavigationUp()
-	case "down":
-		return m.handleNavigationDown()
-	case "enter", " ":
-		return m.handleSelection()
-	case "/":
-		if !m.searchMode {
-			return m.handleSearchToggle()
-		}
-		return m.handleCharacterInput(msg)
-	case "backspace":
-		return m.handleBackspace()
-	case "1", "2", "3", "4":
-		m.handleViewSwitch(msg.String())
+		m.width = msg.Width
+		m.height = msg.Height
+		m.buildForm()
 		return m, nil
-	default:
-		return m.handleCharacterInput(msg)
-	}
-}
-
-func (m *ModelSelectorImpl) handleCancel() (tea.Model, tea.Cmd) {
-	m.cancelled = true
-	m.done = true
-	return m, tea.Quit
-}
-
-func (m *ModelSelectorImpl) handleNavigationUp() (tea.Model, tea.Cmd) {
-	if m.selected > 0 {
-		m.selected--
-	}
-	return m, nil
-}
-
-func (m *ModelSelectorImpl) handleNavigationDown() (tea.Model, tea.Cmd) {
-	if m.selected < len(m.filteredModels)-1 {
-		m.selected++
-	}
-	return m, nil
-}
-
-func (m *ModelSelectorImpl) handleSelection() (tea.Model, tea.Cmd) {
-	if len(m.filteredModels) > 0 {
-		selectedModel := m.filteredModels[m.selected]
-		if err := m.modelService.SelectModel(selectedModel); err == nil {
+	case tea.KeyPressMsg:
+		if msg.String() == "ctrl+c" {
+			m.cancelled = true
 			m.done = true
-			return m, func() tea.Msg {
-				return domain.ModelSelectedEvent{Model: selectedModel}
+			return m, tea.Quit
+		}
+		if !m.sel.GetFiltering() {
+			switch msg.String() {
+			case "1", "2", "3", "4":
+				m.handleViewSwitch(msg.String())
+				return m, nil
 			}
 		}
 	}
-	return m, nil
+
+	return m, m.forwardToForm(msg)
 }
 
-func (m *ModelSelectorImpl) handleSearchToggle() (tea.Model, tea.Cmd) {
-	m.searchMode = true
-	return m, nil
-}
-
-func (m *ModelSelectorImpl) handleBackspace() (tea.Model, tea.Cmd) {
-	if m.searchMode && len(m.searchQuery) > 0 {
-		m.searchQuery = m.searchQuery[:len(m.searchQuery)-1]
-		m.updateSearch()
+// forwardToForm delegates to the huh form and emits the selection event when
+// it completes. A completed form with a failing SelectModel is rebuilt so the
+// selector stays usable.
+func (m *ModelSelectorImpl) forwardToForm(msg tea.Msg) tea.Cmd {
+	model, cmd := m.form.Update(msg)
+	if f, ok := model.(*huh.Form); ok {
+		m.form = f
 	}
-	return m, nil
-}
 
-func (m *ModelSelectorImpl) handleCharacterInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if m.searchMode && len(msg.String()) == 1 && msg.String()[0] >= 32 {
-		m.searchQuery += msg.String()
-		m.updateSearch()
+	if m.form.State != huh.StateCompleted {
+		return cmd
 	}
-	return m, nil
-}
 
-func (m *ModelSelectorImpl) updateSearch() {
-	m.applyFilters()
-	m.selected = 0
+	selectedModel := m.choice
+	if err := m.modelService.SelectModel(selectedModel); err != nil {
+		m.buildForm()
+		return nil
+	}
+	m.done = true
+	return func() tea.Msg {
+		return domain.ModelSelectedEvent{Model: selectedModel}
+	}
 }
 
 func (m *ModelSelectorImpl) handleViewSwitch(key string) {
@@ -176,8 +165,7 @@ func (m *ModelSelectorImpl) handleViewSwitch(key string) {
 	case "4":
 		m.currentView = ModelViewSubscription
 	}
-	m.selected = 0
-	m.applyFilters()
+	m.buildForm()
 }
 
 func (m *ModelSelectorImpl) View() tea.View {
@@ -189,76 +177,23 @@ func (m *ModelSelectorImpl) viewContent() string {
 
 	accentColor := m.styleProvider.GetThemeColor("accent")
 	b.WriteString(m.styleProvider.RenderWithColor("Select a Model", accentColor))
-
 	b.WriteString("\n\n")
 
 	m.writeViewTabs(&b)
 
-	if m.searchMode {
-		statusColor := m.styleProvider.GetThemeColor("status")
-		b.WriteString(m.styleProvider.RenderWithColor("Search: "+m.searchQuery, statusColor))
-		b.WriteString(m.styleProvider.RenderWithColor("│", accentColor))
-		b.WriteString("\n\n")
-	} else {
-		helpText := fmt.Sprintf("Press / to search • %d models available", len(m.filteredModels))
-		b.WriteString(m.styleProvider.RenderDimText(helpText))
-		b.WriteString("\n\n")
-	}
-
-	if len(m.filteredModels) == 0 {
+	if len(m.tabModels()) == 0 {
 		errorColor := m.styleProvider.GetThemeColor("error")
-
-		if m.searchQuery != "" {
-			b.WriteString(m.styleProvider.RenderWithColor(fmt.Sprintf("No models match '%s'", m.searchQuery), errorColor))
-		} else {
-			b.WriteString(m.styleProvider.RenderWithColor("No models available", errorColor))
-		}
+		b.WriteString(m.styleProvider.RenderWithColor("No models available", errorColor))
 		b.WriteString("\n")
 		return b.String()
 	}
 
-	maxVisible := m.height - 10
-	if maxVisible > len(m.filteredModels) {
-		maxVisible = len(m.filteredModels)
-	}
-
-	start := 0
-	if m.selected >= maxVisible {
-		start = m.selected - maxVisible + 1
-	}
-
-	for i := start; i < start+maxVisible && i < len(m.filteredModels); i++ {
-		model := m.filteredModels[i]
-		suffix := m.formatModelSuffix(model)
-
-		if i == m.selected {
-			b.WriteString(m.styleProvider.RenderWithColor("▶ "+model, accentColor))
-		} else {
-			fmt.Fprintf(&b, "  %s", model)
-		}
-		if suffix != "" {
-			b.WriteString(" ")
-			b.WriteString(m.styleProvider.RenderDimText(suffix))
-		}
-		b.WriteString("\n")
-	}
-
-	if len(m.filteredModels) > maxVisible {
-		paginationText := fmt.Sprintf("Showing %d-%d of %d models", start+1, start+maxVisible, len(m.filteredModels))
-		b.WriteString("\n")
-		b.WriteString(m.styleProvider.RenderDimText(paginationText))
-		b.WriteString("\n")
-	}
+	b.WriteString(m.form.View())
 
 	b.WriteString("\n")
-	b.WriteString(strings.Repeat("─", m.width))
+	b.WriteString(strings.Repeat("─", max(m.width, 1)))
 	b.WriteString("\n")
-
-	if m.searchMode {
-		b.WriteString(m.styleProvider.RenderDimText("Type to search, ↑↓ to navigate, Enter to select, Esc to clear search"))
-	} else {
-		b.WriteString(m.styleProvider.RenderDimText("Use ↑↓ arrows to navigate, Enter to select, / to search, 1-4 to filter, Esc/Ctrl+C to cancel"))
-	}
+	b.WriteString(m.styleProvider.RenderDimText("Use ↑↓ arrows to navigate, Enter to select, / to filter, 1-4 to switch tabs, Ctrl+C to cancel"))
 
 	return b.String()
 }
@@ -301,49 +236,30 @@ func formatContextWindow(tokens int) string {
 	}
 }
 
-// applyFilters filters the models based on the current view and search query
-func (m *ModelSelectorImpl) applyFilters() {
-	var baseModels []string
-
+// tabModels returns the models visible under the current pricing tab.
+func (m *ModelSelectorImpl) tabModels() []string {
 	switch m.currentView {
-	case ModelViewAll:
-		baseModels = m.models
 	case ModelViewFree:
-		baseModels = make([]string, 0)
-		for _, model := range m.models {
-			if m.isModelFree(model) {
-				baseModels = append(baseModels, model)
-			}
-		}
+		return m.filterModels(m.isModelFree)
 	case ModelViewPayAsYouGo:
-		baseModels = make([]string, 0)
-		for _, model := range m.models {
-			if !m.isModelFree(model) && !m.isModelSubscription(model) {
-				baseModels = append(baseModels, model)
-			}
-		}
+		return m.filterModels(func(model string) bool {
+			return !m.isModelFree(model) && !m.isModelSubscription(model)
+		})
 	case ModelViewSubscription:
-		baseModels = make([]string, 0)
-		for _, model := range m.models {
-			if m.isModelSubscription(model) {
-				baseModels = append(baseModels, model)
-			}
+		return m.filterModels(m.isModelSubscription)
+	default:
+		return m.models
+	}
+}
+
+func (m *ModelSelectorImpl) filterModels(keep func(string) bool) []string {
+	filtered := make([]string, 0, len(m.models))
+	for _, model := range m.models {
+		if keep(model) {
+			filtered = append(filtered, model)
 		}
 	}
-
-	if m.searchQuery == "" {
-		m.filteredModels = baseModels
-		return
-	}
-
-	m.filteredModels = make([]string, 0)
-	query := strings.ToLower(m.searchQuery)
-
-	for _, model := range baseModels {
-		if strings.Contains(strings.ToLower(model), query) {
-			m.filteredModels = append(m.filteredModels, model)
-		}
-	}
+	return filtered
 }
 
 // isModelFree checks if a model is free (both input and output prices are 0.0).
@@ -387,8 +303,8 @@ func (m *ModelSelectorImpl) IsCancelled() bool {
 
 // GetSelected returns the selected model
 func (m *ModelSelectorImpl) GetSelected() string {
-	if m.IsSelected() && len(m.models) > 0 {
-		return m.models[m.selected]
+	if m.IsSelected() {
+		return m.choice
 	}
 	return ""
 }

--- a/internal/ui/components/model_selection_view.go
+++ b/internal/ui/components/model_selection_view.go
@@ -78,7 +78,10 @@ func (m *ModelSelectorImpl) buildForm() {
 	}
 
 	m.choice = ""
+	// The title line is also where huh renders the / filter input - without
+	// one the filter is invisible while typing.
 	m.sel = huh.NewSelect[string]().
+		Title(fmt.Sprintf("Press / to filter • %d models available", len(tabModels))).
 		Options(options...).
 		Height(m.selectHeight(len(tabModels))).
 		Value(&m.choice)

--- a/internal/ui/components/model_selection_view.go
+++ b/internal/ui/components/model_selection_view.go
@@ -294,6 +294,14 @@ func (m *ModelSelectorImpl) isModelSubscription(model string) bool {
 	return m.pricingService.RequiresPro(model)
 }
 
+// Reset clears the done/cancelled flags and rebuilds the form so the selector
+// can be re-entered after a previous selection.
+func (m *ModelSelectorImpl) Reset() {
+	m.done = false
+	m.cancelled = false
+	m.buildForm()
+}
+
 // IsSelected returns true if a model was selected
 func (m *ModelSelectorImpl) IsSelected() bool {
 	return m.done && !m.cancelled

--- a/internal/ui/components/model_selection_view.go
+++ b/internal/ui/components/model_selection_view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	textinput "charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	huh "charm.land/huh/v2"
 
@@ -29,7 +30,9 @@ const modelSelectChromeLines = 8
 
 // ModelSelectorImpl implements model selection UI as a huh select with the
 // pricing tabs (keys 1-4) layered on top: switching a tab rebuilds the form
-// with that tab's option set. Search is huh's built-in `/` filter.
+// with that tab's option set. Search is a dedicated textinput (entered with
+// `/`) filtering on the model name; huh's built-in filter is disabled since
+// it renders the query into the select's title line instead of a real input.
 type ModelSelectorImpl struct {
 	models         []string
 	width          int
@@ -42,9 +45,11 @@ type ModelSelectorImpl struct {
 	config         *config.Config
 	currentView    ModelViewMode
 
-	form   *huh.Form
-	sel    *huh.Select[string]
-	choice string
+	form       *huh.Form
+	sel        *huh.Select[string]
+	choice     string
+	search     textinput.Model
+	searchMode bool
 }
 
 // NewModelSelector creates a new model selector
@@ -59,6 +64,8 @@ func NewModelSelector(models []string, modelService domain.ModelService, pricing
 		config:         cfg,
 		currentView:    ModelViewAll,
 	}
+	m.search = textinput.New()
+	m.search.Prompt = "Search: "
 	m.buildForm()
 	return m
 }
@@ -67,9 +74,9 @@ func NewModelSelector(models []string, modelService domain.ModelService, pricing
 // form's Init cmd is discarded on purpose: the selector is routed every
 // message while its view is active, so only cursor-blink cosmetics are lost.
 func (m *ModelSelectorImpl) buildForm() {
-	tabModels := m.tabModels()
-	options := make([]huh.Option[string], 0, len(tabModels))
-	for _, model := range tabModels {
+	visible := m.visibleModels()
+	options := make([]huh.Option[string], 0, len(visible))
+	for _, model := range visible {
 		label := model
 		if suffix := m.formatModelSuffix(model); suffix != "" {
 			label = model + " " + suffix
@@ -78,30 +85,44 @@ func (m *ModelSelectorImpl) buildForm() {
 	}
 
 	m.choice = ""
-	// The title line is also where huh renders the / filter input - without
-	// one the filter is invisible while typing.
 	m.sel = huh.NewSelect[string]().
-		Title(fmt.Sprintf("Press / to filter • %d models available", len(tabModels))).
+		Title(fmt.Sprintf("%d models available", len(visible))).
 		Options(options...).
-		Height(m.selectHeight(len(tabModels))).
+		Height(m.selectHeight(len(visible))).
 		Value(&m.choice)
+
+	// huh's own / filter renders the query into the title line instead of a
+	// real input, so it stays disabled in favour of the search textinput.
+	keymap := huh.NewDefaultKeyMap()
+	keymap.Select.Filter.SetEnabled(false)
 
 	m.form = huh.NewForm(huh.NewGroup(m.sel)).
 		WithShowHelp(false).
 		WithWidth(m.width).
+		WithKeyMap(keymap).
 		WithTheme(huhTheme(m.styleProvider))
 	_ = m.form.Init()
 }
 
+// visibleModels is the current tab's models narrowed by the search query,
+// matching on the model name only (not the metadata suffix).
+func (m *ModelSelectorImpl) visibleModels() []string {
+	tabModels := m.tabModels()
+	query := strings.ToLower(strings.TrimSpace(m.search.Value()))
+	if query == "" {
+		return tabModels
+	}
+	filtered := make([]string, 0, len(tabModels))
+	for _, model := range tabModels {
+		if strings.Contains(strings.ToLower(model), query) {
+			filtered = append(filtered, model)
+		}
+	}
+	return filtered
+}
+
 func (m *ModelSelectorImpl) selectHeight(optionCount int) int {
-	h := m.height - modelSelectChromeLines
-	if h > optionCount {
-		h = optionCount
-	}
-	if h < 3 {
-		h = 3
-	}
-	return h
+	return max(min(m.height-modelSelectChromeLines, optionCount), 3)
 }
 
 func (m *ModelSelectorImpl) Init() tea.Cmd {
@@ -121,16 +142,46 @@ func (m *ModelSelectorImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.done = true
 			return m, tea.Quit
 		}
-		if !m.sel.GetFiltering() {
-			switch msg.String() {
-			case "1", "2", "3", "4":
-				m.handleViewSwitch(msg.String())
-				return m, nil
-			}
+		if m.searchMode {
+			return m, m.handleSearchKey(msg)
+		}
+		switch msg.String() {
+		case "1", "2", "3", "4":
+			m.handleViewSwitch(msg.String())
+			return m, nil
+		case "/":
+			m.searchMode = true
+			return m, m.search.Focus()
 		}
 	}
 
 	return m, m.forwardToForm(msg)
+}
+
+// handleSearchKey routes keys while the search input is active: navigation
+// and selection still reach the list, esc clears the search, and everything
+// else edits the query (rebuilding the option set on change).
+func (m *ModelSelectorImpl) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.String() {
+	case "esc":
+		m.searchMode = false
+		m.search.Blur()
+		if m.search.Value() != "" {
+			m.search.SetValue("")
+			m.buildForm()
+		}
+		return nil
+	case "enter", "up", "down":
+		return m.forwardToForm(msg)
+	}
+
+	before := m.search.Value()
+	var cmd tea.Cmd
+	m.search, cmd = m.search.Update(msg)
+	if m.search.Value() != before {
+		m.buildForm()
+	}
+	return cmd
 }
 
 // forwardToForm delegates to the huh form and emits the selection event when
@@ -184,9 +235,18 @@ func (m *ModelSelectorImpl) viewContent() string {
 
 	m.writeViewTabs(&b)
 
-	if len(m.tabModels()) == 0 {
+	if m.searchMode || m.search.Value() != "" {
+		b.WriteString(m.search.View())
+		b.WriteString("\n\n")
+	}
+
+	if len(m.visibleModels()) == 0 {
 		errorColor := m.styleProvider.GetThemeColor("error")
-		b.WriteString(m.styleProvider.RenderWithColor("No models available", errorColor))
+		if query := m.search.Value(); query != "" {
+			b.WriteString(m.styleProvider.RenderWithColor(fmt.Sprintf("No models match %q", query), errorColor))
+		} else {
+			b.WriteString(m.styleProvider.RenderWithColor("No models available", errorColor))
+		}
 		b.WriteString("\n")
 		return b.String()
 	}
@@ -196,7 +256,7 @@ func (m *ModelSelectorImpl) viewContent() string {
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", max(m.width, 1)))
 	b.WriteString("\n")
-	b.WriteString(m.styleProvider.RenderDimText("Use ↑↓ arrows to navigate, Enter to select, / to filter, 1-4 to switch tabs, Ctrl+C to cancel"))
+	b.WriteString(m.styleProvider.RenderDimText("Use ↑↓ arrows to navigate, Enter to select, / to search, esc to clear, 1-4 to switch tabs, Ctrl+C to cancel"))
 
 	return b.String()
 }
@@ -299,6 +359,9 @@ func (m *ModelSelectorImpl) isModelSubscription(model string) bool {
 func (m *ModelSelectorImpl) Reset() {
 	m.done = false
 	m.cancelled = false
+	m.searchMode = false
+	m.search.Blur()
+	m.search.SetValue("")
 	m.buildForm()
 }
 

--- a/internal/ui/components/model_selection_view_test.go
+++ b/internal/ui/components/model_selection_view_test.go
@@ -117,6 +117,66 @@ func TestModelSelector_EnterSelectsAndEmitsEvent(t *testing.T) {
 	assert.Equal(t, "model-b", ms.SelectModelArgsForCall(0))
 }
 
+// typeString feeds a string into the selector one printable key at a time.
+func typeString(m *ModelSelectorImpl, s string) {
+	for _, r := range s {
+		model, _ := m.Update(tea.KeyPressMsg{Code: r, Text: string(r)})
+		*m = *model.(*ModelSelectorImpl)
+	}
+}
+
+// TestModelSelector_SearchFiltersByNameOnly verifies the / search narrows the
+// option set by model name, ignoring the metadata suffix ("free" etc.), and
+// that esc clears the query and restores the full list.
+func TestModelSelector_SearchFiltersByNameOnly(t *testing.T) {
+	m := newFilterTestSelector([]string{"paid-model", "free-model", "subscription-model"})
+
+	typeString(m, "/")
+	assert.True(t, m.searchMode)
+
+	// "free" appears in paid-model's suffix via pricing labels but must only
+	// match the model whose NAME contains it.
+	typeString(m, "free")
+	assert.Equal(t, []string{"free-model"}, m.visibleModels())
+
+	// No name matches "per MTok" even though every paid suffix contains it.
+	typeString(m, "x")
+	assert.Empty(t, m.visibleModels())
+
+	_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	assert.False(t, m.searchMode)
+	assert.Equal(t, "", m.search.Value())
+	assert.Len(t, m.visibleModels(), 3)
+}
+
+// TestModelSelector_SearchEnterSelectsFilteredMatch drives search + Enter and
+// asserts the emitted event carries the filtered match, not an index into the
+// unfiltered list.
+func TestModelSelector_SearchEnterSelectsFilteredMatch(t *testing.T) {
+	ms := &domainmocks.FakeModelService{}
+	pricing := &domainmocks.FakePricingService{}
+	m := NewModelSelector([]string{"alpha", "beta", "gamma"}, ms, pricing, nil, createMockStyleProvider())
+
+	typeString(m, "/gam")
+
+	var selected string
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	for cmd != nil {
+		out := cmd()
+		if out == nil {
+			break
+		}
+		if ev, ok := out.(domain.ModelSelectedEvent); ok {
+			selected = ev.Model
+			break
+		}
+		_, cmd = m.Update(out)
+	}
+
+	assert.Equal(t, "gamma", selected)
+	assert.Equal(t, "gamma", m.GetSelected())
+}
+
 // TestModelSelector_FormatModelSuffixSubscription checks the per-row marker: a
 // subscription model shows "subscription" and suppresses the misleading "free"
 // token, while a genuinely free model still shows "free".

--- a/internal/ui/components/model_selection_view_test.go
+++ b/internal/ui/components/model_selection_view_test.go
@@ -7,7 +7,7 @@ import (
 
 	domain "github.com/inference-gateway/cli/internal/domain"
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
-	"github.com/stretchr/testify/assert"
+	assert "github.com/stretchr/testify/assert"
 )
 
 // newFilterTestSelector builds a selector backed by a fake pricing service with

--- a/internal/ui/components/model_selection_view_test.go
+++ b/internal/ui/components/model_selection_view_test.go
@@ -3,6 +3,9 @@ package components
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,14 +41,13 @@ func newFilterTestSelector(models []string) *ModelSelectorImpl {
 			return ""
 		}
 	}
-	return NewModelSelector(models, nil, pricing, nil, nil)
+	return NewModelSelector(models, nil, pricing, nil, createMockStyleProvider())
 }
 
 func filteredFor(view ModelViewMode, models []string) []string {
 	m := newFilterTestSelector(models)
 	m.currentView = view
-	m.applyFilters()
-	return m.filteredModels
+	return m.tabModels()
 }
 
 // TestModelSelector_FilterBuckets verifies the four filter views are disjoint
@@ -68,6 +70,51 @@ func TestModelSelector_SubscriptionModelExcludedFromFree(t *testing.T) {
 
 	assert.NotContains(t, filteredFor(ModelViewFree, models), "subscription-model")
 	assert.Contains(t, filteredFor(ModelViewSubscription, models), "subscription-model")
+}
+
+// TestModelSelector_EnterSelectsAndEmitsEvent drives the huh select to
+// completion and asserts the selection reaches the model service and the
+// ModelSelectedEvent carries the chosen model.
+func TestModelSelector_EnterSelectsAndEmitsEvent(t *testing.T) {
+	ms := &domainmocks.FakeModelService{}
+	pricing := &domainmocks.FakePricingService{}
+	m := NewModelSelector([]string{"model-a", "model-b"}, ms, pricing, nil, createMockStyleProvider())
+
+	var selected string
+	var pump func(msg tea.Msg)
+	pump = func(msg tea.Msg) {
+		model, cmd := m.Update(msg)
+		m = model.(*ModelSelectorImpl)
+		for cmd != nil {
+			out := cmd()
+			if out == nil {
+				return
+			}
+			if batch, ok := out.(tea.BatchMsg); ok {
+				for _, c := range batch {
+					if c != nil {
+						pump(c())
+					}
+				}
+				return
+			}
+			if ev, ok := out.(domain.ModelSelectedEvent); ok {
+				selected = ev.Model
+				return
+			}
+			model, cmd = m.Update(out)
+			m = model.(*ModelSelectorImpl)
+		}
+	}
+
+	pump(tea.KeyPressMsg{Code: tea.KeyDown})
+	pump(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	assert.Equal(t, "model-b", selected)
+	assert.True(t, m.IsSelected())
+	assert.Equal(t, "model-b", m.GetSelected())
+	assert.Equal(t, 1, ms.SelectModelCallCount())
+	assert.Equal(t, "model-b", ms.SelectModelArgsForCall(0))
 }
 
 // TestModelSelector_FormatModelSuffixSubscription checks the per-row marker: a

--- a/internal/ui/components/question_form_view.go
+++ b/internal/ui/components/question_form_view.go
@@ -183,9 +183,6 @@ func (qv *QuestionFormView) buildForm() {
 		}).
 		Value(&qv.other)
 
-	// huh's default quit key is only ctrl+c, which chat.go reserves for
-	// interrupting the whole turn - rebind quit to esc so esc still cancels
-	// the form (StateAborted) like it always has.
 	keymap := huh.NewDefaultKeyMap()
 	keymap.Quit = key.NewBinding(key.WithKeys("esc"))
 

--- a/internal/ui/components/question_form_view.go
+++ b/internal/ui/components/question_form_view.go
@@ -2,33 +2,52 @@ package components
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
+	key "charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	huh "charm.land/huh/v2"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
-	formatting "github.com/inference-gateway/cli/internal/formatting"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
-// minQuestionOptionWidth is the floor for a truncated option row so a narrow
-// terminal still shows a usable amount of each label/description.
+// minQuestionOptionWidth is the floor for the form width so a narrow terminal
+// still shows a usable amount of each label/description.
 const minQuestionOptionWidth = 20
 
 // otherOptionLabel is the synthesized free-text choice appended to every
 // question. It is not one of the model-provided options.
 const otherOptionLabel = "Other (type your own)"
 
-// QuestionFormView renders the interactive AskUserQuestion form as a bordered
-// box floating above the input (mirroring ApprovalBoxView). It reads the
-// in-progress answer state from the StateManager and renders the current
-// question's options, a checkbox/radio marker per option, the synthesized
-// "Other" free-text row, and a one-line key hint.
+// otherSentinel is the option value standing in for the synthesized "Other"
+// row; real options are their index into question.Options.
+const otherSentinel = -1
+
+// QuestionFormView drives the interactive AskUserQuestion form as a bordered
+// box floating above the input (mirroring ApprovalBoxView). It owns the
+// answer-in-progress state as one huh form per question; the StateManager only
+// carries the questions, the overlay-active flag, and the response channel.
+// The agent loop is blocked in the tool goroutine until the answers are sent
+// on the channel (or it is closed, signalling cancellation).
 type QuestionFormView struct {
 	width         int
 	height        int
 	styleProvider *styles.Provider
 	stateManager  domain.StateManager
+
+	// active is the state this form was built for; if the StateManager's
+	// state no longer matches (cancelled externally), the form is stale.
+	active  *domain.UserQuestionUIState
+	idx     int
+	form    *huh.Form
+	answers []domain.UserQuestionAnswer
+
+	// Form-bound values, reset per question.
+	single int
+	multi  []int
+	other  string
 }
 
 func NewQuestionFormView(styleProvider *styles.Provider, stateManager domain.StateManager) *QuestionFormView {
@@ -47,113 +66,193 @@ func (qv *QuestionFormView) SetHeight(height int) {
 	qv.height = height
 }
 
-func (qv *QuestionFormView) Render() string {
-	if qv.stateManager == nil {
-		return ""
-	}
+// Begin starts a new form for the questions currently in the StateManager.
+// Call it when a UserQuestionRequestedEvent has set up the state.
+func (qv *QuestionFormView) Begin() tea.Cmd {
 	state := qv.stateManager.GetUserQuestionUIState()
-	if state == nil || len(state.Questions) == 0 || state.CurrentIndex >= len(state.Questions) {
-		return ""
+	if state == nil || len(state.Questions) == 0 {
+		return nil
 	}
-	return qv.renderForm(state)
+	qv.active = state
+	qv.idx = 0
+	qv.answers = nil
+	qv.buildForm()
+	return qv.form.Init()
 }
 
-// renderForm frames the current question, its options, and a key hint in a
-// bordered box. The accent border echoes the focused input box below it.
-func (qv *QuestionFormView) renderForm(state *domain.UserQuestionUIState) string {
-	accentColor := qv.styleProvider.GetThemeColor("accent")
-	dimColor := qv.styleProvider.GetThemeColor("dim")
-
-	question := state.Questions[state.CurrentIndex]
-
-	header := fmt.Sprintf(" %s ", strings.TrimSpace(question.Header))
-	progress := fmt.Sprintf("(%d/%d)", state.CurrentIndex+1, len(state.Questions))
-	title := qv.styleProvider.RenderWithColorAndBold(header, accentColor) + " " +
-		qv.styleProvider.RenderWithColor(progress, dimColor)
-
-	parts := []string{
-		title,
-		formatting.TruncateText(question.Question, qv.textBudget()),
-		"",
+// Forward delegates a message to the active form and reacts to completion or
+// abort. All messages (keys and huh's internal command messages) must be
+// routed here while the form is up, or group/field navigation breaks.
+func (qv *QuestionFormView) Forward(msg tea.Msg) tea.Cmd {
+	state := qv.stateManager.GetUserQuestionUIState()
+	if state == nil || state != qv.active || qv.form == nil {
+		qv.reset()
+		return nil
 	}
-	parts = append(parts, qv.renderOptions(state, question)...)
-	parts = append(parts, "", qv.styleProvider.RenderWithColor(qv.hint(state, question), dimColor))
 
-	content := strings.Join(parts, "\n")
-	return qv.styleProvider.RenderBorderedBox(content, accentColor, 0, 1)
+	model, cmd := qv.form.Update(msg)
+	if f, ok := model.(*huh.Form); ok {
+		qv.form = f
+	}
+
+	switch qv.form.State {
+	case huh.StateCompleted:
+		return qv.advance()
+	case huh.StateAborted:
+		qv.stateManager.ClearUserQuestionUIState()
+		qv.reset()
+		return nil
+	default:
+		return cmd
+	}
 }
 
-// renderOptions renders one row per option plus the synthesized "Other" row.
-func (qv *QuestionFormView) renderOptions(state *domain.UserQuestionUIState, question domain.UserQuestion) []string {
-	rows := make([]string, 0, len(question.Options)+1)
+// advance records the completed question's answer and moves to the next one;
+// after the last question it delivers the answers and clears the state.
+func (qv *QuestionFormView) advance() tea.Cmd {
+	qv.answers = append(qv.answers, qv.buildAnswer())
+	qv.idx++
+	if qv.idx < len(qv.active.Questions) {
+		qv.buildForm()
+		return qv.form.Init()
+	}
+
+	if qv.active.ResponseChan != nil {
+		qv.active.ResponseChan <- qv.answers
+	}
+	qv.stateManager.ClearUserQuestionUIState()
+	qv.reset()
+	return nil
+}
+
+func (qv *QuestionFormView) reset() {
+	qv.active = nil
+	qv.form = nil
+	qv.answers = nil
+}
+
+// buildForm builds one huh form for the current question: a select (or
+// multi-select) over the options plus the synthesized "Other" row, and a
+// conditional free-text group shown only when "Other" is chosen.
+func (qv *QuestionFormView) buildForm() {
+	question := qv.active.Questions[qv.idx]
+
+	options := make([]huh.Option[int], 0, len(question.Options)+1)
 	for i, opt := range question.Options {
-		selected := state.Selected[state.CurrentIndex][i]
 		label := opt.Label
 		if opt.Description != "" {
 			label = fmt.Sprintf("%s - %s", opt.Label, opt.Description)
 		}
-		rows = append(rows, qv.renderRow(label, i == state.OptionCursor, selected, question.MultiSelect))
+		options = append(options, huh.NewOption(label, i))
+	}
+	options = append(options, huh.NewOption(otherOptionLabel, otherSentinel))
+
+	title := fmt.Sprintf("%s (%d/%d)", strings.TrimSpace(question.Header), qv.idx+1, len(qv.active.Questions))
+	qv.other = ""
+
+	var choiceField huh.Field
+	if question.MultiSelect {
+		qv.multi = nil
+		choiceField = huh.NewMultiSelect[int]().
+			Title(title).
+			Description(question.Question).
+			Options(options...).
+			Validate(func(v []int) error {
+				if len(v) == 0 {
+					return fmt.Errorf("select at least one option")
+				}
+				return nil
+			}).
+			Value(&qv.multi)
+	} else {
+		qv.single = defaultUserQuestionOption(question)
+		choiceField = huh.NewSelect[int]().
+			Title(title).
+			Description(question.Question).
+			Options(options...).
+			Value(&qv.single)
 	}
 
-	otherCursor := state.OptionCursor == state.OtherRowIndex()
-	otherText := strings.TrimSpace(state.OtherText[state.CurrentIndex])
-	otherActive := state.OtherActive[state.CurrentIndex]
-	otherLabel := otherOptionLabel
-	switch {
-	case otherActive:
-		otherLabel = fmt.Sprintf("Other: %s▏", otherText)
-	case otherText != "":
-		otherLabel = fmt.Sprintf("Other: %s", otherText)
-	}
-	rows = append(rows, qv.renderRow(otherLabel, otherCursor, otherText != "" || otherActive, question.MultiSelect))
-	return rows
+	otherInput := huh.NewInput().
+		Title(otherOptionLabel).
+		Validate(func(s string) error {
+			if strings.TrimSpace(s) == "" {
+				return fmt.Errorf("answer is required")
+			}
+			return nil
+		}).
+		Value(&qv.other)
+
+	// huh's default quit key is only ctrl+c, which chat.go reserves for
+	// interrupting the whole turn - rebind quit to esc so esc still cancels
+	// the form (StateAborted) like it always has.
+	keymap := huh.NewDefaultKeyMap()
+	keymap.Quit = key.NewBinding(key.WithKeys("esc"))
+
+	qv.form = huh.NewForm(
+		huh.NewGroup(choiceField),
+		huh.NewGroup(otherInput).WithHideFunc(func() bool { return !qv.otherChosen(question) }),
+	).
+		WithShowHelp(true).
+		WithWidth(qv.textBudget()).
+		WithKeyMap(keymap).
+		WithTheme(huhTheme(qv.styleProvider))
 }
 
-// renderRow renders a single option line: a cursor caret, a checkbox (multi) or
-// radio (single) marker, and the label. The highlighted row gets a background.
-func (qv *QuestionFormView) renderRow(label string, cursor, selected, multi bool) string {
-	caret := "  "
-	if cursor {
-		caret = "▸ "
+// otherChosen reports whether the synthesized "Other" row is currently chosen.
+func (qv *QuestionFormView) otherChosen(question domain.UserQuestion) bool {
+	if question.MultiSelect {
+		return slices.Contains(qv.multi, otherSentinel)
 	}
-
-	var marker string
-	switch {
-	case multi && selected:
-		marker = "[x] "
-	case multi:
-		marker = "[ ] "
-	case selected:
-		marker = "(•) "
-	default:
-		marker = "( ) "
-	}
-
-	text := formatting.TruncateText(label, qv.textBudget()-len(caret)-len(marker))
-	line := caret + marker + text
-
-	if cursor {
-		return qv.styleProvider.RenderStyledText(line, styles.StyleOptions{
-			Background: qv.styleProvider.GetThemeColor("selection_bg"),
-			Bold:       true,
-		})
-	}
-	return line
+	return qv.single == otherSentinel
 }
 
-// hint returns the dim key-help line, adapted to the current input mode.
-func (qv *QuestionFormView) hint(state *domain.UserQuestionUIState, question domain.UserQuestion) string {
-	if state.OtherActive[state.CurrentIndex] {
-		return "type your answer · enter continue · esc back"
+// buildAnswer materializes the completed current question's answer.
+func (qv *QuestionFormView) buildAnswer() domain.UserQuestionAnswer {
+	question := qv.active.Questions[qv.idx]
+	answer := domain.UserQuestionAnswer{
+		Header:   question.Header,
+		Question: question.Question,
 	}
 	if question.MultiSelect {
-		return "↑/↓ move · space toggle · enter continue · esc cancel"
+		for _, i := range qv.multi {
+			if i >= 0 && i < len(question.Options) {
+				answer.SelectedLabels = append(answer.SelectedLabels, question.Options[i].Label)
+			}
+		}
+	} else if qv.single >= 0 && qv.single < len(question.Options) {
+		answer.SelectedLabels = []string{question.Options[qv.single].Label}
 	}
-	return "↑/↓ select · enter confirm · esc cancel"
+	if qv.otherChosen(question) {
+		answer.OtherText = strings.TrimSpace(qv.other)
+	}
+	return answer
 }
 
-// textBudget is the display width available for a row after reserving room for
-// the box border (2) and horizontal padding (2), plus slack from the right edge.
+// defaultUserQuestionOption returns the option index to pre-select for a
+// single-select question: the first option whose label is marked
+// "(Recommended)" (case-insensitive), otherwise the first option.
+func defaultUserQuestionOption(q domain.UserQuestion) int {
+	for i, opt := range q.Options {
+		if strings.Contains(strings.ToLower(opt.Label), "(recommended)") {
+			return i
+		}
+	}
+	return 0
+}
+
+func (qv *QuestionFormView) Render() string {
+	state := qv.stateManager.GetUserQuestionUIState()
+	if state == nil || state != qv.active || qv.form == nil {
+		return ""
+	}
+	accentColor := qv.styleProvider.GetThemeColor("accent")
+	return qv.styleProvider.RenderBorderedBox(qv.form.View(), accentColor, 0, 1)
+}
+
+// textBudget is the display width available inside the bordered box after
+// reserving room for the border (2) and horizontal padding (2), plus slack
+// from the right edge.
 func (qv *QuestionFormView) textBudget() int {
 	budget := qv.width - 6
 	if budget < minQuestionOptionWidth {

--- a/internal/ui/components/question_form_view_test.go
+++ b/internal/ui/components/question_form_view_test.go
@@ -4,13 +4,15 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	domain "github.com/inference-gateway/cli/internal/domain"
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
-func questionStateForTest() *domain.UserQuestionUIState {
-	return &domain.UserQuestionUIState{
-		Questions: []domain.UserQuestion{
+func questionStateForTest(questions ...domain.UserQuestion) *domain.UserQuestionUIState {
+	if len(questions) == 0 {
+		questions = []domain.UserQuestion{
 			{
 				Header:      "Format",
 				Question:    "Which output format?",
@@ -20,13 +22,48 @@ func questionStateForTest() *domain.UserQuestionUIState {
 					{Label: "YAML", Description: "human readable"},
 				},
 			},
-		},
-		CurrentIndex: 0,
-		OptionCursor: 0,
-		Selected:     []map[int]bool{{}},
-		OtherText:    []string{""},
-		OtherActive:  []bool{false},
+		}
 	}
+	return &domain.UserQuestionUIState{
+		Questions:    questions,
+		ResponseChan: make(chan []domain.UserQuestionAnswer, 1),
+	}
+}
+
+// pumpQuestionForm forwards a message and keeps executing any returned
+// commands, feeding their messages back into the form, until it settles.
+func pumpQuestionForm(v *QuestionFormView, msg tea.Msg) {
+	drainQuestionForm(v, v.Forward(msg))
+}
+
+func drainQuestionForm(v *QuestionFormView, cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	msg := cmd()
+	if msg == nil {
+		return
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			drainQuestionForm(v, c)
+		}
+		return
+	}
+	drainQuestionForm(v, v.Forward(msg))
+}
+
+func newQuestionFormForTest(state *domain.UserQuestionUIState) (*QuestionFormView, *domainmocks.FakeStateManager) {
+	sm := &domainmocks.FakeStateManager{}
+	sm.GetUserQuestionUIStateReturns(state)
+	sm.ClearUserQuestionUIStateCalls(func() {
+		sm.GetUserQuestionUIStateReturns(nil)
+	})
+
+	v := NewQuestionFormView(createMockStyleProvider(), sm)
+	v.SetWidth(80)
+	drainQuestionForm(v, v.Begin())
+	return v, sm
 }
 
 func TestQuestionFormView_RenderNilState(t *testing.T) {
@@ -40,11 +77,7 @@ func TestQuestionFormView_RenderNilState(t *testing.T) {
 }
 
 func TestQuestionFormView_RendersQuestion(t *testing.T) {
-	sm := &domainmocks.FakeStateManager{}
-	sm.GetUserQuestionUIStateReturns(questionStateForTest())
-
-	v := NewQuestionFormView(createMockStyleProvider(), sm)
-	v.SetWidth(80)
+	v, _ := newQuestionFormForTest(questionStateForTest())
 
 	out := v.Render()
 	for _, want := range []string{"Format", "(1/1)", "Which output format?", "JSON", "YAML", "Other"} {
@@ -54,22 +87,81 @@ func TestQuestionFormView_RendersQuestion(t *testing.T) {
 	}
 }
 
-func TestQuestionFormView_MultiSelectCheckboxes(t *testing.T) {
+func TestQuestionFormView_SingleSelectDefaultSubmit(t *testing.T) {
 	state := questionStateForTest()
-	state.Questions[0].MultiSelect = true
-	state.Selected[0][0] = true // JSON selected
+	v, _ := newQuestionFormForTest(state)
 
-	sm := &domainmocks.FakeStateManager{}
-	sm.GetUserQuestionUIStateReturns(state)
+	pumpQuestionForm(v, tea.KeyPressMsg{Code: tea.KeyEnter})
 
-	v := NewQuestionFormView(createMockStyleProvider(), sm)
-	v.SetWidth(80)
-
-	out := v.Render()
-	if !strings.Contains(out, "[x]") {
-		t.Errorf("expected a checked checkbox for the selected option, got:\n%s", out)
+	select {
+	case answers := <-state.ResponseChan:
+		if len(answers) != 1 || len(answers[0].SelectedLabels) != 1 || answers[0].SelectedLabels[0] != "JSON" {
+			t.Errorf("expected [JSON] answer, got %+v", answers)
+		}
+	default:
+		t.Fatal("expected answers on the response channel")
 	}
-	if !strings.Contains(out, "[ ]") {
-		t.Errorf("expected an unchecked checkbox for the unselected option, got:\n%s", out)
+}
+
+func TestQuestionFormView_RecommendedPreselected(t *testing.T) {
+	state := questionStateForTest(domain.UserQuestion{
+		Header:   "Fmt",
+		Question: "q",
+		Options: []domain.UserQuestionOption{
+			{Label: "JSON"}, {Label: "YAML (Recommended)"},
+		},
+	})
+	v, _ := newQuestionFormForTest(state)
+
+	pumpQuestionForm(v, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	select {
+	case answers := <-state.ResponseChan:
+		if len(answers) != 1 || len(answers[0].SelectedLabels) != 1 || answers[0].SelectedLabels[0] != "YAML (Recommended)" {
+			t.Errorf("expected the recommended option, got %+v", answers)
+		}
+	default:
+		t.Fatal("expected answers on the response channel")
+	}
+}
+
+func TestQuestionFormView_MultiSelectToggleAndSubmit(t *testing.T) {
+	state := questionStateForTest(domain.UserQuestion{
+		Header:      "Scope",
+		Question:    "scope?",
+		MultiSelect: true,
+		Options: []domain.UserQuestionOption{
+			{Label: "A"}, {Label: "B"}, {Label: "C"},
+		},
+	})
+	v, _ := newQuestionFormForTest(state)
+
+	pumpQuestionForm(v, tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+	pumpQuestionForm(v, tea.KeyPressMsg{Code: tea.KeyDown})
+	pumpQuestionForm(v, tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+	pumpQuestionForm(v, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	select {
+	case answers := <-state.ResponseChan:
+		if len(answers) != 1 || len(answers[0].SelectedLabels) != 2 ||
+			answers[0].SelectedLabels[0] != "A" || answers[0].SelectedLabels[1] != "B" {
+			t.Errorf("expected [A B], got %+v", answers)
+		}
+	default:
+		t.Fatal("expected answers on the response channel")
+	}
+}
+
+func TestQuestionFormView_EscCancels(t *testing.T) {
+	state := questionStateForTest()
+	v, sm := newQuestionFormForTest(state)
+
+	pumpQuestionForm(v, tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	if sm.ClearUserQuestionUIStateCallCount() == 0 {
+		t.Error("expected esc to clear the question state")
+	}
+	if got := v.Render(); got != "" {
+		t.Errorf("expected empty render after cancel, got %q", got)
 	}
 }

--- a/internal/ui/components/spinner.go
+++ b/internal/ui/components/spinner.go
@@ -6,13 +6,14 @@ import (
 	spinner "charm.land/bubbles/v2/spinner"
 )
 
-// newModernSpinner returns the app-wide spinner (◐◓◑◒ at 10 FPS), unstyled so
-// callers keep coloring frames themselves.
+// newModernSpinner returns the app-wide spinner (braille dots, like
+// spinner.Dot but without its trailing space so frames are width 1),
+// unstyled so callers keep coloring frames themselves.
 func newModernSpinner() spinner.Model {
 	s := spinner.New()
 	s.Spinner = spinner.Spinner{
-		Frames: []string{"◐", "◓", "◑", "◒"},
-		FPS:    100 * time.Millisecond,
+		Frames: []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"},
+		FPS:    time.Second / 10,
 	}
 	return s
 }

--- a/internal/ui/components/spinner.go
+++ b/internal/ui/components/spinner.go
@@ -1,0 +1,18 @@
+package components
+
+import (
+	"time"
+
+	spinner "charm.land/bubbles/v2/spinner"
+)
+
+// newModernSpinner returns the app-wide spinner (◐◓◑◒ at 10 FPS), unstyled so
+// callers keep coloring frames themselves.
+func newModernSpinner() spinner.Model {
+	s := spinner.New()
+	s.Spinner = spinner.Spinner{
+		Frames: []string{"◐", "◓", "◑", "◒"},
+		FPS:    100 * time.Millisecond,
+	}
+	return s
+}

--- a/internal/ui/components/status_view.go
+++ b/internal/ui/components/status_view.go
@@ -291,15 +291,24 @@ func (sv *StatusView) formatSpinnerStatus() (string, string, string) {
 // Derived from state on each render, like reconnectingMessage, so it needs no
 // event ordering guarantees against the tool-progress spinner events.
 func (sv *StatusView) syncApprovalPause() {
-	if awaitingUserDecision(sv.stateManager) {
-		if sv.pausedAt.IsZero() {
-			sv.pausedAt = time.Now()
+	syncApprovalPause(sv.stateManager, &sv.pausedAt, func(pause time.Duration) {
+		sv.startTime = sv.startTime.Add(pause)
+	})
+}
+
+// syncApprovalPause records when the UI becomes blocked on a user decision and,
+// on resume, calls shift with the paused duration so callers can push their
+// running timers forward.
+func syncApprovalPause(sm domain.StateManager, pausedAt *time.Time, shift func(time.Duration)) {
+	if awaitingUserDecision(sm) {
+		if pausedAt.IsZero() {
+			*pausedAt = time.Now()
 		}
 		return
 	}
-	if !sv.pausedAt.IsZero() {
-		sv.startTime = sv.startTime.Add(time.Since(sv.pausedAt))
-		sv.pausedAt = time.Time{}
+	if !pausedAt.IsZero() {
+		shift(time.Since(*pausedAt))
+		*pausedAt = time.Time{}
 	}
 }
 

--- a/internal/ui/components/status_view.go
+++ b/internal/ui/components/status_view.go
@@ -218,27 +218,12 @@ func (sv *StatusView) Render() string {
 		}
 	}
 
-	statusLine := fmt.Sprintf("%s %s", prefix, displayMessage)
+	statusLine := displayMessage
+	if prefix != "" {
+		statusLine = fmt.Sprintf("%s %s", prefix, displayMessage)
+	}
 	styledStatusLine := sv.styleProvider.RenderWithColor(statusLine, color)
 	return styledStatusLine
-}
-
-// getStatusIcon returns the appropriate icon for the current status type
-func (sv *StatusView) getStatusIcon() string {
-	switch sv.statusType {
-	case domain.StatusThinking:
-		return ""
-	case domain.StatusGenerating:
-		return ""
-	case domain.StatusWorking:
-		return ""
-	case domain.StatusProcessing:
-		return ""
-	case domain.StatusPreparing:
-		return ""
-	default:
-		return ""
-	}
 }
 
 // formatStatusWithType enhances the status message with type-specific formatting and progress
@@ -274,12 +259,7 @@ func (sv *StatusView) formatErrorStatus() (string, string, string) {
 }
 
 func (sv *StatusView) formatSpinnerStatus() (string, string, string) {
-	var prefix string
-	if sv.statusType == domain.StatusThinking {
-		prefix = fmt.Sprintf("%s %s", sv.getStatusIcon(), sv.spinner.View())
-	} else {
-		prefix = sv.spinner.View()
-	}
+	prefix := sv.spinner.View()
 
 	elapsed := time.Since(sv.startTime)
 	seconds := elapsed.Seconds()
@@ -316,11 +296,10 @@ func (sv *StatusView) reconnectingMessage() string {
 }
 
 func (sv *StatusView) formatNormalStatus() (string, string, string) {
-	prefix := sv.getStatusIcon()
 	statusColor := sv.styleProvider.GetThemeColor("status")
 	displayMessage := sv.formatStatusWithType(sv.message)
 
-	return prefix, statusColor, displayMessage
+	return "", statusColor, displayMessage
 }
 
 // Bubble Tea interface

--- a/internal/ui/components/status_view.go
+++ b/internal/ui/components/status_view.go
@@ -291,7 +291,7 @@ func (sv *StatusView) formatSpinnerStatus() (string, string, string) {
 // Derived from state on each render, like reconnectingMessage, so it needs no
 // event ordering guarantees against the tool-progress spinner events.
 func (sv *StatusView) syncApprovalPause() {
-	if sv.awaitingUserDecision() {
+	if awaitingUserDecision(sv.stateManager) {
 		if sv.pausedAt.IsZero() {
 			sv.pausedAt = time.Now()
 		}
@@ -303,13 +303,15 @@ func (sv *StatusView) syncApprovalPause() {
 	}
 }
 
-func (sv *StatusView) awaitingUserDecision() bool {
-	if sv.stateManager == nil {
+// awaitingUserDecision reports whether an approval, plan-approval, or
+// user-question overlay is blocked on the user.
+func awaitingUserDecision(sm domain.StateManager) bool {
+	if sm == nil {
 		return false
 	}
-	return sv.stateManager.GetApprovalUIState() != nil ||
-		sv.stateManager.GetPlanApprovalUIState() != nil ||
-		sv.stateManager.GetUserQuestionUIState() != nil
+	return sm.GetApprovalUIState() != nil ||
+		sm.GetPlanApprovalUIState() != nil ||
+		sm.GetUserQuestionUIState() != nil
 }
 
 // reconnectingMessage returns the reconnect notice when the HTTP client is

--- a/internal/ui/components/status_view.go
+++ b/internal/ui/components/status_view.go
@@ -32,6 +32,7 @@ type StatusView struct {
 	keyHintFormatter *hints.Formatter
 	toolName         string
 	stateManager     domain.StateManager
+	pausedAt         time.Time
 }
 
 // SetStateManager wires the state manager so the spinner line can reflect
@@ -93,6 +94,7 @@ func (sv *StatusView) ShowSpinner(message string) {
 	sv.isError = false
 	sv.isSpinner = true
 	sv.startTime = time.Now()
+	sv.pausedAt = time.Time{}
 	sv.statusType = domain.StatusDefault
 	sv.progress = nil
 }
@@ -103,6 +105,7 @@ func (sv *StatusView) ShowSpinnerWithType(message string, statusType domain.Stat
 	sv.isError = false
 	sv.isSpinner = true
 	sv.startTime = time.Now()
+	sv.pausedAt = time.Time{}
 	sv.statusType = statusType
 	sv.progress = progress
 }
@@ -121,6 +124,7 @@ func (sv *StatusView) ClearStatus() {
 	sv.isError = false
 	sv.isSpinner = false
 	sv.startTime = time.Time{}
+	sv.pausedAt = time.Time{}
 	sv.debugInfo = ""
 	sv.statusType = domain.StatusDefault
 	sv.progress = nil
@@ -194,9 +198,13 @@ func (sv *StatusView) Render() string {
 		return ""
 	}
 
+	sv.syncApprovalPause()
+
 	var prefix, color, displayMessage string
 	if sv.isError {
 		prefix, color, displayMessage = sv.formatErrorStatus()
+	} else if sv.isSpinner && !sv.pausedAt.IsZero() {
+		prefix, color, displayMessage = "", sv.styleProvider.GetThemeColor("status"), sv.formatStatusWithType(sv.baseMessage)
 	} else if sv.isSpinner {
 		prefix, color, displayMessage = sv.formatSpinnerStatus()
 	} else {
@@ -275,6 +283,33 @@ func (sv *StatusView) formatSpinnerStatus() (string, string, string) {
 
 	statusColor := sv.styleProvider.GetThemeColor("status")
 	return prefix, statusColor, displayMessage
+}
+
+// syncApprovalPause pauses the spinner and elapsed timer while an approval,
+// plan-approval, or user-question overlay is waiting on the user, and shifts
+// startTime forward on resume so the wait doesn't count as generation time.
+// Derived from state on each render, like reconnectingMessage, so it needs no
+// event ordering guarantees against the tool-progress spinner events.
+func (sv *StatusView) syncApprovalPause() {
+	if sv.awaitingUserDecision() {
+		if sv.pausedAt.IsZero() {
+			sv.pausedAt = time.Now()
+		}
+		return
+	}
+	if !sv.pausedAt.IsZero() {
+		sv.startTime = sv.startTime.Add(time.Since(sv.pausedAt))
+		sv.pausedAt = time.Time{}
+	}
+}
+
+func (sv *StatusView) awaitingUserDecision() bool {
+	if sv.stateManager == nil {
+		return false
+	}
+	return sv.stateManager.GetApprovalUIState() != nil ||
+		sv.stateManager.GetPlanApprovalUIState() != nil ||
+		sv.stateManager.GetUserQuestionUIState() != nil
 }
 
 // reconnectingMessage returns the reconnect notice when the HTTP client is

--- a/internal/ui/components/status_view.go
+++ b/internal/ui/components/status_view.go
@@ -223,7 +223,7 @@ func (sv *StatusView) Render() string {
 		statusLine = fmt.Sprintf("%s %s", prefix, displayMessage)
 	}
 	styledStatusLine := sv.styleProvider.RenderWithColor(statusLine, color)
-	return styledStatusLine
+	return " " + styledStatusLine
 }
 
 // formatStatusWithType enhances the status message with type-specific formatting and progress

--- a/internal/ui/components/status_view.go
+++ b/internal/ui/components/status_view.go
@@ -52,8 +52,7 @@ type StatusState struct {
 }
 
 func NewStatusView(styleProvider *styles.Provider) *StatusView {
-	s := spinner.New()
-	s.Spinner = spinner.Dot
+	s := newModernSpinner()
 	s.Style = styleProvider.GetSpinnerStyle()
 	return &StatusView{
 		message:       "",

--- a/internal/ui/components/status_view_test.go
+++ b/internal/ui/components/status_view_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	domain "github.com/inference-gateway/cli/internal/domain"
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 
@@ -229,5 +230,27 @@ func TestStatusView_StateTransitions(t *testing.T) {
 
 	if sv.IsShowingError() || sv.IsShowingSpinner() {
 		t.Error("Expected no error or spinner after ClearStatus")
+	}
+}
+
+func TestStatusView_Render_PausesSpinnerDuringApproval(t *testing.T) {
+	sv := NewStatusView(createMockStyleProviderForStatus())
+	sm := &domainmocks.FakeStateManager{}
+	sv.SetStateManager(sm)
+	sv.ShowSpinner("Executing tools")
+
+	sm.GetApprovalUIStateReturns(&domain.ApprovalUIState{})
+	paused := sv.Render()
+	if strings.Contains(paused, "(") {
+		t.Errorf("expected no elapsed timer while approval pending, got %q", paused)
+	}
+	if !strings.Contains(paused, "Executing tools") {
+		t.Errorf("expected message to remain visible, got %q", paused)
+	}
+
+	sm.GetApprovalUIStateReturns(nil)
+	resumed := sv.Render()
+	if !strings.Contains(resumed, "(") {
+		t.Errorf("expected elapsed timer after approval resolved, got %q", resumed)
 	}
 }

--- a/internal/ui/components/task_management_view.go
+++ b/internal/ui/components/task_management_view.go
@@ -81,8 +81,7 @@ func NewTaskManager(
 	vp := viewport.New(viewport.WithWidth(80), viewport.WithHeight(20))
 	vp.SetContent("")
 
-	sp := spinner.New()
-	sp.Spinner = spinner.Dot
+	sp := newModernSpinner()
 
 	return &TaskManagerImpl{
 		activeTasks:           make([]TaskInfo, 0),

--- a/internal/ui/components/tool_call_renderer.go
+++ b/internal/ui/components/tool_call_renderer.go
@@ -119,7 +119,7 @@ func (r *ToolCallRenderer) handleToolCallPreview(msg domain.ToolCallPreviewEvent
 		IsComplete: msg.IsComplete,
 	}
 
-	if len(r.tools) == 1 && r.hasActiveTools() {
+	if len(r.tools) == 1 {
 		return r, r.spinner.Tick
 	}
 	return r, nil
@@ -386,21 +386,6 @@ func (r *ToolCallRenderer) ClearPreviews() {
 func (r *ToolCallRenderer) HasActivePreviews() bool {
 	for _, tool := range r.tools {
 		if !tool.IsComplete {
-			return true
-		}
-	}
-	return false
-}
-
-func (r *ToolCallRenderer) hasActiveTools() bool {
-	for _, tool := range r.tools {
-		isRunning := tool.Status == "running" ||
-			tool.Status == "starting" ||
-			tool.Status == "saving" ||
-			tool.Status == "executing" ||
-			tool.Status == "streaming"
-
-		if isRunning {
 			return true
 		}
 	}

--- a/internal/ui/components/tool_call_renderer.go
+++ b/internal/ui/components/tool_call_renderer.go
@@ -26,7 +26,6 @@ type ToolCallRenderer struct {
 	keyHintFormatter KeyHintFormatter
 	lastUpdate       time.Time
 	lastTimerRender  time.Time
-	spinnerStep      int
 }
 
 // KeyHintFormatter provides formatted key hints for actions
@@ -55,13 +54,8 @@ type ToolInfo struct {
 }
 
 func NewToolCallRenderer(styleProvider *styles.Provider) *ToolCallRenderer {
-	s := spinner.New()
-	customDot := spinner.Dot
-	customDot.FPS = 100 * time.Millisecond
-	s.Spinner = customDot
-
 	return &ToolCallRenderer{
-		spinner:       s,
+		spinner:       newModernSpinner(),
 		tools:         make(map[string]*ToolRenderState),
 		styleProvider: styleProvider,
 		width:         80,
@@ -198,15 +192,7 @@ func (r *ToolCallRenderer) handleBashOutputStream(msg domain.BashOutputChunkEven
 func (r *ToolCallRenderer) handleSpinnerTick(msg spinner.TickMsg) (*ToolCallRenderer, tea.Cmd) {
 	var cmd tea.Cmd
 	r.spinner, cmd = r.spinner.Update(msg)
-
-	now := time.Now()
-	r.spinnerStep = (r.spinnerStep + 1) % 4
-	r.lastTimerRender = now
-
-	if r.hasActiveTools() {
-		return r, cmd
-	}
-
+	r.lastTimerRender = time.Now()
 	return r, cmd
 }
 
@@ -273,7 +259,7 @@ func (r *ToolCallRenderer) renderTool(tool *ToolRenderState) string {
 		iconColor = "dim"
 		statusColor = "dim"
 	case "running", "starting", "saving", "executing", "streaming":
-		statusIcon = icons.GetSpinnerFrame(r.spinnerStep)
+		statusIcon = r.spinner.View()
 		if tool.EndTime == nil {
 			elapsed := time.Since(tool.StartTime)
 			statusText = fmt.Sprintf("running %s", r.formatDuration(elapsed))
@@ -349,7 +335,7 @@ func (r *ToolCallRenderer) renderToolCallContent(toolInfo ToolInfo, arguments, s
 		statusIcon = icons.QueuedIcon
 		statusText = "queued"
 	case "executing", "running", "starting", "saving":
-		statusIcon = icons.GetSpinnerFrame(r.spinnerStep)
+		statusIcon = r.spinner.View()
 		statusText = status
 	case "executed", "completed":
 		statusIcon = icons.CheckMark

--- a/internal/ui/components/tool_call_renderer.go
+++ b/internal/ui/components/tool_call_renderer.go
@@ -26,6 +26,8 @@ type ToolCallRenderer struct {
 	keyHintFormatter KeyHintFormatter
 	lastUpdate       time.Time
 	lastTimerRender  time.Time
+	stateManager     domain.StateManager
+	pausedAt         time.Time
 }
 
 // KeyHintFormatter provides formatted key hints for actions
@@ -205,7 +207,37 @@ func (r *ToolCallRenderer) SetKeyHintFormatter(formatter KeyHintFormatter) {
 	r.keyHintFormatter = formatter
 }
 
+// SetStateManager wires the state manager so running-tool timers can pause
+// while an approval or question overlay is blocked on the user.
+func (r *ToolCallRenderer) SetStateManager(stateManager domain.StateManager) {
+	r.stateManager = stateManager
+}
+
+// syncApprovalPause freezes running-tool timers while the user is deciding on
+// an approval or question, and shifts the affected StartTimes forward on
+// resume so the wait doesn't count as execution time. Same derive-from-state
+// pattern as StatusView.syncApprovalPause.
+func (r *ToolCallRenderer) syncApprovalPause() {
+	if awaitingUserDecision(r.stateManager) {
+		if r.pausedAt.IsZero() {
+			r.pausedAt = time.Now()
+		}
+		return
+	}
+	if !r.pausedAt.IsZero() {
+		pause := time.Since(r.pausedAt)
+		for _, tool := range r.tools {
+			if tool.EndTime == nil {
+				tool.StartTime = tool.StartTime.Add(pause)
+			}
+		}
+		r.pausedAt = time.Time{}
+	}
+}
+
 func (r *ToolCallRenderer) RenderPreviews() string {
+	r.syncApprovalPause()
+
 	var allPreviews []string
 	var remainingTools []string
 
@@ -260,10 +292,14 @@ func (r *ToolCallRenderer) renderTool(tool *ToolRenderState) string {
 		statusColor = "dim"
 	case "running", "starting", "saving", "executing", "streaming":
 		statusIcon = r.spinner.View()
-		if tool.EndTime == nil {
+		switch {
+		case !r.pausedAt.IsZero():
+			statusIcon = icons.QueuedIcon
+			statusText = "waiting for your input"
+		case tool.EndTime == nil:
 			elapsed := time.Since(tool.StartTime)
 			statusText = fmt.Sprintf("running %s", r.formatDuration(elapsed))
-		} else {
+		default:
 			statusText = "executing"
 		}
 		iconColor = "accent"

--- a/internal/ui/components/tool_call_renderer.go
+++ b/internal/ui/components/tool_call_renderer.go
@@ -218,21 +218,13 @@ func (r *ToolCallRenderer) SetStateManager(stateManager domain.StateManager) {
 // resume so the wait doesn't count as execution time. Same derive-from-state
 // pattern as StatusView.syncApprovalPause.
 func (r *ToolCallRenderer) syncApprovalPause() {
-	if awaitingUserDecision(r.stateManager) {
-		if r.pausedAt.IsZero() {
-			r.pausedAt = time.Now()
-		}
-		return
-	}
-	if !r.pausedAt.IsZero() {
-		pause := time.Since(r.pausedAt)
+	syncApprovalPause(r.stateManager, &r.pausedAt, func(pause time.Duration) {
 		for _, tool := range r.tools {
 			if tool.EndTime == nil {
 				tool.StartTime = tool.StartTime.Add(pause)
 			}
 		}
-		r.pausedAt = time.Time{}
-	}
+	})
 }
 
 func (r *ToolCallRenderer) RenderPreviews() string {

--- a/internal/ui/components/tool_call_renderer_test.go
+++ b/internal/ui/components/tool_call_renderer_test.go
@@ -1,9 +1,12 @@
 package components
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
 // TestToolCallRenderer_BashOutputStreamLineCounting verifies that a single
@@ -51,5 +54,36 @@ func TestToolCallRenderer_BashOutputStreamLineCounting(t *testing.T) {
 	}
 	if got := state.OutputBuffer[len(state.OutputBuffer)-1]; got != "j" {
 		t.Errorf("expected last preview line to be j, got %q", got)
+	}
+}
+
+// TestToolCallRenderer_PausesTimerDuringApproval verifies the running-tool
+// ticker freezes into a "waiting for your input" label while an approval or
+// question overlay is blocked on the user, and resumes afterwards.
+func TestToolCallRenderer_PausesTimerDuringApproval(t *testing.T) {
+	r := NewToolCallRenderer(createMockStyleProviderForStatus())
+	sm := &domainmocks.FakeStateManager{}
+	r.SetStateManager(sm)
+	r.tools["tc-1"] = &ToolRenderState{
+		CallID:    "tc-1",
+		ToolName:  "AskUserQuestion",
+		Status:    "running",
+		StartTime: time.Now(),
+	}
+	r.toolsOrder = []string{"tc-1"}
+
+	sm.GetUserQuestionUIStateReturns(&domain.UserQuestionUIState{})
+	paused := r.RenderPreviews()
+	if !strings.Contains(paused, "waiting for your input") {
+		t.Errorf("expected waiting label while question pending, got %q", paused)
+	}
+	if strings.Contains(paused, "running") {
+		t.Errorf("expected no running ticker while question pending, got %q", paused)
+	}
+
+	sm.GetUserQuestionUIStateReturns(nil)
+	resumed := r.RenderPreviews()
+	if !strings.Contains(resumed, "running") {
+		t.Errorf("expected running ticker after question answered, got %q", resumed)
 	}
 }

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -253,17 +253,6 @@ func handleToggleRawFormat(app KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cm
 func handleEnterKey(app KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cmd {
 	stateManager := app.GetStateManager()
 
-	approvalState := stateManager.GetApprovalUIState()
-	if approvalState != nil {
-		action := domain.ApprovalAction(approvalState.SelectedIndex)
-		return func() tea.Msg {
-			return domain.ToolApprovalResponseEvent{
-				Action:   action,
-				ToolCall: *approvalState.PendingToolCall,
-			}
-		}
-	}
-
 	planApprovalState := stateManager.GetPlanApprovalUIState()
 	if planApprovalState != nil {
 		action := domain.PlanApprovalAction(planApprovalState.SelectedIndex)
@@ -580,18 +569,6 @@ func handlePageDown(app KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cmd {
 func handleCursorLeftOrPlanNav(app KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cmd {
 	stateManager := app.GetStateManager()
 
-	approvalState := stateManager.GetApprovalUIState()
-	if approvalState != nil {
-		newIndex := approvalState.SelectedIndex - 1
-		if newIndex < 0 {
-			newIndex = int(domain.ApprovalAutoAccept)
-		}
-		stateManager.SetApprovalSelectedIndex(newIndex)
-		return func() tea.Msg {
-			return domain.ApprovalSelectionChangedEvent{NewIndex: newIndex}
-		}
-	}
-
 	planApprovalState := stateManager.GetPlanApprovalUIState()
 	if planApprovalState != nil {
 		newIndex := planApprovalState.SelectedIndex - 1
@@ -609,19 +586,6 @@ func handleCursorLeftOrPlanNav(app KeyHandlerContext, keyMsg tea.KeyPressMsg) te
 
 func handleCursorRightOrPlanNav(app KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cmd {
 	stateManager := app.GetStateManager()
-
-	approvalState := stateManager.GetApprovalUIState()
-	if approvalState != nil {
-		newIndex := approvalState.SelectedIndex + 1
-		if newIndex > int(domain.ApprovalAutoAccept) {
-			newIndex = 0
-		}
-
-		stateManager.SetApprovalSelectedIndex(newIndex)
-		return func() tea.Msg {
-			return domain.ApprovalSelectionChangedEvent{NewIndex: newIndex}
-		}
-	}
 
 	planApprovalState := stateManager.GetPlanApprovalUIState()
 	if planApprovalState != nil {

--- a/internal/ui/keybinding/actions.go
+++ b/internal/ui/keybinding/actions.go
@@ -1026,7 +1026,7 @@ func handleCharacterInput(app KeyHandlerContext, keyMsg tea.KeyPressMsg) tea.Cmd
 	}
 
 	if len(keyStr) > 1 && !keys.IsKnownKey(keyStr) {
-		return handlePasteEvent(app, keyStr)
+		return HandlePasteEvent(app, keyStr)
 	}
 
 	stateManager := app.GetStateManager()
@@ -1092,8 +1092,8 @@ func handleInputChangedAfterTextarea(app KeyHandlerContext, openFileSelection bo
 	)
 }
 
-// handlePasteEvent handles when the terminal sends clipboard content directly
-func handlePasteEvent(app KeyHandlerContext, pastedText string) tea.Cmd {
+// HandlePasteEvent handles when the terminal sends clipboard content directly
+func HandlePasteEvent(app KeyHandlerContext, pastedText string) tea.Cmd {
 	inputView := app.GetInputView()
 	if inputView == nil {
 		return nil

--- a/internal/ui/keybinding/actions_internal_test.go
+++ b/internal/ui/keybinding/actions_internal_test.go
@@ -106,7 +106,7 @@ func TestHandlePasteEventFlashesAndInserts(t *testing.T) {
 	ctx := newFlashCtx(false, "")
 	input := ctx.input.(*uimocks.FakeInputComponent)
 
-	cmd := handlePasteEvent(ctx, "hello world")
+	cmd := HandlePasteEvent(ctx, "hello world")
 	if cmd == nil {
 		t.Fatal("expected a command for a non-empty paste")
 	}
@@ -137,7 +137,7 @@ func TestHandlePasteEventEmptyIsNoop(t *testing.T) {
 	ctx := newFlashCtx(false, "")
 	input := ctx.input.(*uimocks.FakeInputComponent)
 
-	if cmd := handlePasteEvent(ctx, "[]"); cmd != nil {
+	if cmd := HandlePasteEvent(ctx, "[]"); cmd != nil {
 		t.Error("expected a nil command for an empty paste")
 	}
 	if input.SetTextCallCount() != 0 {

--- a/internal/ui/styles/icons/icons.go
+++ b/internal/ui/styles/icons/icons.go
@@ -25,10 +25,6 @@ const (
 	QueuedIcon    = "•"
 	ExecutingIcon = "⚡"
 	BulletIcon    = "•"
-	SpinnerFrames = "⣾⣽⣻⢿⡿⣟⣯⣷"
-	ProgressDots  = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
-	ModernSpinner = "◐◓◑◒"
-	ArrowSpinner  = "▶▷▶▷"
 )
 
 // Icon styles
@@ -44,14 +40,4 @@ func StyledCheckMark() string {
 
 func StyledCrossMark() string {
 	return CrossMarkStyle.Render(CrossMark)
-}
-
-// GetSpinnerFrame returns the appropriate spinner frame based on animation step
-func GetSpinnerFrame(step int) string {
-	frames := ModernSpinner
-	runes := []rune(frames)
-	if len(runes) == 0 {
-		return ExecutingIcon
-	}
-	return string(runes[step%len(runes)])
 }

--- a/internal/ui/styles/provider.go
+++ b/internal/ui/styles/provider.go
@@ -116,7 +116,7 @@ func (p *Provider) RenderInputField(content string, width int, focused bool, bra
 		return rendered
 	}
 
-	return p.spliceBranchIntoTopBorder(rendered, branchLabel, borderColor, theme.GetDimColor())
+	return p.spliceBranchIntoTopBorder(rendered, branchLabel, borderColor, theme.GetStatusColor())
 }
 
 // spliceBranchIntoTopBorder rebuilds the top border line of an already-rendered

--- a/internal/ui/styles/provider.go
+++ b/internal/ui/styles/provider.go
@@ -161,17 +161,24 @@ func (p *Provider) spliceBranchIntoTopBorder(box, label, borderColor, labelColor
 }
 
 // truncateBorderLabel shortens s to at most maxWidth display columns, appending
-// tail when it has to cut. It walks runes so multi-byte names are never split
-// mid-character and wide runes are accounted for.
+// tail when it has to cut. A short final space-separated token (e.g. the PR
+// "#854" in "⎇ branch  #854") is preserved and the cut lands before it, so the
+// PR number survives long branch names. It walks runes so multi-byte names are
+// never split mid-character and wide runes are accounted for.
 func truncateBorderLabel(s string, maxWidth int, tail string) string {
 	if lipgloss.Width(s) <= maxWidth {
 		return s
 	}
-	target := max(maxWidth-lipgloss.Width(tail), 0)
+
+	head, suffix := s, ""
+	if i := strings.LastIndex(s, " "); i >= 0 && lipgloss.Width(s[i:]) <= maxWidth/2 {
+		head, suffix = s[:i], s[i:]
+	}
+	target := max(maxWidth-lipgloss.Width(tail)-lipgloss.Width(suffix), 0)
 
 	var out []rune
 	width := 0
-	for _, r := range s {
+	for _, r := range head {
 		rw := lipgloss.Width(string(r))
 		if width+rw > target {
 			break
@@ -179,7 +186,7 @@ func truncateBorderLabel(s string, maxWidth int, tail string) string {
 		out = append(out, r)
 		width += rw
 	}
-	return string(out) + tail
+	return string(out) + tail + suffix
 }
 
 // RenderInputPlaceholder renders placeholder text

--- a/tests/mocks/domain/fake_state_manager.go
+++ b/tests/mocks/domain/fake_state_manager.go
@@ -335,11 +335,6 @@ type FakeStateManager struct {
 	setAgentModeArgsForCall []struct {
 		arg1 domain.AgentMode
 	}
-	SetApprovalSelectedIndexStub        func(int)
-	setApprovalSelectedIndexMutex       sync.RWMutex
-	setApprovalSelectedIndexArgsForCall []struct {
-		arg1 int
-	}
 	SetChatPendingStub        func()
 	setChatPendingMutex       sync.RWMutex
 	setChatPendingArgsForCall []struct {
@@ -2258,38 +2253,6 @@ func (fake *FakeStateManager) SetAgentModeArgsForCall(i int) domain.AgentMode {
 	fake.setAgentModeMutex.RLock()
 	defer fake.setAgentModeMutex.RUnlock()
 	argsForCall := fake.setAgentModeArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeStateManager) SetApprovalSelectedIndex(arg1 int) {
-	fake.setApprovalSelectedIndexMutex.Lock()
-	fake.setApprovalSelectedIndexArgsForCall = append(fake.setApprovalSelectedIndexArgsForCall, struct {
-		arg1 int
-	}{arg1})
-	stub := fake.SetApprovalSelectedIndexStub
-	fake.recordInvocation("SetApprovalSelectedIndex", []interface{}{arg1})
-	fake.setApprovalSelectedIndexMutex.Unlock()
-	if stub != nil {
-		fake.SetApprovalSelectedIndexStub(arg1)
-	}
-}
-
-func (fake *FakeStateManager) SetApprovalSelectedIndexCallCount() int {
-	fake.setApprovalSelectedIndexMutex.RLock()
-	defer fake.setApprovalSelectedIndexMutex.RUnlock()
-	return len(fake.setApprovalSelectedIndexArgsForCall)
-}
-
-func (fake *FakeStateManager) SetApprovalSelectedIndexCalls(stub func(int)) {
-	fake.setApprovalSelectedIndexMutex.Lock()
-	defer fake.setApprovalSelectedIndexMutex.Unlock()
-	fake.SetApprovalSelectedIndexStub = stub
-}
-
-func (fake *FakeStateManager) SetApprovalSelectedIndexArgsForCall(i int) int {
-	fake.setApprovalSelectedIndexMutex.RLock()
-	defer fake.setApprovalSelectedIndexMutex.RUnlock()
-	argsForCall := fake.setApprovalSelectedIndexArgsForCall[i]
 	return argsForCall.arg1
 }
 

--- a/tests/mocks/domain/fake_state_manager.go
+++ b/tests/mocks/domain/fake_state_manager.go
@@ -9,21 +9,6 @@ import (
 )
 
 type FakeStateManager struct {
-	AdvanceUserQuestionStub        func() bool
-	advanceUserQuestionMutex       sync.RWMutex
-	advanceUserQuestionArgsForCall []struct {
-	}
-	advanceUserQuestionReturns struct {
-		result1 bool
-	}
-	advanceUserQuestionReturnsOnCall map[int]struct {
-		result1 bool
-	}
-	AppendUserQuestionOtherTextStub        func(string)
-	appendUserQuestionOtherTextMutex       sync.RWMutex
-	appendUserQuestionOtherTextArgsForCall []struct {
-		arg1 string
-	}
 	AreAllAgentsReadyStub        func() bool
 	areAllAgentsReadyMutex       sync.RWMutex
 	areAllAgentsReadyArgsForCall []struct {
@@ -34,24 +19,10 @@ type FakeStateManager struct {
 	areAllAgentsReadyReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	BackspaceUserQuestionOtherTextStub        func()
-	backspaceUserQuestionOtherTextMutex       sync.RWMutex
-	backspaceUserQuestionOtherTextArgsForCall []struct {
-	}
 	BroadcastEventStub        func(domain.ChatEvent)
 	broadcastEventMutex       sync.RWMutex
 	broadcastEventArgsForCall []struct {
 		arg1 domain.ChatEvent
-	}
-	BuildUserQuestionAnswersStub        func() []domain.UserQuestionAnswer
-	buildUserQuestionAnswersMutex       sync.RWMutex
-	buildUserQuestionAnswersArgsForCall []struct {
-	}
-	buildUserQuestionAnswersReturns struct {
-		result1 []domain.UserQuestionAnswer
-	}
-	buildUserQuestionAnswersReturnsOnCall map[int]struct {
-		result1 []domain.UserQuestionAnswer
 	}
 	ClearAgentReadinessStub        func()
 	clearAgentReadinessMutex       sync.RWMutex
@@ -426,16 +397,6 @@ type FakeStateManager struct {
 	setTodosArgsForCall []struct {
 		arg1 []domain.TodoItem
 	}
-	SetUserQuestionOptionCursorStub        func(int)
-	setUserQuestionOptionCursorMutex       sync.RWMutex
-	setUserQuestionOptionCursorArgsForCall []struct {
-		arg1 int
-	}
-	SetUserQuestionOtherActiveStub        func(bool)
-	setUserQuestionOtherActiveMutex       sync.RWMutex
-	setUserQuestionOtherActiveArgsForCall []struct {
-		arg1 bool
-	}
 	SetupApprovalUIStateStub        func(*sdk.ChatCompletionMessageToolCall, chan domain.ApprovalAction)
 	setupApprovalUIStateMutex       sync.RWMutex
 	setupApprovalUIStateArgsForCall []struct {
@@ -484,11 +445,6 @@ type FakeStateManager struct {
 	startToolExecutionReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ToggleUserQuestionOptionStub        func(int)
-	toggleUserQuestionOptionMutex       sync.RWMutex
-	toggleUserQuestionOptionArgsForCall []struct {
-		arg1 int
-	}
 	TouchChatActivityStub        func()
 	touchChatActivityMutex       sync.RWMutex
 	touchChatActivityArgsForCall []struct {
@@ -531,91 +487,6 @@ type FakeStateManager struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeStateManager) AdvanceUserQuestion() bool {
-	fake.advanceUserQuestionMutex.Lock()
-	ret, specificReturn := fake.advanceUserQuestionReturnsOnCall[len(fake.advanceUserQuestionArgsForCall)]
-	fake.advanceUserQuestionArgsForCall = append(fake.advanceUserQuestionArgsForCall, struct {
-	}{})
-	stub := fake.AdvanceUserQuestionStub
-	fakeReturns := fake.advanceUserQuestionReturns
-	fake.recordInvocation("AdvanceUserQuestion", []interface{}{})
-	fake.advanceUserQuestionMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeStateManager) AdvanceUserQuestionCallCount() int {
-	fake.advanceUserQuestionMutex.RLock()
-	defer fake.advanceUserQuestionMutex.RUnlock()
-	return len(fake.advanceUserQuestionArgsForCall)
-}
-
-func (fake *FakeStateManager) AdvanceUserQuestionCalls(stub func() bool) {
-	fake.advanceUserQuestionMutex.Lock()
-	defer fake.advanceUserQuestionMutex.Unlock()
-	fake.AdvanceUserQuestionStub = stub
-}
-
-func (fake *FakeStateManager) AdvanceUserQuestionReturns(result1 bool) {
-	fake.advanceUserQuestionMutex.Lock()
-	defer fake.advanceUserQuestionMutex.Unlock()
-	fake.AdvanceUserQuestionStub = nil
-	fake.advanceUserQuestionReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *FakeStateManager) AdvanceUserQuestionReturnsOnCall(i int, result1 bool) {
-	fake.advanceUserQuestionMutex.Lock()
-	defer fake.advanceUserQuestionMutex.Unlock()
-	fake.AdvanceUserQuestionStub = nil
-	if fake.advanceUserQuestionReturnsOnCall == nil {
-		fake.advanceUserQuestionReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.advanceUserQuestionReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *FakeStateManager) AppendUserQuestionOtherText(arg1 string) {
-	fake.appendUserQuestionOtherTextMutex.Lock()
-	fake.appendUserQuestionOtherTextArgsForCall = append(fake.appendUserQuestionOtherTextArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.AppendUserQuestionOtherTextStub
-	fake.recordInvocation("AppendUserQuestionOtherText", []interface{}{arg1})
-	fake.appendUserQuestionOtherTextMutex.Unlock()
-	if stub != nil {
-		fake.AppendUserQuestionOtherTextStub(arg1)
-	}
-}
-
-func (fake *FakeStateManager) AppendUserQuestionOtherTextCallCount() int {
-	fake.appendUserQuestionOtherTextMutex.RLock()
-	defer fake.appendUserQuestionOtherTextMutex.RUnlock()
-	return len(fake.appendUserQuestionOtherTextArgsForCall)
-}
-
-func (fake *FakeStateManager) AppendUserQuestionOtherTextCalls(stub func(string)) {
-	fake.appendUserQuestionOtherTextMutex.Lock()
-	defer fake.appendUserQuestionOtherTextMutex.Unlock()
-	fake.AppendUserQuestionOtherTextStub = stub
-}
-
-func (fake *FakeStateManager) AppendUserQuestionOtherTextArgsForCall(i int) string {
-	fake.appendUserQuestionOtherTextMutex.RLock()
-	defer fake.appendUserQuestionOtherTextMutex.RUnlock()
-	argsForCall := fake.appendUserQuestionOtherTextArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *FakeStateManager) AreAllAgentsReady() bool {
@@ -671,30 +542,6 @@ func (fake *FakeStateManager) AreAllAgentsReadyReturnsOnCall(i int, result1 bool
 	}{result1}
 }
 
-func (fake *FakeStateManager) BackspaceUserQuestionOtherText() {
-	fake.backspaceUserQuestionOtherTextMutex.Lock()
-	fake.backspaceUserQuestionOtherTextArgsForCall = append(fake.backspaceUserQuestionOtherTextArgsForCall, struct {
-	}{})
-	stub := fake.BackspaceUserQuestionOtherTextStub
-	fake.recordInvocation("BackspaceUserQuestionOtherText", []interface{}{})
-	fake.backspaceUserQuestionOtherTextMutex.Unlock()
-	if stub != nil {
-		fake.BackspaceUserQuestionOtherTextStub()
-	}
-}
-
-func (fake *FakeStateManager) BackspaceUserQuestionOtherTextCallCount() int {
-	fake.backspaceUserQuestionOtherTextMutex.RLock()
-	defer fake.backspaceUserQuestionOtherTextMutex.RUnlock()
-	return len(fake.backspaceUserQuestionOtherTextArgsForCall)
-}
-
-func (fake *FakeStateManager) BackspaceUserQuestionOtherTextCalls(stub func()) {
-	fake.backspaceUserQuestionOtherTextMutex.Lock()
-	defer fake.backspaceUserQuestionOtherTextMutex.Unlock()
-	fake.BackspaceUserQuestionOtherTextStub = stub
-}
-
 func (fake *FakeStateManager) BroadcastEvent(arg1 domain.ChatEvent) {
 	fake.broadcastEventMutex.Lock()
 	fake.broadcastEventArgsForCall = append(fake.broadcastEventArgsForCall, struct {
@@ -725,59 +572,6 @@ func (fake *FakeStateManager) BroadcastEventArgsForCall(i int) domain.ChatEvent 
 	defer fake.broadcastEventMutex.RUnlock()
 	argsForCall := fake.broadcastEventArgsForCall[i]
 	return argsForCall.arg1
-}
-
-func (fake *FakeStateManager) BuildUserQuestionAnswers() []domain.UserQuestionAnswer {
-	fake.buildUserQuestionAnswersMutex.Lock()
-	ret, specificReturn := fake.buildUserQuestionAnswersReturnsOnCall[len(fake.buildUserQuestionAnswersArgsForCall)]
-	fake.buildUserQuestionAnswersArgsForCall = append(fake.buildUserQuestionAnswersArgsForCall, struct {
-	}{})
-	stub := fake.BuildUserQuestionAnswersStub
-	fakeReturns := fake.buildUserQuestionAnswersReturns
-	fake.recordInvocation("BuildUserQuestionAnswers", []interface{}{})
-	fake.buildUserQuestionAnswersMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeStateManager) BuildUserQuestionAnswersCallCount() int {
-	fake.buildUserQuestionAnswersMutex.RLock()
-	defer fake.buildUserQuestionAnswersMutex.RUnlock()
-	return len(fake.buildUserQuestionAnswersArgsForCall)
-}
-
-func (fake *FakeStateManager) BuildUserQuestionAnswersCalls(stub func() []domain.UserQuestionAnswer) {
-	fake.buildUserQuestionAnswersMutex.Lock()
-	defer fake.buildUserQuestionAnswersMutex.Unlock()
-	fake.BuildUserQuestionAnswersStub = stub
-}
-
-func (fake *FakeStateManager) BuildUserQuestionAnswersReturns(result1 []domain.UserQuestionAnswer) {
-	fake.buildUserQuestionAnswersMutex.Lock()
-	defer fake.buildUserQuestionAnswersMutex.Unlock()
-	fake.BuildUserQuestionAnswersStub = nil
-	fake.buildUserQuestionAnswersReturns = struct {
-		result1 []domain.UserQuestionAnswer
-	}{result1}
-}
-
-func (fake *FakeStateManager) BuildUserQuestionAnswersReturnsOnCall(i int, result1 []domain.UserQuestionAnswer) {
-	fake.buildUserQuestionAnswersMutex.Lock()
-	defer fake.buildUserQuestionAnswersMutex.Unlock()
-	fake.BuildUserQuestionAnswersStub = nil
-	if fake.buildUserQuestionAnswersReturnsOnCall == nil {
-		fake.buildUserQuestionAnswersReturnsOnCall = make(map[int]struct {
-			result1 []domain.UserQuestionAnswer
-		})
-	}
-	fake.buildUserQuestionAnswersReturnsOnCall[i] = struct {
-		result1 []domain.UserQuestionAnswer
-	}{result1}
 }
 
 func (fake *FakeStateManager) ClearAgentReadiness() {
@@ -2851,70 +2645,6 @@ func (fake *FakeStateManager) SetTodosArgsForCall(i int) []domain.TodoItem {
 	return argsForCall.arg1
 }
 
-func (fake *FakeStateManager) SetUserQuestionOptionCursor(arg1 int) {
-	fake.setUserQuestionOptionCursorMutex.Lock()
-	fake.setUserQuestionOptionCursorArgsForCall = append(fake.setUserQuestionOptionCursorArgsForCall, struct {
-		arg1 int
-	}{arg1})
-	stub := fake.SetUserQuestionOptionCursorStub
-	fake.recordInvocation("SetUserQuestionOptionCursor", []interface{}{arg1})
-	fake.setUserQuestionOptionCursorMutex.Unlock()
-	if stub != nil {
-		fake.SetUserQuestionOptionCursorStub(arg1)
-	}
-}
-
-func (fake *FakeStateManager) SetUserQuestionOptionCursorCallCount() int {
-	fake.setUserQuestionOptionCursorMutex.RLock()
-	defer fake.setUserQuestionOptionCursorMutex.RUnlock()
-	return len(fake.setUserQuestionOptionCursorArgsForCall)
-}
-
-func (fake *FakeStateManager) SetUserQuestionOptionCursorCalls(stub func(int)) {
-	fake.setUserQuestionOptionCursorMutex.Lock()
-	defer fake.setUserQuestionOptionCursorMutex.Unlock()
-	fake.SetUserQuestionOptionCursorStub = stub
-}
-
-func (fake *FakeStateManager) SetUserQuestionOptionCursorArgsForCall(i int) int {
-	fake.setUserQuestionOptionCursorMutex.RLock()
-	defer fake.setUserQuestionOptionCursorMutex.RUnlock()
-	argsForCall := fake.setUserQuestionOptionCursorArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeStateManager) SetUserQuestionOtherActive(arg1 bool) {
-	fake.setUserQuestionOtherActiveMutex.Lock()
-	fake.setUserQuestionOtherActiveArgsForCall = append(fake.setUserQuestionOtherActiveArgsForCall, struct {
-		arg1 bool
-	}{arg1})
-	stub := fake.SetUserQuestionOtherActiveStub
-	fake.recordInvocation("SetUserQuestionOtherActive", []interface{}{arg1})
-	fake.setUserQuestionOtherActiveMutex.Unlock()
-	if stub != nil {
-		fake.SetUserQuestionOtherActiveStub(arg1)
-	}
-}
-
-func (fake *FakeStateManager) SetUserQuestionOtherActiveCallCount() int {
-	fake.setUserQuestionOtherActiveMutex.RLock()
-	defer fake.setUserQuestionOtherActiveMutex.RUnlock()
-	return len(fake.setUserQuestionOtherActiveArgsForCall)
-}
-
-func (fake *FakeStateManager) SetUserQuestionOtherActiveCalls(stub func(bool)) {
-	fake.setUserQuestionOtherActiveMutex.Lock()
-	defer fake.setUserQuestionOtherActiveMutex.Unlock()
-	fake.SetUserQuestionOtherActiveStub = stub
-}
-
-func (fake *FakeStateManager) SetUserQuestionOtherActiveArgsForCall(i int) bool {
-	fake.setUserQuestionOtherActiveMutex.RLock()
-	defer fake.setUserQuestionOtherActiveMutex.RUnlock()
-	argsForCall := fake.setUserQuestionOtherActiveArgsForCall[i]
-	return argsForCall.arg1
-}
-
 func (fake *FakeStateManager) SetupApprovalUIState(arg1 *sdk.ChatCompletionMessageToolCall, arg2 chan domain.ApprovalAction) {
 	fake.setupApprovalUIStateMutex.Lock()
 	fake.setupApprovalUIStateArgsForCall = append(fake.setupApprovalUIStateArgsForCall, struct {
@@ -3184,38 +2914,6 @@ func (fake *FakeStateManager) StartToolExecutionReturnsOnCall(i int, result1 err
 	fake.startToolExecutionReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
-}
-
-func (fake *FakeStateManager) ToggleUserQuestionOption(arg1 int) {
-	fake.toggleUserQuestionOptionMutex.Lock()
-	fake.toggleUserQuestionOptionArgsForCall = append(fake.toggleUserQuestionOptionArgsForCall, struct {
-		arg1 int
-	}{arg1})
-	stub := fake.ToggleUserQuestionOptionStub
-	fake.recordInvocation("ToggleUserQuestionOption", []interface{}{arg1})
-	fake.toggleUserQuestionOptionMutex.Unlock()
-	if stub != nil {
-		fake.ToggleUserQuestionOptionStub(arg1)
-	}
-}
-
-func (fake *FakeStateManager) ToggleUserQuestionOptionCallCount() int {
-	fake.toggleUserQuestionOptionMutex.RLock()
-	defer fake.toggleUserQuestionOptionMutex.RUnlock()
-	return len(fake.toggleUserQuestionOptionArgsForCall)
-}
-
-func (fake *FakeStateManager) ToggleUserQuestionOptionCalls(stub func(int)) {
-	fake.toggleUserQuestionOptionMutex.Lock()
-	defer fake.toggleUserQuestionOptionMutex.Unlock()
-	fake.ToggleUserQuestionOptionStub = stub
-}
-
-func (fake *FakeStateManager) ToggleUserQuestionOptionArgsForCall(i int) int {
-	fake.toggleUserQuestionOptionMutex.RLock()
-	defer fake.toggleUserQuestionOptionMutex.RUnlock()
-	argsForCall := fake.toggleUserQuestionOptionArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *FakeStateManager) TouchChatActivity() {


### PR DESCRIPTION
Closes #833.

Consolidates the hand-rolled interactive UI onto `huh/v2` (already a dependency, proven in the GitHub Action wizard), unifies the dual spinner systems, and authors the missing `huh-v2` repo skill. Net **-458 lines** (986+/1444-) across 28 files. Each step is its own commit and independently revertable.

## What changed

- **Spinners**: one `newModernSpinner()` constructor (`◐◓◑◒`) feeds all 8 render sites; the manual frame counters stepped off `spinner.TickMsg` and `icons.GetSpinnerFrame` are deleted. Visual change: the three former `spinner.Dot` (braille) sites now animate as `◐◓◑◒` too.
- **Theming**: new `huhTheme(styleProvider)` maps the active theme onto a `huh.Theme`; applied to every form, including the previously untheme'd GitHub Action wizard.
- **Plugin install prompt** (`cmd/plugins.go`): raw bufio y/N → standalone `huh.NewConfirm().Run()`. The `--yes` flag and non-interactive-stdin guard are unchanged.
- **AskUserQuestion form**: `QuestionFormView` now owns the answer-in-progress state as one huh form per question (Select/MultiSelect + a `WithHideFunc`-gated "Other" free-text group). `UserQuestionUIState` slims to `{Questions, ResponseChan}`; the seven StateManager mutators, their interface methods, and the centralized key handlers in `chat.go` are deleted. huh's quit key is rebound from ctrl+c to esc (chat reserves ctrl+c for interrupting the turn), preserving esc-cancels.
- **Tool approval**: the three-button row becomes a huh Select in `Inline` mode — a one-line `← Approve →` carousel under the (untouched) diff preview, cycled with the same ←/→ keys. `ApprovalUIState.SelectedIndex`, its plumbing, and `ApprovalSelectionChangedEvent` are deleted. Plan approval is untouched.
- **Model selector**: rebuilt on huh Select; search is a dedicated textinput line (`/` to enter, esc to clear) that filters on the model name only — huh's built-in filter is disabled since it renders the query into the title line with no visible input. Pricing tabs (keys 1-4) rebuild the option set. Fixes two latent bugs along the way: `GetSelected` indexed the unfiltered list with a filtered index, and `chat.go` only checked selection state when `Update` returned a non-nil cmd (huh completion can return nil — selection would hang).
- **Conversation list**: the hand-built fixed-width table becomes a bubbles/v2 `table`; async load, `/` search, and the d→y/N delete flow are unchanged.
- **Skill**: `.agents/skills/huh-v2/SKILL.md`, mirroring the bubbles-v2/bubbletea-v2/lipgloss-v2 shape, sourced from the v2.0.3 module cache and the in-repo wizard. Key gotcha documented: forms complete via huh's internal command messages, so every message must be routed back into the form (and tests must pump returned cmds).

## Corrections to the issue

- `cmd/agent.go:812` is not a prompt — it reads JSON `ApprovalResponse` IPC lines in piped mode. Left untouched.
- The conversation picker's multi-column stats table doesn't fit huh's Select; per discussion it moved to bubbles/v2 `table` instead.

## UX changes to review

- Approval actions render as a one-option-at-a-time carousel (`← Approve →`) instead of three visible buttons.
- In the question form, esc while typing "Other" text cancels the form (previously it stepped back to the options).

## Verification

`task test` and `task lint` green per commit; mocks regenerated where interfaces shrank. Manual TUI pass against the embedded mock gateway (tmux-driven): model tabs/filter/select, conversation table + search + delete confirm, Write-tool approval with diff preview (approve/reject/carousel), allow-listed Bash run, spinners.

The live pass caught and fixed two bugs (final commit): the bubbles table viewport defaults to width 0 (conversation rows rendered as nothing), and huh renders the `/` filter input in the title line (the untitled model select filtered invisibly).

**Pre-existing issue found, not addressed here**: after rejecting a tool approval, the agent session never completes and the next message queues forever ("agent is currently busy"). Reproduced identically on `main`, so it predates this branch — filing separately.
