### PR TITLE
test(agent): add table-driven tests for the 11 untested agent states

### DIFF
--- a/internal/agent/states/blocking_tools_test.go
+++ b/internal/agent/states/blocking_tools_test.go
@@ -1,0 +1,138 @@
+package states
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+func requireAllApproval(*sdk.ChatCompletionMessageToolCall, bool) bool { return true }
+
+// TestBlockingToolsState_GatedToolsAreRejected verifies that with no approver
+// reachable every gated tool is turned into a rejected "Blocked:" tool result
+// (appended to ToolResults, the conversation, and storage in tool-call order)
+// and the batch ends with LastToolFailed set and AllToolsProcessedEvent.
+func TestBlockingToolsState_GatedToolsAreRejected(t *testing.T) {
+	f := newStateFixture()
+	*f.ctx.CurrentToolCalls = makeTools(2)
+	f.ctx.ShouldRequireApproval = requireAllApproval
+	s := NewBlockingToolsState(f.ctx)
+	assert.Equal(t, domain.StateBlockingTools, s.Name())
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+	waitForAllToolsProcessed(t, f.events)
+	f.ctx.WaitGroup.Wait()
+
+	results := *f.ctx.ToolResults
+	require.Len(t, results, 2)
+	for i, entry := range results {
+		require.NotNil(t, entry.ToolExecution, "result %d", i)
+		assert.True(t, entry.ToolExecution.Rejected, "result %d must be rejected", i)
+		assert.False(t, entry.ToolExecution.Success, "result %d must not succeed", i)
+		content, _ := entry.Message.Content.AsMessageContent0()
+		assert.True(t, strings.HasPrefix(content, "Blocked:"), "result %d content: %q", i, content)
+		require.NotNil(t, entry.Message.ToolCallID)
+		assert.Equal(t, fmt.Sprintf("call-%d", i), *entry.Message.ToolCallID, "result %d out of order", i)
+	}
+	assert.Len(t, *f.ctx.AgentCtx.Conversation, 2)
+	assert.Len(t, f.added, 2, "each result must be persisted via AddMessage")
+	assert.True(t, f.ctx.AgentCtx.LastToolFailed)
+	assert.True(t, f.ctx.AgentCtx.HasToolResults)
+}
+
+// TestBlockingToolsState_MixedBatchRunsNonGatedTools verifies tools that do
+// not require approval still execute in a blocked batch, preserving tool-call
+// order.
+func TestBlockingToolsState_MixedBatchRunsNonGatedTools(t *testing.T) {
+	f := newStateFixture()
+	*f.ctx.CurrentToolCalls = makeTools(2)
+	f.ctx.ShouldRequireApproval = func(tc *sdk.ChatCompletionMessageToolCall, _ bool) bool {
+		return tc.ID == "call-0"
+	}
+	s := NewBlockingToolsState(f.ctx)
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+	waitForAllToolsProcessed(t, f.events)
+	f.ctx.WaitGroup.Wait()
+
+	results := *f.ctx.ToolResults
+	require.Len(t, results, 2)
+
+	blocked, executed := results[0], results[1]
+	require.NotNil(t, blocked.ToolExecution)
+	assert.True(t, blocked.ToolExecution.Rejected)
+	require.NotNil(t, blocked.Message.ToolCallID)
+	assert.Equal(t, "call-0", *blocked.Message.ToolCallID)
+
+	require.NotNil(t, executed.ToolExecution)
+	assert.True(t, executed.ToolExecution.Success, "non-gated tool must run normally")
+	assert.False(t, executed.ToolExecution.Rejected)
+	require.NotNil(t, executed.Message.ToolCallID)
+	assert.Equal(t, "call-1", *executed.Message.ToolCallID)
+
+	assert.True(t, f.ctx.AgentCtx.LastToolFailed, "the blocked tool counts as failed")
+}
+
+// TestBlockingToolsState_CancelledSessionSkipsBatch verifies a cancelled
+// session context skips the whole batch but still emits
+// AllToolsProcessedEvent so the loop can wind down.
+func TestBlockingToolsState_CancelledSessionSkipsBatch(t *testing.T) {
+	f := newStateFixture()
+	*f.ctx.CurrentToolCalls = makeTools(2)
+	f.ctx.ShouldRequireApproval = requireAllApproval
+	f.cancelSession()
+	s := NewBlockingToolsState(f.ctx)
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+	waitForAllToolsProcessed(t, f.events)
+	f.ctx.WaitGroup.Wait()
+
+	assert.Empty(t, *f.ctx.ToolResults)
+	assert.False(t, f.ctx.AgentCtx.LastToolFailed)
+}
+
+// TestBlockingToolsState_AllProcessedRoutesToPostToolExecution verifies the
+// AllToolsProcessedEvent leg: transition to PostToolExecution and re-emit, or
+// surface a failed transition.
+func TestBlockingToolsState_AllProcessedRoutesToPostToolExecution(t *testing.T) {
+	tests := []struct {
+		name          string
+		transitionErr error
+		wantErr       bool
+		wantEvents    []domain.AgentEvent
+	}{
+		{
+			name:       "advances to post tool execution",
+			wantEvents: []domain.AgentEvent{domain.MessageReceivedEvent{}},
+		},
+		{
+			name:          "transition failure is returned",
+			transitionErr: errBoom,
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			f.sm.TransitionReturns(tt.transitionErr)
+			s := NewBlockingToolsState(f.ctx)
+
+			err := s.Handle(domain.AllToolsProcessedEvent{})
+
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errBoom)
+			} else {
+				assert.NoError(t, err)
+			}
+			assertTransitions(t, f.sm, domain.StatePostToolExecution)
+			assertEvents(t, f.events, tt.wantEvents...)
+		})
+	}
+}

