### PR TITLE
refactor(agent): unify chat and headless token accumulation

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -82,34 +82,29 @@ type ConversationMessage struct {
 
 // AgentSession manages the background execution session
 type AgentSession struct {
-	agentService          domain.AgentService
-	toolService           domain.ToolService
-	fileService           domain.FileService
-	imageService          domain.ImageService
-	model                 string
-	agentMode             domain.AgentMode
-	conversation          []ConversationMessage
-	sessionID             string
-	maxTurns              int
-	completedTurns        int
-	config                *config.Config
-	conversationRepo      domain.ConversationRepository
-	reminderProvider      domain.SystemReminderProvider
-	hookProvider          domain.HookCommandProvider
-	memoryBackend         domain.MemoryBackend
-	firedReminders        map[string]bool
-	lastToolFailed        bool
-	saveEnabled           bool
-	bgWaiter              *services.BackgroundTasksWaiter
-	requireApproval       bool
-	approvalCh            chan domain.ApprovalResponse
-	rolloverManager       *services.SessionRolloverManager
-	groupKey              string
-	pricingService        domain.PricingService
-	totalPromptTokens     int
-	totalCompletionTokens int
-	totalTokens           int
-	requestCount          int
+	agentService     domain.AgentService
+	toolService      domain.ToolService
+	fileService      domain.FileService
+	imageService     domain.ImageService
+	model            string
+	agentMode        domain.AgentMode
+	conversation     []ConversationMessage
+	sessionID        string
+	maxTurns         int
+	completedTurns   int
+	config           *config.Config
+	conversationRepo domain.ConversationRepository
+	reminderProvider domain.SystemReminderProvider
+	hookProvider     domain.HookCommandProvider
+	memoryBackend    domain.MemoryBackend
+	firedReminders   map[string]bool
+	lastToolFailed   bool
+	saveEnabled      bool
+	bgWaiter         *services.BackgroundTasksWaiter
+	requireApproval  bool
+	approvalCh       chan domain.ApprovalResponse
+	rolloverManager  *services.SessionRolloverManager
+	groupKey         string
 }
 
 // inheritedSubagentMode returns the coding mode a subagent should start in, read
@@ -187,12 +182,16 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 	imageService := svc.GetImageService()
 	conversationRepo := svc.GetConversationRepository()
 	stateManager := svc.GetStateManager()
-	pricingService := svc.GetPricingService()
 
 	agentMode := inheritedSubagentMode()
 	stateManager.SetAgentMode(agentMode)
 
 	saveEnabled := !noSave
+	if !saveEnabled {
+		if persistentRepo, ok := conversationRepo.(*services.PersistentConversationRepository); ok {
+			persistentRepo.SetAutoSave(false)
+		}
+	}
 
 	newSessionID := uuid.New().String()
 	session := &AgentSession{
@@ -221,7 +220,6 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 		),
 		requireApproval: requireApproval,
 		approvalCh:      make(chan domain.ApprovalResponse, 1),
-		pricingService:  pricingService,
 	}
 
 	session.rolloverManager = svc.GetSessionRolloverManager()
