### PR TITLE
fix: TodoWrite should not require approval by default (#881)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1069,6 +1069,7 @@ func (c *Config) IsApprovalRequired(toolName string) bool { // nolint:gocyclo,cy
 		if c.Tools.TodoWrite.RequireApproval != nil {
 			return *c.Tools.TodoWrite.RequireApproval
 		}
+		return false
 	case "Schedule":
 		if c.Tools.Schedule.RequireApproval != nil {
 			return *c.Tools.Schedule.RequireApproval

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -734,6 +734,23 @@ func TestIsApprovalRequired(t *testing.T) {
 			toolName: "WebSearch",
 			expected: true,
 		},
+		{
+			name: "todowrite default no approval even with global true",
+			setup: func(cfg *Config) {
+				cfg.Tools.Safety.RequireApproval = true
+			},
+			toolName: "TodoWrite",
+			expected: false,
+		},
+		{
+			name: "todowrite explicit override to true",
+			setup: func(cfg *Config) {
+				cfg.Tools.Safety.RequireApproval = false
+				cfg.Tools.TodoWrite.RequireApproval = &[]bool{true}[0]
+			},
+			toolName: "TodoWrite",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

TodoWrite is a non-destructive tool (pure memory-based task list management) but `IsApprovalRequired` fell through to `globalApproval` when `todo_write.require_approval` was unset in the user's config, causing it to prompt for approval even though the default config explicitly sets it to `false`.

## Changes

**`config/config.go`** — Added `return false` fallback in the `IsApprovalRequired` TodoWrite case after the per-tool pointer check, matching the existing pattern used by `Wait`, `Memory`, `RequestPlanApproval`, `AskUserQuestion`, and other read-only/non-destructive tools. Users can still opt into approval with `tools.todo_write.require_approval: true`.

**`config/config_test.go`** — Added two test cases:
- "todowrite default no approval even with global true" — nil `RequireApproval` + global `true` → `false`
- "todowrite explicit override to true" — `RequireApproval: true` + global `false` → `true`

## Verification

- All tests pass
- Pre-commit hooks (lint, fmt, tidy, mocks) all green

Closes #881