### PR TITLE
fix(agent): trigger compaction on single-turn tool-output spikes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -182,6 +182,12 @@ type ToolsConfig struct {
 	AskUserQuestion AskUserQuestionToolConfig `yaml:"ask_user_question" mapstructure:"ask_user_question"`
 	Wait            WaitToolConfig            `yaml:"wait" mapstructure:"wait"`
 
+	// MaxResultBytes caps the size of a single tool result fed back to the LLM.
+	// Oversized results are middle-truncated (head + tail kept) so one
+	// pathological output (a huge Read/WebFetch/bash dump) can't dominate the
+	// context window in a single turn. 0 disables the cap.
+	MaxResultBytes int `yaml:"max_result_bytes" mapstructure:"max_result_bytes"`
+
 	Safety SafetyConfig `yaml:"safety" mapstructure:"safety"`
 }
 
@@ -747,7 +753,8 @@ func DefaultConfig() *Config { //nolint:funlen
 			},
 		},
 		Tools: ToolsConfig{
-			Enabled: true,
+			Enabled:        true,
+			MaxResultBytes: 250000,
 			Sandbox: SandboxConfig{
 				Directories: []string{".", "/tmp", ConfigDirName + "/tmp"},
 				ProtectedPaths: []string{

--- a/internal/app/chat_status_bar_test.go
+++ b/internal/app/chat_status_bar_test.go
@@ -164,6 +164,10 @@ func (toolStatsEstimator) GetToolStats(domain.ToolService, domain.AgentMode) (in
 
 func (toolStatsEstimator) EstimateMessagesTokens([]sdk.Message) int { return 0 }
 
+func (toolStatsEstimator) EffectiveContextTokens(lastInputTokens int, _ []sdk.Message) int {
+	return lastInputTokens
+}
+
 func TestStatusBarEnterOpensToolsList(t *testing.T) {
 	app, stateManager := newStatusBarTestApp(t, false, false)
 	statusBar := app.inputStatusBar.(*components.InputStatusBar)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -315,6 +315,7 @@ func (c *ServiceContainer) initializeDomainServices() {
 
 	styleProvider := styles.NewProvider(c.themeService)
 	toolFormatterService := services.NewToolFormatterService(c.toolRegistry, styleProvider)
+	toolFormatterService.SetMaxResultBytes(c.config.Tools.MaxResultBytes)
 
 	storageConfig := storage.NewStorageFromConfig(c.config)
 	storageBackend, err := storage.NewStorage(storageConfig)

--- a/internal/domain/token_estimator.go
+++ b/internal/domain/token_estimator.go
@@ -9,4 +9,10 @@ type TokenEstimator interface {
 
 	// EstimateMessagesTokens estimates the total tokens for a slice of messages
 	EstimateMessagesTokens(messages []sdk.Message) int
+
+	// EffectiveContextTokens estimates what the *next* request will carry: the
+	// larger of the gateway-reported last-request size and a fresh estimate of
+	// the current buffer. The max catches a single-turn tool-output spike that a
+	// stale lastInputTokens alone would miss.
+	EffectiveContextTokens(lastInputTokens int, messages []sdk.Message) int
 }

--- a/internal/services/conversation_optimizer.go
+++ b/internal/services/conversation_optimizer.go
@@ -77,17 +77,17 @@ func NewConversationOptimizer(config OptimizerConfig) domain.ConversationOptimiz
 	}
 }
 
-// estimateTriggerTokens returns the value used to gate auto-compaction. It
-// prefers the gateway-reported LastInputTokens (which includes system prompt
-// and tool definitions) and falls back to the entries-only tokenizer estimate
-// before the first round-trip or when no repo is wired in.
+// estimateTriggerTokens returns the value used to gate auto-compaction: the
+// larger of the gateway-reported LastInputTokens (which includes system prompt
+// and tool definitions) and a fresh tokenizer estimate of the current buffer.
+// Taking the max catches a single-turn tool-output spike that a stale
+// LastInputTokens alone would miss.
 func (co *ConversationOptimizer) estimateTriggerTokens(messages []sdk.Message) int {
+	lastInput := 0
 	if co.repo != nil {
-		if stats := co.repo.GetSessionTokens(); stats.LastInputTokens > 0 {
-			return stats.LastInputTokens
-		}
+		lastInput = co.repo.GetSessionTokens().LastInputTokens
 	}
-	return co.tokenizer.EstimateMessagesTokens(messages)
+	return co.tokenizer.EffectiveContextTokens(lastInput, messages)
 }
 
 // OptimizeMessages reduces token usage by intelligently managing conversation

--- a/internal/services/session_rollover_manager.go
+++ b/internal/services/session_rollover_manager.go
@@ -187,11 +187,10 @@ func (m *SessionRolloverManager) idleTriggerFires(entries []domain.ConversationE
 // when no context window is configured for the model, since there is no
 // meaningful threshold to compare against.
 //
-// Prefers the gateway-reported LastInputTokens from session stats: that value
-// is the authoritative count of what was actually sent (including system
-// prompt and tool definitions) and is also what `/context` displays, so the
-// trigger and the UI stay in lock-step. Falls back to the entries-only
-// estimate before the first round-trip when LastInputTokens is still zero.
+// Uses the larger of the gateway-reported LastInputTokens (the authoritative
+// count of what was actually sent, including system prompt and tool
+// definitions, also what `/context` displays) and a fresh entries estimate, so
+// a single-turn tool-output spike triggers rollover before the oversized send.
 func (m *SessionRolloverManager) tokenTriggerFires(entries []domain.ConversationEntry, model string) bool {
 	autoAt := m.cfg.Compact.AutoAt
 	if autoAt < 1 || autoAt > 80 {
@@ -204,15 +203,12 @@ func (m *SessionRolloverManager) tokenTriggerFires(entries []domain.Conversation
 	}
 	threshold := (contextWindow * autoAt) / 100
 
-	if stats := m.repo.GetSessionTokens(); stats.LastInputTokens > 0 {
-		return stats.LastInputTokens >= threshold
-	}
-
 	msgs := make([]sdk.Message, 0, len(entries))
 	for _, e := range entries {
 		msgs = append(msgs, e.Message)
 	}
-	return m.tokenizer.EstimateMessagesTokens(msgs) >= threshold
+	lastInput := m.repo.GetSessionTokens().LastInputTokens
+	return m.tokenizer.EffectiveContextTokens(lastInput, msgs) >= threshold
 }
 
 // PerformRollover runs the optimizer with force=true to produce a summary,

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -239,25 +239,27 @@ func TestShouldRollover_TokenTriggerFiresFromLastInputTokens(t *testing.T) {
 	}
 }
 
-func TestShouldRollover_TokenTriggerDoesNotFireWhenLastInputBelowThreshold(t *testing.T) {
+func TestShouldRollover_TokenTriggerFiresOnSingleTurnSpike(t *testing.T) {
 	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
 	defer cleanup()
 
-	// Large entries that *would* trip the entries-only fallback…
+	// Large entries appended this turn (e.g. a huge tool result) that push the
+	// *pending* request well over the threshold…
 	bigContent := strings.Repeat("token ", 2000)
 	for i := 0; i < 10; i++ {
 		addUserMessage(t, repo, bigContent, time.Now())
 	}
 
-	// …but the gateway-reported count is well below the threshold. The
-	// gateway count must win - its number includes provider-specific
-	// reformatting and is what `/context` shows.
+	// …while the gateway-reported LastInputTokens is still the small, stale
+	// count from the last successful round-trip. Gating on the stale value
+	// alone would miss the spike and let an oversized request go out (the bug);
+	// the fresh estimate must win so rollover fires before the send.
 	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 1000, 100, 1100); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 
-	if mgr.ShouldRollover("moonshot/moonshot-v1-8k") {
-		t.Error("LastInputTokens below threshold should not trigger rollover, even if entries-only estimate is large")
+	if !mgr.ShouldRollover("moonshot/moonshot-v1-8k") {
+		t.Error("a single-turn estimate spike above threshold should trigger rollover even when LastInputTokens is stale and small")
 	}
 }
 

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -243,17 +243,11 @@ func TestShouldRollover_TokenTriggerFiresOnSingleTurnSpike(t *testing.T) {
 	mgr, repo, _, _, cleanup := newRolloverManagerForTest(t, 80, 0)
 	defer cleanup()
 
-	// Large entries appended this turn (e.g. a huge tool result) that push the
-	// *pending* request well over the threshold…
 	bigContent := strings.Repeat("token ", 2000)
 	for i := 0; i < 10; i++ {
 		addUserMessage(t, repo, bigContent, time.Now())
 	}
 
-	// …while the gateway-reported LastInputTokens is still the small, stale
-	// count from the last successful round-trip. Gating on the stale value
-	// alone would miss the spike and let an oversized request go out (the bug);
-	// the fresh estimate must win so rollover fires before the send.
 	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 1000, 100, 1100); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}

--- a/internal/services/tokenizer.go
+++ b/internal/services/tokenizer.go
@@ -130,6 +130,15 @@ func (t *TokenizerService) EstimateMessagesTokens(messages []sdk.Message) int {
 	return totalTokens
 }
 
+// EffectiveContextTokens returns the larger of lastInputTokens and a fresh
+// estimate, so a single-turn tool-output spike isn't masked by a stale count.
+func (t *TokenizerService) EffectiveContextTokens(lastInputTokens int, messages []sdk.Message) int {
+	if est := t.EstimateMessagesTokens(messages); est > lastInputTokens {
+		return est
+	}
+	return lastInputTokens
+}
+
 // EstimateToolDefinitionsTokens estimates tokens for tool definitions
 func (t *TokenizerService) EstimateToolDefinitionsTokens(tools []sdk.ChatCompletionTool) int {
 	if len(tools) == 0 {

--- a/internal/services/tokenizer_test.go
+++ b/internal/services/tokenizer_test.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	sdk "github.com/inference-gateway/sdk"
+
 	domain "github.com/inference-gateway/cli/internal/domain"
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
-	sdk "github.com/inference-gateway/sdk"
 )
 
 func TestNewTokenizerService(t *testing.T) {

--- a/internal/services/tokenizer_test.go
+++ b/internal/services/tokenizer_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -585,5 +586,24 @@ func TestGetToolStats(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestEffectiveContextTokens(t *testing.T) {
+	tok := NewTokenizerService(DefaultTokenizerConfig())
+	msgs := []sdk.Message{{Role: sdk.User, Content: sdk.NewMessageContent(strings.Repeat("word ", 4000))}}
+
+	est := tok.EstimateMessagesTokens(msgs)
+	if est <= 0 {
+		t.Fatalf("estimate should be positive, got %d", est)
+	}
+
+	// Stale small last-input count must not mask the large pending estimate.
+	if got := tok.EffectiveContextTokens(1000, msgs); got != est {
+		t.Errorf("estimate spike should win: got %d, want %d", got, est)
+	}
+	// When the reported count is larger, it wins.
+	if got := tok.EffectiveContextTokens(est+5000, msgs); got != est+5000 {
+		t.Errorf("larger lastInput should win: got %d, want %d", got, est+5000)
 	}
 }

--- a/internal/services/tool_formatter.go
+++ b/internal/services/tool_formatter.go
@@ -16,9 +16,10 @@ import (
 
 // ToolFormatterService provides formatting for tool results by delegating to individual tools
 type ToolFormatterService struct {
-	toolRegistry  ToolRegistry
-	styleProvider *styles.Provider
-	hintFormatter HintProvider
+	toolRegistry   ToolRegistry
+	styleProvider  *styles.Provider
+	hintFormatter  HintProvider
+	maxResultBytes int
 }
 
 // HintProvider resolves keybinding hints for tool result affordances.
@@ -32,6 +33,13 @@ type HintProvider interface {
 // is simply omitted.
 func (s *ToolFormatterService) SetHintFormatter(h HintProvider) {
 	s.hintFormatter = h
+}
+
+// SetMaxResultBytes caps the size of a single tool result fed back to the LLM
+// (FormatToolResultForLLM). 0 disables the cap. Wired from tools.max_result_bytes
+// in the container so one oversized tool output can't dominate the context window.
+func (s *ToolFormatterService) SetMaxResultBytes(n int) {
+	s.maxResultBytes = n
 }
 
 func (s *ToolFormatterService) toggleKey() string {
@@ -289,10 +297,29 @@ func (s *ToolFormatterService) FormatToolResultForLLM(result *domain.ToolExecuti
 
 	tool, err := s.toolRegistry.GetTool(result.ToolName)
 	if err != nil {
-		return s.formatFallback(result, domain.FormatterLLM)
+		return capToolResult(s.formatFallback(result, domain.FormatterLLM), s.maxResultBytes)
 	}
 
-	return safeToolFormat(result.ToolName, func() string { return tool.FormatResult(result, domain.FormatterLLM) })
+	formatted := safeToolFormat(result.ToolName, func() string { return tool.FormatResult(result, domain.FormatterLLM) })
+	return capToolResult(formatted, s.maxResultBytes)
+}
+
+// capToolResult middle-truncates an oversized tool result (keeping the head and
+// tail, since both ends usually matter - e.g. an error at the end) with a marker
+// telling the model to re-run narrower. A cap of 0 (or content within the cap)
+// returns the content unchanged.
+func capToolResult(content string, maxBytes int) string {
+	if maxBytes <= 0 || len(content) <= maxBytes {
+		return content
+	}
+	const marker = "\n… [%d bytes truncated — re-run with a narrower query/offset for the full output] …\n"
+	keep := maxBytes - len(fmt.Sprintf(marker, len(content)))
+	if keep < 2 {
+		return content[:maxBytes]
+	}
+	head := keep / 2
+	tail := keep - head
+	return content[:head] + fmt.Sprintf(marker, len(content)-head-tail) + content[len(content)-tail:]
 }
 
 // formatFallback provides fallback formatting when tool is not available

--- a/internal/services/tool_formatter_test.go
+++ b/internal/services/tool_formatter_test.go
@@ -420,3 +420,27 @@ func TestFormatDurationShort(t *testing.T) {
 		}
 	}
 }
+
+func TestCapToolResult(t *testing.T) {
+	if got := capToolResult("hello", 0); got != "hello" {
+		t.Errorf("cap 0 should be unlimited, got %q", got)
+	}
+	if got := capToolResult("hello", 100); got != "hello" {
+		t.Errorf("content within cap should be unchanged, got %q", got)
+	}
+
+	big := strings.Repeat("a", 500) + "TAIL_MARKER"
+	got := capToolResult(big, 200)
+	if len(got) > 200 {
+		t.Errorf("capped output %d exceeds cap 200", len(got))
+	}
+	if !strings.HasPrefix(got, "aaaa") {
+		t.Error("head should be preserved")
+	}
+	if !strings.HasSuffix(got, "TAIL_MARKER") {
+		t.Error("tail should be preserved")
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Error("truncation marker should be present")
+	}
+}

--- a/internal/shortcuts/core.go
+++ b/internal/shortcuts/core.go
@@ -109,8 +109,6 @@ func (c *ContextShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 
 	contextWindowSize, windowKnown := models.LookupContextWindow(currentModel)
 
-	// Larger of the two so a single-turn tool-output spike shows instead of
-	// lagging behind the last round-trip; the estimate winning means approximate.
 	estimate := c.estimateCurrentContextSize()
 	contextTokens := stats.LastInputTokens
 	estimated := false

--- a/internal/shortcuts/core.go
+++ b/internal/shortcuts/core.go
@@ -109,11 +109,14 @@ func (c *ContextShortcut) Execute(ctx context.Context, args []string) (ShortcutR
 
 	contextWindowSize, windowKnown := models.LookupContextWindow(currentModel)
 
+	// Larger of the two so a single-turn tool-output spike shows instead of
+	// lagging behind the last round-trip; the estimate winning means approximate.
+	estimate := c.estimateCurrentContextSize()
 	contextTokens := stats.LastInputTokens
 	estimated := false
-	if contextTokens == 0 {
-		contextTokens = c.estimateCurrentContextSize()
-		estimated = contextTokens > 0
+	if estimate > contextTokens {
+		contextTokens = estimate
+		estimated = true
 	}
 
 	var output strings.Builder

--- a/internal/shortcuts/core_test.go
+++ b/internal/shortcuts/core_test.go
@@ -24,6 +24,13 @@ func (s *stubTokenEstimator) EstimateMessagesTokens([]sdk.Message) int {
 	return s.estimate
 }
 
+func (s *stubTokenEstimator) EffectiveContextTokens(lastInputTokens int, _ []sdk.Message) int {
+	if s.estimate > lastInputTokens {
+		return s.estimate
+	}
+	return lastInputTokens
+}
+
 func TestContextShortcut_Execute_UsesProviderUsageWhenAvailable(t *testing.T) {
 	repo := &domainmocks.FakeConversationRepository{}
 	repo.GetSessionTokensReturns(domain.SessionTokenStats{

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -657,34 +657,32 @@ func (isb *InputStatusBar) totalInputTokensOrEstimate() int {
 
 // currentContextTokensOrEstimate returns an approximation of the tokens that
 // would be sent in the next request - i.e. how full the model's context window
-// is right now. Prefers the gateway-reported LastInputTokens (which includes
-// the system prompt and tool definitions, matching what the optimizer and
-// session-rollover manager use); falls back to a tokenizer estimate of the
-// current message buffer before the first round-trip.
+// is right now. Takes the larger of the gateway-reported LastInputTokens (which
+// includes the system prompt and tool definitions, matching what the optimizer
+// and session-rollover manager use) and a fresh tokenizer estimate of the
+// current buffer, so a single-turn tool-output spike shows up immediately
+// instead of lagging behind the last round-trip.
 func (isb *InputStatusBar) currentContextTokensOrEstimate() int {
 	if isb.conversationRepo == nil {
 		return 0
 	}
 
 	stats := isb.conversationRepo.GetSessionTokens()
-	if stats.LastInputTokens > 0 {
-		return stats.LastInputTokens
-	}
 
 	if isb.tokenEstimator == nil {
-		return 0
+		return stats.LastInputTokens
 	}
 
 	messages := isb.conversationRepo.GetMessages()
 	if len(messages) == 0 {
-		return 0
+		return stats.LastInputTokens
 	}
 
 	sdkMessages := make([]sdk.Message, 0, len(messages))
 	for _, entry := range messages {
 		sdkMessages = append(sdkMessages, entry.Message)
 	}
-	return isb.tokenEstimator.EstimateMessagesTokens(sdkMessages)
+	return isb.tokenEstimator.EffectiveContextTokens(stats.LastInputTokens, sdkMessages)
 }
 
 // buildCostIndicator builds the cost indicator text

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -31,6 +31,13 @@ func (s *stubTokenEstimator) EstimateMessagesTokens([]sdk.Message) int {
 	return s.estimate
 }
 
+func (s *stubTokenEstimator) EffectiveContextTokens(lastInputTokens int, _ []sdk.Message) int {
+	if s.estimate > lastInputTokens {
+		return s.estimate
+	}
+	return lastInputTokens
+}
+
 // readinessStateManager returns a real ApplicationState whose readiness matches
 // the given TotalAgents/ReadyAgents (nil r leaves readiness uninitialized).
 func readinessStateManager(r *domain.AgentReadinessState) *domain.ApplicationState {


### PR DESCRIPTION
## Problem

A chat hit `maximum context length is 1048565 tokens, however you requested 1299008 tokens` on `deepseek-v4-flash` — while the status bar still read **Context: 11.8%**. Both were true.

Auto-compaction (`compact.auto_at`, default 80%) and every context indicator gated on the gateway-reported `LastInputTokens` — the size of the last *successful* request (~124K = 11.8%). A single turn that appended a large tool result (Read / WebFetch / bash dump / A2A artifact) jumped the *pending* payload from ~12% of the window straight past 100% in one step. Because no round-trip ever recorded a `LastInputTokens` in the 80–100% band, compaction compared the stale value against the threshold, saw headroom, and sent the oversized request — which the gateway rejected. The **11.8%** indicator was the same lagging value.

## Fix

**1. Gate & indicators measure the *pending* payload.** New `TokenEstimator.EffectiveContextTokens(lastInput, msgs)` returns `max(lastInput, freshEstimate)`, so a single-turn spike trips the 80% line before the send. Wired into the four sites that trusted the stale value:
- compaction gate — `conversation_optimizer.go` `estimateTriggerTokens`
- session/channel rollover — `session_rollover_manager.go` `tokenTriggerFires`
- status bar — `input_status_bar.go` `currentContextTokensOrEstimate`
- `/context` — `shortcuts/core.go`

On calm turns `LastInputTokens` stays the larger, so accuracy is unchanged; the estimate only wins on a spike.

**2. Cap individual tool results.** New `tools.max_result_bytes` (default `250000`, `0` disables) middle-truncates (head + tail + marker) at the single `FormatToolResultForLLM` funnel, so one oversized output can't dominate the window in the first place.

## Tests

- Inverted the test that encoded the bug as intended behavior (`TokenTriggerDoesNotFireWhenLastInputBelowThreshold` → `TokenTriggerFiresOnSingleTurnSpike`).
- Added `TestEffectiveContextTokens` and `TestCapToolResult`.
- `task test` + `golangci-lint` pass clean.

## Notes

- The estimate omits system-prompt + tool-def tokens (a slight under-count on borderline turns), but the 80% threshold leaves headroom; a fully accurate pre-send count would need the gateway tokenizer.
- `250000` is a tunable default — a genuinely large legitimate `Read` now gets a "re-run narrower" marker; the `0` escape hatch restores old behavior.