### PR TITLE
refactor(tui): drop dead single-space key bindings in components_keymap

### DIFF
--- a/internal/ui/components/components_keymap.go
+++ b/internal/ui/components/components_keymap.go
@@ -48,7 +48,7 @@ var taskManagerKeys = struct {
 	deny:      key.NewBinding(key.WithKeys("n", "N", "esc")),
 	close:     key.NewBinding(key.WithKeys("q", "esc", "i", "ctrl+c")),
 	pgUp:      key.NewBinding(key.WithKeys("pgup", "b")),
-	pgDown:    key.NewBinding(key.WithKeys("pgdown", "f", " ")),
+	pgDown:    key.NewBinding(key.WithKeys("pgdown", "f")),
 	top:       key.NewBinding(key.WithKeys("g")),
 	bottom:    key.NewBinding(key.WithKeys("G")),
 	backspace: key.NewBinding(key.WithKeys("backspace")),
@@ -90,7 +90,7 @@ var conversationSelectorKeys = struct {
 	deny      key.Binding
 }{
 	cancel:    key.NewBinding(key.WithKeys("ctrl+c", "esc")),
-	enter:     key.NewBinding(key.WithKeys("enter", " ")),
+	enter:     key.NewBinding(key.WithKeys("enter")),
 	search:    key.NewBinding(key.WithKeys("/")),
 	delete:    key.NewBinding(key.WithKeys("d", "delete")),
 	backspace: key.NewBinding(key.WithKeys("backspace")),
@@ -111,7 +111,7 @@ var helpViewKeys = struct {
 	navUp:   key.NewBinding(key.WithKeys("up", "k")),
 	navDown: key.NewBinding(key.WithKeys("down", "j")),
 	pgUp:    key.NewBinding(key.WithKeys("pgup", "b")),
-	pgDown:  key.NewBinding(key.WithKeys("pgdown", "f", " ")),
+	pgDown:  key.NewBinding(key.WithKeys("pgdown", "f")),
 	top:     key.NewBinding(key.WithKeys("home", "g")),
 	bottom:  key.NewBinding(key.WithKeys("end", "G")),
 }
@@ -124,7 +124,7 @@ var listViewKeys = struct {
 }{
 	cancel:    key.NewBinding(key.WithKeys("ctrl+c")),
 	esc:       key.NewBinding(key.WithKeys("esc")),
-	selectKey: key.NewBinding(key.WithKeys("enter", " ")),
+	selectKey: key.NewBinding(key.WithKeys("enter")),
 }
 
 var fileSelectionKeys = struct {


### PR DESCRIPTION
## Summary

Follow-up cleanup from #876. Removes four dead literal `" "` (single-space) keys
from the hand-written binding sets in `internal/ui/components/components_keymap.go`:

- `taskManagerKeys.pgDown`
- `helpViewKeys.pgDown`
- `listViewKeys.selectKey` (shared by a2a / tools / theme views)
- `conversationSelectorKeys.enter`

## Why it's dead

In bubbletea v2 a space press stringifies to `"space"`, not `" "` (ultraviolet
`Key.String()` excludes `Text == " "` and falls back to `Keystroke()` -> `"space"`).
`key.Matches` does plain string equality, so the `" "` entries can never fire.
They were carried over verbatim from the old `switch msg.String()` `case " ":`
(which never matched either).

## Why it's safe

Behavior-preserving. Space paging/selection already comes from the underlying
bubbles component keymaps on the `default:` fallthrough (viewport binds PageDown
to `pgdown/space/f`; list/table handle space-select). Removing a token that
never matched cannot change dispatch.

## Testing

- `go build ./...`
- `go test ./internal/ui/... ./internal/app/...` green
- `golangci-lint run ./internal/ui/components/...` -> 0 issues

Closes #877
