### PR TITLE
feat(tui): card-based tool-call formatter overhaul + scrollable approval review (#864)

### DIFF
--- a/internal/agent/tools/a2a_query_agent.go
+++ b/internal/agent/tools/a2a_query_agent.go
@@ -142,20 +142,11 @@ func (t *A2AQueryAgentTool) FormatForLLM(result *domain.ToolExecutionResult) str
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatter.FormatAsJSON(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatter.FormatAsJSON(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 func (t *A2AQueryAgentTool) FormatForUI(result *domain.ToolExecutionResult) string {

--- a/internal/agent/tools/a2a_query_task.go
+++ b/internal/agent/tools/a2a_query_task.go
@@ -197,78 +197,58 @@ func (t *A2AQueryTaskTool) FormatForLLM(result *domain.ToolExecutionResult) stri
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
 	if result.Data == nil {
-		hasDataSection := false
-		output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-		return output.String()
+		return t.formatter.FormatExpanded(result, "")
 	}
 
 	queryResult, ok := result.Data.(A2AQueryTaskResult)
 	if !ok || queryResult.Task == nil {
-		dataContent := t.formatter.FormatAsJSON(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
-		hasDataSection := result.Data != nil
-		output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-		return output.String()
+		return t.formatter.FormatExpanded(result, t.formatter.FormatAsJSON(result.Data))
 	}
 
+	var body strings.Builder
 	task := queryResult.Task
-	fmt.Fprintf(&output, "Task Status: %s\n", task.Status.State)
+	fmt.Fprintf(&body, "Task Status: %s\n", task.Status.State)
 
 	if isFailedTaskState(task.Status.State) {
 		if reason := failureReasonFromTask(*task); reason != "" {
-			fmt.Fprintf(&output, "\nFailure reason: %s\n", reason)
+			fmt.Fprintf(&body, "\nFailure reason: %s\n", reason)
 		}
 	}
 
 	hasArtifacts := len(task.Artifacts) > 0
 	if !hasArtifacts {
-		output.WriteString("\nNo artifacts available for this task.\n")
-		output.WriteString("\nFull Task Data:\n")
-		dataContent := t.formatter.FormatAsJSON(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
-		hasDataSection := result.Data != nil
-		output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-		return output.String()
+		body.WriteString("\nNo artifacts available for this task.\n")
+		body.WriteString("\nFull Task Data:\n")
+		body.WriteString(t.formatter.FormatAsJSON(result.Data))
+		return t.formatter.FormatExpanded(result, body.String())
 	}
 
-	fmt.Fprintf(&output, "\nArtifacts (%d):\n", len(task.Artifacts))
+	fmt.Fprintf(&body, "\nArtifacts (%d):\n", len(task.Artifacts))
 	for i, artifact := range task.Artifacts {
-		fmt.Fprintf(&output, "%d. ", i+1)
+		fmt.Fprintf(&body, "%d. ", i+1)
 		if artifact.Name != nil {
-			fmt.Fprintf(&output, "Name: %s", *artifact.Name)
+			fmt.Fprintf(&body, "Name: %s", *artifact.Name)
 		}
-		fmt.Fprintf(&output, " (ID: %s)", artifact.ArtifactID)
+		fmt.Fprintf(&body, " (ID: %s)", artifact.ArtifactID)
 
 		if artifact.Metadata != nil {
 			if url, ok := (*artifact.Metadata)["url"].(string); ok {
-				fmt.Fprintf(&output, "\n   Download URL: %s", url)
+				fmt.Fprintf(&body, "\n   Download URL: %s", url)
 			}
 			if mimeType, ok := (*artifact.Metadata)["mime_type"].(string); ok {
-				fmt.Fprintf(&output, "\n   MIME Type: %s", mimeType)
+				fmt.Fprintf(&body, "\n   MIME Type: %s", mimeType)
 			}
 			if size, ok := (*artifact.Metadata)["size"].(float64); ok {
-				fmt.Fprintf(&output, "\n   Size: %d bytes", int64(size))
+				fmt.Fprintf(&body, "\n   Size: %d bytes", int64(size))
 			}
 		}
-		output.WriteString("\n")
+		body.WriteString("\n")
 	}
 
-	output.WriteString("\nFull Task Data:\n")
-	dataContent := t.formatter.FormatAsJSON(result.Data)
-	hasMetadata := len(result.Metadata) > 0
-	output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	body.WriteString("\nFull Task Data:\n")
+	body.WriteString(t.formatter.FormatAsJSON(result.Data))
+	return t.formatter.FormatExpanded(result, body.String())
 }
 
 func (t *A2AQueryTaskTool) FormatForUI(result *domain.ToolExecutionResult) string {

--- a/internal/agent/tools/a2a_task.go
+++ b/internal/agent/tools/a2a_task.go
@@ -576,19 +576,11 @@ func (t *A2ASubmitTaskTool) FormatForLLM(result *domain.ToolExecutionResult) str
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent, hasMetadata := t.formatA2ATaskData(result.Data, result.Metadata)
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent, _ = t.formatA2ATaskData(result.Data, result.Metadata)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatA2ATaskData formats the task data content and returns it along with metadata presence

--- a/internal/agent/tools/agent.go
+++ b/internal/agent/tools/agent.go
@@ -701,13 +701,11 @@ func (t *AgentTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 	if result == nil {
 		return "Agent result unavailable"
 	}
-	var out strings.Builder
-	out.WriteString(t.formatter.FormatExpandedHeader(result))
+	var dataContent string
 	if result.Data != nil {
-		out.WriteString(t.formatter.FormatDataSection(t.formatAgentData(result.Data), len(result.Metadata) > 0))
+		dataContent = t.formatAgentData(result.Data)
 	}
-	out.WriteString(t.formatter.FormatExpandedFooter(result, result.Data != nil))
-	return out.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 func (t *AgentTool) formatAgentData(data any) string {

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -523,20 +523,11 @@ func (t *BashTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatBashData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatBashData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatBashData formats bash-specific data

--- a/internal/agent/tools/delete.go
+++ b/internal/agent/tools/delete.go
@@ -382,20 +382,11 @@ func (t *DeleteTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatDeleteData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatDeleteData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatDeleteData formats delete-specific data

--- a/internal/agent/tools/edit.go
+++ b/internal/agent/tools/edit.go
@@ -603,32 +603,20 @@ func (t *EditTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	showGitDiff := result.Success && result.Arguments != nil
 	if showGitDiff {
-		output.WriteString("\n")
 		themeService := domain.NewThemeProvider()
 		styleProvider := styles.NewProvider(themeService)
 		diffRenderer := components.NewDiffRenderer(styleProvider).SetContextLines(components.InlineDiffContextLines)
 		diffInfo := t.GetDiffInfo(result.Arguments)
 		diffInfo.Title = "← Edits applied →"
-		output.WriteString(diffRenderer.RenderDiff(*diffInfo))
-		output.WriteString("\n")
+		dataContent = diffRenderer.RenderDiff(*diffInfo)
+	} else if result.Data != nil {
+		dataContent = t.formatEditData(result.Data)
 	}
 
-	if !showGitDiff && result.Data != nil {
-		dataContent := t.formatEditData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
-	}
-
-	hasDataSection := !showGitDiff && result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // ShouldCollapseArg determines if an argument should be collapsed in display

--- a/internal/agent/tools/grep.go
+++ b/internal/agent/tools/grep.go
@@ -1067,20 +1067,11 @@ func (t *GrepTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatGrepData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatGrepData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatGrepData formats grep-specific data

--- a/internal/agent/tools/mcp_tool.go
+++ b/internal/agent/tools/mcp_tool.go
@@ -353,20 +353,11 @@ func (t *MCPTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "MCP tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatMCPData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatMCPData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatMCPData formats MCP-specific data for display

--- a/internal/agent/tools/mcp_tool.go
+++ b/internal/agent/tools/mcp_tool.go
@@ -388,7 +388,6 @@ func (t *MCPTool) formatMCPData(data any) string {
 
 // ShouldCollapseArg determines if an argument should be collapsed in display
 func (t *MCPTool) ShouldCollapseArg(key string) bool {
-	// Collapse large content fields
 	return key == "content" || key == "data" || key == "text"
 }
 

--- a/internal/agent/tools/memory.go
+++ b/internal/agent/tools/memory.go
@@ -777,14 +777,7 @@ func (t *MemoryTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Memory operation result unavailable"
 	}
 
-	var output strings.Builder
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-	output.WriteString(t.formatMemoryResultData(result))
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, t.formatMemoryResultData(result))
 }
 
 func (t *MemoryTool) formatMemoryResultData(result *domain.ToolExecutionResult) string {
@@ -793,28 +786,22 @@ func (t *MemoryTool) formatMemoryResultData(result *domain.ToolExecutionResult) 
 		return ""
 	}
 
-	connector := "└─"
-	if len(result.Metadata) > 0 {
-		connector = "├─"
-	}
-
 	var output strings.Builder
-	fmt.Fprintf(&output, "%s Result:\n", connector)
-	fmt.Fprintf(&output, "   Operation: %s\n", memResult.Operation)
+	fmt.Fprintf(&output, "Operation: %s\n", memResult.Operation)
 	if memResult.Name != "" {
-		fmt.Fprintf(&output, "   Name: %s\n", memResult.Name)
+		fmt.Fprintf(&output, "Name: %s\n", memResult.Name)
 	}
 	if memResult.Type != "" {
-		fmt.Fprintf(&output, "   Type: %s\n", memResult.Type)
+		fmt.Fprintf(&output, "Type: %s\n", memResult.Type)
 	}
 	if memResult.Path != "" {
-		fmt.Fprintf(&output, "   Path: %s\n", memResult.Path)
+		fmt.Fprintf(&output, "Path: %s\n", memResult.Path)
 	}
 	if memResult.Message != "" {
-		fmt.Fprintf(&output, "   %s\n", memResult.Message)
+		fmt.Fprintf(&output, "%s\n", memResult.Message)
 	}
 	if memResult.Content != "" && memResult.Operation == OperationRead {
-		fmt.Fprintf(&output, "   Content:\n%s\n", memResult.Content)
+		fmt.Fprintf(&output, "Content:\n%s\n", memResult.Content)
 	}
 	return output.String()
 }

--- a/internal/agent/tools/multiedit.go
+++ b/internal/agent/tools/multiedit.go
@@ -639,37 +639,26 @@ func (t *MultiEditTool) FormatForLLM(result *domain.ToolExecutionResult) string 
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
-	if result.Success && result.Arguments != nil && result.Data != nil {
-		output.WriteString("\n")
+	var dataContent string
+	switch {
+	case result.Success && result.Arguments != nil && result.Data != nil:
 		themeService := domain.NewThemeProvider()
 		styleProvider := styles.NewProvider(themeService)
 		diffRenderer := components.NewDiffRenderer(styleProvider).SetContextLines(components.InlineDiffContextLines)
 		diffInfo := t.getActualDiffInfo(result)
-		output.WriteString(diffRenderer.RenderDiff(*diffInfo))
-		output.WriteString("\n")
-	} else if !result.Success && result.Arguments != nil {
-		output.WriteString("\n")
+		dataContent = diffRenderer.RenderDiff(*diffInfo)
+	case !result.Success && result.Arguments != nil:
 		themeService := domain.NewThemeProvider()
 		styleProvider := styles.NewProvider(themeService)
 		diffRenderer := components.NewDiffRenderer(styleProvider).SetContextLines(components.InlineDiffContextLines)
 		diffInfo := t.GetDiffInfo(result.Arguments)
 		diffInfo.Title = "← Simulated diff preview →"
-		output.WriteString(diffRenderer.RenderDiff(*diffInfo))
-		output.WriteString("\n")
-	} else if result.Data != nil {
-		dataContent := t.formatMultiEditData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = diffRenderer.RenderDiff(*diffInfo)
+	case result.Data != nil:
+		dataContent = t.formatMultiEditData(result.Data)
 	}
 
-	hasDataSection := result.Success && result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatMultiEditData formats multi-edit-specific data

--- a/internal/agent/tools/read.go
+++ b/internal/agent/tools/read.go
@@ -503,20 +503,11 @@ func (t *ReadTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatReadData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatReadData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatReadData formats read-specific data

--- a/internal/agent/tools/schedule.go
+++ b/internal/agent/tools/schedule.go
@@ -487,13 +487,11 @@ func (t *ScheduleTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 	if result == nil {
 		return "Schedule result unavailable"
 	}
-	var out strings.Builder
-	out.WriteString(t.formatter.FormatExpandedHeader(result))
+	var dataContent string
 	if result.Data != nil {
-		out.WriteString(t.formatter.FormatDataSection(t.formatScheduleData(result.Data), len(result.Metadata) > 0))
+		dataContent = t.formatScheduleData(result.Data)
 	}
-	out.WriteString(t.formatter.FormatExpandedFooter(result, result.Data != nil))
-	return out.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 func (t *ScheduleTool) formatScheduleData(data any) string {

--- a/internal/agent/tools/todowrite.go
+++ b/internal/agent/tools/todowrite.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -323,82 +322,11 @@ func (t *TodoWriteTool) FormatForLLM(result *domain.ToolExecutionResult) string 
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatTodoData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatTodoData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
-}
-
-// formatExpandedHeader formats the expanded view header with TodoWrite-specific collapse logic
-func (t *TodoWriteTool) formatExpandedHeader(result *domain.ToolExecutionResult) string {
-	var output strings.Builder
-	toolCall := t.formatToolCallWithCollapse(result.Arguments)
-
-	fmt.Fprintf(&output, "%s\n", toolCall)
-	fmt.Fprintf(&output, "├─ ⏱️  Duration: %s\n", t.formatter.FormatDuration(result))
-	fmt.Fprintf(&output, "├─ 📊 Status: %s\n", t.formatter.FormatStatus(result.Success))
-
-	if result.Error != "" {
-		fmt.Fprintf(&output, "├─ %s Error: %s\n", icons.CrossMarkStyle.Render(icons.CrossMark), result.Error)
-	}
-
-	if len(result.Arguments) > 0 {
-		output.WriteString("├─ 📝 Arguments:\n")
-		keys := make([]string, 0, len(result.Arguments))
-		for key := range result.Arguments {
-			keys = append(keys, key)
-		}
-		slices.Sort(keys)
-
-		for i, key := range keys {
-			value := result.Arguments[key]
-			if t.ShouldCollapseArg(key) {
-				value = "..."
-			}
-			hasMore := i < len(keys)-1 || result.Data != nil || len(result.Metadata) > 0
-			if hasMore {
-				fmt.Fprintf(&output, "│  ├─ %s: %v\n", key, value)
-			} else {
-				fmt.Fprintf(&output, "│  └─ %s: %v\n", key, value)
-			}
-		}
-	}
-
-	return output.String()
-}
-
-// formatToolCallWithCollapse formats a tool call with TodoWrite-specific collapse logic
-func (t *TodoWriteTool) formatToolCallWithCollapse(args map[string]any) string {
-	if len(args) == 0 {
-		return "TodoWrite()"
-	}
-
-	keys := make([]string, 0, len(args))
-	for key := range args {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-
-	argPairs := make([]string, 0, len(args))
-	for _, key := range keys {
-		value := args[key]
-		if t.ShouldCollapseArg(key) {
-			value = `"..."`
-		}
-		argPairs = append(argPairs, fmt.Sprintf("%s=%v", key, value))
-	}
-
-	return fmt.Sprintf("TodoWrite(%s)", strings.Join(argPairs, ", "))
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatTodoData formats todo-specific data with progress visualization

--- a/internal/agent/tools/tree.go
+++ b/internal/agent/tools/tree.go
@@ -614,20 +614,11 @@ func (t *TreeTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatTreeData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatTreeData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatTreeData formats tree-specific data

--- a/internal/agent/tools/web_fetch.go
+++ b/internal/agent/tools/web_fetch.go
@@ -325,20 +325,11 @@ func (t *WebFetchTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatFetchData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatFetchData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatFetchData formats web fetch-specific data

--- a/internal/agent/tools/web_search.go
+++ b/internal/agent/tools/web_search.go
@@ -648,20 +648,11 @@ func (t *WebSearchTool) FormatForLLM(result *domain.ToolExecutionResult) string 
 		return "Tool execution result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-
+	var dataContent string
 	if result.Data != nil {
-		dataContent := t.formatSearchData(result.Data)
-		hasMetadata := len(result.Metadata) > 0
-		output.WriteString(t.formatter.FormatDataSection(dataContent, hasMetadata))
+		dataContent = t.formatSearchData(result.Data)
 	}
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, dataContent)
 }
 
 // formatSearchData formats web search-specific data

--- a/internal/agent/tools/write.go
+++ b/internal/agent/tools/write.go
@@ -216,15 +216,7 @@ func (t *WriteTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		return "Write operation result unavailable"
 	}
 
-	var output strings.Builder
-
-	output.WriteString(t.formatter.FormatExpandedHeader(result))
-	output.WriteString(t.formatWriteResultData(result))
-
-	hasDataSection := result.Data != nil
-	output.WriteString(t.formatter.FormatExpandedFooter(result, hasDataSection))
-
-	return output.String()
+	return t.formatter.FormatExpanded(result, t.formatWriteResultData(result))
 }
 
 // formatWriteResultData formats the write result data section
@@ -243,16 +235,10 @@ func (t *WriteTool) formatWriteResultData(result *domain.ToolExecutionResult) st
 		action = "Created"
 	}
 
-	connector := "└─"
-	if len(result.Metadata) > 0 {
-		connector = "├─"
-	}
-
 	var output strings.Builder
-	fmt.Fprintf(&output, "%s Result:\n", connector)
-	fmt.Fprintf(&output, "   %s file: %s\n", action, writeResult.FilePath)
-	fmt.Fprintf(&output, "   Bytes written: %d\n", writeResult.BytesWritten)
-	fmt.Fprintf(&output, "   Lines: %d\n", writeResult.LinesWritten)
+	fmt.Fprintf(&output, "%s file: %s\n", action, writeResult.FilePath)
+	fmt.Fprintf(&output, "Bytes written: %d\n", writeResult.BytesWritten)
+	fmt.Fprintf(&output, "Lines: %d\n", writeResult.LinesWritten)
 
 	return output.String()
 }

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -819,6 +819,12 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 				return []tea.Cmd{cmd}
 			}
 			return nil
+		case tea.KeyUp, tea.KeyDown:
+			// While the diff is expanded (ctrl+o), up/down scroll it; otherwise
+			// they fall through to their normal handling.
+			if app.scrollApprovalDiff(keyMsg.Code) {
+				return nil
+			}
 		}
 	}
 
@@ -2587,8 +2593,29 @@ func isCommandInput(input string) bool {
 	return strings.HasPrefix(input, "/") || strings.HasPrefix(input, "!")
 }
 
-// ToggleToolResultExpansion toggles tool result expansion
+// scrollApprovalDiff scrolls the expanded approval diff by one line for up/down and
+// reports whether it handled the key. It only acts while the diff is expanded so
+// up/down keep their normal behaviour otherwise.
+func (app *ChatApplication) scrollApprovalDiff(code rune) bool {
+	if !app.approvalBoxView.IsExpanded() {
+		return false
+	}
+	if code == tea.KeyUp {
+		app.approvalBoxView.ScrollDiff(-1)
+	} else {
+		app.approvalBoxView.ScrollDiff(1)
+	}
+	return true
+}
+
+// ToggleToolResultExpansion toggles tool result expansion. While an approval is
+// pending, ctrl+o instead expands the pending diff preview so it can be reviewed
+// in full before approving — consistent with expanding tool results inline.
 func (app *ChatApplication) ToggleToolResultExpansion() {
+	if app.approvalBoxView != nil && app.approvalBoxView.IsActive() {
+		app.approvalBoxView.ToggleExpanded()
+		return
+	}
 	app.toggleToolResultExpansion()
 }
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -215,6 +215,7 @@ func NewChatApplication(
 	app.toolCallRenderer.SetStateManager(app.stateManager)
 	app.conversationView = factory.CreateConversationView(app.themeService)
 	toolFormatterService := services.NewToolFormatterService(app.toolRegistry, styleProvider)
+	app.toolCallRenderer.SetToolFormatter(toolFormatterService)
 
 	configDir := cfg.GetConfigDir()
 	app.configDir = configDir
@@ -271,6 +272,7 @@ func NewChatApplication(
 	app.helpBar = factory.CreateHelpBar(app.themeService)
 	app.helpView = components.NewHelpView(app.themeService, styleProvider)
 	app.queueBoxView = components.NewQueueBoxView(styleProvider)
+	app.queueBoxView.SetToolFormatter(toolFormatterService)
 	app.todoBoxView = components.NewTodoBoxView(styleProvider)
 	app.snippetAttachmentsView = components.NewSnippetAttachmentsView(styleProvider)
 	app.focusAttachments = focusAttachmentsBinding(app.config.Chat.Keybindings)

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -804,7 +804,6 @@ func (app *ChatApplication) handleChatView(msg tea.Msg) []tea.Cmd {
 func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea.Cmd {
 	var cmds []tea.Cmd
 
-	// While an AskUserQuestion form is up it captures all keys (like the
 	if app.stateManager.GetUserQuestionUIState() != nil && !key.Matches(keyMsg, guardKeys.interrupt) {
 		if cmd := app.questionFormView.Forward(keyMsg); cmd != nil {
 			return []tea.Cmd{cmd}
@@ -820,8 +819,6 @@ func (app *ChatApplication) handleChatViewKeyPress(keyMsg tea.KeyPressMsg) []tea
 			}
 			return nil
 		case tea.KeyUp, tea.KeyDown:
-			// While the diff is expanded (ctrl+o), up/down scroll it; otherwise
-			// they fall through to their normal handling.
 			if app.scrollApprovalDiff(keyMsg.Code) {
 				return nil
 			}

--- a/internal/domain/formatter.go
+++ b/internal/domain/formatter.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 
+	"charm.land/lipgloss/v2/tree"
+
 	"github.com/inference-gateway/cli/internal/ui/styles/colors"
 	"github.com/inference-gateway/cli/internal/ui/styles/icons"
 )
@@ -283,6 +285,80 @@ func (f CustomFormatter) FormatExpandedHeader(result *ToolExecutionResult) strin
 	}
 
 	return output.String()
+}
+
+// FormatExpanded renders the full expanded result as a single native lipgloss/tree,
+// replacing the hand-drawn ├─/└─ connectors that used to live across three methods.
+// dataContent is the tool-specific result body (may be ""). Output is plain: the UI
+// wraps and themes it (services.themeTreeLines); LLM / headless consume it as-is.
+func (f BaseFormatter) FormatExpanded(result *ToolExecutionResult, dataContent string) string {
+	return renderExpandedTree(f.FormatToolCall(result.Arguments, false), result, dataContent, f.argValue)
+}
+
+// FormatExpanded renders the expanded tree using the custom collapse behavior.
+func (f CustomFormatter) FormatExpanded(result *ToolExecutionResult, dataContent string) string {
+	return renderExpandedTree(f.FormatToolCall(result.Arguments, false), result, dataContent, f.argValue)
+}
+
+// argValue formats a single argument value for the expanded view, honoring the
+// formatter's collapse behavior (BaseFormatter truncates to 50; CustomFormatter uses "...").
+func (f BaseFormatter) argValue(key string, value any) string {
+	if f.ShouldCollapseArg(key) {
+		return f.collapseArgValue(value, 50)
+	}
+	return fmt.Sprintf("%v", value)
+}
+
+func (f CustomFormatter) argValue(key string, value any) string {
+	if f.ShouldCollapseArg(key) {
+		return "..."
+	}
+	return fmt.Sprintf("%v", value)
+}
+
+// renderExpandedTree builds the shared native tree from a result. It is the single
+// source of the ├──/╰── connectors, replacing the per-method hand drawing.
+func renderExpandedTree(toolCall string, result *ToolExecutionResult, dataContent string, argValue func(string, any) string) string {
+	base := BaseFormatter{}
+	t := tree.Root(toolCall).Enumerator(tree.RoundedEnumerator)
+
+	t.Child("Duration: " + base.FormatDuration(result))
+	t.Child("Status: " + base.FormatStatus(result.Success))
+	if result.Error != "" {
+		t.Child("Error: " + result.Error)
+	}
+
+	if len(result.Arguments) > 0 {
+		keys := make([]string, 0, len(result.Arguments))
+		for key := range result.Arguments {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+		args := tree.Root("Arguments:")
+		for _, key := range keys {
+			args.Child(fmt.Sprintf("%s: %s", key, argValue(key, result.Arguments[key])))
+		}
+		t.Child(args)
+	}
+
+	if dataContent != "" {
+		t.Child(tree.Root("Result:").Child(strings.TrimRight(dataContent, "\n")))
+	}
+
+	if len(result.Metadata) > 0 {
+		keys := make([]string, 0, len(result.Metadata))
+		for key := range result.Metadata {
+			keys = append(keys, key)
+		}
+		slices.Sort(keys)
+		meta := tree.Root("Metadata:")
+		for _, key := range keys {
+			meta.Child(fmt.Sprintf("%s: %v", key, result.Metadata[key]))
+		}
+		t.Child(meta)
+	}
+
+	return t.String()
 }
 
 // GetFileName extracts filename from a path

--- a/internal/domain/formatter.go
+++ b/internal/domain/formatter.go
@@ -6,10 +6,10 @@ import (
 	"slices"
 	"strings"
 
-	"charm.land/lipgloss/v2/tree"
+	tree "charm.land/lipgloss/v2/tree"
 
-	"github.com/inference-gateway/cli/internal/ui/styles/colors"
-	"github.com/inference-gateway/cli/internal/ui/styles/icons"
+	colors "github.com/inference-gateway/cli/internal/ui/styles/colors"
+	icons "github.com/inference-gateway/cli/internal/ui/styles/icons"
 )
 
 // BaseFormatter provides common formatting functionality that tools can embed

--- a/internal/domain/formatter.go
+++ b/internal/domain/formatter.go
@@ -6,10 +6,9 @@ import (
 	"slices"
 	"strings"
 
-	tree "charm.land/lipgloss/v2/tree"
-
 	colors "github.com/inference-gateway/cli/internal/ui/styles/colors"
 	icons "github.com/inference-gateway/cli/internal/ui/styles/icons"
+	tree "github.com/inference-gateway/cli/internal/ui/styles/tree"
 )
 
 // BaseFormatter provides common formatting functionality that tools can embed
@@ -190,10 +189,16 @@ func (f CustomFormatter) argValue(key string, value any) string {
 // source of the ├──/╰── connectors, replacing the per-method hand drawing.
 func renderExpandedTree(toolCall string, result *ToolExecutionResult, dataContent string, argValue func(string, any) string) string {
 	base := BaseFormatter{}
-	t := tree.Root(toolCall).Enumerator(tree.RoundedEnumerator)
+	t := tree.Root(toolCall).Rounded()
 
+	// Plain status (glyph only, no ANSI): this tree feeds the LLM/headless path
+	// as-is, and the UI re-themes it via services.themeTreeLines.
+	status := icons.CheckMark + " Success"
+	if !result.Success {
+		status = icons.CrossMark + " Failed"
+	}
 	t.Child("Duration: " + base.FormatDuration(result))
-	t.Child("Status: " + base.FormatStatus(result.Success))
+	t.Child("Status: " + status)
 	if result.Error != "" {
 		t.Child("Error: " + result.Error)
 	}

--- a/internal/domain/formatter.go
+++ b/internal/domain/formatter.go
@@ -112,98 +112,6 @@ func (f BaseFormatter) FormatDuration(result *ToolExecutionResult) string {
 	return fmt.Sprintf("%dh%dm", hours, minutes)
 }
 
-// FormatExpandedHeader formats the expanded view header with tool call and metadata
-func (f BaseFormatter) FormatExpandedHeader(result *ToolExecutionResult) string {
-	var output strings.Builder
-	toolCall := f.FormatToolCall(result.Arguments, false)
-
-	fmt.Fprintf(&output, "%s\n", toolCall)
-	fmt.Fprintf(&output, "├─ Duration: %s\n", f.FormatDuration(result))
-	fmt.Fprintf(&output, "├─ Status: %s\n", f.FormatStatus(result.Success))
-
-	if result.Error != "" {
-		fmt.Fprintf(&output, "├─ Error: %s\n", result.Error)
-	}
-
-	if len(result.Arguments) > 0 {
-		output.WriteString("├─ Arguments:\n")
-		keys := make([]string, 0, len(result.Arguments))
-		for key := range result.Arguments {
-			keys = append(keys, key)
-		}
-		slices.Sort(keys)
-
-		for i, key := range keys {
-			value := result.Arguments[key]
-			if f.ShouldCollapseArg(key) {
-				value = f.collapseArgValue(value, 50)
-			}
-			hasMore := i < len(keys)-1 || result.Data != nil || len(result.Metadata) > 0
-			if hasMore {
-				fmt.Fprintf(&output, "│  ├─ %s: %v\n", key, value)
-			} else {
-				fmt.Fprintf(&output, "│  └─ %s: %v\n", key, value)
-			}
-		}
-	}
-
-	return output.String()
-}
-
-// FormatExpandedFooter formats the expanded view footer with metadata
-func (f BaseFormatter) FormatExpandedFooter(result *ToolExecutionResult, hasDataSection bool) string {
-	if len(result.Metadata) == 0 {
-		return ""
-	}
-
-	var output strings.Builder
-	if hasDataSection {
-		output.WriteString("└─ Metadata:\n")
-	} else {
-		output.WriteString("└─ Metadata:\n")
-	}
-
-	keys := make([]string, 0, len(result.Metadata))
-	for key := range result.Metadata {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-
-	for i, key := range keys {
-		if i == len(keys)-1 {
-			fmt.Fprintf(&output, "   └─ %s: %s\n", key, result.Metadata[key])
-		} else {
-			fmt.Fprintf(&output, "   ├─ %s: %s\n", key, result.Metadata[key])
-		}
-	}
-
-	return output.String()
-}
-
-// FormatDataSection formats the data section with proper indentation
-func (f BaseFormatter) FormatDataSection(dataContent string, hasMetadata bool) string {
-	if dataContent == "" {
-		return ""
-	}
-
-	var output strings.Builder
-	if hasMetadata {
-		output.WriteString("├─ Result:\n")
-	} else {
-		output.WriteString("└─ Result:\n")
-	}
-
-	for _, line := range strings.Split(strings.TrimRight(dataContent, "\n"), "\n") {
-		if hasMetadata {
-			fmt.Fprintf(&output, "│  %s\n", line)
-		} else {
-			fmt.Fprintf(&output, "   %s\n", line)
-		}
-	}
-
-	return output.String()
-}
-
 // FormatAsJSON formats data as JSON if possible, falls back to string representation
 func (f BaseFormatter) FormatAsJSON(data any) string {
 	if jsonData, err := json.MarshalIndent(data, "", "  "); err == nil {
@@ -247,44 +155,6 @@ func (f CustomFormatter) FormatToolCall(args map[string]any, expanded bool) stri
 	}
 
 	return fmt.Sprintf("%s(%s)", f.toolName, f.joinArgs(argPairs))
-}
-
-// FormatExpandedHeader overrides BaseFormatter to use custom collapse logic
-func (f CustomFormatter) FormatExpandedHeader(result *ToolExecutionResult) string {
-	var output strings.Builder
-	toolCall := f.FormatToolCall(result.Arguments, false)
-
-	fmt.Fprintf(&output, "%s\n", toolCall)
-	fmt.Fprintf(&output, "├─ Duration: %s\n", f.FormatDuration(result))
-	fmt.Fprintf(&output, "├─ Status: %s\n", f.FormatStatus(result.Success))
-
-	if result.Error != "" {
-		fmt.Fprintf(&output, "├─ Error: %s\n", result.Error)
-	}
-
-	if len(result.Arguments) > 0 {
-		output.WriteString("├─ Arguments:\n")
-		keys := make([]string, 0, len(result.Arguments))
-		for key := range result.Arguments {
-			keys = append(keys, key)
-		}
-		slices.Sort(keys)
-
-		for i, key := range keys {
-			value := result.Arguments[key]
-			if f.ShouldCollapseArg(key) {
-				value = "..."
-			}
-			isLast := i == len(keys)-1
-			prefix := "│ ├─"
-			if isLast {
-				prefix = "│ └─"
-			}
-			fmt.Fprintf(&output, "%s %s: %v\n", prefix, key, value)
-		}
-	}
-
-	return output.String()
 }
 
 // FormatExpanded renders the full expanded result as a single native lipgloss/tree,
@@ -342,7 +212,7 @@ func renderExpandedTree(toolCall string, result *ToolExecutionResult, dataConten
 	}
 
 	if dataContent != "" {
-		t.Child(tree.Root("Result:").Child(strings.TrimRight(dataContent, "\n")))
+		t.Child("Result:\n" + strings.TrimRight(dataContent, "\n"))
 	}
 
 	if len(result.Metadata) > 0 {

--- a/internal/domain/formatter_test.go
+++ b/internal/domain/formatter_test.go
@@ -1,0 +1,47 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFormatExpandedNativeTree verifies the expanded result renders as a native
+// lipgloss/tree (rounded ├──/╰── connectors), keeps the field order, nests the
+// Result body and arguments, and is not wrapped in a card (LLM/headless stay plain).
+func TestFormatExpandedNativeTree(t *testing.T) {
+	f := NewBaseFormatter("Bash")
+	result := &ToolExecutionResult{
+		ToolName:  "Bash",
+		Success:   true,
+		Duration:  120 * time.Millisecond,
+		Arguments: map[string]any{"command": "ls -la"},
+		Metadata:  map[string]string{"exit_code": "0"},
+	}
+
+	out := f.FormatExpanded(result, "line one\nline two")
+
+	for _, want := range []string{
+		"Bash(command=ls -la)",
+		"├── Duration: 120ms",
+		"├── Arguments:",
+		"│   ╰── command: ls -la",
+		"Result:",
+		"line one",
+		"╰── Metadata:",
+		"exit_code: 0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expanded tree missing %q in:\n%s", want, out)
+		}
+	}
+
+	// native rounded glyphs replace the old single-dash form
+	if strings.Contains(out, "├─ ") || strings.Contains(out, "└─ ") {
+		t.Errorf("expected native ├──/╰── glyphs, found old single-dash connectors:\n%s", out)
+	}
+	// LLM/headless output must not be wrapped in a card
+	if strings.Contains(out, "╭") || strings.Contains(out, "╮") {
+		t.Errorf("LLM expanded output must not be card-framed:\n%s", out)
+	}
+}

--- a/internal/domain/formatter_test.go
+++ b/internal/domain/formatter_test.go
@@ -36,11 +36,9 @@ func TestFormatExpandedNativeTree(t *testing.T) {
 		}
 	}
 
-	// native rounded glyphs replace the old single-dash form
 	if strings.Contains(out, "├─ ") || strings.Contains(out, "└─ ") {
 		t.Errorf("expected native ├──/╰── glyphs, found old single-dash connectors:\n%s", out)
 	}
-	// LLM/headless output must not be wrapped in a card
 	if strings.Contains(out, "╭") || strings.Contains(out, "╮") {
 		t.Errorf("LLM expanded output must not be card-framed:\n%s", out)
 	}

--- a/internal/domain/formatter_test.go
+++ b/internal/domain/formatter_test.go
@@ -42,4 +42,7 @@ func TestFormatExpandedNativeTree(t *testing.T) {
 	if strings.Contains(out, "╭") || strings.Contains(out, "╮") {
 		t.Errorf("LLM expanded output must not be card-framed:\n%s", out)
 	}
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("LLM expanded output must be ANSI-free (no color escapes):\n%q", out)
+	}
 }

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -902,6 +902,10 @@ type ToolFormatter interface {
 	// FormatToolCall formats a tool call for consistent display
 	FormatToolCall(toolName string, args map[string]any) string
 
+	// RenderToolSummary renders the shared "<icon> Name(args) <trailing>" line used by
+	// the collapsed status line, live preview, approval summary and queue preview.
+	RenderToolSummary(icon, toolName string, args map[string]any, trailing string, terminalWidth int) string
+
 	// FormatToolResultForUI formats tool execution results for UI display
 	FormatToolResultForUI(result *ToolExecutionResult, terminalWidth int) string
 

--- a/internal/services/tool_formatter.go
+++ b/internal/services/tool_formatter.go
@@ -128,30 +128,59 @@ func (s *ToolFormatterService) FormatToolResultForUI(result *domain.ToolExecutio
 		return "Tool execution result unavailable"
 	}
 
+	dim := s.styleProvider.GetThemeColor("dim")
+	inner := s.cardWidth(terminalWidth) - 4 // minus border + horizontal padding
+
 	if result.Rejected {
-		line := s.statusLine(result, terminalWidth)
+		body := s.statusLine(result, terminalWidth)
 		if hint := s.expandHint(); hint != "" {
-			line += "\n" + s.styleProvider.RenderWithColor("    "+hint, s.styleProvider.GetThemeColor("dim"))
+			body += "\n" + s.styleProvider.RenderWithColor(hint, dim)
 		}
-		return line
+		return s.wrapCard(result.ToolName, body, terminalWidth)
 	}
 
-	lines, more := previewLines(s.resultBody(result), result.Success, contentWidth(terminalWidth))
+	lines, more := previewLines(s.resultBody(result), result.Success, inner)
 
-	out := make([]string, 0, len(lines)+2)
+	out := make([]string, 0, len(lines)+3)
 	out = append(out, s.statusLine(result, terminalWidth))
-
-	dim := s.styleProvider.GetThemeColor("dim")
-	for _, ln := range lines {
-		out = append(out, s.styleProvider.RenderWithColor("    "+ln, dim))
+	if len(lines) > 0 {
+		out = append(out, s.styleProvider.RenderWithColor(strings.Repeat("─", inner), dim))
+		for _, ln := range lines {
+			out = append(out, s.styleProvider.RenderWithColor(ln, dim))
+		}
 	}
 	if footer := s.collapsedFooter(more); footer != "" {
-		out = append(out, s.styleProvider.RenderWithColor("    "+footer, dim))
+		out = append(out, s.styleProvider.PlaceHorizontal(inner, "", s.styleProvider.RenderWithColor(footer, dim)))
 	}
-	return strings.Join(out, "\n")
+	return s.wrapCard(result.ToolName, strings.Join(out, "\n"), terminalWidth)
 }
 
-// statusLine renders the compact "<icon> Name(args) · <duration>" header.
+// RenderToolSummary renders the shared "<icon> Name(args) <trailing>" line used by the
+// collapsed status line, the live preview, the approval summary and the queue preview.
+// icon and trailing are already-styled by the caller (each surface owns its own status
+// semantics); the tool name and the width-aware, path-shortened argument preview are
+// formatted identically everywhere, replacing the per-call-site drift (e.g. the old
+// byte-slice `args[:47]` truncation in the live renderer). Pass icon=="" / trailing==""
+// to omit either segment.
+func (s *ToolFormatterService) RenderToolSummary(icon, toolName string, args map[string]any, trailing string, terminalWidth int) string {
+	line := toolName
+	if icon != "" {
+		line = icon + " " + toolName
+	}
+	argsPreview := s.formatArgsPreview(args, s.argsPreviewBudget(toolName, terminalWidth))
+	if argsPreview != "" && argsPreview != "{}" {
+		line += "(" + argsPreview + ")"
+	} else {
+		line += "()"
+	}
+	if trailing != "" {
+		line += " " + trailing
+	}
+	return line
+}
+
+// statusLine renders the compact "<icon> Name(args) · <duration>" header via the
+// shared summary renderer.
 func (s *ToolFormatterService) statusLine(result *domain.ToolExecutionResult, terminalWidth int) string {
 	icon := icons.CheckMark
 	iconColor := "success"
@@ -159,19 +188,36 @@ func (s *ToolFormatterService) statusLine(result *domain.ToolExecutionResult, te
 		icon = icons.CrossMark
 		iconColor = "error"
 	}
-
 	styledIcon := s.styleProvider.RenderWithColor(icon, s.styleProvider.GetThemeColor(iconColor))
+
 	suffix, suffixColor := "· "+formatDurationShort(result.Duration), "dim"
 	if result.Rejected {
 		suffix, suffixColor = "· Rejected", "error"
 	}
-	styledDur := s.styleProvider.RenderWithColor(suffix, s.styleProvider.GetThemeColor(suffixColor))
+	styledSuffix := s.styleProvider.RenderWithColor(suffix, s.styleProvider.GetThemeColor(suffixColor))
 
-	argsPreview := s.formatArgsPreview(result.Arguments, s.argsPreviewBudget(result.ToolName, terminalWidth))
-	if argsPreview != "" && argsPreview != "{}" {
-		return fmt.Sprintf("%s %s(%s) %s", styledIcon, result.ToolName, argsPreview, styledDur)
+	return s.RenderToolSummary(styledIcon, result.ToolName, result.Arguments, styledSuffix, terminalWidth)
+}
+
+// cardWidth is the content width for a tool-result card at the given terminal width.
+func (s *ToolFormatterService) cardWidth(terminalWidth int) int {
+	w := formatting.GetResponsiveWidth(terminalWidth) - 2 // rounded border adds 2 columns
+	if w < 20 {
+		w = 20
 	}
-	return fmt.Sprintf("%s %s() %s", styledIcon, result.ToolName, styledDur)
+	return w
+}
+
+// wrapCard frames content in a rounded card whose top border carries the tool name,
+// coloured by tool type (AC8): a subtle border with an accent title, no emoji.
+func (s *ToolFormatterService) wrapCard(toolName, content string, terminalWidth int) string {
+	return s.styleProvider.RenderTitledCard(
+		content,
+		toolName,
+		s.styleProvider.GetThemeColor("border"),
+		s.styleProvider.ToolTitleColor(toolName),
+		s.cardWidth(terminalWidth),
+	)
 }
 
 // argsPreviewBudget is the width available for the inline argument preview on the
@@ -232,12 +278,13 @@ func (s *ToolFormatterService) FormatToolResultExpanded(result *domain.ToolExecu
 		tree = safeToolFormat(result.ToolName, func() string { return tool.FormatResult(result, domain.FormatterLLM) })
 	}
 
-	tree = wrapTreeLines(tree, formatting.GetResponsiveWidth(terminalWidth))
-	themed := s.themeTreeLines(tree)
+	inner := s.cardWidth(terminalWidth) - 4 // minus border + horizontal padding
+	tree = wrapTreeLines(tree, inner)
+	body := s.themeTreeLines(tree)
 	if hint := s.collapseHintLine(result); hint != "" {
-		return themed + "\n" + hint
+		body += "\n" + hint
 	}
-	return themed
+	return s.wrapCard(result.ToolName, body, terminalWidth)
 }
 
 // FormatToolResultForLLM formats tool execution results for LLM consumption

--- a/internal/services/tool_formatter.go
+++ b/internal/services/tool_formatter.go
@@ -274,16 +274,11 @@ func (s *ToolFormatterService) formatFallback(result *domain.ToolExecutionResult
 		return fmt.Sprintf("%s %s %s", statusIcon, toolCall, statusText)
 
 	case domain.FormatterLLM:
-		var output strings.Builder
-		output.WriteString(formatter.FormatExpandedHeader(result))
+		var dataContent string
 		if result.Data != nil {
-			dataContent := formatter.FormatAsJSON(result.Data)
-			hasMetadata := len(result.Metadata) > 0
-			output.WriteString(formatter.FormatDataSection(dataContent, hasMetadata))
+			dataContent = formatter.FormatAsJSON(result.Data)
 		}
-		hasDataSection := result.Data != nil
-		output.WriteString(formatter.FormatExpandedFooter(result, hasDataSection))
-		return output.String()
+		return formatter.FormatExpanded(result, dataContent)
 
 	default:
 		if result.Success {

--- a/internal/services/tool_formatter.go
+++ b/internal/services/tool_formatter.go
@@ -129,7 +129,7 @@ func (s *ToolFormatterService) FormatToolResultForUI(result *domain.ToolExecutio
 	}
 
 	dim := s.styleProvider.GetThemeColor("dim")
-	inner := s.cardWidth(terminalWidth) - 4 // minus border + horizontal padding
+	inner := s.cardWidth(terminalWidth) - 4
 
 	if result.Rejected {
 		body := s.statusLine(result, terminalWidth)

--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -20,6 +20,29 @@ var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
 func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }
 
+// stripCard removes the rounded card framing (top/bottom border and the "│ … │"
+// per line, plus horizontal padding) added by wrapCard, returning the inner content
+// for structural assertions. Call it on already-ANSI-stripped output.
+func stripCard(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) < 3 {
+		return s
+	}
+	inner := make([]string, 0, len(lines)-2)
+	for _, ln := range lines[1 : len(lines)-1] {
+		ln = strings.TrimSuffix(ln, "│")
+		ln = strings.TrimPrefix(ln, "│")
+		ln = strings.TrimPrefix(ln, " ")
+		inner = append(inner, strings.TrimRight(ln, " "))
+	}
+	return strings.Join(inner, "\n")
+}
+
+// cardTitle returns the top-border line of a card (carries the tool name).
+func cardTitle(s string) string {
+	return strings.SplitN(s, "\n", 2)[0]
+}
+
 // fakeTool is a configurable domain.Tool (and ResultBodyProvider) for formatter tests.
 type fakeTool struct {
 	name         string
@@ -95,24 +118,25 @@ func TestFormatToolResultForUI_CollapsedSuccessTruncatesToFive(t *testing.T) {
 	tool := &fakeTool{name: "Bash", hasBody: true, body: "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8"}
 	svc := newTestService(tool)
 
-	out := stripANSI(svc.FormatToolResultForUI(bashResult(true, map[string]any{"command": "git branch"}), 80))
-	lines := strings.Split(out, "\n")
+	full := stripANSI(svc.FormatToolResultForUI(bashResult(true, map[string]any{"command": "git branch"}), 80))
+	if !strings.Contains(cardTitle(full), "Bash") {
+		t.Errorf("card top border missing tool name: %q", cardTitle(full))
+	}
+	lines := strings.Split(stripCard(full), "\n")
 
 	if !strings.Contains(lines[0], "Bash(command=git branch)") || !strings.Contains(lines[0], "19ms") {
 		t.Fatalf("status line missing name/duration: %q", lines[0])
 	}
-	if len(lines) != 7 {
-		t.Fatalf("expected 7 lines, got %d: %#v", len(lines), lines)
+	// status + dim separator + 5 preview lines + footer
+	if len(lines) != 8 {
+		t.Fatalf("expected 8 inner lines, got %d: %#v", len(lines), lines)
 	}
 	for i, want := range []string{"l1", "l2", "l3", "l4", "l5"} {
-		if strings.TrimSpace(lines[1+i]) != want {
-			t.Errorf("preview line %d = %q, want %q", i, lines[1+i], want)
-		}
-		if !strings.HasPrefix(lines[1+i], "    ") {
-			t.Errorf("preview line %d not indented: %q", i, lines[1+i])
+		if strings.TrimSpace(lines[2+i]) != want {
+			t.Errorf("preview line %d = %q, want %q", i, lines[2+i], want)
 		}
 	}
-	footer := lines[6]
+	footer := lines[7]
 	if !strings.Contains(footer, "+3 lines") || !strings.Contains(footer, "ctrl+o to expand") {
 		t.Errorf("footer = %q, want +3 lines + expand hint", footer)
 	}
@@ -125,17 +149,18 @@ func TestFormatToolResultForUI_FailureShowsFullBody(t *testing.T) {
 	tool := &fakeTool{name: "Bash", hasBody: true, body: "e1\ne2\ne3\ne4\ne5"}
 	svc := newTestService(tool)
 
-	out := stripANSI(svc.FormatToolResultForUI(bashResult(false, map[string]any{"command": "boom"}), 80))
-	lines := strings.Split(out, "\n")
+	inner := stripCard(stripANSI(svc.FormatToolResultForUI(bashResult(false, map[string]any{"command": "boom"}), 80)))
+	lines := strings.Split(inner, "\n")
 
-	if len(lines) != 7 {
-		t.Fatalf("expected 7 lines, got %d: %#v", len(lines), lines)
+	// status + separator + 5 full body lines + hint footer
+	if len(lines) != 8 {
+		t.Fatalf("expected 8 inner lines, got %d: %#v", len(lines), lines)
 	}
-	if strings.Contains(out, "+") && strings.Contains(out, "more") {
-		t.Errorf("failure output should not truncate: %q", out)
+	if strings.Contains(inner, "+") && strings.Contains(inner, "more") {
+		t.Errorf("failure output should not truncate: %q", inner)
 	}
-	if strings.Contains(out, "+5") {
-		t.Errorf("failure output should not show a hidden-line count: %q", out)
+	if strings.Contains(inner, "+5") {
+		t.Errorf("failure output should not show a hidden-line count: %q", inner)
 	}
 	if !strings.Contains(lines[len(lines)-1], "ctrl+o to expand") {
 		t.Errorf("footer should still show expand hint: %q", lines[len(lines)-1])
@@ -147,14 +172,14 @@ func TestFormatToolResultForUI_SummaryFallsBackToPreview(t *testing.T) {
 	svc := newTestService(tool)
 
 	res := &domain.ToolExecutionResult{ToolName: "Write", Success: true, Duration: 5 * time.Millisecond}
-	out := stripANSI(svc.FormatToolResultForUI(res, 80))
-	lines := strings.Split(out, "\n")
+	lines := strings.Split(stripCard(stripANSI(svc.FormatToolResultForUI(res, 80))), "\n")
 
-	if len(lines) != 3 {
-		t.Fatalf("expected status + 1 preview + footer = 3 lines, got %d: %#v", len(lines), lines)
+	// status + separator + 1 preview + footer
+	if len(lines) != 4 {
+		t.Fatalf("expected status + separator + 1 preview + footer = 4 lines, got %d: %#v", len(lines), lines)
 	}
-	if strings.TrimSpace(lines[1]) != "Created main.go (123 bytes)" {
-		t.Errorf("preview line = %q", lines[1])
+	if strings.TrimSpace(lines[2]) != "Created main.go (123 bytes)" {
+		t.Errorf("preview line = %q", lines[2])
 	}
 }
 
@@ -162,8 +187,7 @@ func TestFormatToolResultForUI_NoBodyOmitsPreview(t *testing.T) {
 	tool := &fakeTool{name: "Bash", hasBody: true, body: ""} // empty body, e.g. silent success
 	svc := newTestService(tool)
 
-	out := stripANSI(svc.FormatToolResultForUI(bashResult(true, nil), 80))
-	lines := strings.Split(out, "\n")
+	lines := strings.Split(stripCard(stripANSI(svc.FormatToolResultForUI(bashResult(true, nil), 80))), "\n")
 
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines (status + hint), got %d: %#v", len(lines), lines)
@@ -184,8 +208,7 @@ func TestFormatToolResultForUI_RejectedShowsStatusAndHintOnly(t *testing.T) {
 		Error:     "rejected by user",
 		Arguments: map[string]any{"command": "rm -rf x"},
 	}
-	out := stripANSI(svc.FormatToolResultForUI(res, 80))
-	lines := strings.Split(out, "\n")
+	lines := strings.Split(stripCard(stripANSI(svc.FormatToolResultForUI(res, 80))), "\n")
 
 	if len(lines) != 2 {
 		t.Fatalf("expected status + hint = 2 lines, got %d: %#v", len(lines), lines)
@@ -211,7 +234,11 @@ func TestFormatToolResultExpanded_ThemingPreservesTree(t *testing.T) {
 	tool := &fakeTool{name: "Bash", llm: tree}
 	svc := newTestService(tool)
 
-	out := stripANSI(svc.FormatToolResultExpanded(bashResult(true, nil), 80))
+	full := stripANSI(svc.FormatToolResultExpanded(bashResult(true, nil), 80))
+	if !strings.Contains(cardTitle(full), "Bash") {
+		t.Errorf("expanded card top border missing tool name: %q", cardTitle(full))
+	}
+	out := stripCard(full)
 
 	want := tree + "\n· ctrl+o to collapse"
 	if out != want {

--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -256,6 +256,47 @@ func TestFormatToolResultExpanded_AlwaysExpandOmitsHint(t *testing.T) {
 	}
 }
 
+// TestRenderToolSummary_SharedAndWidthAware checks the one summary builder used by
+// every surface: it formats the name + width-aware argument preview identically and
+// omits an empty icon/trailing.
+func TestRenderToolSummary_SharedAndWidthAware(t *testing.T) {
+	svc := newTestService(&fakeTool{name: "Bash"})
+
+	full := stripANSI(svc.RenderToolSummary("i", "Bash", map[string]any{"command": "ls"}, "t", 80))
+	if full != "i Bash(command=ls) t" {
+		t.Errorf("summary = %q, want %q", full, "i Bash(command=ls) t")
+	}
+
+	noIcon := stripANSI(svc.RenderToolSummary("", "Bash", nil, "", 80))
+	if noIcon != "Bash()" {
+		t.Errorf("summary without icon/args = %q, want %q", noIcon, "Bash()")
+	}
+
+	// long values are truncated to the budget, never byte-sliced mid-rune
+	long := strings.Repeat("λ", 200)
+	got := stripANSI(svc.RenderToolSummary("", "Bash", map[string]any{"command": long}, "", 80))
+	if !strings.Contains(got, "…") && !strings.Contains(got, "...") {
+		t.Errorf("long value should be truncated with an ellipsis: %q", got)
+	}
+	if strings.Contains(got, "�") {
+		t.Errorf("truncation split a multibyte rune: %q", got)
+	}
+}
+
+// TestFormatToolResultForLLM_NoCard guards that the LLM/headless path is never
+// card-framed and carries no injected UI styling.
+func TestFormatToolResultForLLM_NoCard(t *testing.T) {
+	tree := "Bash(command=x)\n├── Duration: 1ms\n╰── Result:\n   ok"
+	svc := newTestService(&fakeTool{name: "Bash", llm: tree})
+	got := svc.FormatToolResultForLLM(bashResult(true, nil))
+	if strings.ContainsAny(got, "╭╮╯") {
+		t.Errorf("LLM output must not be card-framed: %q", got)
+	}
+	if got != tree {
+		t.Errorf("LLM output must be the tool tree verbatim: got %q want %q", got, tree)
+	}
+}
+
 func TestFormatToolResultForLLM_Unchanged(t *testing.T) {
 	tree := "Bash(command=x)\n├─ Duration: 1ms\n└─ Result:\n   ok"
 	tool := &fakeTool{name: "Bash", llm: tree}

--- a/internal/services/tool_result_view.go
+++ b/internal/services/tool_result_view.go
@@ -78,16 +78,6 @@ func capLines(lines []string, width int) []string {
 	return out
 }
 
-// contentWidth is the width available for preview content after reserving room for
-// the left indent and a small right buffer.
-func contentWidth(terminalWidth int) int {
-	w := formatting.GetResponsiveWidth(terminalWidth) - 6
-	if w < 20 {
-		return 20
-	}
-	return w
-}
-
 // pluralizeLines formats the hidden-line count ("+1 line" / "+3 lines").
 func pluralizeLines(n int) string {
 	if n == 1 {

--- a/internal/services/tool_result_view.go
+++ b/internal/services/tool_result_view.go
@@ -260,16 +260,17 @@ func splitTreePrefix(line string) (prefix, rest string) {
 
 func isTreeRune(r rune) bool {
 	switch r {
-	case ' ', '│', '├', '└', '─':
+	case ' ', '│', '├', '└', '╰', '─':
 		return true
 	}
 	return false
 }
 
-// isFieldLine reports whether the prefix denotes a structured field (├─ / └─),
-// as opposed to a continuation/body line (spaces or "│ " only).
+// isFieldLine reports whether the prefix denotes a structured field (├─ / └─ / ╰─),
+// as opposed to a continuation/body line (spaces or "│ " only). ╰ is the rounded
+// last-child corner emitted by lipgloss/tree's RoundedEnumerator.
 func isFieldLine(prefix string) bool {
-	return strings.Contains(prefix, "├─") || strings.Contains(prefix, "└─")
+	return strings.Contains(prefix, "├─") || strings.Contains(prefix, "└─") || strings.Contains(prefix, "╰─")
 }
 
 // splitLabel splits "Label: value" at the first colon, keeping the colon on the label.

--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -29,6 +29,11 @@ const (
 	maxPreviewLines     = 30
 	defaultPreviewLines = 16
 
+	// expandedReservedLines is the vertical space kept for the header, input,
+	// status bar, and box chrome when the diff is expanded (ctrl+o), so even a
+	// full-file diff leaves the input on-screen.
+	expandedReservedLines = 12
+
 	// diffBorderPadding is the box border (2) plus horizontal padding (2) reserved
 	// when sizing the diff to the available width; minDiffWidth keeps it usable on
 	// very narrow terminals.
@@ -48,6 +53,45 @@ type ApprovalBoxView struct {
 	active *domain.ApprovalUIState
 	form   *huh.Form
 	choice domain.ApprovalAction
+
+	// expanded switches the diff from the height-capped preview to a scrollable
+	// window over the full diff (ctrl+o), mirroring the conversation view's
+	// tool-result expansion. scrollOffset is the first visible diff line in that
+	// window. Both reset for each new approval.
+	expanded     bool
+	scrollOffset int
+}
+
+// ToggleExpanded flips between the capped diff preview and the scrollable full-diff
+// window, matching the ctrl+o tool-result expansion in the conversation view.
+func (av *ApprovalBoxView) ToggleExpanded() {
+	av.expanded = !av.expanded
+	av.scrollOffset = 0
+}
+
+// ScrollDiff moves the expanded diff window by delta lines (up/down). It is a no-op
+// unless the diff is expanded; the top is clamped here and the bottom at render time
+// (which is where the window height is known).
+func (av *ApprovalBoxView) ScrollDiff(delta int) {
+	if !av.expanded {
+		return
+	}
+	av.scrollOffset += delta
+	if av.scrollOffset < 0 {
+		av.scrollOffset = 0
+	}
+}
+
+// IsActive reports whether an approval is currently being shown, so the caller can
+// route ctrl+o to this box instead of the conversation.
+func (av *ApprovalBoxView) IsActive() bool {
+	return av.active != nil && av.form != nil
+}
+
+// IsExpanded reports whether the diff is in the scrollable expanded view, so the
+// caller can route up/down to scroll it instead of the conversation.
+func (av *ApprovalBoxView) IsExpanded() bool {
+	return av.expanded
 }
 
 func NewApprovalBoxView(styleProvider *styles.Provider, stateManager domain.ApprovalUIManager, toolFormatter domain.ToolFormatter) *ApprovalBoxView {
@@ -90,6 +134,8 @@ func (av *ApprovalBoxView) Begin() tea.Cmd {
 	}
 	av.active = state
 	av.choice = domain.ApprovalApprove
+	av.expanded = false
+	av.scrollOffset = 0
 	av.form = huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[domain.ApprovalAction]().
@@ -198,32 +244,58 @@ func (av *ApprovalBoxView) renderDiffPreview(toolName string, args map[string]an
 	return av.capLines(rendered), true
 }
 
-// capLines bounds the preview height so a large edit can't blow out the layout: it
-// keeps the first previewLineLimit() lines and replaces the rest with a dim
-// "… N more lines" hint. The full diff still renders in the conversation after the
-// edit runs.
+// capLines bounds the preview height so a large edit can't blow out the layout.
+// Collapsed it keeps the first previewLineLimit() lines with a "… N more lines"
+// hint; expanded (ctrl+o) it shows a scrollable window over the whole diff so a
+// file larger than the screen stays fully reviewable while the action buttons stay
+// pinned. The full diff still renders in the conversation after the edit runs.
 func (av *ApprovalBoxView) capLines(s string) string {
 	body := strings.TrimRight(s, "\n")
 	lines := strings.Split(body, "\n")
 	limit := av.previewLineLimit()
 	if len(lines) <= limit {
+		av.scrollOffset = 0
 		return body
 	}
 
-	hidden := len(lines) - limit
+	if !av.expanded {
+		hidden := len(lines) - limit
+		hint := av.styleProvider.RenderDimText(
+			fmt.Sprintf("… %d more lines (ctrl+o to expand, full diff shown after approval)", hidden),
+		)
+		return strings.Join(lines[:limit], "\n") + "\n" + hint
+	}
+
+	// Clamp the bottom here (the window height is only known now); the top is
+	// clamped on scroll.
+	maxOffset := len(lines) - limit
+	if av.scrollOffset > maxOffset {
+		av.scrollOffset = maxOffset
+	}
+	window := strings.Join(lines[av.scrollOffset:av.scrollOffset+limit], "\n")
 	hint := av.styleProvider.RenderDimText(
-		fmt.Sprintf("… %d more lines (full diff shown after approval)", hidden),
+		fmt.Sprintf("↑/↓ scroll · lines %d-%d of %d (ctrl+o to collapse)",
+			av.scrollOffset+1, av.scrollOffset+limit, len(lines)),
 	)
-	return strings.Join(lines[:limit], "\n") + "\n" + hint
+	return window + "\n" + hint
 }
 
-// previewLineLimit is the max diff lines shown in the box: about half the terminal
-// height so the conversation and input keep room, bounded to
-// [minPreviewLines, maxPreviewLines]. It falls back to defaultPreviewLines before
+// previewLineLimit is the number of diff lines shown in the box at once. Collapsed
+// it is about half the terminal height so the conversation and input keep room,
+// bounded to [minPreviewLines, maxPreviewLines]; expanded (ctrl+o) it grows to fill
+// the screen (minus the header, input, and box chrome so the layout can't overflow)
+// and the rest is reached by scrolling. It falls back to defaultPreviewLines before
 // the terminal height is known (height <= 0).
 func (av *ApprovalBoxView) previewLineLimit() int {
 	if av.height <= 0 {
 		return defaultPreviewLines
+	}
+	if av.expanded {
+		limit := av.height - expandedReservedLines
+		if limit < minPreviewLines {
+			return minPreviewLines
+		}
+		return limit
 	}
 	limit := av.height / 2
 	if limit < minPreviewLines {

--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -82,10 +82,18 @@ func (av *ApprovalBoxView) ScrollDiff(delta int) {
 	}
 }
 
-// IsActive reports whether an approval is currently being shown, so the caller can
-// route ctrl+o to this box instead of the conversation.
+// IsActive reports whether an approval is *currently* being shown, so the caller can
+// route ctrl+o to this box instead of the conversation. It consults the live
+// StateManager (like Render does) rather than trusting av.active/av.form alone: those
+// fields are only reset by the form's own completion, so after an approval is cleared
+// externally (rejection resolved, timeout) they can linger — and a stale true here
+// would swallow ctrl+o from the rejected result the user is trying to expand.
 func (av *ApprovalBoxView) IsActive() bool {
-	return av.active != nil && av.form != nil
+	if av.stateManager == nil || av.active == nil || av.form == nil {
+		return false
+	}
+	state := av.stateManager.GetApprovalUIState()
+	return state != nil && state == av.active
 }
 
 // IsExpanded reports whether the diff is in the scrollable expanded view, so the

--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -274,8 +274,6 @@ func (av *ApprovalBoxView) capLines(s string) string {
 		return strings.Join(lines[:limit], "\n") + "\n" + hint
 	}
 
-	// Clamp the bottom here (the window height is only known now); the top is
-	// clamped on scroll.
 	maxOffset := len(lines) - limit
 	if av.scrollOffset > maxOffset {
 		av.scrollOffset = maxOffset

--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -227,7 +227,7 @@ func (av *ApprovalBoxView) renderSummary(tc *sdk.ChatCompletionMessageToolCall) 
 // this package for the diff renderer, so importing it back for its name constants
 // would create an import cycle.
 func (av *ApprovalBoxView) renderDiffPreview(toolName string, args map[string]any) (string, bool) {
-	renderer := NewDiffRenderer(av.styleProvider).SetWidth(av.diffWidth())
+	renderer := NewDiffRenderer(av.styleProvider).SetWidth(av.diffWidth()).SetMaxLines(-1)
 
 	var rendered string
 	switch toolName {

--- a/internal/ui/components/approval_box_view_test.go
+++ b/internal/ui/components/approval_box_view_test.go
@@ -34,6 +34,12 @@ func (argsAwareToolFormatter) FormatToolResultExpanded(*domain.ToolExecutionResu
 }
 func (argsAwareToolFormatter) FormatToolResultForLLM(*domain.ToolExecutionResult) string { return "" }
 func (argsAwareToolFormatter) ShouldAlwaysExpandTool(string) bool                        { return false }
+func (argsAwareToolFormatter) RenderToolSummary(icon, toolName string, args map[string]any, trailing string, _ int) string {
+	if p, ok := args["file_path"]; ok {
+		return fmt.Sprintf("%s %s(file_path=%v) %s", icon, toolName, p, trailing)
+	}
+	return fmt.Sprintf("%s %s() %s", icon, toolName, trailing)
+}
 
 func approvalStateWith(toolName, arguments string) *domain.ApprovalUIState {
 	return &domain.ApprovalUIState{

--- a/internal/ui/components/approval_box_view_test.go
+++ b/internal/ui/components/approval_box_view_test.go
@@ -211,6 +211,65 @@ func TestApprovalBox_CapsLongDiffWithHint(t *testing.T) {
 	}
 }
 
+// TestApprovalBox_ExpandScrollsToDiffTail asserts ctrl+o (ToggleExpanded) opens a
+// scrollable window whose tail is reachable with ScrollDiff, so a diff taller than
+// the screen is fully reviewable; collapsing resets it.
+func TestApprovalBox_ExpandScrollsToDiffTail(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&b, "LINE_%02d\n", i)
+	}
+	args := fmt.Sprintf(`{"file_path":"/x/y.txt","old_string":"","new_string":%q}`, b.String())
+
+	sm := approvalStateManager(approvalStateWith("Edit", args))
+
+	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
+	av.SetWidth(80)
+	av.SetHeight(30) // collapsed cap -> 15; expanded window -> height-12 = 18
+
+	_ = av.Begin()
+
+	// Expanding shows the diff head as a scrollable window, tail still off-screen.
+	av.ToggleExpanded()
+	top := stripANSI(av.Render())
+	if !strings.Contains(top, "LINE_00") {
+		t.Fatalf("expanded window should start at the diff head:\n%s", top)
+	}
+	if strings.Contains(top, "LINE_39") {
+		t.Fatalf("diff tail should be below the fold before scrolling:\n%s", top)
+	}
+	if !strings.Contains(top, "scroll") {
+		t.Errorf("expanded window should show a scroll hint:\n%s", top)
+	}
+
+	// Scrolling down far enough brings the tail into the window.
+	av.ScrollDiff(1000)
+	bottom := stripANSI(av.Render())
+	if !strings.Contains(bottom, "LINE_39") {
+		t.Errorf("scrolling down should reveal the diff tail:\n%s", bottom)
+	}
+
+	// Collapsing resets to the capped head preview.
+	av.ToggleExpanded()
+	if recollapsed := stripANSI(av.Render()); strings.Contains(recollapsed, "LINE_39") {
+		t.Errorf("collapsing should return to the capped head, LINE_39 still present:\n%s", recollapsed)
+	}
+}
+
+// TestApprovalBox_IsActive reports true only while a form is built for a pending
+// approval, so ctrl+o routes here instead of the conversation.
+func TestApprovalBox_IsActive(t *testing.T) {
+	sm := approvalStateManager(approvalStateWith("Edit", `{"file_path":"/x/y.txt","old_string":"OLD","new_string":"NEW"}`))
+	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
+	if av.IsActive() {
+		t.Error("IsActive should be false before Begin")
+	}
+	_ = av.Begin()
+	if !av.IsActive() {
+		t.Error("IsActive should be true after Begin with a pending approval")
+	}
+}
+
 // TestApprovalBox_DiffToolIgnoresFormatter asserts the diff path does not depend on
 // the tool formatter (a nil formatter still yields a diff, not the name fallback).
 func TestApprovalBox_DiffToolIgnoresFormatter(t *testing.T) {

--- a/internal/ui/components/approval_box_view_test.go
+++ b/internal/ui/components/approval_box_view_test.go
@@ -270,6 +270,25 @@ func TestApprovalBox_IsActive(t *testing.T) {
 	}
 }
 
+// TestApprovalBox_IsActiveFalseAfterExternalClear guards the esc-rejection bug: esc
+// clears the StateManager's approval state without completing the form, so av.active
+// /av.form linger. IsActive must consult the live state and report false, or ctrl+o
+// would be swallowed by the defunct box instead of expanding the rejected result.
+func TestApprovalBox_IsActiveFalseAfterExternalClear(t *testing.T) {
+	sm := approvalStateManager(approvalStateWith("Write", `{"file_path":"/x/y.txt","content":"hi"}`))
+	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
+	_ = av.Begin()
+	if !av.IsActive() {
+		t.Fatal("precondition: IsActive true while the approval is pending")
+	}
+
+	sm.ClearApprovalUIState()
+
+	if av.IsActive() {
+		t.Error("IsActive must be false once the approval state is cleared externally")
+	}
+}
+
 // TestApprovalBox_DiffToolIgnoresFormatter asserts the diff path does not depend on
 // the tool formatter (a nil formatter still yields a diff, not the name fallback).
 func TestApprovalBox_DiffToolIgnoresFormatter(t *testing.T) {

--- a/internal/ui/components/approval_box_view_test.go
+++ b/internal/ui/components/approval_box_view_test.go
@@ -225,11 +225,10 @@ func TestApprovalBox_ExpandScrollsToDiffTail(t *testing.T) {
 
 	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
 	av.SetWidth(80)
-	av.SetHeight(30) // collapsed cap -> 15; expanded window -> height-12 = 18
+	av.SetHeight(30)
 
 	_ = av.Begin()
 
-	// Expanding shows the diff head as a scrollable window, tail still off-screen.
 	av.ToggleExpanded()
 	top := stripANSI(av.Render())
 	if !strings.Contains(top, "LINE_00") {
@@ -242,14 +241,12 @@ func TestApprovalBox_ExpandScrollsToDiffTail(t *testing.T) {
 		t.Errorf("expanded window should show a scroll hint:\n%s", top)
 	}
 
-	// Scrolling down far enough brings the tail into the window.
 	av.ScrollDiff(1000)
 	bottom := stripANSI(av.Render())
 	if !strings.Contains(bottom, "LINE_39") {
 		t.Errorf("scrolling down should reveal the diff tail:\n%s", bottom)
 	}
 
-	// Collapsing resets to the capped head preview.
 	av.ToggleExpanded()
 	if recollapsed := stripANSI(av.Render()); strings.Contains(recollapsed, "LINE_39") {
 		t.Errorf("collapsing should return to the capped head, LINE_39 still present:\n%s", recollapsed)
@@ -321,7 +318,6 @@ const (
 // is tightened to 2 context lines: the 2 nearest unchanged lines on each side
 // remain while the 3rd-out lines (and beyond) are trimmed.
 func TestApprovalBox_EditDiffUsesTwoContextLines(t *testing.T) {
-	// "/x/y.txt" does not exist -> editDiff falls back to a snippet diff.
 	args := fmt.Sprintf(`{"file_path":"/x/y.txt","old_string":%q,"new_string":%q}`, oldContextSnippet, newContextSnippet)
 
 	sm := approvalStateManager(approvalStateWith("Edit", args))

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -257,26 +257,86 @@ func (cv *ConversationView) ResetUserScroll() {
 
 func (cv *ConversationView) ToggleToolResultExpansion(index int) {
 	if index >= 0 && index < len(cv.conversation) {
-		cv.expandedToolResults[index] = !cv.IsToolResultExpanded(index)
-		if cv.navigationMode != NavigationModeMessageHistory {
-			cv.updateViewportContentFull()
-		}
+		cv.rebuildPreservingScroll(func() {
+			cv.expandedToolResults[index] = !cv.IsToolResultExpanded(index)
+		}, index)
 	}
 }
 
 func (cv *ConversationView) ToggleAllToolResultsExpansion() {
 	expand := !cv.anyToolResultExpanded()
-	cv.allToolsExpanded = expand
 
+	changed := make([]int, 0, len(cv.conversation))
 	for i, entry := range cv.conversation {
 		if entry.Message.Role == "tool" {
-			cv.expandedToolResults[i] = expand
+			changed = append(changed, i)
 		}
 	}
 
-	if cv.navigationMode != NavigationModeMessageHistory {
-		cv.updateViewportContentFull()
+	cv.rebuildPreservingScroll(func() {
+		cv.allToolsExpanded = expand
+		for _, i := range changed {
+			cv.expandedToolResults[i] = expand
+		}
+	}, changed...)
+}
+
+// rebuildPreservingScroll applies mutate (the expand/collapse state change) and
+// re-renders the viewport while keeping the content the user is looking at anchored
+// in place. Expanding an entry that sits above the viewport top would otherwise shift
+// everything down and make the view jump; we offset by the height delta of the changed
+// entries above the current scroll position. The old layout is measured before mutate
+// runs, so the delta is real. When the user is following the tail we stay pinned to the
+// bottom.
+func (cv *ConversationView) rebuildPreservingScroll(mutate func(), changed ...int) {
+	if cv.navigationMode == NavigationModeMessageHistory {
+		mutate()
+		return
 	}
+	if !cv.userScrolledUp {
+		mutate()
+		cv.updateViewportContentFull() // GotoBottom keeps us on the tail
+		return
+	}
+
+	oldOffset := cv.Viewport.YOffset()
+	oldSpans := cv.entryLineSpans()
+
+	mutate()
+	cv.updateViewportContentFull()
+
+	newSpans := cv.entryLineSpans()
+	delta := 0
+	for _, idx := range changed {
+		old, ok := oldSpans[idx]
+		if !ok || old[0] >= oldOffset {
+			continue // entry starts at or below the viewport top: no shift needed
+		}
+		if nw, ok := newSpans[idx]; ok {
+			delta += nw[1] - old[1]
+		}
+	}
+	if delta != 0 {
+		cv.Viewport.SetYOffset(oldOffset + delta)
+	}
+}
+
+// entryLineSpans returns, per visible conversation entry, its {startLine, height}
+// in the rendered viewport content - the same coordinate space YOffset uses. Heights
+// come from the same cached per-entry render updateViewportContentFull emits, so the
+// two stay in lockstep.
+func (cv *ConversationView) entryLineSpans() map[int][2]int {
+	spans := make(map[int][2]int, len(cv.conversation))
+	line := 0
+	for i, entry := range cv.conversation {
+		if entry.Hidden {
+			continue
+		}
+		h := cv.styleProvider.GetHeight(cv.renderEntryCached(entry, i))
+		spans[i] = [2]int{line, h}
+		line += h
+	}
+	return spans
 }
 
 // anyToolResultExpanded reports whether any tool result is currently expanded,
@@ -320,17 +380,19 @@ func (cv *ConversationView) SetDefaultExpandedTools(names map[string]bool) {
 }
 
 func (cv *ConversationView) ToggleAllThinkingExpansion() {
-	cv.allThinkingExpanded = !cv.allThinkingExpanded
-
+	changed := make([]int, 0, len(cv.conversation))
 	for i, entry := range cv.conversation {
 		if entry.ReasoningContent != "" {
-			cv.expandedThinkingBlocks[i] = cv.allThinkingExpanded
+			changed = append(changed, i)
 		}
 	}
 
-	if cv.navigationMode != NavigationModeMessageHistory {
-		cv.updateViewportContentFull()
-	}
+	cv.rebuildPreservingScroll(func() {
+		cv.allThinkingExpanded = !cv.allThinkingExpanded
+		for _, i := range changed {
+			cv.expandedThinkingBlocks[i] = cv.allThinkingExpanded
+		}
+	}, changed...)
 }
 
 func (cv *ConversationView) IsThinkingExpanded(index int) bool {

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -264,10 +264,6 @@ func (cv *ConversationView) ToggleToolResultExpansion(index int) {
 }
 
 func (cv *ConversationView) ToggleAllToolResultsExpansion() {
-	// Expand-first: unless every tool result is already expanded, the press
-	// expands them all. Collapsing only happens once everything is expanded. This
-	// keeps a lone collapsed card (e.g. a rejected write) responsive to the first
-	// ctrl+o even when other results — like a default-expanded Edit diff — are open.
 	expand := !cv.allToolResultsExpanded()
 
 	changed := make([]int, 0, len(cv.conversation))
@@ -299,7 +295,7 @@ func (cv *ConversationView) rebuildPreservingScroll(mutate func(), changed ...in
 	}
 	if !cv.userScrolledUp {
 		mutate()
-		cv.updateViewportContentFull() // GotoBottom keeps us on the tail
+		cv.updateViewportContentFull()
 		return
 	}
 
@@ -314,7 +310,7 @@ func (cv *ConversationView) rebuildPreservingScroll(mutate func(), changed ...in
 	for _, idx := range changed {
 		old, ok := oldSpans[idx]
 		if !ok || old[0] >= oldOffset {
-			continue // entry starts at or below the viewport top: no shift needed
+			continue
 		}
 		if nw, ok := newSpans[idx]; ok {
 			delta += nw[1] - old[1]

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -264,7 +264,11 @@ func (cv *ConversationView) ToggleToolResultExpansion(index int) {
 }
 
 func (cv *ConversationView) ToggleAllToolResultsExpansion() {
-	expand := !cv.anyToolResultExpanded()
+	// Expand-first: unless every tool result is already expanded, the press
+	// expands them all. Collapsing only happens once everything is expanded. This
+	// keeps a lone collapsed card (e.g. a rejected write) responsive to the first
+	// ctrl+o even when other results — like a default-expanded Edit diff — are open.
+	expand := !cv.allToolResultsExpanded()
 
 	changed := make([]int, 0, len(cv.conversation))
 	for i, entry := range cv.conversation {
@@ -339,15 +343,22 @@ func (cv *ConversationView) entryLineSpans() map[int][2]int {
 	return spans
 }
 
-// anyToolResultExpanded reports whether any tool result is currently expanded,
-// honoring per-tool defaults (e.g. Edit/MultiEdit diffs default to expanded).
-func (cv *ConversationView) anyToolResultExpanded() bool {
+// allToolResultsExpanded reports whether every tool result is currently expanded
+// (honoring per-tool defaults), so the global toggle collapses only when there is
+// nothing left to expand. False when there are no tool results, which makes the
+// first press an expand no-op rather than a surprising collapse.
+func (cv *ConversationView) allToolResultsExpanded() bool {
+	found := false
 	for i, entry := range cv.conversation {
-		if entry.Message.Role == "tool" && cv.IsToolResultExpanded(i) {
-			return true
+		if entry.Message.Role != "tool" {
+			continue
+		}
+		found = true
+		if !cv.IsToolResultExpanded(i) {
+			return false
 		}
 	}
-	return false
+	return found
 }
 
 // IsToolResultExpanded returns the effective expansion of a tool result: an

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -1305,3 +1305,72 @@ func TestConversationView_RenderCache(t *testing.T) {
 		}
 	})
 }
+
+// heightFormatter renders a tool result as `collapsed` lines when collapsed and
+// `expanded` lines when expanded, giving scroll-anchoring math a real height delta.
+type heightFormatter struct{ collapsed, expanded int }
+
+func (heightFormatter) FormatToolCall(name string, _ map[string]any) string { return name + "()" }
+func (f heightFormatter) FormatToolResultForUI(_ *domain.ToolExecutionResult, _ int) string {
+	return strings.TrimRight(strings.Repeat("c\n", f.collapsed), "\n")
+}
+func (f heightFormatter) FormatToolResultExpanded(_ *domain.ToolExecutionResult, _ int) string {
+	return strings.TrimRight(strings.Repeat("e\n", f.expanded), "\n")
+}
+func (heightFormatter) FormatToolResultForLLM(_ *domain.ToolExecutionResult) string { return "" }
+func (heightFormatter) ShouldAlwaysExpandTool(string) bool                          { return false }
+func (heightFormatter) RenderToolSummary(icon, name string, _ map[string]any, trailing string, _ int) string {
+	return strings.TrimSpace(icon + " " + name + "() " + trailing)
+}
+
+func scrollTestView(t *testing.T) *ConversationView {
+	t.Helper()
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetToolFormatter(heightFormatter{collapsed: 2, expanded: 6})
+	cv.SetWidth(80)
+	cv.SetHeight(8)
+	conv := make([]domain.ConversationEntry, 0, 6)
+	for i := 0; i < 6; i++ {
+		conv = append(conv, domain.ConversationEntry{
+			Message:       sdk.Message{Role: sdk.Tool, Content: sdk.NewMessageContent("x")},
+			ToolExecution: &domain.ToolExecutionResult{ToolName: "Bash"},
+			Time:          time.Now(),
+		})
+	}
+	cv.SetConversation(conv)
+	return cv
+}
+
+func TestRebuildPreservingScroll_AnchorsAboveViewportEntry(t *testing.T) {
+	cv := scrollTestView(t)
+
+	cv.userScrolledUp = true
+	spans := cv.entryLineSpans()
+	cv.Viewport.SetYOffset(spans[2][0]) // viewport top at entry 2, so entries 0,1 are above
+	before := cv.Viewport.YOffset()
+	beforeH0 := spans[0][1]
+
+	cv.ToggleToolResultExpansion(0) // expand an entry above the viewport top
+
+	afterH0 := cv.entryLineSpans()[0][1]
+	if afterH0 <= beforeH0 {
+		t.Fatalf("expanded entry should be taller: collapsed=%d expanded=%d", beforeH0, afterH0)
+	}
+	if got, want := cv.Viewport.YOffset(), before+(afterH0-beforeH0); got != want {
+		t.Errorf("YOffset not anchored: got %d, want %d (delta %d)", got, want, afterH0-beforeH0)
+	}
+}
+
+func TestRebuildPreservingScroll_IgnoresBelowViewportEntry(t *testing.T) {
+	cv := scrollTestView(t)
+
+	cv.userScrolledUp = true
+	cv.Viewport.SetYOffset(0) // viewport top at the very top; entry 5 is below it
+	before := cv.Viewport.YOffset()
+
+	cv.ToggleToolResultExpansion(5)
+
+	if got := cv.Viewport.YOffset(); got != before {
+		t.Errorf("toggling a below-viewport entry must not move the offset: got %d, want %d", got, before)
+	}
+}

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -315,7 +315,6 @@ func TestConversationView_ToggleAllExpandsCollapsedAmongExpanded(t *testing.T) {
 		t.Fatal("precondition: Edit expanded, rejected Write collapsed")
 	}
 
-	// First press must expand the collapsed Write (not just collapse the Edit).
 	cv.ToggleAllToolResultsExpansion()
 	if !cv.IsToolResultExpanded(1) {
 		t.Error("expected first ToggleAll to expand the collapsed rejected write")
@@ -324,7 +323,6 @@ func TestConversationView_ToggleAllExpandsCollapsedAmongExpanded(t *testing.T) {
 		t.Error("expected the already-expanded Edit to stay expanded")
 	}
 
-	// Everything is expanded now, so the next press collapses all.
 	cv.ToggleAllToolResultsExpansion()
 	if cv.IsToolResultExpanded(0) || cv.IsToolResultExpanded(1) {
 		t.Error("expected second ToggleAll to collapse everything")
@@ -1386,11 +1384,11 @@ func TestRebuildPreservingScroll_AnchorsAboveViewportEntry(t *testing.T) {
 
 	cv.userScrolledUp = true
 	spans := cv.entryLineSpans()
-	cv.Viewport.SetYOffset(spans[2][0]) // viewport top at entry 2, so entries 0,1 are above
+	cv.Viewport.SetYOffset(spans[2][0])
 	before := cv.Viewport.YOffset()
 	beforeH0 := spans[0][1]
 
-	cv.ToggleToolResultExpansion(0) // expand an entry above the viewport top
+	cv.ToggleToolResultExpansion(0)
 
 	afterH0 := cv.entryLineSpans()[0][1]
 	if afterH0 <= beforeH0 {

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -291,6 +291,46 @@ func TestConversationView_ToggleAllCollapsesDefaultExpanded(t *testing.T) {
 	}
 }
 
+// TestConversationView_ToggleAllExpandsCollapsedAmongExpanded guards the rejected-write
+// bug: with a default-expanded Edit next to a collapsed result, the first ctrl+o must
+// expand everything (so the collapsed card opens), not collapse-first and leave it shut.
+func TestConversationView_ToggleAllExpandsCollapsedAmongExpanded(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetToolFormatter(&stubToolFormatter{})
+
+	cv.SetConversation([]domain.ConversationEntry{
+		{
+			Message:       sdk.Message{Role: sdk.Tool, Content: sdk.NewMessageContent("edited")},
+			ToolExecution: &domain.ToolExecutionResult{ToolName: "Edit"}, // default-expanded
+			Time:          time.Now(),
+		},
+		{
+			Message:       sdk.Message{Role: sdk.Tool, Content: sdk.NewMessageContent("rejected")},
+			ToolExecution: &domain.ToolExecutionResult{ToolName: "Write", Rejected: true}, // collapsed
+			Time:          time.Now(),
+		},
+	})
+
+	if !cv.IsToolResultExpanded(0) || cv.IsToolResultExpanded(1) {
+		t.Fatal("precondition: Edit expanded, rejected Write collapsed")
+	}
+
+	// First press must expand the collapsed Write (not just collapse the Edit).
+	cv.ToggleAllToolResultsExpansion()
+	if !cv.IsToolResultExpanded(1) {
+		t.Error("expected first ToggleAll to expand the collapsed rejected write")
+	}
+	if !cv.IsToolResultExpanded(0) {
+		t.Error("expected the already-expanded Edit to stay expanded")
+	}
+
+	// Everything is expanded now, so the next press collapses all.
+	cv.ToggleAllToolResultsExpansion()
+	if cv.IsToolResultExpanded(0) || cv.IsToolResultExpanded(1) {
+		t.Error("expected second ToggleAll to collapse everything")
+	}
+}
+
 func TestConversationView_SetWidth(t *testing.T) {
 	cv := NewConversationView(createMockStyleProvider())
 

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -43,6 +43,9 @@ func (s *stubToolFormatter) FormatToolResultForLLM(result *domain.ToolExecutionR
 	return "Tool: " + result.ToolName
 }
 func (s *stubToolFormatter) ShouldAlwaysExpandTool(_ string) bool { return false }
+func (s *stubToolFormatter) RenderToolSummary(icon, toolName string, _ map[string]any, trailing string, _ int) string {
+	return strings.TrimSpace(icon + " " + toolName + "() " + trailing)
+}
 
 // createMockStyleProvider creates a mock styles provider for testing
 func createMockStyleProvider() *styles.Provider {

--- a/internal/ui/components/diff_renderer.go
+++ b/internal/ui/components/diff_renderer.go
@@ -24,8 +24,14 @@ const InlineDiffContextLines = 2
 type DiffRenderer struct {
 	styleProvider *styles.Provider
 	width         int
-	contextLines  int // 0 keeps diffview's default (3); >0 overrides it
+	contextLines  int
+	maxLines      int
 }
+
+// defaultContentPreviewLines caps the new-file preview so a huge file can't blow
+// out a non-scrollable caller. Callers that bound the height themselves (e.g. the
+// scrollable approval box) opt out via SetMaxLines(-1).
+const defaultContentPreviewLines = 50
 
 // DiffInfo carries the inputs for a single diff render.
 type DiffInfo struct {
@@ -53,6 +59,11 @@ func (d *DiffRenderer) SetWidth(w int) *DiffRenderer { d.width = w; return d }
 // below each change. Pass 0 (the default) to keep the diffview default. Returns
 // the renderer for chaining.
 func (d *DiffRenderer) SetContextLines(n int) *DiffRenderer { d.contextLines = n; return d }
+
+// SetMaxLines overrides the new-file preview line cap: 0 keeps the default, a
+// positive n caps at n, and a negative n renders every line (for callers that
+// bound the height themselves, like the scrollable approval box). Chains.
+func (d *DiffRenderer) SetMaxLines(n int) *DiffRenderer { d.maxLines = n; return d }
 
 // RenderEditToolArguments renders Edit tool arguments as a diff. When the target
 // file can be read and old_string is found in it, it diffs the real file content
@@ -306,12 +317,17 @@ func hexLuminance(hex string) float64 {
 
 func (d *DiffRenderer) renderContentPreview(content string) string {
 	lines := strings.Split(content, "\n")
+	if len(lines) > 1 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	limit := d.contentPreviewLimit()
 	var out strings.Builder
 	maxWidth := len(fmt.Sprintf("%d", len(lines)))
 	gutter := d.styleProvider.RenderDimText(" │ ")
 
 	for i, line := range lines {
-		if i >= 50 {
+		if limit >= 0 && i >= limit {
 			remaining := len(lines) - i
 			out.WriteString(d.styleProvider.RenderStyledText(
 				fmt.Sprintf("\n... %d more lines ...", remaining),
@@ -327,6 +343,15 @@ func (d *DiffRenderer) renderContentPreview(content string) string {
 		}
 	}
 	return out.String()
+}
+
+// contentPreviewLimit resolves the new-file preview cap: 0 → default, <0 →
+// unlimited (negative), >0 → that value.
+func (d *DiffRenderer) contentPreviewLimit() int {
+	if d.maxLines == 0 {
+		return defaultContentPreviewLines
+	}
+	return d.maxLines
 }
 
 // DiffStats represents statistics about a diff.

--- a/internal/ui/components/diff_renderer_test.go
+++ b/internal/ui/components/diff_renderer_test.go
@@ -214,6 +214,45 @@ func TestDiffRenderer_RenderMultiEditToolArguments(t *testing.T) {
 	})
 }
 
+// TestDiffRenderer_WriteNewFilePreviewCap covers the new-file preview line cap:
+// the default caps at 50 with a "more lines" footer, a trailing newline does not
+// produce a phantom extra line, and SetMaxLines(-1) renders every line uncapped.
+func TestDiffRenderer_WriteNewFilePreviewCap(t *testing.T) {
+	styleProvider := styles.NewProvider(domain.NewThemeProvider())
+
+	var b strings.Builder
+	for i := 1; i <= 50; i++ {
+		b.WriteString("line\n")
+	}
+	args := map[string]any{"file_path": "/no/such/file_probe.txt", "content": b.String()}
+
+	capped := stripANSI(NewDiffRenderer(styleProvider).RenderWriteToolArguments(args))
+	if strings.Contains(capped, "more lines") {
+		t.Errorf("50 lines + trailing newline should not be truncated, got a footer:\n%s", capped)
+	}
+	if !strings.Contains(capped, "50 │") {
+		t.Errorf("expected line 50 to render, got:\n%s", capped)
+	}
+
+	b.Reset()
+	for i := 1; i <= 60; i++ {
+		b.WriteString("line\n")
+	}
+	args["content"] = b.String()
+	over := stripANSI(NewDiffRenderer(styleProvider).RenderWriteToolArguments(args))
+	if !strings.Contains(over, "more lines") {
+		t.Errorf("60 lines should be capped with a footer, got:\n%s", over)
+	}
+
+	full := stripANSI(NewDiffRenderer(styleProvider).SetMaxLines(-1).RenderWriteToolArguments(args))
+	if strings.Contains(full, "more lines") {
+		t.Errorf("SetMaxLines(-1) should render uncapped, got a footer:\n%s", full)
+	}
+	if !strings.Contains(full, "60 │") {
+		t.Errorf("expected line 60 to render uncapped, got:\n%s", full)
+	}
+}
+
 func TestDiffRenderer_Construction(t *testing.T) {
 	themeService := domain.NewThemeProvider()
 	styleProvider := styles.NewProvider(themeService)

--- a/internal/ui/components/queue_box_view.go
+++ b/internal/ui/components/queue_box_view.go
@@ -16,6 +16,7 @@ import (
 type QueueBoxView struct {
 	width         int
 	styleProvider *styles.Provider
+	toolFormatter domain.ToolFormatter
 }
 
 func NewQueueBoxView(styleProvider *styles.Provider) *QueueBoxView {
@@ -23,6 +24,12 @@ func NewQueueBoxView(styleProvider *styles.Provider) *QueueBoxView {
 		width:         80,
 		styleProvider: styleProvider,
 	}
+}
+
+// SetToolFormatter wires the shared tool formatter so queued tool calls show their
+// width-aware argument preview instead of a bare "Name(...)".
+func (qv *QueueBoxView) SetToolFormatter(f domain.ToolFormatter) {
+	qv.toolFormatter = f
 }
 
 func (qv *QueueBoxView) SetWidth(width int) {
@@ -106,6 +113,9 @@ func (qv *QueueBoxView) formatToolCallsPreview(toolCalls []sdk.ChatCompletionMes
 	}
 
 	toolCall := toolCalls[0]
+	if qv.toolFormatter != nil {
+		return qv.toolFormatter.RenderToolSummary("", toolCall.Function.Name, parseToolArgs(toolCall.Function.Arguments), "", qv.width)
+	}
 	return fmt.Sprintf("%s(...)", toolCall.Function.Name)
 }
 

--- a/internal/ui/components/tool_call_renderer.go
+++ b/internal/ui/components/tool_call_renderer.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -23,11 +24,66 @@ type ToolCallRenderer struct {
 	tools            map[string]*ToolRenderState
 	toolsOrder       []string
 	styleProvider    *styles.Provider
+	toolFormatter    domain.ToolFormatter
 	keyHintFormatter KeyHintFormatter
 	lastUpdate       time.Time
 	lastTimerRender  time.Time
 	stateManager     approvalOverlayReader
 	pausedAt         time.Time
+}
+
+// SetToolFormatter wires the shared tool formatter so live previews render the
+// same width-aware "<icon> Name(args) <status>" summary as the collapsed results,
+// instead of a byte-truncated raw-JSON preview.
+func (r *ToolCallRenderer) SetToolFormatter(f domain.ToolFormatter) {
+	r.toolFormatter = f
+}
+
+// summaryLine builds the shared tool summary. args are the raw JSON string carried
+// by the live tool state; icon and trailing are already styled by the caller.
+func (r *ToolCallRenderer) summaryLine(icon, name, argsJSON, trailing string) string {
+	if r.toolFormatter != nil {
+		return r.toolFormatter.RenderToolSummary(icon, name, parseToolArgs(argsJSON), trailing, r.width)
+	}
+	line := name
+	if icon != "" {
+		line = icon + " " + name
+	}
+	line += "()"
+	if trailing != "" {
+		line += " " + trailing
+	}
+	return line
+}
+
+// liveCard frames a running tool's preview in a rounded card whose top border carries
+// the tool name, coloured by tool type (AC8).
+func (r *ToolCallRenderer) liveCard(name, content string) string {
+	w := r.width - 2
+	if w < 20 {
+		w = 20
+	}
+	return r.styleProvider.RenderTitledCard(
+		content, name,
+		r.styleProvider.GetThemeColor("border"),
+		r.styleProvider.ToolTitleColor(name),
+		w,
+	)
+}
+
+// parseToolArgs decodes a tool-call arguments JSON object into a map. It returns nil
+// for empty or not-yet-complete (streaming) JSON, so the summary shows "Name()" until
+// the arguments finish accumulating rather than a truncated fragment.
+func parseToolArgs(argsJSON string) map[string]any {
+	argsJSON = strings.TrimSpace(argsJSON)
+	if argsJSON == "" || argsJSON == "{}" {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(argsJSON), &m); err != nil {
+		return nil
+	}
+	return m
 }
 
 // KeyHintFormatter provides formatted key hints for actions
@@ -323,30 +379,19 @@ func (r *ToolCallRenderer) renderTool(tool *ToolRenderState) string {
 		statusColor = "dim"
 	}
 
-	argsPreview := r.formatArgsPreview(tool.Arguments)
-	if argsPreview == "" || argsPreview == "{}" {
-		argsPreview = ""
-	}
-
 	styledIcon := r.styleProvider.RenderWithColor(statusIcon, r.styleProvider.GetThemeColor(iconColor))
 	styledStatus := r.styleProvider.RenderWithColor(statusText, r.styleProvider.GetThemeColor(statusColor))
 
-	var singleLine string
-	if argsPreview != "" {
-		singleLine = fmt.Sprintf("%s %s(%s) %s", styledIcon, tool.ToolName, argsPreview, styledStatus)
-	} else {
-		singleLine = fmt.Sprintf("%s %s() %s", styledIcon, tool.ToolName, styledStatus)
-	}
+	header := r.summaryLine(styledIcon, tool.ToolName, tool.Arguments, styledStatus)
 
-	if r.shouldRenderBashOutput(tool) {
-		return r.renderBashOutput(tool, singleLine)
+	switch {
+	case r.shouldRenderBashOutput(tool):
+		return r.liveCard(tool.ToolName, r.renderBashOutput(tool, header))
+	case r.shouldShowBackgroundHint(tool):
+		return r.liveCard(tool.ToolName, r.renderBackgroundHint(tool, header))
+	default:
+		return r.liveCard(tool.ToolName, header)
 	}
-
-	if r.shouldShowBackgroundHint(tool) {
-		return r.renderBackgroundHint(tool, singleLine)
-	}
-
-	return singleLine
 }
 
 func (r *ToolCallRenderer) renderCompletedToolCall(toolCall sdk.ChatCompletionMessageToolCall, status string) string {
@@ -376,34 +421,12 @@ func (r *ToolCallRenderer) renderToolCallContent(toolInfo ToolInfo, arguments, s
 		statusText = status
 	}
 
-	argsPreview := r.formatArgsPreview(arguments)
-	if argsPreview == "" || argsPreview == "{}" {
-		argsPreview = ""
-	}
-
-	var singleLine string
-	if argsPreview != "" {
-		singleLine = fmt.Sprintf("%s %s(%s) %s", statusIcon, toolInfo.Name, argsPreview, statusText)
-	} else {
-		singleLine = fmt.Sprintf("%s %s() %s", statusIcon, toolInfo.Name, statusText)
-	}
+	singleLine := r.summaryLine(statusIcon, toolInfo.Name, arguments, statusText)
 
 	toolNameColor := r.styleProvider.GetThemeColor("accent")
 	styledLine := r.styleProvider.RenderWithColor(singleLine, toolNameColor)
 
 	return styledLine
-}
-
-func (r *ToolCallRenderer) formatArgsPreview(args string) string {
-	if args == "" {
-		return ""
-	}
-
-	args = strings.TrimSpace(args)
-	if len(args) > 50 {
-		return args[:47] + "..."
-	}
-	return args
 }
 
 func (r *ToolCallRenderer) ClearPreviews() {

--- a/internal/ui/styles/provider.go
+++ b/internal/ui/styles/provider.go
@@ -639,6 +639,37 @@ func (p *Provider) RenderBorderedBox(text, borderColor string, paddingV, padding
 		Render(text)
 }
 
+// RenderTitledCard renders content in a rounded, width-set, padded box with title
+// spliced into the top border (right-aligned). Reuses the same top-border splice as
+// RenderInputField. Pass "" for title to get a plain bordered box at the given width.
+func (p *Provider) RenderTitledCard(content, title, borderColor, titleColor string, width int) string {
+	box := roundedBox.
+		Width(width).
+		BorderForeground(lipgloss.Color(borderColor)).
+		Padding(0, 1).
+		Render(content)
+	if title == "" {
+		return box
+	}
+	return p.spliceBranchIntoTopBorder(box, title, borderColor, titleColor)
+}
+
+// ToolTitleColor returns the accent hex color used to differentiate a tool type on
+// its card's titled border (AC8, no emoji): shells, file mutations, A2A, and generic
+// each get a distinct theme color.
+func (p *Provider) ToolTitleColor(toolName string) string {
+	switch {
+	case strings.HasPrefix(toolName, "A2A"):
+		return p.GetThemeColor("user")
+	case toolName == "Bash":
+		return p.GetThemeColor("status")
+	case toolName == "Edit" || toolName == "MultiEdit" || toolName == "Write":
+		return p.GetThemeColor("diffAdd")
+	default:
+		return p.GetThemeColor("accent")
+	}
+}
+
 // RenderCenteredBoldWithColor renders text centered, bold, and with a specific color
 func (p *Provider) RenderCenteredBoldWithColor(text, hexColor string, width int) string {
 	return boldStyle.

--- a/internal/ui/styles/provider_test.go
+++ b/internal/ui/styles/provider_test.go
@@ -1,10 +1,62 @@
 package styles
 
 import (
+	"strings"
 	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
+
+// TestRenderTitledCard checks the card frames content with a rounded border, splices
+// the title into the top border, keeps every line the same width, and renders the
+// requested content inside.
+func TestRenderTitledCard(t *testing.T) {
+	p := NewProvider(domain.NewThemeProvider())
+
+	out := p.RenderTitledCard("hello\nworld", "Bash", p.GetThemeColor("border"), p.GetThemeColor("accent"), 40)
+	plain := stripSGR(out)
+	lines := strings.Split(plain, "\n")
+
+	if len(lines) < 4 {
+		t.Fatalf("expected a bordered box, got %d lines: %q", len(lines), plain)
+	}
+	if !strings.HasPrefix(lines[0], "╭") || !strings.Contains(lines[0], "Bash") {
+		t.Errorf("top border missing rounded corner/title: %q", lines[0])
+	}
+	last := lines[len(lines)-1]
+	if !strings.HasPrefix(last, "╰") || !strings.HasSuffix(last, "╯") {
+		t.Errorf("bottom border missing rounded corners: %q", last)
+	}
+	if !strings.Contains(plain, "hello") || !strings.Contains(plain, "world") {
+		t.Errorf("card body missing content: %q", plain)
+	}
+	w := lipgloss.Width(lines[0])
+	for i, ln := range lines {
+		if got := lipgloss.Width(ln); got != w {
+			t.Errorf("line %d width %d != %d: %q", i, got, w, ln)
+		}
+	}
+}
+
+func stripSGR(s string) string {
+	var b strings.Builder
+	inEsc := false
+	for _, r := range s {
+		switch {
+		case r == '\x1b':
+			inEsc = true
+		case inEsc && r == 'm':
+			inEsc = false
+		case inEsc:
+			// skip
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
 
 // TestProviderStyleCache exercises the lazy per-theme style cache: renders
 // must be stable while the theme is unchanged and pick up a SetTheme switch

--- a/internal/ui/styles/tree/tree.go
+++ b/internal/ui/styles/tree/tree.go
@@ -1,0 +1,33 @@
+// Package tree wraps charm.land/lipgloss/v2/tree so packages outside the styling
+// layer (notably internal/domain formatters) can render rounded-connector trees
+// without importing lipgloss directly — the same leaf-package convention as
+// internal/ui/styles/{colors,icons}. Output is plain text; connectors only.
+package tree
+
+import gloss "charm.land/lipgloss/v2/tree"
+
+// Tree is a node in a connector tree. Start with Root; the zero value is not usable.
+type Tree struct{ t *gloss.Tree }
+
+// Root starts a new tree with the given label.
+func Root(label string) *Tree { return &Tree{t: gloss.Root(label)} }
+
+// Rounded switches connectors to rounded glyphs (├──/╰──); children inherit it.
+func (t *Tree) Rounded() *Tree {
+	t.t.Enumerator(gloss.RoundedEnumerator)
+	return t
+}
+
+// Child appends children; each may be a string or a nested *Tree.
+func (t *Tree) Child(children ...any) *Tree {
+	for i, c := range children {
+		if sub, ok := c.(*Tree); ok {
+			children[i] = sub.t
+		}
+	}
+	t.t.Child(children...)
+	return t
+}
+
+// String renders the tree to plain text.
+func (t *Tree) String() string { return t.t.String() }


### PR DESCRIPTION
## Summary

Closes #864 — a card-based visual overhaul of the tool-call formatter, plus a set of approval-box review fixes surfaced during testing.

The four surfaces that render a tool call (`statusLine`, live `renderTool`, approval summary, queue preview) each built `icon Name(args) status` differently — one width-aware, another a naive `args[:47]` byte-cut that dumped raw JSON and broke multibyte runes. Collapsed/expanded results had no card framing, the expanded tree was hand-drawn `├─`/`└─` runes re-themed line-by-line, and toggling expand/collapse jumped the scroll position. This unifies all of it.

## What changed (#864 acceptance criteria)

- **Shared summary renderer** — one width-aware `<icon> Name(args) <status>` builder (`ToolFormatter.RenderToolSummary`); the status line, live preview, approval summary and queue preview all route through it. Killed the `args[:47]` byte-slice.
- **Live previews in cards** — running tools render in a titled card (spinner as the status icon, bash output inside).
- **Collapsed results in cards** — status line → dim separator → preview → right-aligned footer.
- **Native `lipgloss/tree`** — expanded results build one real `tree` (`RoundedEnumerator`); all ~18 tools + the service fallback migrated; the hand-drawn connectors deleted.
- **LLM/headless stays plain** — cards/colors gated to the UI methods; LLM output is ANSI-free with `├──`/`╰──` glyphs.
- **Scroll preserved** — `rebuildPreservingScroll` anchors the view across expand/collapse.
- **Tool-type differentiation without emoji** — border-title accent color per type; removed todowrite's emoji header.
- **Argument rendering** — width-aware, path-shortened, rune-safe.
- **Queue previews** show arguments instead of a bare `Name(...)`.

## Approval-box review fixes (found while testing)

- **Scrollable ctrl+o expansion** — the approval diff was capped to ~half the screen with no way to review the rest. ctrl+o now opens a scrollable full-diff window (↑/↓ scroll) that fills the screen while the Approve/Reject buttons stay pinned, so a file larger than the terminal is fully reviewable.
- **No double-cap** — the new-file preview hard-capped at 50 lines with its own footer, shadowing the scroll window and showing a phantom `… 1 more lines` on an exactly-50-line file (trailing-newline off-by-one). The renderer now drops the empty trailing element and takes a configurable cap; the expanded box renders every line and is its own single height bound.
- **Expand-first toggle** — global ctrl+o collapsed-first whenever anything was expanded, so a lone collapsed card (e.g. a rejected write next to a default-expanded Edit diff) ignored the first press. It now expands-first unless everything is already open.
- **esc-rejection routing** — rejecting with esc clears the approval state without completing the form, leaving the box's local fields stale; `IsActive()` kept returning true and swallowed ctrl+o. It now consults the live StateManager, so a rejected result expands again.

## Testing

- `task test` (unit + integration), `task test:e2e`, and `task lint` all pass.
- Cards, scrollable expansion, and all four approval fixes verified live in the chat TUI (tmux + mock gateway).
- Headless/LLM expanded output confirmed plain (no ANSI, native `├──`/`╰──`).

## Notes

- Public TUI surface (`feat:`) → a matching `[DOCS]` ticket for `inference-gateway/docs` will follow.
- One known non-blocker: a rejected mutating tool's expanded view shows `content: ...` (the formatter elides the arg, same as a successful write, which has no result body when rejected). Can add a rejected-diff view as a follow-up if wanted.
