### PR TITLE
refactor(tui): centralize key bindings into components_keymap.go, switch to key.Matches dispatch

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -371,30 +371,30 @@ func NewChatApplication(
 
 // updateHelpBarShortcuts updates the help bar with essential keyboard shortcuts
 func (app *ChatApplication) updateHelpBarShortcuts() {
-	app.helpBar.SetShortcuts(app.collectKeyShortcuts())
+	app.helpBar.SetShortcuts(app.collectKeyBindings())
 }
 
-// collectKeyShortcuts gathers the input-prefix hints and the active keybinding
+// collectKeyBindings gathers the input-prefix hints and the active keybinding
 // shortcuts into a single list, shared by the help bar and the /help overlay.
-func (app *ChatApplication) collectKeyShortcuts() []ui.KeyShortcut {
-	shortcuts := []ui.KeyShortcut{
-		{Key: "!", Description: "for bash mode"},
-		{Key: "!!", Description: "for tools mode"},
-		{Key: "/", Description: "for shortcuts"},
-		{Key: "@", Description: "for file paths"},
-		{Key: "#", Description: "for github issues"},
+func (app *ChatApplication) collectKeyBindings() []key.Binding {
+	bindings := []key.Binding{
+		key.NewBinding(key.WithKeys("!"), key.WithHelp("!", "for bash mode")),
+		key.NewBinding(key.WithKeys("!!"), key.WithHelp("!!", "for tools mode")),
+		key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "for shortcuts")),
+		key.NewBinding(key.WithKeys("@"), key.WithHelp("@", "for file paths")),
+		key.NewBinding(key.WithKeys("#"), key.WithHelp("#", "for github issues")),
 	}
 
 	if app.keyBindingManager != nil {
 		for _, kbShortcut := range app.keyBindingManager.GetHelpShortcuts() {
-			shortcuts = append(shortcuts, ui.KeyShortcut{
-				Key:         kbShortcut.Key,
-				Description: kbShortcut.Description,
-			})
+			bindings = append(bindings, key.NewBinding(
+				key.WithKeys(kbShortcut.Key),
+				key.WithHelp(kbShortcut.Key, kbShortcut.Description),
+			))
 		}
 	}
 
-	return shortcuts
+	return bindings
 }
 
 // Init initializes the application
@@ -1764,7 +1764,14 @@ func (app *ChatApplication) handleHelpViewTrigger() []tea.Cmd {
 	width, height := app.stateManager.GetDimensions()
 	app.helpView.SetWidth(width)
 	app.helpView.SetHeight(height)
-	app.helpView.SetContent(app.buildHelpCommands(), app.collectKeyShortcuts())
+
+	bindings := app.collectKeyBindings()
+	shortcuts := make([]ui.KeyShortcut, len(bindings))
+	for i, b := range bindings {
+		h := b.Help()
+		shortcuts[i] = ui.KeyShortcut{Key: h.Key, Description: h.Desc}
+	}
+	app.helpView.SetContent(app.buildHelpCommands(), shortcuts)
 
 	if err := app.stateManager.TransitionToView(domain.ViewStateHelp); err != nil {
 		cmds = append(cmds, func() tea.Msg {

--- a/internal/ui/autocomplete/autocomplete.go
+++ b/internal/ui/autocomplete/autocomplete.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	key "charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
 	sdk "github.com/inference-gateway/sdk"
@@ -17,6 +18,21 @@ import (
 	ui "github.com/inference-gateway/cli/internal/ui"
 	colors "github.com/inference-gateway/cli/internal/ui/styles/colors"
 )
+
+// autocompleteKeys holds the key.Binding set for the autocomplete overlay.
+var autocompleteKeys = struct {
+	navUp   key.Binding
+	navDown key.Binding
+	tab     key.Binding
+	enter   key.Binding
+	esc     key.Binding
+}{
+	navUp:   key.NewBinding(key.WithKeys("up", "ctrl+p")),
+	navDown: key.NewBinding(key.WithKeys("down", "ctrl+n")),
+	tab:     key.NewBinding(key.WithKeys("tab")),
+	enter:   key.NewBinding(key.WithKeys("enter")),
+	esc:     key.NewBinding(key.WithKeys("esc")),
+}
 
 // ShortcutOption represents a shortcut option for autocomplete
 type ShortcutOption struct {
@@ -675,13 +691,13 @@ func (a *AutocompleteImpl) filterSuggestions() {
 }
 
 // HandleKey processes key input for autocomplete navigation
-func (a *AutocompleteImpl) HandleKey(key tea.KeyPressMsg) (bool, string) {
+func (a *AutocompleteImpl) HandleKey(k tea.KeyPressMsg) (bool, string) {
 	if !a.visible || len(a.filtered) == 0 {
 		return false, ""
 	}
 
-	switch key.String() {
-	case "up", "ctrl+p":
+	switch {
+	case key.Matches(k, autocompleteKeys.navUp):
 		if a.selected > 0 {
 			a.selected--
 		} else {
@@ -689,7 +705,7 @@ func (a *AutocompleteImpl) HandleKey(key tea.KeyPressMsg) (bool, string) {
 		}
 		return true, ""
 
-	case "down", "ctrl+n":
+	case key.Matches(k, autocompleteKeys.navDown):
 		if a.selected < len(a.filtered)-1 {
 			a.selected++
 		} else {
@@ -697,17 +713,17 @@ func (a *AutocompleteImpl) HandleKey(key tea.KeyPressMsg) (bool, string) {
 		}
 		return true, ""
 
-	case "tab":
+	case key.Matches(k, autocompleteKeys.tab):
 		if a.selected >= len(a.filtered) {
 			return true, ""
 		}
 		return a.handleSelection()
 
-	case "enter":
+	case key.Matches(k, autocompleteKeys.enter):
 		a.visible = false
 		return false, ""
 
-	case "esc":
+	case key.Matches(k, autocompleteKeys.esc):
 		a.visible = false
 		return true, ""
 	}

--- a/internal/ui/components/a2a_agents_view.go
+++ b/internal/ui/components/a2a_agents_view.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 
+	key "charm.land/bubbles/v2/key"
 	list "charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
@@ -175,17 +176,17 @@ func (m *A2AAgentsViewImpl) handleKey(msg tea.KeyPressMsg) (handled bool, cmd te
 		return false, nil
 	}
 
-	switch msg.String() {
-	case "ctrl+c":
+	switch {
+	case key.Matches(msg, listViewKeys.cancel):
 		m.cancelled = true
 		return true, nil
-	case "esc":
+	case key.Matches(msg, listViewKeys.esc):
 		if m.list.FilterState() == list.FilterApplied {
 			return false, nil
 		}
 		m.cancelled = true
 		return true, nil
-	case "enter", " ":
+	case key.Matches(msg, listViewKeys.selectKey):
 		return true, nil
 	}
 	return false, nil

--- a/internal/ui/components/components_keymap.go
+++ b/internal/ui/components/components_keymap.go
@@ -1,0 +1,196 @@
+package components
+
+import (
+	key "charm.land/bubbles/v2/key"
+)
+
+// Centralised key.Binding sets for per-view components. These are navigation
+// keys local to their overlay and are not user-remappable; each set follows
+// the guardKeys pattern from internal/app/chat_keymap.go.
+
+var taskManagerKeys = struct {
+	quit      key.Binding
+	enter     key.Binding
+	navUp     key.Binding
+	navDown   key.Binding
+	info      key.Binding
+	cancel    key.Binding
+	search    key.Binding
+	escape    key.Binding
+	tab1      key.Binding
+	tab2      key.Binding
+	tab3      key.Binding
+	tab4      key.Binding
+	tab5      key.Binding
+	confirm   key.Binding
+	deny      key.Binding
+	close     key.Binding
+	pgUp      key.Binding
+	pgDown    key.Binding
+	top       key.Binding
+	bottom    key.Binding
+	backspace key.Binding
+}{
+	quit:      key.NewBinding(key.WithKeys("q", "esc", "ctrl+c")),
+	enter:     key.NewBinding(key.WithKeys("enter")),
+	navUp:     key.NewBinding(key.WithKeys("up", "k")),
+	navDown:   key.NewBinding(key.WithKeys("down", "j")),
+	info:      key.NewBinding(key.WithKeys("i")),
+	cancel:    key.NewBinding(key.WithKeys("c")),
+	search:    key.NewBinding(key.WithKeys("/")),
+	escape:    key.NewBinding(key.WithKeys("esc")),
+	tab1:      key.NewBinding(key.WithKeys("1")),
+	tab2:      key.NewBinding(key.WithKeys("2")),
+	tab3:      key.NewBinding(key.WithKeys("3")),
+	tab4:      key.NewBinding(key.WithKeys("4")),
+	tab5:      key.NewBinding(key.WithKeys("5")),
+	confirm:   key.NewBinding(key.WithKeys("y", "Y")),
+	deny:      key.NewBinding(key.WithKeys("n", "N", "esc")),
+	close:     key.NewBinding(key.WithKeys("q", "esc", "i", "ctrl+c")),
+	pgUp:      key.NewBinding(key.WithKeys("pgup", "b")),
+	pgDown:    key.NewBinding(key.WithKeys("pgdown", "f", " ")),
+	top:       key.NewBinding(key.WithKeys("g")),
+	bottom:    key.NewBinding(key.WithKeys("G")),
+	backspace: key.NewBinding(key.WithKeys("backspace")),
+}
+
+var modelSelectorKeys = struct {
+	cancel    key.Binding
+	tab1      key.Binding
+	tab2      key.Binding
+	tab3      key.Binding
+	tab4      key.Binding
+	search    key.Binding
+	enter     key.Binding
+	navUp     key.Binding
+	navDown   key.Binding
+	escape    key.Binding
+	backspace key.Binding
+}{
+	cancel:    key.NewBinding(key.WithKeys("ctrl+c")),
+	tab1:      key.NewBinding(key.WithKeys("1")),
+	tab2:      key.NewBinding(key.WithKeys("2")),
+	tab3:      key.NewBinding(key.WithKeys("3")),
+	tab4:      key.NewBinding(key.WithKeys("4")),
+	search:    key.NewBinding(key.WithKeys("/")),
+	enter:     key.NewBinding(key.WithKeys("enter")),
+	navUp:     key.NewBinding(key.WithKeys("up")),
+	navDown:   key.NewBinding(key.WithKeys("down")),
+	escape:    key.NewBinding(key.WithKeys("esc")),
+	backspace: key.NewBinding(key.WithKeys("backspace")),
+}
+
+var conversationSelectorKeys = struct {
+	cancel    key.Binding
+	enter     key.Binding
+	search    key.Binding
+	delete    key.Binding
+	backspace key.Binding
+	confirm   key.Binding
+	deny      key.Binding
+}{
+	cancel:    key.NewBinding(key.WithKeys("ctrl+c", "esc")),
+	enter:     key.NewBinding(key.WithKeys("enter", " ")),
+	search:    key.NewBinding(key.WithKeys("/")),
+	delete:    key.NewBinding(key.WithKeys("d", "delete")),
+	backspace: key.NewBinding(key.WithKeys("backspace")),
+	confirm:   key.NewBinding(key.WithKeys("y", "Y")),
+	deny:      key.NewBinding(key.WithKeys("n", "N", "esc")),
+}
+
+var helpViewKeys = struct {
+	dismiss key.Binding
+	navUp   key.Binding
+	navDown key.Binding
+	pgUp    key.Binding
+	pgDown  key.Binding
+	top     key.Binding
+	bottom  key.Binding
+}{
+	dismiss: key.NewBinding(key.WithKeys("esc", "q", "ctrl+c")),
+	navUp:   key.NewBinding(key.WithKeys("up", "k")),
+	navDown: key.NewBinding(key.WithKeys("down", "j")),
+	pgUp:    key.NewBinding(key.WithKeys("pgup", "b")),
+	pgDown:  key.NewBinding(key.WithKeys("pgdown", "f", " ")),
+	top:     key.NewBinding(key.WithKeys("home", "g")),
+	bottom:  key.NewBinding(key.WithKeys("end", "G")),
+}
+
+// listViewKeys is shared by a2a_agents, tools, and theme selection views.
+var listViewKeys = struct {
+	cancel    key.Binding
+	esc       key.Binding
+	selectKey key.Binding
+}{
+	cancel:    key.NewBinding(key.WithKeys("ctrl+c")),
+	esc:       key.NewBinding(key.WithKeys("esc")),
+	selectKey: key.NewBinding(key.WithKeys("enter", " ")),
+}
+
+var fileSelectionKeys = struct {
+	navUp     key.Binding
+	navDown   key.Binding
+	selectKey key.Binding
+	backspace key.Binding
+	cancel    key.Binding
+}{
+	navUp:     key.NewBinding(key.WithKeys("up")),
+	navDown:   key.NewBinding(key.WithKeys("down")),
+	selectKey: key.NewBinding(key.WithKeys("enter", "return")),
+	backspace: key.NewBinding(key.WithKeys("backspace")),
+	cancel:    key.NewBinding(key.WithKeys("esc")),
+}
+
+// fileExplorerFindKeys drives the find-in-tree text-input sub-mode of the file
+// explorer. These are inherent text-entry keys (not user-remappable); the
+// switch only catches control keys  and lets printable characters fall
+// through to the query buffer.
+var fileExplorerFindKeys = struct {
+	cancel    key.Binding
+	escape    key.Binding
+	navUp     key.Binding
+	navDown   key.Binding
+	enter     key.Binding
+	backspace key.Binding
+}{
+	cancel:    key.NewBinding(key.WithKeys("ctrl+c")),
+	escape:    key.NewBinding(key.WithKeys("esc")),
+	navUp:     key.NewBinding(key.WithKeys("up")),
+	navDown:   key.NewBinding(key.WithKeys("down")),
+	enter:     key.NewBinding(key.WithKeys("enter")),
+	backspace: key.NewBinding(key.WithKeys("backspace")),
+}
+
+// fileExplorerAnnotateKeys drives the inline annotation text-input sub-mode.
+var fileExplorerAnnotateKeys = struct {
+	cancel    key.Binding
+	escape    key.Binding
+	enter     key.Binding
+	backspace key.Binding
+}{
+	cancel:    key.NewBinding(key.WithKeys("ctrl+c")),
+	escape:    key.NewBinding(key.WithKeys("esc")),
+	enter:     key.NewBinding(key.WithKeys("enter")),
+	backspace: key.NewBinding(key.WithKeys("backspace")),
+}
+
+var inputViewKeys = struct {
+	tab        key.Binding
+	navUp      key.Binding
+	navDown    key.Binding
+	navigation []key.Binding
+}{
+	tab:     key.NewBinding(key.WithKeys("tab")),
+	navUp:   key.NewBinding(key.WithKeys("up")),
+	navDown: key.NewBinding(key.WithKeys("down")),
+	navigation: []key.Binding{
+		key.NewBinding(key.WithKeys("up")),
+		key.NewBinding(key.WithKeys("down")),
+		key.NewBinding(key.WithKeys("left")),
+		key.NewBinding(key.WithKeys("right")),
+		key.NewBinding(key.WithKeys("ctrl+a")),
+		key.NewBinding(key.WithKeys("ctrl+e")),
+		key.NewBinding(key.WithKeys("home")),
+		key.NewBinding(key.WithKeys("end")),
+	},
+}

--- a/internal/ui/components/conversation_selection_view.go
+++ b/internal/ui/components/conversation_selection_view.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	key "charm.land/bubbles/v2/key"
 	spinner "charm.land/bubbles/v2/spinner"
 	table "charm.land/bubbles/v2/table"
 	tea "charm.land/bubbletea/v2"
@@ -215,25 +216,25 @@ func (c *ConversationSelectorImpl) handleKeyInput(msg tea.KeyPressMsg) (tea.Mode
 		return c.handleDeleteConfirmation(msg)
 	}
 
-	switch msg.String() {
-	case "ctrl+c", "esc":
+	switch {
+	case key.Matches(msg, conversationSelectorKeys.cancel):
 		if c.searchMode {
 			return c.handleSearchClear()
 		}
 		return c.handleCancel()
-	case "enter", " ":
+	case key.Matches(msg, conversationSelectorKeys.enter):
 		return c.handleSelection()
-	case "d", "delete":
+	case key.Matches(msg, conversationSelectorKeys.delete):
 		if !c.searchMode && len(c.filteredConversations) > 0 {
 			return c.handleDeleteRequest()
 		}
 		return c, nil
-	case "/":
+	case key.Matches(msg, conversationSelectorKeys.search):
 		if !c.searchMode {
 			return c.handleSearchToggle()
 		}
 		return c.handleCharacterInput(msg)
-	case "backspace":
+	case key.Matches(msg, conversationSelectorKeys.backspace):
 		return c.handleBackspace()
 	default:
 		if c.searchMode {
@@ -359,10 +360,10 @@ func (c *ConversationSelectorImpl) handleDeleteRequest() (tea.Model, tea.Cmd) {
 }
 
 func (c *ConversationSelectorImpl) handleDeleteConfirmation(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "y", "Y":
+	switch {
+	case key.Matches(msg, conversationSelectorKeys.confirm):
 		return c.performDelete()
-	case "n", "N", "esc":
+	case key.Matches(msg, conversationSelectorKeys.deny):
 		c.confirmDelete = false
 		c.deleteError = nil
 		return c, nil

--- a/internal/ui/components/diff_viewer.go
+++ b/internal/ui/components/diff_viewer.go
@@ -3,9 +3,9 @@ package components
 import (
 	"fmt"
 	"path/filepath"
-	"slices"
 	"strings"
 
+	key "charm.land/bubbles/v2/key"
 	viewport "charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 
@@ -59,13 +59,13 @@ const (
 // diffKeymap resolves pressed keys to configurable diff-panel action IDs and
 // exposes each action's primary key for footer hints.
 type diffKeymap struct {
-	keys map[string][]string // actionID -> effective keys
+	bindings map[string]key.Binding // actionID -> key.Binding
 }
 
-// match returns the first of the candidate action IDs bound to the pressed key.
-func (k diffKeymap) match(pressed string, candidates ...string) string {
+// matches returns the first of the candidate action IDs matching the pressed key.
+func (k diffKeymap) matches(msg tea.KeyPressMsg, candidates ...string) string {
 	for _, id := range candidates {
-		if slices.Contains(k.keys[id], pressed) {
+		if b, ok := k.bindings[id]; ok && key.Matches(msg, b) {
 			return id
 		}
 	}
@@ -74,18 +74,10 @@ func (k diffKeymap) match(pressed string, candidates ...string) string {
 
 // display returns the primary (first) key bound to an action, for hint text.
 func (k diffKeymap) display(actionID string) string {
-	if ks := k.keys[actionID]; len(ks) > 0 {
-		return ks[0]
+	if b, ok := k.bindings[actionID]; ok {
+		return b.Help().Key
 	}
 	return ""
-}
-
-// normalizeKey maps the raw space key (" ") to the "space" token used in config.
-func normalizeKey(s string) string {
-	if s == " " {
-		return "space"
-	}
-	return s
 }
 
 // rowKind classifies a visible row in the changes tree.
@@ -211,7 +203,7 @@ func NewDiffViewer(source gitdiff.Source, styleProvider *styles.Provider, themeS
 		styleProvider:  styleProvider,
 		themeService:   themeService,
 		diffRenderer:   NewDiffRenderer(styleProvider),
-		keymap:         diffKeymap{keys: config.ResolveNamespaceBindings(kb, config.NamespaceDiffViewer)},
+		keymap:         newDiffKeymap(kb, config.NamespaceDiffViewer),
 		collapsed:      make(map[string]bool),
 		viewport:       vp,
 		loading:        true,
@@ -312,6 +304,22 @@ func isMutatingAction(action string) bool {
 
 func (t *DiffViewerImpl) IsDone() bool      { return t.done }
 func (t *DiffViewerImpl) IsCancelled() bool { return t.cancel }
+
+// newDiffKeymap builds a diffKeymap from the config namespace bindings, wrapping
+// each action's key strings into a key.Binding.
+func newDiffKeymap(kb config.KeybindingsConfig, namespace config.KeyNamespace) diffKeymap {
+	raw := config.ResolveNamespaceBindings(kb, namespace)
+	bindings := make(map[string]key.Binding, len(raw))
+	for id, keys := range raw {
+		opts := []key.BindingOpt{key.WithKeys(keys...)}
+		if len(keys) > 0 {
+			// primary key drives footer hints via display()/Help().Key
+			opts = append(opts, key.WithHelp(keys[0], ""))
+		}
+		bindings[id] = key.NewBinding(opts...)
+	}
+	return diffKeymap{bindings: bindings}
+}
 
 // HintText returns the footer hint for the current mode (tree vs patch).
 func (t *DiffViewerImpl) HintText() string {
@@ -447,18 +455,17 @@ func (t *DiffViewerImpl) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if t.patchMode {
 		return t.handlePatchKey(msg)
 	}
-	pressed := normalizeKey(msg.String())
 	if t.confirmDiscard != nil {
-		return t.handleDiscardConfirm(pressed)
+		return t.handleDiscardConfirm(msg)
 	}
-	if pressed == "ctrl+c" {
+	if key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))) {
 		t.cancel = true
 		return t, nil
 	}
-	if pressed == "ctrl+r" {
+	if key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+r"))) {
 		return t, t.loadCmd()
 	}
-	matched := t.keymap.match(pressed,
+	matched := t.keymap.matches(msg,
 		actDiffNavUp, actDiffNavDown, actDiffToggle, actDiffExpand, actDiffCollapse,
 		actDiffStage, actDiffUnstage, actDiffStageAll, actDiffUnstageAll,
 		actDiffDiscard, actDiffPatch, actDiffEdit, actDiffCommit, actDiffSwitchTab,
@@ -624,11 +631,11 @@ func (t *DiffViewerImpl) discardCmd(fc gitdiff.FileChange) tea.Cmd {
 
 // handleDiscardConfirm resolves the pending discard confirmation: `y` discards
 // the file's working-tree changes; any other key cancels.
-func (t *DiffViewerImpl) handleDiscardConfirm(key string) (tea.Model, tea.Cmd) {
+func (t *DiffViewerImpl) handleDiscardConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	fc := t.confirmDiscard
 	t.confirmDiscard = nil
 	t.dirtyDiff = true
-	if key == "y" && fc != nil {
+	if key.Matches(msg, key.NewBinding(key.WithKeys("y"))) && fc != nil {
 		return t, t.discardCmd(*fc)
 	}
 	return t, nil
@@ -699,7 +706,7 @@ func (t *DiffViewerImpl) updateEditor(msg tea.Msg) (tea.Model, tea.Cmd) {
 // [ / ] jump hunks; esc clears a selection or exits. New-action candidates are
 // listed before apply so they win any shared key.
 func (t *DiffViewerImpl) handlePatchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch t.keymap.match(normalizeKey(msg.String()),
+	switch t.keymap.matches(msg,
 		actDiffCancel, actDiffNavUp, actDiffNavDown,
 		actDiffPatchSelect, actDiffPatchSplit, actDiffHunkPrev, actDiffHunkNext,
 		actDiffPatchApply, actDiffScrollUp, actDiffScrollDown, actDiffHalfUp, actDiffHalfDown) {

--- a/internal/ui/components/diff_viewer_test.go
+++ b/internal/ui/components/diff_viewer_test.go
@@ -583,7 +583,7 @@ func TestDiffViewer_EditKeyBound(t *testing.T) {
 		diffs:    map[string][2]string{},
 	}
 	v := newTestDiffViewer(src)
-	if v.keymap.match("v", actDiffEdit) != actDiffEdit {
+	if v.keymap.matches(tea.KeyPressMsg{Code: 'v', Text: "v"}, actDiffEdit) != actDiffEdit {
 		t.Errorf("default 'v' should be bound to the diff-viewer edit action")
 	}
 }

--- a/internal/ui/components/file_explorer.go
+++ b/internal/ui/components/file_explorer.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	key "charm.land/bubbles/v2/key"
 	viewport "charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 
@@ -164,7 +165,7 @@ func NewFileExplorer(root string, styleProvider *styles.Provider, themeService d
 		root:          root,
 		styleProvider: styleProvider,
 		themeService:  themeService,
-		keymap:        diffKeymap{keys: config.ResolveNamespaceBindings(kb, config.NamespaceExplorer)},
+		keymap:        newDiffKeymap(kb, config.NamespaceExplorer),
 		children:      make(map[string][]explorerNode),
 		expanded:      make(map[string]bool),
 		viewport:      vp,
@@ -314,16 +315,15 @@ func (t *FileExplorerImpl) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if t.findMode {
 		return t.handleFindKey(msg)
 	}
-	pressed := normalizeKey(msg.String())
-	if pressed == "ctrl+c" { // universal escape; intentionally not remappable
+	if key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))) { // universal escape; intentionally not remappable
 		t.cancel = true
 		return t, nil
 	}
-	if pressed == "ctrl+r" { // manual refresh (replaces the deleted 1s poll)
+	if key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+r"))) { // manual refresh
 		t.refresh()
 		return t, nil
 	}
-	switch t.keymap.match(pressed,
+	switch t.keymap.matches(msg,
 		actExpNavUp, actExpNavDown, actExpToggle, actExpExpand, actExpCollapse,
 		actExpOpen, actExpFind, actExpToggleHidden, actExpSelect,
 		actExpScrollUp, actExpScrollDown, actExpHalfUp, actExpHalfDown, actExpCancel) {
@@ -497,23 +497,23 @@ func (t *FileExplorerImpl) exitFind() {
 }
 
 func (t *FileExplorerImpl) handleFindKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch normalizeKey(msg.String()) {
-	case "ctrl+c":
+	switch {
+	case key.Matches(msg, fileExplorerFindKeys.cancel):
 		t.cancel = true
 		return t, nil
-	case "esc":
+	case key.Matches(msg, fileExplorerFindKeys.escape):
 		t.exitFind()
 		return t, nil
-	case "up":
+	case key.Matches(msg, fileExplorerFindKeys.navUp):
 		t.findCursor = clampInt(t.findCursor-1, 0, max(len(t.filtered)-1, 0))
 		return t, nil
-	case "down":
+	case key.Matches(msg, fileExplorerFindKeys.navDown):
 		t.findCursor = clampInt(t.findCursor+1, 0, max(len(t.filtered)-1, 0))
 		return t, nil
-	case "enter":
+	case key.Matches(msg, fileExplorerFindKeys.enter):
 		t.acceptFind()
 		return t, nil
-	case "backspace":
+	case key.Matches(msg, fileExplorerFindKeys.backspace):
 		if r := []rune(t.findQuery); len(r) > 0 {
 			t.findQuery = string(r[:len(r)-1])
 			t.applyFilter()
@@ -667,18 +667,17 @@ func (t *FileExplorerImpl) movePreviewCursor(delta int) {
 }
 
 func (t *FileExplorerImpl) handleSelectKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	pressed := normalizeKey(msg.String())
-	if pressed == "ctrl+c" { // universal escape; intentionally not remappable
+	if key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+c"))) { // universal escape; intentionally not remappable
 		t.cancel = true
 		return t, nil
 	}
-	switch t.keymap.match(pressed,
+	switch t.keymap.matches(msg,
 		actExpNavUp, actExpNavDown, actExpToggleSelect, actExpAnnotate,
 		actExpSubmit, actExpCancel) {
 	case actExpCancel:
 		// esc exits select mode (preserving selections); q (or any other cancel
 		// binding) closes the explorer, carrying captured selections to chat.
-		if pressed == "esc" {
+		if key.Matches(msg, key.NewBinding(key.WithKeys("esc"))) {
 			t.exitSelectMode()
 		} else {
 			t.done = true
@@ -712,18 +711,18 @@ func (t *FileExplorerImpl) handleSelectKey(msg tea.KeyPressMsg) (tea.Model, tea.
 // (storing the selection), esc cancels (keeping the anchor so the user can
 // retry). Mirrors handleFindKey's typing model.
 func (t *FileExplorerImpl) handleAnnotateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch normalizeKey(msg.String()) {
-	case "ctrl+c":
+	switch {
+	case key.Matches(msg, fileExplorerAnnotateKeys.cancel):
 		t.cancel = true
 		return t, nil
-	case "esc":
+	case key.Matches(msg, fileExplorerAnnotateKeys.escape):
 		t.annotateMode = false
 		t.annotateInput = ""
 		return t, nil
-	case "enter":
+	case key.Matches(msg, fileExplorerAnnotateKeys.enter):
 		t.confirmAnnotation()
 		return t, nil
-	case "backspace":
+	case key.Matches(msg, fileExplorerAnnotateKeys.backspace):
 		if r := []rune(t.annotateInput); len(r) > 0 {
 			t.annotateInput = string(r[:len(r)-1])
 		}

--- a/internal/ui/components/file_selection_handler.go
+++ b/internal/ui/components/file_selection_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	key "charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -32,32 +33,32 @@ func (h *FileSelectionHandler) HandleKeyEvent(
 ) (newSearchQuery string, newSelectedIndex int, action FileSelectionAction, selectedFile string) {
 	filteredFiles := h.filterFiles(files, searchQuery)
 
-	switch keyMsg.String() {
-	case "up":
+	switch {
+	case key.Matches(keyMsg, fileSelectionKeys.navUp):
 		if selectedIndex > 0 {
 			return searchQuery, selectedIndex - 1, FileSelectionActionNone, ""
 		}
 		return searchQuery, selectedIndex, FileSelectionActionNone, ""
 
-	case "down":
+	case key.Matches(keyMsg, fileSelectionKeys.navDown):
 		if selectedIndex < len(filteredFiles)-1 {
 			return searchQuery, selectedIndex + 1, FileSelectionActionNone, ""
 		}
 		return searchQuery, selectedIndex, FileSelectionActionNone, ""
 
-	case "enter", "return":
+	case key.Matches(keyMsg, fileSelectionKeys.selectKey):
 		if len(filteredFiles) > 0 && selectedIndex >= 0 && selectedIndex < len(filteredFiles) {
 			return searchQuery, selectedIndex, FileSelectionActionSelect, filteredFiles[selectedIndex]
 		}
 		return searchQuery, selectedIndex, FileSelectionActionNone, ""
 
-	case "backspace":
+	case key.Matches(keyMsg, fileSelectionKeys.backspace):
 		if len(searchQuery) > 0 {
 			return searchQuery[:len(searchQuery)-1], selectedIndex, FileSelectionActionNone, ""
 		}
 		return searchQuery, selectedIndex, FileSelectionActionNone, ""
 
-	case "esc":
+	case key.Matches(keyMsg, fileSelectionKeys.cancel):
 		return searchQuery, selectedIndex, FileSelectionActionCancel, ""
 
 	default:

--- a/internal/ui/components/help_bar.go
+++ b/internal/ui/components/help_bar.go
@@ -10,7 +10,6 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
-	ui "github.com/inference-gateway/cli/internal/ui"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
@@ -18,7 +17,7 @@ import (
 type HelpBar struct {
 	enabled       bool
 	width         int
-	shortcuts     []ui.KeyShortcut
+	shortcuts     []key.Binding
 	styleProvider *styles.Provider
 	help          help.Model
 
@@ -30,21 +29,21 @@ func NewHelpBar(styleProvider *styles.Provider) *HelpBar {
 	return &HelpBar{
 		enabled:       false,
 		width:         80,
-		shortcuts:     make([]ui.KeyShortcut, 0),
+		shortcuts:     make([]key.Binding, 0),
 		styleProvider: styleProvider,
 		help:          help.New(),
 	}
 }
 
-func (hb *HelpBar) SetShortcuts(shortcuts []ui.KeyShortcut) {
-	sortedShortcuts := make([]ui.KeyShortcut, len(shortcuts))
+func (hb *HelpBar) SetShortcuts(shortcuts []key.Binding) {
+	sortedShortcuts := make([]key.Binding, len(shortcuts))
 	copy(sortedShortcuts, shortcuts)
 
-	slices.SortFunc(sortedShortcuts, func(a, b ui.KeyShortcut) int {
-		if c := cmp.Compare(a.Key, b.Key); c != 0 {
+	slices.SortFunc(sortedShortcuts, func(a, b key.Binding) int {
+		if c := cmp.Compare(a.Help().Key, b.Help().Key); c != 0 {
 			return c
 		}
-		return cmp.Compare(a.Description, b.Description)
+		return cmp.Compare(a.Help().Desc, b.Help().Desc)
 	})
 
 	hb.shortcuts = sortedShortcuts
@@ -97,16 +96,10 @@ func (hb *HelpBar) refreshStyles() {
 	hb.help.Styles.FullSeparator = lipgloss.NewStyle().Foreground(dimColor)
 }
 
-// helpColumns converts the sorted shortcuts into key.Binding columns laid out
-// column-major, so each column reads top to bottom.
+// helpColumns returns the sorted bindings as column-major groups, so each
+// column reads top to bottom.
 func (hb *HelpBar) helpColumns() [][]key.Binding {
-	bindings := make([]key.Binding, 0, len(hb.shortcuts))
-	for _, s := range hb.shortcuts {
-		bindings = append(bindings, key.NewBinding(
-			key.WithKeys(s.Key),
-			key.WithHelp(s.Key, s.Description),
-		))
-	}
+	bindings := hb.shortcuts
 
 	cols := hb.columnCount()
 	rowsPerCol := (len(bindings) + cols - 1) / cols

--- a/internal/ui/components/help_bar_test.go
+++ b/internal/ui/components/help_bar_test.go
@@ -4,12 +4,18 @@ import (
 	"strings"
 	"testing"
 
+	key "charm.land/bubbles/v2/key"
+
 	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 
-	ui "github.com/inference-gateway/cli/internal/ui"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
+
+// kb builds a key.Binding with a help key/description for help-bar tests.
+func kb(k, desc string) key.Binding {
+	return key.NewBinding(key.WithKeys(k), key.WithHelp(k, desc))
+}
 
 // createMockStyleProviderForHelpBar creates a mock styles provider for testing
 func createMockStyleProviderForHelpBar() *styles.Provider {
@@ -38,10 +44,10 @@ func TestNewHelpBar(t *testing.T) {
 func TestHelpBar_SetShortcuts(t *testing.T) {
 	hb := NewHelpBar(createMockStyleProviderForHelpBar())
 
-	shortcuts := []ui.KeyShortcut{
-		{Key: "Enter", Description: "Send message"},
-		{Key: "Ctrl+C", Description: "Cancel"},
-		{Key: "↑↓", Description: "History"},
+	shortcuts := []key.Binding{
+		kb("Enter", "Send message"),
+		kb("Ctrl+C", "Cancel"),
+		kb("↑↓", "History"),
 	}
 
 	hb.SetShortcuts(shortcuts)
@@ -50,16 +56,16 @@ func TestHelpBar_SetShortcuts(t *testing.T) {
 		t.Errorf("Expected 3 shortcuts, got %d", len(hb.shortcuts))
 	}
 
-	if hb.shortcuts[0].Key != "Ctrl+C" {
-		t.Errorf("Expected first shortcut key 'Ctrl+C', got '%s'", hb.shortcuts[0].Key)
+	if got := hb.shortcuts[0].Help().Key; got != "Ctrl+C" {
+		t.Errorf("Expected first shortcut key 'Ctrl+C', got '%s'", got)
 	}
 
-	if hb.shortcuts[0].Description != "Cancel" {
-		t.Errorf("Expected first shortcut description 'Cancel', got '%s'", hb.shortcuts[0].Description)
+	if got := hb.shortcuts[0].Help().Desc; got != "Cancel" {
+		t.Errorf("Expected first shortcut description 'Cancel', got '%s'", got)
 	}
 
-	if hb.shortcuts[1].Key != "Enter" {
-		t.Errorf("Expected second shortcut key 'Enter', got '%s'", hb.shortcuts[1].Key)
+	if got := hb.shortcuts[1].Help().Key; got != "Enter" {
+		t.Errorf("Expected second shortcut key 'Enter', got '%s'", got)
 	}
 }
 
@@ -131,10 +137,10 @@ func TestHelpBar_Render_WithShortcuts(t *testing.T) {
 	hb := NewHelpBar(styleProvider)
 	hb.SetEnabled(true)
 
-	shortcuts := []ui.KeyShortcut{
-		{Key: "Enter", Description: "Send"},
-		{Key: "Ctrl+C", Description: "Cancel"},
-		{Key: "?", Description: "Help"},
+	shortcuts := []key.Binding{
+		kb("Enter", "Send"),
+		kb("Ctrl+C", "Cancel"),
+		kb("?", "Help"),
 	}
 
 	hb.SetShortcuts(shortcuts)
@@ -162,9 +168,9 @@ func TestHelpBar_Render_LongShortcuts(t *testing.T) {
 	hb.SetEnabled(true)
 	hb.SetWidth(20)
 
-	shortcuts := []ui.KeyShortcut{
-		{Key: "Ctrl+Shift+Alt+D", Description: "Very long description that should be truncated"},
-		{Key: "F1", Description: "Short"},
+	shortcuts := []key.Binding{
+		kb("Ctrl+Shift+Alt+D", "Very long description that should be truncated"),
+		kb("F1", "Short"),
 	}
 
 	hb.SetShortcuts(shortcuts)
@@ -183,7 +189,7 @@ func TestHelpBar_Render_EmptyShortcuts(t *testing.T) {
 	hb := NewHelpBar(createMockStyleProviderForHelpBar())
 	hb.SetEnabled(true)
 
-	hb.SetShortcuts([]ui.KeyShortcut{})
+	hb.SetShortcuts([]key.Binding{})
 	output := hb.Render()
 
 	if output != "" {
@@ -195,8 +201,8 @@ func TestHelpBar_Render_SingleShortcut(t *testing.T) {
 	hb := NewHelpBar(createMockStyleProviderForHelpBar())
 	hb.SetEnabled(true)
 
-	shortcuts := []ui.KeyShortcut{
-		{Key: "?", Description: "Help"},
+	shortcuts := []key.Binding{
+		kb("?", "Help"),
 	}
 
 	hb.SetShortcuts(shortcuts)

--- a/internal/ui/components/help_view.go
+++ b/internal/ui/components/help_view.go
@@ -4,6 +4,7 @@ import (
 	"image/color"
 	"strings"
 
+	key "charm.land/bubbles/v2/key"
 	viewport "charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
@@ -109,20 +110,20 @@ func (h *HelpViewImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (h *HelpViewImpl) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc", "q", "ctrl+c":
+	switch {
+	case key.Matches(msg, helpViewKeys.dismiss):
 		h.cancelled = true
-	case "up", "k":
+	case key.Matches(msg, helpViewKeys.navUp):
 		h.viewport.ScrollUp(1)
-	case "down", "j":
+	case key.Matches(msg, helpViewKeys.navDown):
 		h.viewport.ScrollDown(1)
-	case "pgup", "b":
+	case key.Matches(msg, helpViewKeys.pgUp):
 		h.viewport.PageUp()
-	case "pgdown", "f", " ":
+	case key.Matches(msg, helpViewKeys.pgDown):
 		h.viewport.PageDown()
-	case "home", "g":
+	case key.Matches(msg, helpViewKeys.top):
 		h.viewport.GotoTop()
-	case "end", "G":
+	case key.Matches(msg, helpViewKeys.bottom):
 		h.viewport.GotoBottom()
 	default:
 		var cmd tea.Cmd

--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -857,21 +857,19 @@ func (iv *InputView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return iv, cmd
 }
 
-func (iv *InputView) HandleKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	keyStr := key.String()
-
-	if keyStr == "tab" {
+func (iv *InputView) HandleKey(k tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if key.Matches(k, inputViewKeys.tab) {
 		if iv.HasHistorySuggestion() && iv.GetCursor() == len(iv.ta.Value()) {
 			iv.cycleHistorySuggestion()
 			return iv, nil
 		}
 	}
 
-	switch keyStr {
-	case "up":
+	switch {
+	case key.Matches(k, inputViewKeys.navUp):
 		iv.navigateHistoryUp()
 		return iv, nil
-	case "down":
+	case key.Matches(k, inputViewKeys.navDown):
 		if !iv.IsNavigatingHistory() {
 			return iv, func() tea.Msg { return domain.FocusStatusBarEvent{} }
 		}
@@ -879,12 +877,32 @@ func (iv *InputView) HandleKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return iv, nil
 	}
 
-	if keyStr != "up" && keyStr != "down" && keyStr != "left" && keyStr != "right" &&
-		keyStr != "ctrl+a" && keyStr != "ctrl+e" && keyStr != "home" && keyStr != "end" {
+	if !key.Matches(k, inputViewKeys.navUp) &&
+		!key.Matches(k, inputViewKeys.navDown) &&
+		!isNavigationKey(k) {
 		iv.historyManager.ResetNavigation()
 	}
 
 	return iv, nil
+}
+
+// isNavigationKey reports whether the key is a cursor-movement key that should not
+// reset history navigation.
+func isNavigationKey(msg tea.KeyPressMsg) bool {
+	navigationKeys := []key.Binding{
+		key.NewBinding(key.WithKeys("left")),
+		key.NewBinding(key.WithKeys("right")),
+		key.NewBinding(key.WithKeys("ctrl+a")),
+		key.NewBinding(key.WithKeys("ctrl+e")),
+		key.NewBinding(key.WithKeys("home")),
+		key.NewBinding(key.WithKeys("end")),
+	}
+	for _, b := range navigationKeys {
+		if key.Matches(msg, b) {
+			return true
+		}
+	}
+	return false
 }
 
 func (iv *InputView) CanHandle(key tea.KeyPressMsg) bool {

--- a/internal/ui/components/input_view.go
+++ b/internal/ui/components/input_view.go
@@ -877,9 +877,9 @@ func (iv *InputView) HandleKey(k tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return iv, nil
 	}
 
-	if !key.Matches(k, inputViewKeys.navUp) &&
-		!key.Matches(k, inputViewKeys.navDown) &&
-		!isNavigationKey(k) {
+	// navUp/navDown already returned above; only cursor-movement keys should
+	// preserve history navigation, everything else resets it.
+	if !isNavigationKey(k) {
 		iv.historyManager.ResetNavigation()
 	}
 
@@ -889,20 +889,7 @@ func (iv *InputView) HandleKey(k tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // isNavigationKey reports whether the key is a cursor-movement key that should not
 // reset history navigation.
 func isNavigationKey(msg tea.KeyPressMsg) bool {
-	navigationKeys := []key.Binding{
-		key.NewBinding(key.WithKeys("left")),
-		key.NewBinding(key.WithKeys("right")),
-		key.NewBinding(key.WithKeys("ctrl+a")),
-		key.NewBinding(key.WithKeys("ctrl+e")),
-		key.NewBinding(key.WithKeys("home")),
-		key.NewBinding(key.WithKeys("end")),
-	}
-	for _, b := range navigationKeys {
-		if key.Matches(msg, b) {
-			return true
-		}
-	}
-	return false
+	return key.Matches(msg, inputViewKeys.navigation...)
 }
 
 func (iv *InputView) CanHandle(key tea.KeyPressMsg) bool {

--- a/internal/ui/components/model_selection_view.go
+++ b/internal/ui/components/model_selection_view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	key "charm.land/bubbles/v2/key"
 	textinput "charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	huh "charm.land/huh/v2"
@@ -137,7 +138,7 @@ func (m *ModelSelectorImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.buildForm()
 		return m, nil
 	case tea.KeyPressMsg:
-		if msg.String() == "ctrl+c" {
+		if key.Matches(msg, modelSelectorKeys.cancel) {
 			m.cancelled = true
 			m.done = true
 			return m, tea.Quit
@@ -145,11 +146,20 @@ func (m *ModelSelectorImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.searchMode {
 			return m, m.handleSearchKey(msg)
 		}
-		switch msg.String() {
-		case "1", "2", "3", "4":
-			m.handleViewSwitch(msg.String())
+		switch {
+		case key.Matches(msg, modelSelectorKeys.tab1):
+			m.handleViewSwitch("1")
 			return m, nil
-		case "/":
+		case key.Matches(msg, modelSelectorKeys.tab2):
+			m.handleViewSwitch("2")
+			return m, nil
+		case key.Matches(msg, modelSelectorKeys.tab3):
+			m.handleViewSwitch("3")
+			return m, nil
+		case key.Matches(msg, modelSelectorKeys.tab4):
+			m.handleViewSwitch("4")
+			return m, nil
+		case key.Matches(msg, modelSelectorKeys.search):
 			m.searchMode = true
 			return m, m.search.Focus()
 		}
@@ -162,8 +172,8 @@ func (m *ModelSelectorImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // and selection still reach the list, esc clears the search, and everything
 // else edits the query (rebuilding the option set on change).
 func (m *ModelSelectorImpl) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
-	switch msg.String() {
-	case "esc":
+	switch {
+	case key.Matches(msg, modelSelectorKeys.escape):
 		m.searchMode = false
 		m.search.Blur()
 		if m.search.Value() != "" {
@@ -171,7 +181,9 @@ func (m *ModelSelectorImpl) handleSearchKey(msg tea.KeyPressMsg) tea.Cmd {
 			m.buildForm()
 		}
 		return nil
-	case "enter", "up", "down":
+	case key.Matches(msg, modelSelectorKeys.enter),
+		key.Matches(msg, modelSelectorKeys.navUp),
+		key.Matches(msg, modelSelectorKeys.navDown):
 		return m.forwardToForm(msg)
 	}
 

--- a/internal/ui/components/task_management_view.go
+++ b/internal/ui/components/task_management_view.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	key "charm.land/bubbles/v2/key"
 	spinner "charm.land/bubbles/v2/spinner"
 	viewport "charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
@@ -378,34 +379,34 @@ func (t *TaskManagerImpl) handleKeyInput(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		return t.handleSearchInput(msg)
 	}
 
-	switch msg.String() {
-	case "q", "esc", "ctrl+c":
+	switch {
+	case key.Matches(msg, taskManagerKeys.quit):
 		t.cancelled = true
 		return t, nil
 
-	case "enter":
+	case key.Matches(msg, taskManagerKeys.enter):
 		if len(t.filteredTasks) > 0 && t.selected < len(t.filteredTasks) {
 			t.showInfo = true
 			return t, nil
 		}
 
-	case "up", "k":
+	case key.Matches(msg, taskManagerKeys.navUp):
 		if t.selected > 0 {
 			t.selected--
 		}
 
-	case "down", "j":
+	case key.Matches(msg, taskManagerKeys.navDown):
 		if t.selected < len(t.filteredTasks)-1 {
 			t.selected++
 		}
 
-	case "i":
+	case key.Matches(msg, taskManagerKeys.info):
 		if len(t.filteredTasks) > 0 && t.selected < len(t.filteredTasks) {
 			t.showInfo = true
 			return t, nil
 		}
 
-	case "c":
+	case key.Matches(msg, taskManagerKeys.cancel):
 		if len(t.filteredTasks) > 0 && t.selected < len(t.filteredTasks) {
 			task := t.filteredTasks[t.selected]
 			if isCancellable(task) {
@@ -414,12 +415,24 @@ func (t *TaskManagerImpl) handleKeyInput(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			}
 		}
 
-	case "/":
+	case key.Matches(msg, taskManagerKeys.search):
 		t.searchMode = true
 		return t, nil
 
-	case "1", "2", "3", "4", "5":
-		t.handleViewSwitch(msg.String())
+	case key.Matches(msg, taskManagerKeys.tab1):
+		t.handleViewSwitch("1")
+		return t, nil
+	case key.Matches(msg, taskManagerKeys.tab2):
+		t.handleViewSwitch("2")
+		return t, nil
+	case key.Matches(msg, taskManagerKeys.tab3):
+		t.handleViewSwitch("3")
+		return t, nil
+	case key.Matches(msg, taskManagerKeys.tab4):
+		t.handleViewSwitch("4")
+		return t, nil
+	case key.Matches(msg, taskManagerKeys.tab5):
+		t.handleViewSwitch("5")
 		return t, nil
 
 	}
@@ -444,15 +457,15 @@ func (t *TaskManagerImpl) handleViewSwitch(key string) {
 }
 
 func (t *TaskManagerImpl) handleCancelConfirmation(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "y", "Y":
+	switch {
+	case key.Matches(msg, taskManagerKeys.confirm):
 		t.confirmCancel = false
 		if t.selected < len(t.filteredTasks) {
 			task := t.filteredTasks[t.selected]
 			return t, t.cancelTaskCmd(task)
 		}
 
-	case "n", "N", "esc":
+	case key.Matches(msg, taskManagerKeys.deny):
 		t.confirmCancel = false
 	}
 
@@ -462,21 +475,21 @@ func (t *TaskManagerImpl) handleCancelConfirmation(msg tea.KeyPressMsg) (tea.Mod
 func (t *TaskManagerImpl) handleInfoView(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg.String() {
-	case "q", "esc", "i", "ctrl+c":
+	switch {
+	case key.Matches(msg, taskManagerKeys.close):
 		t.showInfo = false
 		return t, nil
-	case "up", "k":
+	case key.Matches(msg, taskManagerKeys.navUp):
 		t.infoViewport.ScrollUp(1)
-	case "down", "j":
+	case key.Matches(msg, taskManagerKeys.navDown):
 		t.infoViewport.ScrollDown(1)
-	case "pgup", "b":
+	case key.Matches(msg, taskManagerKeys.pgUp):
 		t.infoViewport.PageUp()
-	case "pgdown", "f", " ":
+	case key.Matches(msg, taskManagerKeys.pgDown):
 		t.infoViewport.PageDown()
-	case "g":
+	case key.Matches(msg, taskManagerKeys.top):
 		t.infoViewport.GotoTop()
-	case "G":
+	case key.Matches(msg, taskManagerKeys.bottom):
 		t.infoViewport.GotoBottom()
 	default:
 		t.infoViewport, cmd = t.infoViewport.Update(msg)
@@ -486,25 +499,25 @@ func (t *TaskManagerImpl) handleInfoView(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 }
 
 func (t *TaskManagerImpl) handleSearchInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc":
+	switch {
+	case key.Matches(msg, taskManagerKeys.escape):
 		t.searchMode = false
 		t.searchQuery = ""
 		t.applyFilters()
 
-	case "enter":
+	case key.Matches(msg, taskManagerKeys.enter):
 		t.searchMode = false
 		t.applyFilters()
 
-	case "backspace":
+	case key.Matches(msg, taskManagerKeys.backspace):
 		if len(t.searchQuery) > 0 {
 			t.searchQuery = t.searchQuery[:len(t.searchQuery)-1]
 			t.applyFilters()
 		}
 
 	default:
-		if len(msg.String()) == 1 {
-			t.searchQuery += msg.String()
+		if k := msg.String(); len(k) == 1 {
+			t.searchQuery += k
 			t.applyFilters()
 		}
 	}

--- a/internal/ui/components/theme_selection_view.go
+++ b/internal/ui/components/theme_selection_view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	key "charm.land/bubbles/v2/key"
 	list "charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
@@ -154,17 +155,17 @@ func (m *ThemeSelectorImpl) handleKey(msg tea.KeyPressMsg) (handled bool, cmd te
 		return false, nil
 	}
 
-	switch msg.String() {
-	case "ctrl+c":
+	switch {
+	case key.Matches(msg, listViewKeys.cancel):
 		m.cancel()
 		return true, nil
-	case "esc":
+	case key.Matches(msg, listViewKeys.esc):
 		if m.list.FilterState() == list.FilterApplied {
 			return false, nil
 		}
 		m.cancel()
 		return true, nil
-	case "enter", " ":
+	case key.Matches(msg, listViewKeys.selectKey):
 		return true, m.selectTheme()
 	}
 	return false, nil

--- a/internal/ui/components/tools_view.go
+++ b/internal/ui/components/tools_view.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	key "charm.land/bubbles/v2/key"
 	list "charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
 	lipgloss "charm.land/lipgloss/v2"
@@ -202,17 +203,17 @@ func (m *ToolsViewImpl) handleKey(msg tea.KeyPressMsg) (handled bool, cmd tea.Cm
 		return false, nil
 	}
 
-	switch msg.String() {
-	case "ctrl+c":
+	switch {
+	case key.Matches(msg, listViewKeys.cancel):
 		m.cancelled = true
 		return true, nil
-	case "esc":
+	case key.Matches(msg, listViewKeys.esc):
 		if m.list.FilterState() == list.FilterApplied {
 			return false, nil
 		}
 		m.cancelled = true
 		return true, nil
-	case "enter", " ":
+	case key.Matches(msg, listViewKeys.selectKey):
 		return true, nil
 	}
 	return false, nil

--- a/internal/ui/interfaces.go
+++ b/internal/ui/interfaces.go
@@ -1,7 +1,9 @@
 package ui
 
 import (
+	key "charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+
 	domain "github.com/inference-gateway/cli/internal/domain"
 	colors "github.com/inference-gateway/cli/internal/ui/styles/colors"
 )
@@ -142,7 +144,7 @@ type InputStatusBarComponent interface {
 
 // HelpBarComponent interface for help bar
 type HelpBarComponent interface {
-	SetShortcuts(shortcuts []KeyShortcut)
+	SetShortcuts(shortcuts []key.Binding)
 	IsEnabled() bool
 	SetEnabled(enabled bool)
 	SetWidth(width int)

--- a/tests/mocks/ui/fake_help_bar_component.go
+++ b/tests/mocks/ui/fake_help_bar_component.go
@@ -4,6 +4,7 @@ package ui
 import (
 	"sync"
 
+	"charm.land/bubbles/v2/key"
 	"github.com/inference-gateway/cli/internal/ui"
 )
 
@@ -38,10 +39,10 @@ type FakeHelpBarComponent struct {
 	setHeightArgsForCall []struct {
 		arg1 int
 	}
-	SetShortcutsStub        func([]ui.KeyShortcut)
+	SetShortcutsStub        func([]key.Binding)
 	setShortcutsMutex       sync.RWMutex
 	setShortcutsArgsForCall []struct {
-		arg1 []ui.KeyShortcut
+		arg1 []key.Binding
 	}
 	SetWidthStub        func(int)
 	setWidthMutex       sync.RWMutex
@@ -222,15 +223,15 @@ func (fake *FakeHelpBarComponent) SetHeightArgsForCall(i int) int {
 	return argsForCall.arg1
 }
 
-func (fake *FakeHelpBarComponent) SetShortcuts(arg1 []ui.KeyShortcut) {
-	var arg1Copy []ui.KeyShortcut
+func (fake *FakeHelpBarComponent) SetShortcuts(arg1 []key.Binding) {
+	var arg1Copy []key.Binding
 	if arg1 != nil {
-		arg1Copy = make([]ui.KeyShortcut, len(arg1))
+		arg1Copy = make([]key.Binding, len(arg1))
 		copy(arg1Copy, arg1)
 	}
 	fake.setShortcutsMutex.Lock()
 	fake.setShortcutsArgsForCall = append(fake.setShortcutsArgsForCall, struct {
-		arg1 []ui.KeyShortcut
+		arg1 []key.Binding
 	}{arg1Copy})
 	stub := fake.SetShortcutsStub
 	fake.recordInvocation("SetShortcuts", []interface{}{arg1Copy})
@@ -246,13 +247,13 @@ func (fake *FakeHelpBarComponent) SetShortcutsCallCount() int {
 	return len(fake.setShortcutsArgsForCall)
 }
 
-func (fake *FakeHelpBarComponent) SetShortcutsCalls(stub func([]ui.KeyShortcut)) {
+func (fake *FakeHelpBarComponent) SetShortcutsCalls(stub func([]key.Binding)) {
 	fake.setShortcutsMutex.Lock()
 	defer fake.setShortcutsMutex.Unlock()
 	fake.SetShortcutsStub = stub
 }
 
-func (fake *FakeHelpBarComponent) SetShortcutsArgsForCall(i int) []ui.KeyShortcut {
+func (fake *FakeHelpBarComponent) SetShortcutsArgsForCall(i int) []key.Binding {
 	fake.setShortcutsMutex.RLock()
 	defer fake.setShortcutsMutex.RUnlock()
 	argsForCall := fake.setShortcutsArgsForCall[i]


### PR DESCRIPTION
## Summary

Migrates all per-view overlay components from raw `switch msg.String()` dispatch to centralized `key.Binding` sets using `switch { case key.Matches(msg, k.xxx): ... }`. Also switches the help bar from a custom `KeyShortcut` type to `[]key.Binding`.

Closes #853.

## Key Changes

- **New file:** `internal/ui/components/components_keymap.go` — centralized `key.Binding` sets for all overlay components (task manager, model selector, conversation selector, help view, diff viewer, file explorer, file selection, input view, a2a agents, tools, theme selection, plus find/annotate sub-modes)
- **Removed:** custom `KeyShortcut` type from `internal/ui/interfaces.go`, `normalizeKey` helper from `file_explorer.go`
- **HelpBar:** `SetShortcuts([]key.Binding)` instead of `SetShortcuts([]KeyShortcut)`; consumes bindings directly instead of re-wrapping at render time
- **diff_viewer/file_explorer:** retain `keybindings.yaml` remappability via `newDiffKeymap` wrapping `config.ResolveNamespaceBindings`

## Acceptance Criteria (from #853)

- [x] All listed components dispatch via `key.Matches` against declared `key.Binding` sets
- [x] `diff_viewer`/`file_explorer` keep their `keybindings.yaml` remappability
- [x] `HelpBar` consumes `[]key.Binding` directly
- [x] No remaining `switch msg.String()` dispatch under `internal/ui/`

## Files Changed

```
19 files changed, 434 insertions(+), 182 deletions(-)
 internal/app/chat.go                               |  37 ++--
 internal/ui/autocomplete/autocomplete.go           |  30 ++-
 internal/ui/components/a2a_agents_view.go          |   9 +-
 internal/ui/components/components_keymap.go        | 163 +++++++++++++
 internal/ui/components/conversation_selection_view.go | 19 +-
 internal/ui/components/diff_viewer.go              |  55 ++---
 internal/ui/components/diff_viewer_test.go         |   2 +-
 internal/ui/components/file_explorer.go            |  26 +--
 internal/ui/components/file_selection_handler.go   |  13 +-
 internal/ui/components/help_bar.go                 |  30 +--
 internal/ui/components/help_bar_test.go            |  48 ++--
 internal/ui/components/help_view.go                |  17 +-
 internal/ui/components/input_view.go               |  36 ++--
 internal/ui/components/model_selection_view.go     |  28 ++-
 internal/ui/components/task_management_view.go     |  67 +++---
 internal/ui/components/theme_selection_view.go     |   9 +-
 internal/ui/components/tools_view.go               |   9 +-
 internal/ui/interfaces.go                          |   4 +-
 tests/mocks/ui/fake_help_bar_component.go          |  17 +-
```