--- a/internal/agent/states/checking_queue_test.go
+++ b/internal/agent/states/checking_queue_test.go
@@ -1,0 +1,112 @@
+package states
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// TestCheckingQueueState_Handle covers the routing priorities of the
+// CheckingQueue executor: pending tool results stream first (without touching
+// the queue), queued messages are drained with the drain hooks, a cancelled
+// session short-circuits to Completing, met completion conditions go to
+// Completing, and otherwise the loop continues with a new stream.
+func TestCheckingQueueState_Handle(t *testing.T) {
+	tests := []struct {
+		name            string
+		event           domain.AgentEvent
+		setup           func(f *stateFixture)
+		transitionErr   error
+		wantErr         bool
+		wantTransitions []domain.AgentExecutionState
+		wantEvents      []domain.AgentEvent
+		wantHooks       []domain.HookPoint
+		wantDrainCalls  int
+	}{
+		{
+			name:            "tool results pending stream first without draining",
+			event:           domain.MessageReceivedEvent{},
+			setup:           func(f *stateFixture) { f.ctx.AgentCtx.HasToolResults = true },
+			wantTransitions: []domain.AgentExecutionState{domain.StateStreamingLLM},
+			wantEvents:      []domain.AgentEvent{domain.StartStreamingEvent{}},
+		},
+		{
+			name:  "queued messages are drained with both drain hooks",
+			event: domain.MessageReceivedEvent{},
+			setup: func(f *stateFixture) {
+				f.queue.IsEmptyReturns(false)
+				f.drainReturns = 2
+			},
+			wantTransitions: []domain.AgentExecutionState{domain.StateStreamingLLM},
+			wantEvents:      []domain.AgentEvent{domain.StartStreamingEvent{}},
+			wantHooks:       []domain.HookPoint{domain.HookPreQueueDrain, domain.HookPostQueueDrain},
+			wantDrainCalls:  1,
+		},
+		{
+			name:            "drain of zero messages skips the post-drain hook",
+			event:           domain.MessageReceivedEvent{},
+			setup:           func(f *stateFixture) { f.queue.IsEmptyReturns(false) },
+			wantTransitions: []domain.AgentExecutionState{domain.StateStreamingLLM},
+			wantEvents:      []domain.AgentEvent{domain.StartStreamingEvent{}},
+			wantHooks:       []domain.HookPoint{domain.HookPreQueueDrain},
+			wantDrainCalls:  1,
+		},
+		{
+			name:            "cancelled session completes without another turn",
+			event:           domain.MessageReceivedEvent{},
+			setup:           func(f *stateFixture) { f.cancelSession() },
+			wantTransitions: []domain.AgentExecutionState{domain.StateCompleting},
+			wantEvents:      []domain.AgentEvent{domain.CompletionRequestedEvent{}},
+		},
+		{
+			name:            "completion conditions met",
+			event:           domain.MessageReceivedEvent{},
+			setup:           func(f *stateFixture) { f.sm.CanTransitionReturns(true) },
+			wantTransitions: []domain.AgentExecutionState{domain.StateCompleting},
+			wantEvents:      []domain.AgentEvent{domain.CompletionRequestedEvent{}},
+		},
+		{
+			name:            "default continues the loop with a new stream",
+			event:           domain.MessageReceivedEvent{},
+			wantTransitions: []domain.AgentExecutionState{domain.StateStreamingLLM},
+			wantEvents:      []domain.AgentEvent{domain.StartStreamingEvent{}},
+		},
+		{
+			name:            "transition failure is returned",
+			event:           domain.MessageReceivedEvent{},
+			transitionErr:   errBoom,
+			wantErr:         true,
+			wantTransitions: []domain.AgentExecutionState{domain.StateStreamingLLM},
+		},
+		{
+			name:  "stray event is a no-op",
+			event: domain.CompletionRequestedEvent{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			hooks := f.recordHooks()
+			if tt.setup != nil {
+				tt.setup(f)
+			}
+			f.sm.TransitionReturns(tt.transitionErr)
+			s := NewCheckingQueueState(f.ctx)
+			assert.Equal(t, domain.StateCheckingQueue, s.Name())
+
+			err := s.Handle(tt.event)
+
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errBoom)
+			} else {
+				assert.NoError(t, err)
+			}
+			assertTransitions(t, f.sm, tt.wantTransitions...)
+			assertEvents(t, f.events, tt.wantEvents...)
+			assert.Equal(t, tt.wantHooks, *hooks)
+			assert.Equal(t, tt.wantDrainCalls, f.drainCalls, "BatchDrainQueue calls")
+		})
+	}
+}

