### PR TITLE
fix(chat): consistent preview for rejected tool calls

### DIFF
--- a/cmd/conversations_test.go
+++ b/cmd/conversations_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestRenderConversationsJSON(t *testing.T) {
-	// Create test conversations
 	conversations := []storage.ConversationSummary{
 		{
 			ID:           "12345678-1234-1234-1234-123456789abc",
@@ -47,19 +46,13 @@ func TestRenderConversationsJSON(t *testing.T) {
 		},
 	}
 
-	// Render JSON
 	err := renderConversationsJSON(conversations)
 	if err != nil {
 		t.Fatalf("renderConversationsJSON() failed: %v", err)
 	}
-
-	// Note: Since the function prints to stdout, we can't easily capture it in this test
-	// In a real scenario, we would refactor to accept an io.Writer
-	// For now, we just verify no error occurred
 }
 
 func TestRenderConversationsJSON_Structure(t *testing.T) {
-	// Test that JSON structure is correct by creating sample data
 	conversations := []storage.ConversationSummary{
 		{
 			ID:           "test-id-1",
@@ -76,7 +69,6 @@ func TestRenderConversationsJSON_Structure(t *testing.T) {
 		},
 	}
 
-	// Create the expected output structure
 	output := struct {
 		Conversations []storage.ConversationSummary `json:"conversations"`
 		Count         int                           `json:"count"`
@@ -85,13 +77,11 @@ func TestRenderConversationsJSON_Structure(t *testing.T) {
 		Count:         len(conversations),
 	}
 
-	// Marshal to JSON
 	jsonBytes, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		t.Fatalf("Failed to marshal JSON: %v", err)
 	}
 
-	// Verify JSON contains expected fields
 	jsonStr := string(jsonBytes)
 	if !strings.Contains(jsonStr, `"conversations"`) {
 		t.Error("JSON output missing 'conversations' field")
@@ -111,9 +101,6 @@ func TestRenderConversationsTable_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("renderConversationsTable() with empty conversations failed: %v", err)
 	}
-
-	// Function should print "No conversations found" message
-	// Since we can't easily capture stdout in this test, we just verify no error
 }
 
 func TestRenderConversationsTable_WithData(t *testing.T) {
@@ -140,7 +127,6 @@ func TestRenderConversationsTable_WithData(t *testing.T) {
 }
 
 func TestRenderConversationsTable_Pagination(t *testing.T) {
-	// Create 60 conversations to test pagination
 	conversations := make([]storage.ConversationSummary, 60)
 	for i := 0; i < 60; i++ {
 		conversations[i] = storage.ConversationSummary{
@@ -158,13 +144,11 @@ func TestRenderConversationsTable_Pagination(t *testing.T) {
 		}
 	}
 
-	// Test first page
 	err := renderConversationsTable(conversations[:50], 50, 0)
 	if err != nil {
 		t.Fatalf("renderConversationsTable() page 1 failed: %v", err)
 	}
 
-	// Test second page
 	err = renderConversationsTable(conversations[50:], 50, 50)
 	if err != nil {
 		t.Fatalf("renderConversationsTable() page 2 failed: %v", err)
@@ -206,7 +190,7 @@ func TestRenderConversationsTable_ZeroCost(t *testing.T) {
 				RequestCount:      1,
 			},
 			CostStats: domain.SessionCostStats{
-				TotalCost: 0.0, // Zero cost should display as "-"
+				TotalCost: 0.0,
 			},
 		},
 	}
@@ -229,7 +213,7 @@ func TestRenderConversationsTable_VariousCosts(t *testing.T) {
 				RequestCount:      1,
 			},
 			CostStats: domain.SessionCostStats{
-				TotalCost: 0.0023, // Should show 4 decimals
+				TotalCost: 0.0023,
 			},
 		},
 		{
@@ -242,7 +226,7 @@ func TestRenderConversationsTable_VariousCosts(t *testing.T) {
 				RequestCount:      1,
 			},
 			CostStats: domain.SessionCostStats{
-				TotalCost: 0.142, // Should show 3 decimals
+				TotalCost: 0.142,
 			},
 		},
 		{
@@ -255,7 +239,7 @@ func TestRenderConversationsTable_VariousCosts(t *testing.T) {
 				RequestCount:      1,
 			},
 			CostStats: domain.SessionCostStats{
-				TotalCost: 5.47, // Should show 2 decimals
+				TotalCost: 5.47,
 			},
 		},
 	}
@@ -290,13 +274,11 @@ func TestRenderConversationsTable_LargeNumbers(t *testing.T) {
 }
 
 func TestRenderMarkdown(t *testing.T) {
-	// Test that renderMarkdown doesn't fail with valid markdown
 	markdown := "# Test Header\n\nSome **bold** text."
 
 	_, err := renderMarkdown(markdown)
 	if err != nil {
 		t.Logf("renderMarkdown() returned error (may fail in test environment): %v", err)
-		// Don't fail the test - glamour may not work in all test environments
 	}
 }
 
@@ -306,12 +288,10 @@ func TestRenderMarkdown_EmptyString(t *testing.T) {
 	_, err := renderMarkdown(markdown)
 	if err != nil {
 		t.Logf("renderMarkdown() with empty string returned error: %v", err)
-		// Don't fail - may not work in test environment
 	}
 }
 
 func TestRenderMarkdown_Table(t *testing.T) {
-	// Test with markdown table similar to what we generate
 	markdown := `| ID | Title | Count |
 |-----|-------|-------|
 | 123 | Test  | 5     |
@@ -320,7 +300,6 @@ func TestRenderMarkdown_Table(t *testing.T) {
 	_, err := renderMarkdown(markdown)
 	if err != nil {
 		t.Logf("renderMarkdown() with table returned error: %v", err)
-		// Don't fail - may not work in test environment
 	}
 }
 
@@ -392,7 +371,6 @@ func TestBuildConversationShowText_PlainAndHeaders(t *testing.T) {
 }
 
 func TestBuildConversationShowText_HiddenTagAndToolCallID(t *testing.T) {
-	// Include hidden so the [hidden] tag and tool entry are both present.
 	entries := filterConversationEntries(makeShowEntries(), true)
 	out := buildConversationShowText(entries, "s")
 
@@ -477,8 +455,6 @@ func TestBuildConversationShowJSON_Empty(t *testing.T) {
 }
 
 func TestToConversationShowEntry_Multimodal(t *testing.T) {
-	// Mirrors how the codebase persists image entries: an Images attachment on
-	// an entry whose Message.Content carries no extractable text.
 	got := toConversationShowEntry(domain.ConversationEntry{
 		Message: sdk.Message{Role: sdk.User},
 		Images: []domain.ImageAttachment{

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -919,11 +919,9 @@ func (s *AgentServiceImpl) executeTool(
 		approved, err := s.requestToolApproval(ctx, tc, eventPublisher)
 		if err != nil {
 			logger.Error("failed to request tool approval", "tool", tc.Function.Name, "error", err)
-			s.conversationRepo.RemovePendingToolCallByID(tc.ID)
 			return s.createErrorEntry(tc, err, startTime)
 		}
 		if !approved {
-			s.conversationRepo.RemovePendingToolCallByID(tc.ID)
 			return s.createRejectionEntry(tc, startTime)
 		}
 		wasApproved = true
@@ -1324,6 +1322,10 @@ func (s *AgentServiceImpl) requestToolApproval(
 		err = fmt.Errorf("approval request cancelled: %w", ctx.Err())
 	case <-time.After(constants.ApprovalTimeout):
 		err = fmt.Errorf("approval request timed out")
+	}
+
+	if err != nil || !approved {
+		s.conversationRepo.RemovePendingToolCallByID(tc.ID)
 	}
 
 	return approved, err

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -922,6 +922,7 @@ func (s *AgentServiceImpl) executeTool(
 			return s.createErrorEntry(tc, err, startTime)
 		}
 		if !approved {
+			eventPublisher.publishToolStatusChange(tc.ID, tc.Function.Name, "failed", "rejected", nil)
 			return s.createRejectionEntry(tc, startTime)
 		}
 		wasApproved = true

--- a/internal/agent/states/approving_tools.go
+++ b/internal/agent/states/approving_tools.go
@@ -262,6 +262,17 @@ func (s *ApprovingToolsState) finishApprovals(round *toolRound) {
 func (s *ApprovingToolsState) buildRejectionEntry(tc sdk.ChatCompletionMessageToolCall) domain.ConversationEntry {
 	logger.Debug("tool rejected by user", "tool", tc.Function.Name)
 
+	s.ctx.PublishChatEvent(domain.ToolExecutionProgressEvent{
+		BaseChatEvent: domain.BaseChatEvent{
+			RequestID: s.ctx.Request.RequestID,
+			Timestamp: time.Now(),
+		},
+		ToolCallID: tc.ID,
+		ToolName:   tc.Function.Name,
+		Status:     "failed",
+		Message:    "rejected",
+	})
+
 	rejectionMessage := sdk.Message{
 		Role:       sdk.Tool,
 		Content:    sdk.NewMessageContent(fmt.Sprintf("Tool execution rejected by user: %s", tc.Function.Name)),

--- a/internal/agent/states/approving_tools.go
+++ b/internal/agent/states/approving_tools.go
@@ -1,6 +1,7 @@
 package states
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -267,14 +268,20 @@ func (s *ApprovingToolsState) buildRejectionEntry(tc sdk.ChatCompletionMessageTo
 		ToolCallID: &tc.ID,
 	}
 
+	var args map[string]any
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		args = make(map[string]any)
+	}
+
 	return domain.ConversationEntry{
 		Message: rejectionMessage,
 		Time:    time.Now(),
 		ToolExecution: &domain.ToolExecutionResult{
-			ToolName: tc.Function.Name,
-			Success:  false,
-			Error:    "rejected by user",
-			Rejected: true,
+			ToolName:  tc.Function.Name,
+			Arguments: args,
+			Success:   false,
+			Error:     "rejected by user",
+			Rejected:  true,
 		},
 	}
 }

--- a/internal/agent/states/approving_tools_test.go
+++ b/internal/agent/states/approving_tools_test.go
@@ -250,9 +250,14 @@ func TestApprovingToolsState_RejectionStopsTurn(t *testing.T) {
 
 // TestApprovingToolsState_RejectionEntryKeepsArguments verifies the rejected
 // tool entry carries the original call arguments so the UI renders
-// "Bash(command=...)" instead of a bare "Bash()" (issue #861).
+// "Bash(command=...)" instead of a bare "Bash()", and that a "failed" progress
+// event is published so the queued preview line is dropped (issue #861).
 func TestApprovingToolsState_RejectionEntryKeepsArguments(t *testing.T) {
-	s := &ApprovingToolsState{}
+	var published []domain.ChatEvent
+	ctx, _, _, _ := newApprovingCtx(nil, domain.AgentModeStandard, nil, nil)
+	ctx.PublishChatEvent = func(e domain.ChatEvent) { published = append(published, e) }
+	s := &ApprovingToolsState{ctx: ctx}
+
 	tc := sdk.ChatCompletionMessageToolCall{
 		ID:       "call-0",
 		Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Bash", Arguments: `{"command":"rm -rf /tmp/x"}`},
@@ -262,6 +267,12 @@ func TestApprovingToolsState_RejectionEntryKeepsArguments(t *testing.T) {
 
 	require.NotNil(t, entry.ToolExecution)
 	assert.Equal(t, map[string]any{"command": "rm -rf /tmp/x"}, entry.ToolExecution.Arguments)
+
+	require.Len(t, published, 1)
+	progress, ok := published[0].(domain.ToolExecutionProgressEvent)
+	require.True(t, ok, "rejection must publish a ToolExecutionProgressEvent")
+	assert.Equal(t, "call-0", progress.ToolCallID)
+	assert.Equal(t, "failed", progress.Status)
 
 	tc.Function.Arguments = "not-json"
 	entry = s.buildRejectionEntry(tc)

--- a/internal/agent/states/approving_tools_test.go
+++ b/internal/agent/states/approving_tools_test.go
@@ -248,6 +248,27 @@ func TestApprovingToolsState_RejectionStopsTurn(t *testing.T) {
 	assert.False(t, ctx.AgentCtx.HasToolResults, "rejection must clear HasToolResults so the turn completes")
 }
 
+// TestApprovingToolsState_RejectionEntryKeepsArguments verifies the rejected
+// tool entry carries the original call arguments so the UI renders
+// "Bash(command=...)" instead of a bare "Bash()" (issue #861).
+func TestApprovingToolsState_RejectionEntryKeepsArguments(t *testing.T) {
+	s := &ApprovingToolsState{}
+	tc := sdk.ChatCompletionMessageToolCall{
+		ID:       "call-0",
+		Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Bash", Arguments: `{"command":"rm -rf /tmp/x"}`},
+	}
+
+	entry := s.buildRejectionEntry(tc)
+
+	require.NotNil(t, entry.ToolExecution)
+	assert.Equal(t, map[string]any{"command": "rm -rf /tmp/x"}, entry.ToolExecution.Arguments)
+
+	tc.Function.Arguments = "not-json"
+	entry = s.buildRejectionEntry(tc)
+	require.NotNil(t, entry.ToolExecution)
+	assert.NotNil(t, entry.ToolExecution.Arguments, "malformed args must fall back to an empty map")
+}
+
 // TestApprovingToolsState_ApprovedBatchKeepsToolResults verifies the inverse of
 // the rejection case: a fully approved batch leaves HasToolResults set so the
 // agent streams a follow-up turn responding to the results.

--- a/internal/services/tool_formatter.go
+++ b/internal/services/tool_formatter.go
@@ -128,6 +128,14 @@ func (s *ToolFormatterService) FormatToolResultForUI(result *domain.ToolExecutio
 		return "Tool execution result unavailable"
 	}
 
+	if result.Rejected {
+		line := s.statusLine(result, terminalWidth)
+		if hint := s.expandHint(); hint != "" {
+			line += "\n" + s.styleProvider.RenderWithColor("    "+hint, s.styleProvider.GetThemeColor("dim"))
+		}
+		return line
+	}
+
 	lines, more := previewLines(s.resultBody(result), result.Success, contentWidth(terminalWidth))
 
 	out := make([]string, 0, len(lines)+2)
@@ -153,7 +161,11 @@ func (s *ToolFormatterService) statusLine(result *domain.ToolExecutionResult, te
 	}
 
 	styledIcon := s.styleProvider.RenderWithColor(icon, s.styleProvider.GetThemeColor(iconColor))
-	styledDur := s.styleProvider.RenderWithColor("· "+formatDurationShort(result.Duration), s.styleProvider.GetThemeColor("dim"))
+	suffix, suffixColor := "· "+formatDurationShort(result.Duration), "dim"
+	if result.Rejected {
+		suffix, suffixColor = "· Rejected", "error"
+	}
+	styledDur := s.styleProvider.RenderWithColor(suffix, s.styleProvider.GetThemeColor(suffixColor))
 
 	argsPreview := s.formatArgsPreview(result.Arguments, s.argsPreviewBudget(result.ToolName, terminalWidth))
 	if argsPreview != "" && argsPreview != "{}" {

--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -173,6 +173,34 @@ func TestFormatToolResultForUI_NoBodyOmitsPreview(t *testing.T) {
 	}
 }
 
+func TestFormatToolResultForUI_RejectedShowsStatusAndHintOnly(t *testing.T) {
+	tool := &fakeTool{name: "Bash", preview: "Execution failed"}
+	svc := newTestService(tool)
+
+	res := &domain.ToolExecutionResult{
+		ToolName:  "Bash",
+		Success:   false,
+		Rejected:  true,
+		Error:     "rejected by user",
+		Arguments: map[string]any{"command": "rm -rf x"},
+	}
+	out := stripANSI(svc.FormatToolResultForUI(res, 80))
+	lines := strings.Split(out, "\n")
+
+	if len(lines) != 2 {
+		t.Fatalf("expected status + hint = 2 lines, got %d: %#v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "Bash(command=rm -rf x)") || !strings.Contains(lines[0], "· Rejected") {
+		t.Errorf("status line = %q, want args and Rejected label", lines[0])
+	}
+	if strings.Contains(lines[0], "0ns") {
+		t.Errorf("rejected status line should not show a duration: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "ctrl+o to expand") {
+		t.Errorf("expected expand hint, got %q", lines[1])
+	}
+}
+
 func TestFormatToolResultExpanded_ThemingPreservesTree(t *testing.T) {
 	tree := "Bash(command=git branch)\n" +
 		"├─ Duration: 19ms\n" +

--- a/internal/ui/markdown/renderer_test.go
+++ b/internal/ui/markdown/renderer_test.go
@@ -100,17 +100,17 @@ func TestContainsMarkdownSkipsToolOutput(t *testing.T) {
 		{
 			name:     "tool output with box drawing",
 			content:  "Bash(command=ls)\n├─ Duration: 100ms\n└─ Status: Success",
-			expected: false, // Should skip due to box-drawing characters
+			expected: false,
 		},
 		{
 			name:     "tool output with duration and status",
 			content:  "Duration: 500ms Status: ✓ Success",
-			expected: false, // Should skip due to Duration/Status pattern
+			expected: false,
 		},
 		{
 			name:     "tool output with vertical line",
 			content:  "Arguments:\n│ file: test.go",
-			expected: false, // Should skip due to │ character
+			expected: false,
 		},
 		{
 			name:     "empty string",
@@ -169,16 +169,11 @@ func TestContainsMarkdownDetectsRealMarkdown(t *testing.T) {
 }
 
 func TestRendererWithNilThemeService(t *testing.T) {
-	// Test that renderer handles nil gracefully
-	// This would be a real integration test with the actual domain.ThemeService
-	// For now, we test the containsMarkdown function which is the core logic
-
 	content := "# Hello\n\nThis is a **test**"
 	assert.True(t, containsMarkdown(content))
 }
 
 func TestCodeBlockDetection(t *testing.T) {
-	// Code blocks are particularly important for TUI rendering
 	codeBlocks := []string{
 		"```go\npackage main\n```",
 		"```python\nprint('hello')\n```",


### PR DESCRIPTION
## Summary

Fixes #861.

- The state-machine rejection path (`buildRejectionEntry`) never populated `ToolExecution.Arguments`, so a rejected tool rendered as a bare `Bash() · rejected` with no indication of what was rejected. It now parses the original call arguments, matching the blocked and legacy rejection paths.
- `requestToolApproval` now removes the pending approval entry on rejection/error/timeout, so the rejection is no longer rendered twice (marked pending entry + tool result entry).
- The collapsed rejected result renders as a single `✗ Tool(args) · Rejected` status line with the expand hint, instead of a meaningless `· 0ns` duration and a generic "Execution failed" body.

## Testing

- `TestApprovingToolsState_RejectionEntryKeepsArguments` covers the argument fix (including malformed-JSON fallback).
- `TestFormatToolResultForUI_RejectedShowsStatusAndHintOnly` covers the collapsed rejected rendering.
- Full `go test ./...` and `golangci-lint` pass.

no docs ticket: internal-only fix