### PR TITLE
fix(tui): render tool cards and markdown at full terminal width

### DIFF
--- a/internal/formatting/formatting.go
+++ b/internal/formatting/formatting.go
@@ -23,26 +23,16 @@ func WrapText(text string, width int) string {
 	return wordwrap.String(text, width)
 }
 
-// GetResponsiveWidth calculates appropriate width based on terminal size
+// GetResponsiveWidth returns the content width for a terminal: the full width
+// minus a small right margin, floored at minWidth. No upper cap — content fills
+// the screen at any terminal size.
 func GetResponsiveWidth(terminalWidth int) int {
 	const (
-		minWidth    = 40
-		maxWidth    = 150
-		rightBuffer = 6
-		margin      = rightBuffer
+		minWidth = 40
+		margin   = 6
 	)
 
-	availableWidth := terminalWidth - margin
-
-	if availableWidth < minWidth {
-		return minWidth
-	}
-
-	if availableWidth > maxWidth {
-		return maxWidth
-	}
-
-	return availableWidth
+	return max(terminalWidth-margin, minWidth)
 }
 
 // FormatResponsiveMessage formats a message with responsive text wrapping

--- a/internal/services/tool_formatter.go
+++ b/internal/services/tool_formatter.go
@@ -199,13 +199,10 @@ func (s *ToolFormatterService) statusLine(result *domain.ToolExecutionResult, te
 	return s.RenderToolSummary(styledIcon, result.ToolName, result.Arguments, styledSuffix, terminalWidth)
 }
 