--- a/internal/agent/states/completing_test.go
+++ b/internal/agent/states/completing_test.go
@@ -21,3 +21,74 @@ func TestCompletingState_IgnoresNonCompletionEvents(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, events, "non-completion event must not enqueue any follow-up event")
 }
+
+// TestCompletingState_Complete covers the finalization paths: an empty queue
+// publishes the final completion (with the post_session hook) and returns to
+// Idle, messages queued during completion restart the loop instead, a
+// cancelled session publishes cancellation rather than completion, and a
+// failed transition surfaces the error.
+func TestCompletingState_Complete(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(f *stateFixture)
+		transitionErr   error
+		wantErr         bool
+		wantTransitions []domain.AgentExecutionState
+		wantEvents      []domain.AgentEvent
+		wantHooks       []domain.HookPoint
+		wantComplete    int
+		wantCancelled   int
+	}{
+		{
+			name:            "empty queue publishes completion and returns to idle",
+			wantTransitions: []domain.AgentExecutionState{domain.StateIdle},
+			wantHooks:       []domain.HookPoint{domain.HookPostSession},
+			wantComplete:    1,
+		},
+		{
+			name:            "messages queued during completion restart the loop",
+			setup:           func(f *stateFixture) { f.queue.IsEmptyReturns(false) },
+			wantTransitions: []domain.AgentExecutionState{domain.StateCheckingQueue},
+			wantEvents:      []domain.AgentEvent{domain.MessageReceivedEvent{}},
+		},
+		{
+			name:            "cancelled session publishes cancellation instead of completion",
+			setup:           func(f *stateFixture) { f.cancelSession() },
+			wantTransitions: []domain.AgentExecutionState{domain.StateIdle},
+			wantCancelled:   1,
+		},
+		{
+			name:            "transition failure is returned",
+			transitionErr:   errBoom,
+			wantErr:         true,
+			wantTransitions: []domain.AgentExecutionState{domain.StateIdle},
+			wantHooks:       []domain.HookPoint{domain.HookPostSession},
+			wantComplete:    1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			hooks := f.recordHooks()
+			if tt.setup != nil {
+				tt.setup(f)
+			}
+			f.sm.TransitionReturns(tt.transitionErr)
+			s := NewCompletingState(f.ctx)
+			assert.Equal(t, domain.StateCompleting, s.Name())
+
+			err := s.Handle(domain.CompletionRequestedEvent{})
+
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errBoom)
+			} else {
+				assert.NoError(t, err)
+			}
+			assertTransitions(t, f.sm, tt.wantTransitions...)
+			assertEvents(t, f.events, tt.wantEvents...)
+			assert.Equal(t, tt.wantHooks, *hooks)
+			assert.Len(t, f.completeCalls, tt.wantComplete, "PublishChatComplete calls")
+			assert.Equal(t, tt.wantCancelled, f.cancelCalls, "PublishChatCancelled calls")
+		})
+	}
+}