@@ -677,13 +675,6 @@ func (s *AgentSession) buildContentParts(msg ConversationMessage) []sdk.ContentP
 }
 
 func (s *AgentSession) processSyncResponse(response *domain.ChatSyncResponse, requestID string) error {
-	if response.Usage != nil {
-		s.totalPromptTokens += int(response.Usage.PromptTokens)
-		s.totalCompletionTokens += int(response.Usage.CompletionTokens)
-		s.totalTokens += int(response.Usage.TotalTokens)
-		s.requestCount++
-	}
-
 	if response.Content == "" && len(response.ToolCalls) == 0 {
 		return nil
 	}
@@ -703,19 +694,6 @@ func (s *AgentSession) processSyncResponse(response *domain.ChatSyncResponse, re
 
 	s.addMessage(assistantMsg)
 	s.outputMessage(assistantMsg)
-
-	if s.saveEnabled && s.conversationRepo != nil && response.Usage != nil {
-		go func() {
-			if err := s.conversationRepo.AddTokenUsage(
-				s.model,
-				int(response.Usage.PromptTokens),
-				int(response.Usage.CompletionTokens),
-				int(response.Usage.TotalTokens),
-			); err != nil {
-				logger.Warn("failed to track token usage", "error", err)
-			}
-		}()
-	}
 
 	if len(response.ToolCalls) == 0 {
 		return nil
@@ -1325,20 +1303,22 @@ func (s *AgentSession) outputStatusMessage(messageType, message string, metadata
 }
 
 // emitSessionStats emits a single structured session_stats JSON line summarizing token usage and
-// dollar cost for this run. Token counts come from session-local accumulators (independent of
-// --no-save); cost is computed via the shared PricingService so the pricing table is never
-// duplicated. Invoked via defer in execute() so it fires on completion, early error, and panic
+// dollar cost. Totals come from the conversation repository's session accumulator - the same
+// source /cost reads in chat - fed by the shared AgentService accumulation path (issue #835), so
+// they are session/conversation-scoped: resumed sessions include restored history and a mid-run
+// rollover resets them with the conversation. Accumulation is in-memory and thus independent of
+// --no-save. Invoked via defer in execute() so it fires on completion, early error, and panic
 // unwind. Suppressed when no usage-bearing request occurred.
 func (s *AgentSession) emitSessionStats() {
-	if s.requestCount == 0 {
+	if s.conversationRepo == nil {
 		return
 	}
 
-	var inputCost, outputCost, totalCost float64
-	if s.pricingService != nil {
-		inputCost, outputCost, totalCost = s.pricingService.CalculateCost(
-			s.model, s.totalPromptTokens, s.totalCompletionTokens)
+	tokenStats := s.conversationRepo.GetSessionTokens()
+	if tokenStats.RequestCount == 0 {
+		return
 	}
+	costStats := s.conversationRepo.GetSessionCostStats()
 
 	currency := "USD"
 	if s.config != nil && s.config.Pricing.Currency != "" {
@@ -1347,14 +1327,14 @@ func (s *AgentSession) emitSessionStats() {
 
 	s.outputStatusMessage("session_stats", "Session complete", map[string]any{
 		"model":             s.model,
-		"prompt_tokens":     s.totalPromptTokens,
-		"completion_tokens": s.totalCompletionTokens,
-		"total_tokens":      s.totalTokens,
-		"requests":          s.requestCount,
+		"prompt_tokens":     tokenStats.TotalInputTokens,
+		"completion_tokens": tokenStats.TotalOutputTokens,
+		"total_tokens":      tokenStats.TotalTokens,
+		"requests":          tokenStats.RequestCount,
 		"cost": map[string]any{
-			"input":    inputCost,
-			"output":   outputCost,
-			"total":    totalCost,
+			"input":    costStats.TotalInputCost,
+			"output":   costStats.TotalOutputCost,
+			"total":    costStats.TotalCost,
 			"currency": currency,
 		},
 	})

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -684,8 +684,6 @@ func TestEmitSessionStatsFullLine(t *testing.T) {
 	session := &AgentSession{
 		model:  "deepseek/deepseek-v4-flash",
 		config: &config.Config{Pricing: config.PricingConfig{Currency: "USD"}},
-		// 7 requests at 3000/180/3180 tokens, each costing 0.25/0.125/0.375
-		// (binary-exact so the accumulated sums compare with ==).
 		conversationRepo: seededRepo(t, fakePricing(0.25, 0.125, 0.375),
 			"deepseek/deepseek-v4-flash", 7, 3000, 180, 3180),
 	}

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -666,15 +666,28 @@ func decodeStatsLine(t *testing.T, session *AgentSession) sessionStatsLine {
 	return got
 }
 
+// seededRepo returns an in-memory conversation repository - the shared sink the
+// agent service accumulates into - seeded with n AddTokenUsage calls of the
+// given per-request token counts.
+func seededRepo(t *testing.T, pricing domain.PricingService, model string, n, prompt, completion, total int) *services.InMemoryConversationRepository {
+	t.Helper()
+	repo := services.NewInMemoryConversationRepository(nil, pricing)
+	for range n {
+		if err := repo.AddTokenUsage(model, prompt, completion, total); err != nil {
+			t.Fatalf("AddTokenUsage: %v", err)
+		}
+	}
+	return repo
+}
+
 func TestEmitSessionStatsFullLine(t *testing.T) {
 	session := &AgentSession{
-		model:                 "deepseek/deepseek-v4-flash",
-		pricingService:        fakePricing(0.0021, 0.0008, 0.0029),
-		config:                &config.Config{Pricing: config.PricingConfig{Currency: "USD"}},
-		totalPromptTokens:     21000,
-		totalCompletionTokens: 1260,
-		totalTokens:           22260,
-		requestCount:          7,
+		model:  "deepseek/deepseek-v4-flash",
+		config: &config.Config{Pricing: config.PricingConfig{Currency: "USD"}},
+		// 7 requests at 3000/180/3180 tokens, each costing 0.25/0.125/0.375
+		// (binary-exact so the accumulated sums compare with ==).
+		conversationRepo: seededRepo(t, fakePricing(0.25, 0.125, 0.375),
+			"deepseek/deepseek-v4-flash", 7, 3000, 180, 3180),
 	}
 
 	got := decodeStatsLine(t, session)
@@ -695,8 +708,8 @@ func TestEmitSessionStatsFullLine(t *testing.T) {
 	if got.Requests != 7 {
 		t.Errorf("Requests = %d, want 7", got.Requests)
 	}
-	if got.Cost.Input != 0.0021 || got.Cost.Output != 0.0008 || got.Cost.Total != 0.0029 {
-		t.Errorf("cost = %v/%v/%v, want 0.0021/0.0008/0.0029",
+	if got.Cost.Input != 1.75 || got.Cost.Output != 0.875 || got.Cost.Total != 2.625 {
+		t.Errorf("cost = %v/%v/%v, want 1.75/0.875/2.625",
 			got.Cost.Input, got.Cost.Output, got.Cost.Total)
 	}
 	if got.Cost.Currency != "USD" {
@@ -705,22 +718,31 @@ func TestEmitSessionStatsFullLine(t *testing.T) {
 }
 
 func TestEmitSessionStatsSuppressedWhenNoRequests(t *testing.T) {
-	session := &AgentSession{config: &config.Config{}}
-	out := captureStdout(t, session.emitSessionStats)
-	if strings.TrimSpace(out) != "" {
-		t.Errorf("expected no output for zero requests, got %q", out)
-	}
+	t.Run("empty repo", func(t *testing.T) {
+		session := &AgentSession{
+			config:           &config.Config{},
+			conversationRepo: services.NewInMemoryConversationRepository(nil, nil),
+		}
+		out := captureStdout(t, session.emitSessionStats)
+		if strings.TrimSpace(out) != "" {
+			t.Errorf("expected no output for zero requests, got %q", out)
+		}
+	})
+
+	t.Run("nil repo", func(t *testing.T) {
+		session := &AgentSession{config: &config.Config{}}
+		out := captureStdout(t, session.emitSessionStats)
+		if strings.TrimSpace(out) != "" {
+			t.Errorf("expected no output with nil repo, got %q", out)
+		}
+	})
 }
 
 func TestEmitSessionStatsZeroCostWhenPricingDisabled(t *testing.T) {
 	session := &AgentSession{
-		model:                 "some/model",
-		pricingService:        fakePricing(0, 0, 0),
-		config:                &config.Config{Pricing: config.PricingConfig{Currency: "USD"}},
-		totalPromptTokens:     10,
-		totalCompletionTokens: 5,
-		totalTokens:           15,
-		requestCount:          1,
+		model:            "some/model",
+		config:           &config.Config{Pricing: config.PricingConfig{Currency: "USD"}},
+		conversationRepo: seededRepo(t, fakePricing(0, 0, 0), "some/model", 1, 10, 5, 15),
 	}
 
 	got := decodeStatsLine(t, session)
@@ -735,10 +757,9 @@ func TestEmitSessionStatsZeroCostWhenPricingDisabled(t *testing.T) {
 
 func TestEmitSessionStatsCurrencyFallback(t *testing.T) {
 	session := &AgentSession{
-		model:          "some/model",
-		pricingService: fakePricing(0, 0, 0.01),
-		config:         &config.Config{},
-		requestCount:   1,
+		model:            "some/model",
+		config:           &config.Config{},
+		conversationRepo: seededRepo(t, fakePricing(0, 0, 0.01), "some/model", 1, 10, 5, 15),
 	}
 
 	got := decodeStatsLine(t, session)
@@ -750,11 +771,9 @@ func TestEmitSessionStatsCurrencyFallback(t *testing.T) {
 
 func TestEmitSessionStatsNilPricingServiceSafe(t *testing.T) {
 	session := &AgentSession{
-		model:             "some/model",
-		pricingService:    nil,
-		config:            &config.Config{},
-		totalPromptTokens: 10,
-		requestCount:      1,
+		model:            "some/model",
+		config:           &config.Config{},
+		conversationRepo: seededRepo(t, nil, "some/model", 1, 10, 0, 10),
 	}
 
 	got := decodeStatsLine(t, session)
@@ -765,59 +784,6 @@ func TestEmitSessionStatsNilPricingServiceSafe(t *testing.T) {
 	if got.PromptTokens != 10 {
 		t.Errorf("PromptTokens = %d, want 10", got.PromptTokens)
 	}
-}
-
-func TestProcessSyncResponseAccumulatesTokens(t *testing.T) {
-	cfg := &config.Config{Agent: config.AgentConfig{MaxConcurrentTools: 1}}
-
-	usage := func(p, c, total int64) *sdk.CompletionUsage {
-		return &sdk.CompletionUsage{PromptTokens: p, CompletionTokens: c, TotalTokens: total}
-	}
-
-	t.Run("accumulates usage from a content response", func(t *testing.T) {
-		session := &AgentSession{config: cfg, conversation: []ConversationMessage{}}
-		_ = captureStdout(t, func() {
-			if err := session.processSyncResponse(&domain.ChatSyncResponse{
-				Content: "done", Usage: usage(100, 20, 120),
-			}, "req_1"); err != nil {
-				t.Fatalf("processSyncResponse: %v", err)
-			}
-		})
-		if session.totalPromptTokens != 100 || session.totalCompletionTokens != 20 ||
-			session.totalTokens != 120 || session.requestCount != 1 {
-			t.Errorf("accumulators = %d/%d/%d req=%d, want 100/20/120 req=1",
-				session.totalPromptTokens, session.totalCompletionTokens,
-				session.totalTokens, session.requestCount)
-		}
-	})
-
-	t.Run("nil usage does not increment request count", func(t *testing.T) {
-		session := &AgentSession{config: cfg, conversation: []ConversationMessage{}}
-		_ = captureStdout(t, func() {
-			if err := session.processSyncResponse(&domain.ChatSyncResponse{Content: "done"}, "req_1"); err != nil {
-				t.Fatalf("processSyncResponse: %v", err)
-			}
-		})
-		if session.requestCount != 0 {
-			t.Errorf("requestCount = %d, want 0 for nil usage", session.requestCount)
-		}
-	})
-
-	t.Run("usage counted even when response content is empty", func(t *testing.T) {
-		session := &AgentSession{config: cfg, conversation: []ConversationMessage{}}
-		if err := session.processSyncResponse(&domain.ChatSyncResponse{
-			Content: "", Usage: usage(5, 3, 8),
-		}, "req_1"); err != nil {
-			t.Fatalf("processSyncResponse: %v", err)
-		}
-		if session.requestCount != 1 || session.totalTokens != 8 {
-			t.Errorf("requestCount=%d totalTokens=%d, want 1 / 8 (increment precedes early return)",
-				session.requestCount, session.totalTokens)
-		}
-		if len(session.conversation) != 0 {
-			t.Errorf("expected no message recorded for empty response, got %d", len(session.conversation))
-		}
-	})
 }
 
 func TestConvertFromConversationEntry(t *testing.T) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -402,6 +402,8 @@ func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*
 
 	startTime := time.Now()
 
+	var availableTools []sdk.ChatCompletionTool
+
 	response, err := func(timeoutCtx context.Context, model string, messages []sdk.Message) (*sdk.CreateChatCompletionResponse, error) {
 		provider, modelName, err := s.parseProvider(model)
 		if err != nil {
@@ -421,7 +423,7 @@ func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*
 			if s.stateManager != nil {
 				mode = s.stateManager.GetAgentMode()
 			}
-			availableTools := s.toolService.ListToolsForMode(mode)
+			availableTools = s.toolService.ListToolsForMode(mode)
 			if len(availableTools) > 0 {
 				client = s.client.WithTools(&availableTools)
 			}
@@ -442,12 +444,19 @@ func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*
 
 	content, reasoningContent, toolCalls := extractFirstChoice(response)
 
+	effectiveUsage := s.storeIterationMetrics(req.RequestID, req.Model, startTime, response.Usage, &storeIterationMetricsInput{
+		inputMessages:   messages,
+		outputContent:   content,
+		outputToolCalls: toolCalls,
+		availableTools:  availableTools,
+	})
+
 	syncResponse := &domain.ChatSyncResponse{
 		RequestID:        req.RequestID,
 		Content:          content,
 		ReasoningContent: reasoningContent,
 		ToolCalls:        toolCalls,
-		Usage:            response.Usage,
+		Usage:            effectiveUsage,
 		Duration:         duration,
 	}
 
@@ -715,13 +724,16 @@ type storeIterationMetricsInput struct {
 
 // storeIterationMetrics stores metrics for the current iteration and accumulates session tokens.
 // If the provider doesn't return usage metrics, it uses the tokenizer polyfill to estimate them.
+// It returns the effective (possibly polyfilled) usage that was accumulated, or nil when there
+// was nothing to record. Both the streaming path and the sync Run path funnel through here so
+// chat and headless token accounting stay identical (issue #835).
 func (s *AgentServiceImpl) storeIterationMetrics(
 	requestID string,
 	model string,
 	startTime time.Time,
 	usage *sdk.CompletionUsage,
 	polyfillInput *storeIterationMetricsInput,
-) {
+) *sdk.CompletionUsage {
 	effectiveUsage := usage
 
 	if s.tokenizer != nil && s.tokenizer.ShouldUsePolyfill(usage) && polyfillInput != nil {
@@ -734,7 +746,7 @@ func (s *AgentServiceImpl) storeIterationMetrics(
 	}
 
 	if effectiveUsage == nil {
-		return
+		return nil
 	}
 
 	metrics := &domain.ChatMetrics{
@@ -754,6 +766,8 @@ func (s *AgentServiceImpl) storeIterationMetrics(
 	); err != nil {
 		logger.Error("failed to add token usage to session", "error", err)
 	}
+
+	return effectiveUsage
 }
 
 func (s *AgentServiceImpl) optimizeConversation(_ context.Context, req *domain.AgentRequest, conversation []sdk.Message, eventPublisher *eventPublisher) []sdk.Message {

--- a/internal/services/persistent_conversation.go
+++ b/internal/services/persistent_conversation.go
@@ -227,6 +227,8 @@ func (r *PersistentConversationRepository) GetCurrentConversationMetadata() stor
 
 // SetAutoSave enables or disables automatic saving after each operation
 func (r *PersistentConversationRepository) SetAutoSave(enabled bool) {
+	r.metadataMutex.Lock()
+	defer r.metadataMutex.Unlock()
 	r.autoSave = enabled
 }
 

--- a/tests/integration/agent_gateway_test.go
+++ b/tests/integration/agent_gateway_test.go
@@ -366,3 +366,35 @@ func TestSyncRunParsesNonStreamingResponse(t *testing.T) {
 	require.Equal(t, "gpt-4o", reqs[0].Model, "provider prefix must be stripped from the wire model")
 	require.Equal(t, "openai", reqs[0].Provider)
 }
+
+// TestSyncAndStreamAccumulateIdenticalSessionTokens is the acceptance check for
+// issue #835: both the sync (headless) and streaming (chat) paths funnel through
+// the same storeIterationMetrics accumulator, so for an identical scenario the
+// session totals in the shared conversation repository must match.
+func TestSyncAndStreamAccumulateIdenticalSessionTokens(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	defer cancel()
+
+	syncEnv := newEnv(t)
+	resp, err := syncEnv.container.GetAgentService().Run(ctx, &domain.AgentRequest{
+		RequestID: "req-usage-sync",
+		Model:     mockgateway.DefaultModel,
+		Messages:  []sdk.Message{userMessage(t, "report your usage")},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Usage)
+	require.EqualValues(t, 142, resp.Usage.TotalTokens)
+
+	syncStats := syncEnv.container.GetConversationRepository().GetSessionTokens()
+	require.Equal(t, 142, syncStats.TotalTokens, "sync Run must accumulate into the shared session sink")
+	require.Equal(t, 100, syncStats.TotalInputTokens)
+	require.Equal(t, 42, syncStats.TotalOutputTokens)
+	require.Equal(t, 1, syncStats.RequestCount)
+
+	streamEnv := newEnv(t)
+	res := streamEnv.runStream(ctx, t, "report your usage")
+	require.Empty(t, res.errs)
+
+	streamStats := streamEnv.container.GetConversationRepository().GetSessionTokens()
+	require.Equal(t, streamStats, syncStats, "headless totals must equal chat totals for the same scenario")
+}


### PR DESCRIPTION
Closes #835

## What

Routes the sync `AgentService.Run` path (headless) through the same `storeIterationMetrics` accumulator the streaming (chat) path already uses, and deletes the headless duplicates. The shared sink was already there — the conversation repository's `AddTokenUsage`/`GetSessionTokens`/`GetSessionCostStats` (what `/cost` reads); the root cause was that `Run` skipped it.

- `internal/agent/agent.go`: `Run` now calls `storeIterationMetrics` (tokenizer polyfill included) and returns the effective usage in `ChatSyncResponse.Usage`, so per-message output matches what was accumulated.
- `cmd/agent.go`: drops the four inline counters, the ad-hoc `AddTokenUsage` goroutine, and the direct `PricingService` cost recomputation; `emitSessionStats` reads the repo's session token and cost stats. `--no-save` now calls `SetAutoSave(false)` so accumulation stays in-memory only.
- `internal/services/persistent_conversation.go`: `SetAutoSave` takes the metadata mutex (one-line hardening).
- New integration test `TestSyncAndStreamAccumulateIdenticalSessionTokens`: both paths against the mock gateway's `usage-report` scenario accumulate identical session totals (142 tokens).

## Acceptance criteria (#835)

- ✅ Single accumulation code path; headless totals equal chat totals for identical mock scenarios (asserted via `usage-report`, 142 tokens)
- ✅ `/cost` and the headless final stats read from the same source (the conversation repo session stats)

## Intended behavior changes

- `session_stats` is now **session/conversation-scoped** (same numbers `/cost` shows) instead of run-scoped. Fresh sessions (CI, subagents, scheduler/heartbeat) are unchanged; resumed sessions (`--session-id` under channels) now include restored history; a mid-run rollover resets totals with the conversation. No programmatic consumer parses these values (agentrunner ignores `session_stats` lines).
- A usage-less provider response previously didn't count toward headless `requests`; the polyfill now counts it with estimated tokens — chat parity, the point of the change.
- `--no-save` + resumed session + mid-run rollover: `StartNewConversation` saves explicitly (ignores auto-save), and the persisted metadata's token stats now include the `--no-save` run's usage. Pre-existing save path, marginally widened.

## Verification

- `task test`, `task test:e2e` (race), `task lint` all green.
- Manual: `INFER_GATEWAY_MOCK=true infer agent "report your usage" --no-save` emits `session_stats` with 142+15 tokens and repo-computed cost; storage untouched under `--no-save`; save-enabled run persists the same accumulated stats.

no docs ticket: internal-only refactor