### PR TITLE
fix(tui): show real file line numbers in Edit tool diffs (#870)

### DIFF
--- a/internal/agent/tools/edit.go
+++ b/internal/agent/tools/edit.go
@@ -329,10 +329,16 @@ func (t *EditTool) executeEdit(filePath, oldString, newString string, replaceAll
 
 	diff := generateDiff(originalContentStr, newContent)
 
+	startLine := 0
+	if before, _, found := strings.Cut(originalContentStr, effectiveOld); found {
+		startLine = strings.Count(before, "\n") + 1
+	}
+
 	result := &domain.EditToolResult{
 		FilePath:             filePath,
 		OldString:            effectiveOld,
 		NewString:            effectiveNew,
+		StartLine:            startLine,
 		ReplacedCount:        replacedCount,
 		ReplaceAll:           replaceAll,
 		FileModified:         fileModified,
@@ -609,6 +615,9 @@ func (t *EditTool) FormatForLLM(result *domain.ToolExecutionResult) string {
 		themeService := domain.NewThemeProvider()
 		styleProvider := styles.NewProvider(themeService)
 		diffRenderer := components.NewDiffRenderer(styleProvider).SetContextLines(components.InlineDiffContextLines)
+		if editResult, ok := result.Data.(*domain.EditToolResult); ok {
+			diffRenderer.SetStartLine(editResult.StartLine)
+		}
 		diffInfo := t.GetDiffInfo(result.Arguments)
 		diffInfo.Title = "← Edits applied →"
 		dataContent = diffRenderer.RenderDiff(*diffInfo)

--- a/internal/agent/tools/edit_test.go
+++ b/internal/agent/tools/edit_test.go
@@ -1025,7 +1025,7 @@ func TestEditTool_Execute_TableDriven(t *testing.T) {
 	}
 }
 
-func TestEditTool_FormatResult_TableDriven(t *testing.T) {
+func TestEditTool_FormatResult_TableDriven(t *testing.T) { //nolint:funlen
 	cfg := &config.Config{
 		Tools: config.ToolsConfig{
 			Enabled: true,
@@ -1140,6 +1140,25 @@ func TestEditTool_FormatResult_TableDriven(t *testing.T) {
 			},
 			formatType: domain.FormatterUI,
 			contains:   []string{"Edit("},
+		},
+		{
+			name: "FormatLLM - diff shows real file line numbers",
+			result: &domain.ToolExecutionResult{
+				ToolName: "Edit",
+				Success:  true,
+				Arguments: map[string]any{
+					"file_path":  "/path/to/file.go",
+					"old_string": "alpha\nbeta\ngamma",
+					"new_string": "alpha\nBETA\ngamma",
+				},
+				Data: &domain.EditToolResult{
+					FilePath:     "/path/to/file.go",
+					FileModified: true,
+					StartLine:    50,
+				},
+			},
+			formatType: domain.FormatterLLM,
+			contains:   []string{"51"},
 		},
 		{
 			name:       "FormatResult - nil result",

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -983,6 +983,7 @@ type EditToolResult struct {
 	LinesDifference      int    `json:"lines_difference"`
 	Diff                 string `json:"diff,omitempty"`
 	WhitespaceNormalized bool   `json:"whitespace_normalized,omitempty"`
+	StartLine            int    `json:"start_line,omitempty"`
 }
 
 // TreeToolResult represents the result of a tree operation

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -2324,6 +2324,7 @@ func (cv *ConversationView) renderEditToolArgs(args map[string]any) string {
 	if hasOld && hasNew && hasPath {
 		fmt.Fprintf(&result, "  File: %s\n\n", filePath)
 		diffRenderer := NewDiffRenderer(cv.styleProvider).SetContextLines(InlineDiffContextLines)
+		diffRenderer.SetStartLine(snippetStartLine(filePath, oldStr))
 		diffInfo := DiffInfo{
 			FilePath:   filePath,
 			OldContent: oldStr,

--- a/internal/ui/components/diff_renderer.go
+++ b/internal/ui/components/diff_renderer.go
@@ -29,6 +29,7 @@ type DiffRenderer struct {
 	width         int
 	contextLines  int
 	maxLines      int
+	startLine     int
 }
 
 // defaultContentPreviewLines caps the new-file preview so a huge file can't blow
@@ -67,6 +68,12 @@ func (d *DiffRenderer) SetContextLines(n int) *DiffRenderer { d.contextLines = n
 // positive n caps at n, and a negative n renders every line (for callers that
 // bound the height themselves, like the scrollable approval box). Chains.
 func (d *DiffRenderer) SetMaxLines(n int) *DiffRenderer { d.maxLines = n; return d }
+
+// SetStartLine tells the renderer that the diffed content is a snippet whose
+// first line is line n in the real file (1-based), so gutter line numbers show
+// the actual file positions instead of counting from 1. Pass 0 (the default)
+// when the content is already whole-file. Chains.
+func (d *DiffRenderer) SetStartLine(n int) *DiffRenderer { d.startLine = n; return d }
 
 // RenderEditToolArguments renders Edit tool arguments as a diff. When the target
 // file can be read and old_string is found in it, it diffs the real file content
@@ -239,6 +246,21 @@ func editFileContents(filePath, oldString, newString string, replaceAll bool) (b
 	return before, after, true
 }
 
+func snippetStartLine(filePath, oldString string) int {
+	if oldString == "" {
+		return 0
+	}
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return 0
+	}
+	before, _, found := strings.Cut(string(content), oldString)
+	if !found {
+		return 0
+	}
+	return strings.Count(before, "\n") + 1
+}
+
 func (d *DiffRenderer) snippetDiff(filePath, oldString, newString string) string {
 	return d.buildDiffView(filePath, ensureTrailingNL(oldString), ensureTrailingNL(newString)).String()
 }
@@ -258,6 +280,9 @@ func (d *DiffRenderer) buildDiffView(filePath, before, after string) *diffview.D
 		WithChromaStyle(d.chromaStyle())
 	if d.contextLines > 0 {
 		dv = dv.ContextLines(d.contextLines)
+	}
+	if d.startLine > 1 {
+		dv = dv.LineNumberOffset(d.startLine - 1)
 	}
 	if d.width > 0 {
 		dv = dv.Width(d.width)

--- a/internal/ui/components/diffview/diffview.go
+++ b/internal/ui/components/diffview/diffview.go
@@ -55,17 +55,18 @@ type file struct {
 
 // DiffView is the fluent builder + renderer.
 type DiffView struct {
-	layout        Layout
-	splitMinWidth int
-	before        file
-	after         file
-	fileName      string
-	contextLines  int
-	lineNumbers   bool
-	width         int
-	tabWidth      int
-	style         Style
-	chromaStyle   *chroma.Style
+	layout           Layout
+	splitMinWidth    int
+	before           file
+	after            file
+	fileName         string
+	contextLines     int
+	lineNumbers      bool
+	lineNumberOffset int
+	width            int
+	tabWidth         int
+	style            Style
+	chromaStyle      *chroma.Style
 
 	// computed lazily on String()
 	isComputed      bool
@@ -137,6 +138,11 @@ func (dv *DiffView) WithChromaStyle(s *chroma.Style) *DiffView {
 // ContextLines sets the number of unchanged context lines around each hunk.
 func (dv *DiffView) ContextLines(n int) *DiffView { dv.contextLines = n; return dv }
 
+// LineNumberOffset shifts every displayed line number by n. Use it when the
+// before/after content is a snippet lifted out of a larger file so the gutter
+// reflects the snippet's real position (pass the snippet's first line minus 1).
+func (dv *DiffView) LineNumberOffset(n int) *DiffView { dv.lineNumberOffset = n; return dv }
+
 // String renders the diff.
 func (dv *DiffView) String() string {
 	dv.normalizeLineEndings()
@@ -204,6 +210,12 @@ func (dv *DiffView) computeDiff() error {
 		dv.before.content, edits,
 		dv.contextLines,
 	)
+	if dv.lineNumberOffset != 0 {
+		for i := range dv.unified.Hunks {
+			dv.unified.Hunks[i].FromLine += dv.lineNumberOffset
+			dv.unified.Hunks[i].ToLine += dv.lineNumberOffset
+		}
+	}
 	return dv.err
 }
 

--- a/internal/ui/components/diffview/diffview_test.go
+++ b/internal/ui/components/diffview/diffview_test.go
@@ -67,6 +67,26 @@ func TestUnifiedRendersWithLineNumbers(t *testing.T) {
 	}
 }
 
+func TestLineNumberOffsetShiftsGutter(t *testing.T) {
+	before := "alpha\nbeta\ngamma\n"
+	after := "alpha\nBETA\ngamma\n"
+
+	out := New().
+		Before("f", before).
+		After("f", after).
+		Layout(LayoutUnified).
+		LineNumberOffset(99).
+		String()
+	plain := stripANSI(out)
+
+	if !strings.Contains(plain, "101") {
+		t.Fatalf("expected offset line number 101 in output:\n%s", plain)
+	}
+	if strings.Contains(plain, "@@ -2,") || strings.Contains(plain, "@@ -1,") {
+		t.Fatalf("hunk header should reflect offset, got:\n%s", plain)
+	}
+}
+
 func TestAutoLayoutPicksSplitWhenWide(t *testing.T) {
 	dv := New().
 		Before("f", "a\n").


### PR DESCRIPTION
## Summary

The Edit tool rendered its diff from the `old_string`→`new_string` snippet, so `diffview` numbered the changed lines `1, 2, 3…` instead of their actual positions in the file (issue #870).

Root cause: the snippet has no knowledge of where it sits in the file, and after the edit runs the file no longer contains `old_string`, so the renderer can't re-derive positions. The approval **preview** already diffs whole-file content (correct numbers), but the completed result card and the pending approval card render the snippet.

## Fix

Thread the edit's start line through as a gutter offset:

- `diffview`: new `LineNumberOffset(n)` shifts hunk `FromLine`/`ToLine` once in `computeDiff`, so digit width, hunk header, and both unified/split layouts all pick it up.
- `DiffRenderer.SetStartLine(n)` applies `LineNumberOffset(n-1)`.
- `EditToolResult.StartLine` is recorded in `executeEdit` (line of the first replaced occurrence) and passed by `FormatForLLM` for the completed card.
- The pending card computes the start line from the still-unedited file via `snippetStartLine`.

## Tests

- `TestLineNumberOffsetShiftsGutter` (diffview) — gutter and hunk header reflect the offset.
- New `FormatResult` case asserting the completed Edit diff shows real file line numbers.

## Notes

- Not applied to MultiEdit: its per-edit snippets shift as edits apply, so a single offset isn't correct there.
- Internal-only UI fix — no docs ticket needed.