--- a/internal/agent/states/evaluating_tools_test.go
+++ b/internal/agent/states/evaluating_tools_test.go
@@ -1,0 +1,120 @@
+package states
+
+import (
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// TestEvaluatingToolsState_ApprovalRouting covers how a batch that needs
+// approval is routed by deliverability: promptable approvals go to
+// ApprovingTools (dispatching the pre_tool hook), a batch whose every gated
+// tool resolves to approval_behaviour=block goes to BlockingTools (no
+// pre_tool hook), and a mixed batch still prompts.
+func TestEvaluatingToolsState_ApprovalRouting(t *testing.T) {
+	blockAll := func(*sdk.ChatCompletionMessageToolCall) string { return config.ApprovalBehaviourBlock }
+	blockFirst := func(tc *sdk.ChatCompletionMessageToolCall) string {
+		if tc.ID == "call-0" {
+			return config.ApprovalBehaviourBlock
+		}
+		return config.ApprovalBehaviourPrompt
+	}
+
+	tests := []struct {
+		name           string
+		delivery       func(*sdk.ChatCompletionMessageToolCall) string
+		wantTransition domain.AgentExecutionState
+		wantHooks      []domain.HookPoint
+	}{
+		{
+			name:           "deliverable approval routes to approving tools",
+			wantTransition: domain.StateApprovingTools,
+			wantHooks:      []domain.HookPoint{domain.HookPreTool},
+		},
+		{
+			name:           "undeliverable approval for every gated tool routes to blocking tools",
+			delivery:       blockAll,
+			wantTransition: domain.StateBlockingTools,
+		},
+		{
+			name:           "mixed deliverability still prompts",
+			delivery:       blockFirst,
+			wantTransition: domain.StateApprovingTools,
+			wantHooks:      []domain.HookPoint{domain.HookPreTool},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			hooks := f.recordHooks()
+			*f.ctx.CurrentToolCalls = makeTools(2)
+			f.ctx.ShouldRequireApproval = func(*sdk.ChatCompletionMessageToolCall, bool) bool { return true }
+			f.ctx.ApprovalDelivery = tt.delivery
+			s := NewEvaluatingToolsState(f.ctx)
+			assert.Equal(t, domain.StateEvaluatingTools, s.Name())
+
+			require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+
+			assertTransitions(t, f.sm, tt.wantTransition)
+			assertEvents(t, f.events, domain.MessageReceivedEvent{})
+			assert.Equal(t, tt.wantHooks, *hooks)
+			require.Len(t, f.completeCalls, 1, "tool calls must be published before evaluation")
+			assert.Len(t, f.completeCalls[0].toolCalls, 2)
+		})
+	}
+}
+
+// TestEvaluatingToolsState_NoApprovalSpawnsExecutor verifies a batch with no
+// gated tools transitions to ExecutingTools and launches the tool executor on
+// a background goroutine (which owns the WaitGroup.Done, mirroring
+// EventDrivenAgent.executeTools).
+func TestEvaluatingToolsState_NoApprovalSpawnsExecutor(t *testing.T) {
+	f := newStateFixture()
+	hooks := f.recordHooks()
+	*f.ctx.CurrentToolCalls = makeTools(2)
+	ran := make(chan struct{})
+	executor := func() {
+		defer f.ctx.WaitGroup.Done()
+		close(ran)
+	}
+	f.ctx.ToolExecutor = &executor
+	s := NewEvaluatingToolsState(f.ctx)
+
+	require.NoError(t, s.Handle(domain.MessageReceivedEvent{}))
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tool executor was not invoked")
+	}
+	f.ctx.WaitGroup.Wait()
+
+	assertTransitions(t, f.sm, domain.StateExecutingTools)
+	assertEvents(t, f.events)
+	assert.Equal(t, []domain.HookPoint{domain.HookPreTool}, *hooks)
+}
+
+// TestEvaluatingToolsState_TransitionFailureIsReturned verifies a failed
+// transition surfaces the error and the executor is never launched.
+func TestEvaluatingToolsState_TransitionFailureIsReturned(t *testing.T) {
+	f := newStateFixture()
+	*f.ctx.CurrentToolCalls = makeTools(1)
+	f.sm.TransitionReturns(errBoom)
+	executorRan := false
+	executor := func() { executorRan = true; f.ctx.WaitGroup.Done() }
+	f.ctx.ToolExecutor = &executor
+	s := NewEvaluatingToolsState(f.ctx)
+
+	err := s.Handle(domain.MessageReceivedEvent{})
+
+	assert.ErrorIs(t, err, errBoom)
+	assertEvents(t, f.events)
+	assert.False(t, executorRan, "executor must not run when the transition fails")
+}

--- a/internal/agent/states/executing_tools_test.go
+++ b/internal/agent/states/executing_tools_test.go
@@ -1,0 +1,71 @@
+package states
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// TestExecutingToolsState_Handle covers the two ToolsCompletedEvent routes
+// (continue to PostToolExecution, or Stop=true → the Stopped terminal),
+// transition-failure propagation on both, and stray-event tolerance.
+func TestExecutingToolsState_Handle(t *testing.T) {
+	tests := []struct {
+		name            string
+		event           domain.AgentEvent
+		transitionErr   error
+		wantErr         bool
+		wantTransitions []domain.AgentExecutionState
+		wantEvents      []domain.AgentEvent
+	}{
+		{
+			name:            "completed tools continue to post tool execution",
+			event:           domain.ToolsCompletedEvent{},
+			wantTransitions: []domain.AgentExecutionState{domain.StatePostToolExecution},
+			wantEvents:      []domain.AgentEvent{domain.MessageReceivedEvent{}},
+		},
+		{
+			name:            "stop signal terminates the loop",
+			event:           domain.ToolsCompletedEvent{Stop: true},
+			wantTransitions: []domain.AgentExecutionState{domain.StateStopped},
+		},
+		{
+			name:            "transition failure is returned",
+			event:           domain.ToolsCompletedEvent{},
+			transitionErr:   errBoom,
+			wantErr:         true,
+			wantTransitions: []domain.AgentExecutionState{domain.StatePostToolExecution},
+		},
+		{
+			name:            "stop transition failure is returned",
+			event:           domain.ToolsCompletedEvent{Stop: true},
+			transitionErr:   errBoom,
+			wantErr:         true,
+			wantTransitions: []domain.AgentExecutionState{domain.StateStopped},
+		},
+		{
+			name:  "stray event is a no-op",
+			event: domain.MessageReceivedEvent{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			f.sm.TransitionReturns(tt.transitionErr)
+			s := NewExecutingToolsState(f.ctx)
+			assert.Equal(t, domain.StateExecutingTools, s.Name())
+
+			err := s.Handle(tt.event)
+
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errBoom)
+			} else {
+				assert.NoError(t, err)
+			}
+			assertTransitions(t, f.sm, tt.wantTransitions...)
+			assertEvents(t, f.events, tt.wantEvents...)
+		})
+	}
+}