-// cardWidth is the content width for a tool-result card at the given terminal width.
-func (s *ToolFormatterService) cardWidth(terminalWidth int) int {
-	w := formatting.GetResponsiveWidth(terminalWidth) - 2 // rounded border adds 2 columns
-	if w < 20 {
-		w = 20
-	}
-	return w
+// cardWidth is the outer width for a tool-result card; the caller passes an
+// already-responsive width and lipgloss Width() includes the border.
+func (s *ToolFormatterService) cardWidth(width int) int {
+	return max(width, 20)
 }
 
 // wrapCard frames content in a rounded card whose top border carries the tool name,
@@ -221,16 +218,13 @@ func (s *ToolFormatterService) wrapCard(toolName, content string, terminalWidth 
 }
 
 // argsPreviewBudget is the width available for the inline argument preview on the
-// collapsed status line, after reserving room for the icon, tool name, parentheses
-// and the trailing duration. It scales with the terminal width so long values (e.g.
-// bash commands) stay readable on wide terminals instead of being clipped to a fixed
-// cap; the full value is always available via ctrl+o.
-func (s *ToolFormatterService) argsPreviewBudget(toolName string, terminalWidth int) int {
+// collapsed status line, after reserving room for the icon, name and duration.
+func (s *ToolFormatterService) argsPreviewBudget(toolName string, width int) int {
 	const (
 		reserved = 18
 		minimum  = 50
 	)
-	budget := formatting.GetResponsiveWidth(terminalWidth) - len(toolName) - reserved
+	budget := width - len(toolName) - reserved
 	if budget < minimum {
 		return minimum
 	}

--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -10,6 +10,7 @@ import (
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 
+	lipgloss "charm.land/lipgloss/v2"
 	sdk "github.com/inference-gateway/sdk"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -280,6 +281,25 @@ func TestRenderToolSummary_SharedAndWidthAware(t *testing.T) {
 	}
 	if strings.Contains(got, "�") {
 		t.Errorf("truncation split a multibyte rune: %q", got)
+	}
+}
+
+// TestFormatToolResultForUI_CardWidthTracksInput checks the card fills the width it is
+// handed and grows with the terminal, rather than double-shrinking.
+func TestFormatToolResultForUI_CardWidthTracksInput(t *testing.T) {
+	svc := newTestService(&fakeTool{name: "Bash", hasBody: true, body: "l1\nl2"})
+
+	for _, w := range []int{60, 100, 148} {
+		card := svc.FormatToolResultForUI(bashResult(true, map[string]any{"command": "ls"}), w)
+		if got := lipgloss.Width(stripANSI(card)); got != w {
+			t.Errorf("card outer width at input %d = %d, want %d (must not double-shrink)", w, got, w)
+		}
+	}
+
+	narrow := lipgloss.Width(stripANSI(svc.FormatToolResultForUI(bashResult(true, nil), 60)))
+	wide := lipgloss.Width(stripANSI(svc.FormatToolResultForUI(bashResult(true, nil), 120)))
+	if wide <= narrow {
+		t.Errorf("card width should grow with terminal width: 60→%d, 120→%d", narrow, wide)
 	}
 }
 

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -15,6 +15,7 @@ import (
 	spinner "charm.land/bubbles/v2/spinner"
 	viewport "charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
 
 	sdk "github.com/inference-gateway/sdk"
 
@@ -462,6 +463,9 @@ func (cv *ConversationView) SetWidth(width int) {
 	if cv.markdownRenderer != nil {
 		cv.markdownRenderer.SetWidth(width)
 	}
+	if cv.toolCallRenderer != nil {
+		cv.toolCallRenderer.SetWidth(width)
+	}
 }
 
 func (cv *ConversationView) SetHeight(height int) {
@@ -532,14 +536,7 @@ func (cv *ConversationView) renderStreamingContent() string {
 		result.WriteString(thinkingBlock)
 	}
 
-	rolePrefixLength := 13
-	if model != "" {
-		rolePrefixLength += len(fmt.Sprintf(" (%s)", model))
-	}
-
-	wrapWidth := max(cv.width-rolePrefixLength, 40)
-
-	streamingContent = formatting.FormatResponsiveMessage(streamingContent, wrapWidth)
+	streamingContent = cv.applyMarkdownIfEnabled(streamingContent, max(cv.width-2, 40))
 
 	assistantColor := cv.styleProvider.GetThemeColor("assistant")
 	var roleStyled string
@@ -552,10 +549,7 @@ func (cv *ConversationView) renderStreamingContent() string {
 		roleStyled = cv.styleProvider.RenderWithColor("⏺ Assistant:", assistantColor)
 	}
 
-	result.WriteString(roleStyled)
-	result.WriteString(" ")
-	result.WriteString(streamingContent)
-	result.WriteString("\n")
+	cv.writeRoleAndBody(&result, roleStyled, streamingContent)
 	return result.String()
 }
 
@@ -886,15 +880,30 @@ func (cv *ConversationView) renderShortcutOutput(result *strings.Builder, roleSt
 
 // renderInlineContent renders content inline with the role
 func (cv *ConversationView) renderInlineContent(result *strings.Builder, roleStyled string, entry domain.ConversationEntry, contentStr string, wrapWidth int) {
-	var formattedContent string
 	if entry.Message.Role == sdk.Assistant && cv.markdownRenderer != nil && !cv.rawFormat {
-		formattedContent = cv.applyMarkdownIfEnabled(contentStr, wrapWidth)
-	} else {
-		formattedContent = formatting.FormatResponsiveMessage(contentStr, wrapWidth)
+		body := cv.applyMarkdownIfEnabled(contentStr, max(cv.width-2, 40))
+		cv.writeRoleAndBody(result, roleStyled, body)
+		return
 	}
+	formattedContent := formatting.FormatResponsiveMessage(contentStr, wrapWidth)
 	result.WriteString(roleStyled)
 	result.WriteString(" ")
 	result.WriteString(formattedContent)
+	result.WriteString("\n")
+}
+
+// writeRoleAndBody joins a role prefix and an already-wrapped body. The body wraps
+// to the full width, so its first line is kept on the role line only when it still
+// fits after the prefix; otherwise the body starts on its own line to avoid clipping.
+func (cv *ConversationView) writeRoleAndBody(result *strings.Builder, roleStyled, body string) {
+	result.WriteString(roleStyled)
+	firstLine, _, _ := strings.Cut(body, "\n")
+	if lipgloss.Width(roleStyled)+1+lipgloss.Width(firstLine) <= cv.width {
+		result.WriteString(" ")
+	} else {
+		result.WriteString("\n")
+	}
+	result.WriteString(body)
 	result.WriteString("\n")
 }
 
@@ -1284,7 +1293,7 @@ func (cv *ConversationView) handleMouseEvents(msg tea.Msg) tea.Cmd {
 // handleWindowSizeEvents processes window resize events
 func (cv *ConversationView) handleWindowSizeEvents(msg tea.Msg) tea.Cmd {
 	if windowMsg, ok := msg.(tea.WindowSizeMsg); ok {
-		cv.SetWidth(windowMsg.Width)
+		cv.SetWidth(formatting.GetResponsiveWidth(windowMsg.Width))
 		cv.height = windowMsg.Height
 		if cv.navigationMode != NavigationModeMessageHistory {
 			cv.updateViewportContentFull()

--- a/internal/ui/components/tool_call_renderer.go
+++ b/internal/ui/components/tool_call_renderer.go
@@ -59,10 +59,7 @@ func (r *ToolCallRenderer) summaryLine(icon, name, argsJSON, trailing string) st
 // liveCard frames a running tool's preview in a rounded card whose top border carries
 // the tool name, coloured by tool type (AC8).
 func (r *ToolCallRenderer) liveCard(name, content string) string {
-	w := r.width - 2
-	if w < 20 {
-		w = 20
-	}
+	w := max(r.width, 20)
 	return r.styleProvider.RenderTitledCard(
 		content, name,
 		r.styleProvider.GetThemeColor("border"),


### PR DESCRIPTION
Closes #867.

Tool-call cards and streamed markdown were rendering far narrower than the terminal, collapsing text into a thin column.

## Root causes & fixes

- **Live tool-call cards stuck at 80 cols** (the screenshot in #867) — the `ToolCallRenderer` never received `WindowSizeMsg`; the conversation view now propagates its width to the child renderer.
- **Completed cards double-shrank** — `GetResponsiveWidth` was applied twice (view + formatter) plus a bogus `-2` that assumed lipgloss `Width()` excludes the border. Removed, so cards fill the width they're handed. (A test proved lipgloss v2 `Width()` includes the border.)
- **Streaming "reload"** — streamed text rendered as plain and re-rendered through glamour on completion (a visible restyle "pop"). Streaming now uses the same markdown path.
- **150-col cap removed** — `GetResponsiveWidth` no longer hard-caps content, so wide terminals are fully used (messages + cards).
- **Markdown wrapped too narrow** — the full `Assistant (model):` prefix was subtracted from every line even though wrapped lines start at the margin. The body now wraps at full width; its first line stays inline with the role only when it fits (measured with `lipgloss.Width`), otherwise it drops to its own line to avoid clipping.

## Verification

- New regression test asserts card outer width tracks the input width and grows with the terminal.
- Driven end-to-end against the mock gateway (tmux, 200 cols): live + completed cards fill the width with no mid-line collapse; markdown fills to ~192 cols; short replies stay inline (`Assistant (model): Hey!...`), long replies drop to their own line with no clip; streaming matches the completed render.
- `task test` (0 failures) and `task lint` pass clean.