--- a/internal/agent/states/idle_test.go
+++ b/internal/agent/states/idle_test.go
@@ -1,0 +1,60 @@
+package states
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// TestIdleState_Handle drives the Idle executor through its three paths: a
+// MessageReceivedEvent starts the loop (transition to CheckingQueue and
+// re-emit the event there), a failed transition surfaces the error without
+// emitting, and any other event is ignored.
+func TestIdleState_Handle(t *testing.T) {
+	tests := []struct {
+		name            string
+		event           domain.AgentEvent
+		transitionErr   error
+		wantErr         bool
+		wantTransitions []domain.AgentExecutionState
+		wantEvents      []domain.AgentEvent
+	}{
+		{
+			name:            "message received starts the loop",
+			event:           domain.MessageReceivedEvent{},
+			wantTransitions: []domain.AgentExecutionState{domain.StateCheckingQueue},
+			wantEvents:      []domain.AgentEvent{domain.MessageReceivedEvent{}},
+		},
+		{
+			name:            "transition failure is returned and nothing is emitted",
+			event:           domain.MessageReceivedEvent{},
+			transitionErr:   errBoom,
+			wantErr:         true,
+			wantTransitions: []domain.AgentExecutionState{domain.StateCheckingQueue},
+		},
+		{
+			name:  "stray event is a no-op",
+			event: domain.CompletionRequestedEvent{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			f.sm.TransitionReturns(tt.transitionErr)
+			s := NewIdleState(f.ctx)
+			assert.Equal(t, domain.StateIdle, s.Name())
+
+			err := s.Handle(tt.event)
+
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errBoom)
+			} else {
+				assert.NoError(t, err)
+			}
+			assertTransitions(t, f.sm, tt.wantTransitions...)
+			assertEvents(t, f.events, tt.wantEvents...)
+		})
+	}
+}

--- a/internal/agent/states/post_stream_test.go
+++ b/internal/agent/states/post_stream_test.go
@@ -1,0 +1,91 @@
+package states
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// TestPostStreamState_Handle covers the routing after a completed stream:
+// queued messages win over everything, tool calls route to EvaluatingTools,
+// no tools after at least one turn completes (publishing the final chat event
+// and clearing HasToolResults), and turn zero continues the loop.
+func TestPostStreamState_Handle(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(f *stateFixture)
+		transitionErr   error
+		wantErr         bool
+		wantTransitions []domain.AgentExecutionState
+		wantEvents      []domain.AgentEvent
+		check           func(t *testing.T, f *stateFixture)
+	}{
+		{
+			name:            "queued messages return to checking queue",
+			setup:           func(f *stateFixture) { f.queue.IsEmptyReturns(false) },
+			wantTransitions: []domain.AgentExecutionState{domain.StateCheckingQueue},
+			wantEvents:      []domain.AgentEvent{domain.MessageReceivedEvent{}},
+		},
+		{
+			name:            "tool calls route to evaluating tools",
+			setup:           func(f *stateFixture) { *f.ctx.CurrentToolCalls = makeTools(1) },
+			wantTransitions: []domain.AgentExecutionState{domain.StateEvaluatingTools},
+			wantEvents:      []domain.AgentEvent{domain.MessageReceivedEvent{}},
+		},
+		{
+			name: "no tools after a turn completes",
+			setup: func(f *stateFixture) {
+				f.ctx.AgentCtx.Turns = 1
+				f.ctx.AgentCtx.HasToolResults = true
+			},
+			wantTransitions: []domain.AgentExecutionState{domain.StateCompleting},
+			wantEvents:      []domain.AgentEvent{domain.CompletionRequestedEvent{}},
+			check: func(t *testing.T, f *stateFixture) {
+				assert.False(t, f.ctx.AgentCtx.HasToolResults, "HasToolResults must be cleared")
+				require.Len(t, f.completeCalls, 1, "final chat completion must be published")
+				assert.Empty(t, f.completeCalls[0].toolCalls)
+			},
+		},
+		{
+			name:            "no tools on turn zero continues the loop",
+			wantTransitions: []domain.AgentExecutionState{domain.StateCheckingQueue},
+			wantEvents:      []domain.AgentEvent{domain.MessageReceivedEvent{}},
+		},
+		{
+			name:            "transition failure is returned",
+			setup:           func(f *stateFixture) { f.ctx.AgentCtx.Turns = 1 },
+			transitionErr:   errBoom,
+			wantErr:         true,
+			wantTransitions: []domain.AgentExecutionState{domain.StateCompleting},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			hooks := f.recordHooks()
+			if tt.setup != nil {
+				tt.setup(f)
+			}
+			f.sm.TransitionReturns(tt.transitionErr)
+			s := NewPostStreamState(f.ctx)
+			assert.Equal(t, domain.StatePostStream, s.Name())
+
+			err := s.Handle(domain.MessageReceivedEvent{})
+
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errBoom)
+			} else {
+				assert.NoError(t, err)
+			}
+			assertTransitions(t, f.sm, tt.wantTransitions...)
+			assertEvents(t, f.events, tt.wantEvents...)
+			assert.Equal(t, []domain.HookPoint{domain.HookPostStream}, *hooks, "post_stream hook dispatched on every path")
+			if tt.check != nil {
+				tt.check(t, f)
+			}
+		})
+	}
+}

--- a/internal/agent/states/post_tool_execution_test.go
+++ b/internal/agent/states/post_tool_execution_test.go
@@ -1,0 +1,95 @@
+package states
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// TestPostToolExecutionState_Handle covers the routing after a completed tool
+// batch: an empty queue either completes or continues to the next turn, a
+// non-empty queue is drained (with drain hooks) before continuing, and a
+// cancelled session drains then completes without another LLM turn (the
+// issue #532 contract). The post_tool hook fires on every path.
+func TestPostToolExecutionState_Handle(t *testing.T) {
+	tests := []struct {
+		name            string
+		setup           func(f *stateFixture)
+		transitionErr   error
+		wantErr         bool
+		wantTransitions []domain.AgentExecutionState
+		wantEvents      []domain.AgentEvent
+		wantHooks       []domain.HookPoint
+		wantDrainCalls  int
+	}{
+		{
+			name:            "queue empty and can complete",
+			setup:           func(f *stateFixture) { f.sm.CanTransitionReturns(true) },
+			wantTransitions: []domain.AgentExecutionState{domain.StateCompleting},
+			wantEvents:      []domain.AgentEvent{domain.CompletionRequestedEvent{}},
+			wantHooks:       []domain.HookPoint{domain.HookPostTool},
+		},
+		{
+			name:            "queue empty and cannot complete continues to next turn",
+			wantTransitions: []domain.AgentExecutionState{domain.StateCheckingQueue},
+			wantEvents:      []domain.AgentEvent{domain.MessageReceivedEvent{}},
+			wantHooks:       []domain.HookPoint{domain.HookPostTool},
+		},
+		{
+			name: "queued messages are drained before the next turn",
+			setup: func(f *stateFixture) {
+				f.queue.IsEmptyReturns(false)
+				f.drainReturns = 1
+			},
+			wantTransitions: []domain.AgentExecutionState{domain.StateCheckingQueue},
+			wantEvents:      []domain.AgentEvent{domain.MessageReceivedEvent{}},
+			wantHooks:       []domain.HookPoint{domain.HookPostTool, domain.HookPreQueueDrain, domain.HookPostQueueDrain},
+			wantDrainCalls:  1,
+		},
+		{
+			name: "cancelled session drains then completes without another turn",
+			setup: func(f *stateFixture) {
+				f.queue.IsEmptyReturns(false)
+				f.drainReturns = 1
+				f.cancelSession()
+			},
+			wantTransitions: []domain.AgentExecutionState{domain.StateCompleting},
+			wantEvents:      []domain.AgentEvent{domain.CompletionRequestedEvent{}},
+			wantHooks:       []domain.HookPoint{domain.HookPostTool, domain.HookPreQueueDrain, domain.HookPostQueueDrain},
+			wantDrainCalls:  1,
+		},
+		{
+			name:            "transition failure is returned",
+			transitionErr:   errBoom,
+			wantErr:         true,
+			wantTransitions: []domain.AgentExecutionState{domain.StateCheckingQueue},
+			wantHooks:       []domain.HookPoint{domain.HookPostTool},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			hooks := f.recordHooks()
+			if tt.setup != nil {
+				tt.setup(f)
+			}
+			f.sm.TransitionReturns(tt.transitionErr)
+			s := NewPostToolExecutionState(f.ctx)
+			assert.Equal(t, domain.StatePostToolExecution, s.Name())
+
+			err := s.Handle(domain.MessageReceivedEvent{})
+
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errBoom)
+			} else {
+				assert.NoError(t, err)
+			}
+			assertTransitions(t, f.sm, tt.wantTransitions...)
+			assertEvents(t, f.events, tt.wantEvents...)
+			assert.Equal(t, tt.wantHooks, *hooks)
+			assert.Equal(t, tt.wantDrainCalls, f.drainCalls, "BatchDrainQueue calls")
+		})
+	}
+}

--- a/internal/agent/states/states_helpers_test.go
+++ b/internal/agent/states/states_helpers_test.go
@@ -1,0 +1,142 @@
+package states
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+)
+
+var errBoom = errors.New("boom")
+
+// completeCall records one PublishChatComplete invocation.
+type completeCall struct {
+	reasoning string
+	toolCalls []sdk.ChatCompletionMessageToolCall
+}
+
+// stateFixture wires a StateContext against the counterfeiter fakes
+// (FakeAgentStateMachine, FakeMessageQueue) with recording stubs for every
+// callback the state executors touch. Defaults: empty queue, live session
+// context, no tool calls, no approval required, DispatchHooks nil (the
+// executors' nil-guard path) unless recordHooks is called.
+type stateFixture struct {
+	ctx    *domain.StateContext
+	sm     *domainmocks.FakeAgentStateMachine
+	queue  *domainmocks.FakeMessageQueue
+	events chan domain.AgentEvent
+
+	drainReturns  int
+	drainCalls    int
+	completeCalls []completeCall
+	cancelCalls   int
+	added         []domain.ConversationEntry
+}
+
+func newStateFixture() *stateFixture {
+	f := &stateFixture{
+		sm:     &domainmocks.FakeAgentStateMachine{},
+		queue:  &domainmocks.FakeMessageQueue{},
+		events: make(chan domain.AgentEvent, 16),
+	}
+	f.queue.IsEmptyReturns(true)
+
+	conv := []sdk.Message{}
+	msg := sdk.Message{}
+	toolCalls := []*sdk.ChatCompletionMessageToolCall{}
+	reasoning := ""
+	idx := 0
+	results := []domain.ConversationEntry{}
+
+	f.ctx = &domain.StateContext{
+		StateMachine: f.sm,
+		AgentCtx: &domain.AgentContext{
+			Ctx:          context.Background(),
+			MessageQueue: f.queue,
+			Conversation: &conv,
+		},
+		Events:                f.events,
+		WaitGroup:             &sync.WaitGroup{},
+		Mutex:                 &sync.Mutex{},
+		CurrentMessage:        &msg,
+		CurrentToolCalls:      &toolCalls,
+		CurrentReasoning:      &reasoning,
+		CurrentToolIndex:      &idx,
+		ToolResults:           &results,
+		Request:               &domain.AgentRequest{RequestID: "req-1"},
+		GetMetrics:            func(string) *domain.ChatMetrics { return nil },
+		ShouldRequireApproval: func(*sdk.ChatCompletionMessageToolCall, bool) bool { return false },
+		AddMessage: func(e domain.ConversationEntry) error {
+			f.added = append(f.added, e)
+			return nil
+		},
+		BatchDrainQueue: func() int {
+			f.drainCalls++
+			return f.drainReturns
+		},
+		ExecuteToolInternal: func(tc sdk.ChatCompletionMessageToolCall, _ bool) domain.ConversationEntry {
+			return toolEntry(tc)
+		},
+		PublishChatEvent: func(domain.ChatEvent) {},
+		PublishChatComplete: func(reasoning string, tcs []sdk.ChatCompletionMessageToolCall, _ *domain.ChatMetrics) {
+			f.completeCalls = append(f.completeCalls, completeCall{reasoning: reasoning, toolCalls: tcs})
+		},
+		PublishChatCancelled: func(*domain.ChatMetrics) { f.cancelCalls++ },
+	}
+	return f
+}
+
+// recordHooks installs a DispatchHooks recorder and returns the dispatched
+// hook points (nil until the first dispatch, so it compares equal to an
+// absent expectation).
+func (f *stateFixture) recordHooks() *[]domain.HookPoint {
+	var hooks []domain.HookPoint
+	f.ctx.DispatchHooks = func(h domain.HookPoint) { hooks = append(hooks, h) }
+	return &hooks
+}
+
+// cancelSession replaces the session context with an already-cancelled one.
+func (f *stateFixture) cancelSession() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	f.ctx.AgentCtx.Ctx = ctx
+}
+
+// assertTransitions asserts the exact sequence of Transition targets requested
+// on the fake state machine.
+func assertTransitions(t *testing.T, sm *domainmocks.FakeAgentStateMachine, want ...domain.AgentExecutionState) {
+	t.Helper()
+	require.Equal(t, len(want), sm.TransitionCallCount(), "unexpected number of transitions")
+	for i, target := range want {
+		_, got := sm.TransitionArgsForCall(i)
+		assert.Equal(t, target, got, "transition %d target", i)
+	}
+}
+
+// assertEvents drains the buffered events channel and asserts the emitted
+// events match want by type, in order.
+func assertEvents(t *testing.T, events chan domain.AgentEvent, want ...domain.AgentEvent) {
+	t.Helper()
+	var got []domain.AgentEvent
+drain:
+	for {
+		select {
+		case e := <-events:
+			got = append(got, e)
+		default:
+			break drain
+		}
+	}
+	require.Len(t, got, len(want), "unexpected emitted events: %v", got)
+	for i, w := range want {
+		assert.IsType(t, w, got[i], "event %d", i)
+	}
+}

--- a/internal/agent/states/streaming_llm_test.go
+++ b/internal/agent/states/streaming_llm_test.go
@@ -1,0 +1,74 @@
+package states
+
+import (
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// TestStreamingLLMState_StartStreamingSpawnsGoroutine verifies that a
+// StartStreamingEvent launches the StartStreaming callback on a background
+// goroutine tracked by the shared WaitGroup, without transitioning or
+// emitting anything itself.
+func TestStreamingLLMState_StartStreamingSpawnsGoroutine(t *testing.T) {
+	f := newStateFixture()
+	started := make(chan struct{})
+	f.ctx.StartStreaming = func() { close(started) }
+	s := NewStreamingLLMState(f.ctx)
+	assert.Equal(t, domain.StateStreamingLLM, s.Name())
+
+	require.NoError(t, s.Handle(domain.StartStreamingEvent{}))
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartStreaming was not invoked")
+	}
+	f.ctx.WaitGroup.Wait()
+
+	assertTransitions(t, f.sm)
+	assertEvents(t, f.events)
+}
+
+// TestStreamingLLMState_StreamCompletedStoresDataAndAdvances verifies the
+// completed stream's message, tool calls and reasoning are stored into the
+// shared state (and AgentCtx.ToolCalls for the transition guards) before
+// advancing to PostStream.
+func TestStreamingLLMState_StreamCompletedStoresDataAndAdvances(t *testing.T) {
+	f := newStateFixture()
+	tools := makeTools(2)
+	evt := domain.StreamCompletedEvent{
+		Message:   sdk.Message{Role: sdk.Assistant, Content: sdk.NewMessageContent("hello")},
+		ToolCalls: tools,
+		Reasoning: "thinking",
+	}
+	s := NewStreamingLLMState(f.ctx)
+
+	require.NoError(t, s.Handle(evt))
+
+	assert.Equal(t, evt.Message, *f.ctx.CurrentMessage)
+	assert.Equal(t, tools, *f.ctx.CurrentToolCalls)
+	assert.Equal(t, "thinking", *f.ctx.CurrentReasoning)
+	assert.Equal(t, tools, f.ctx.AgentCtx.ToolCalls)
+	assertTransitions(t, f.sm, domain.StatePostStream)
+	assertEvents(t, f.events, domain.MessageReceivedEvent{})
+}
+
+// TestStreamingLLMState_TransitionFailureIsReturned verifies a failed
+// transition to PostStream surfaces the error and emits nothing.
+func TestStreamingLLMState_TransitionFailureIsReturned(t *testing.T) {
+	f := newStateFixture()
+	f.sm.TransitionReturns(errBoom)
+	s := NewStreamingLLMState(f.ctx)
+
+	err := s.Handle(domain.StreamCompletedEvent{})
+
+	assert.ErrorIs(t, err, errBoom)
+	assertEvents(t, f.events)
+}

--- a/internal/agent/states/terminal_states_test.go
+++ b/internal/agent/states/terminal_states_test.go
@@ -1,0 +1,44 @@
+package states
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// TestTerminalStates_IgnoreAllEvents verifies the three terminal states
+// (Cancelled, Error, Stopped) report the right name and treat every event as
+// a no-op: no error, no transition, nothing emitted — so the event loop can
+// exit cleanly once one of them is reached.
+func TestTerminalStates_IgnoreAllEvents(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(ctx *domain.StateContext) domain.StateHandler
+		want  domain.AgentExecutionState
+	}{
+		{"cancelled", NewCancelledState, domain.StateCancelled},
+		{"error", NewErrorState, domain.StateError},
+		{"stopped", NewStoppedState, domain.StateStopped},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStateFixture()
+			s := tt.build(f.ctx)
+			assert.Equal(t, tt.want, s.Name())
+
+			for _, evt := range []domain.AgentEvent{
+				domain.MessageReceivedEvent{},
+				domain.CompletionRequestedEvent{},
+				domain.AllToolsProcessedEvent{},
+				domain.ToolsCompletedEvent{},
+			} {
+				assert.NoError(t, s.Handle(evt), "event %T", evt)
+			}
+
+			assertTransitions(t, f.sm)
+			assertEvents(t, f.events)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #838.

All 13 state executors in `internal/agent/states/` are now tested (previously 2 of 13). No production code changes.

- New shared `stateFixture` (`states_helpers_test.go`) wires `domain.StateContext` against the existing counterfeiter fakes (`FakeAgentStateMachine`, `FakeMessageQueue`) with recording stubs for every callback the executors touch, plus `assertTransitions`/`assertEvents` helpers.
- Table-driven tests for the routing states (`idle`, `checking_queue`, `post_stream`, `post_tool_execution`, `executing_tools`, `completing`, terminal trio); scenario-style tests (matching the existing `approving_tools` pattern) where goroutines are involved (`streaming_llm`, `evaluating_tools`, `blocking_tools`).
- Every state covers the happy path plus at least one failure path (transition-error propagation); the three terminal no-op states (`cancelled`/`error`/`stopped`) share one table since their behavior is identical.

## Acceptance criteria

- [x] All 13 states covered; `internal/agent/states` test/source LOC ≈ 1.1:1 (1338 test / 1212 source), 88% statement coverage
- [x] Happy path + at least one failure path per state
- [x] `task test:race` green (full repo)

no docs ticket: internal-only tests
