### PR TITLE
fix(tui): keep arg highlight on truncation and expand summary with ctrl+o

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -300,6 +300,7 @@ func NewChatApplication(
 	}
 
 	app.toolCallRenderer.SetKeyHintFormatter(keyHintFormatter)
+	app.approvalBoxView.SetKeyHintFormatter(keyHintFormatter)
 	app.modelSelector = components.NewModelSelector(models, app.modelService, app.pricingService, app.config, styleProvider)
 	app.themeSelector = components.NewThemeSelector(app.themeService, styleProvider)
 	app.toolsView = components.NewToolsView(app.toolService, app.stateManager, styleProvider)

--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -225,13 +225,45 @@ func (av *ApprovalBoxView) renderBody(tc *sdk.ChatCompletionMessageToolCall) str
 // what will be executed. Truncation happens on the plain string first so the ANSI
 // colour codes never throw off the width budget.
 func (av *ApprovalBoxView) renderSummary(tc *sdk.ChatCompletionMessageToolCall) string {
+	full := av.toolCallSummary(tc)
+	budget := av.summaryBudget()
+	oneLine := formatting.TruncateText(full, budget)
+	fits := oneLine == full
+
+	// ctrl+o (ToggleExpanded) soft-wraps the full argument list instead of the
+	// truncated one-liner, so a long command can be reviewed in full before
+	// approving — mirroring the diff-preview expansion. wordwrap is ANSI-aware and
+	// the terminal keeps the accent colour active across wrapped lines, so we can
+	// colour first and wrap after.
+	// ponytail: unbounded height when expanded; route through capLines() if a
+	// pathologically long command ever blows out the box.
+	if av.expanded && !fits {
+		return av.highlightSummary(formatting.WrapText(full, budget)) + "\n" +
+			av.styleProvider.RenderDimText("(ctrl+o to collapse)")
+	}
+
+	line := av.highlightSummary(oneLine)
+	if fits {
+		return line
+	}
+	return line + "\n" + av.styleProvider.RenderDimText("(ctrl+o to expand)")
+}
+
+// highlightSummary renders the name and parentheses dim and the inner arguments in
+// the accent colour. When the closing ')' is missing (truncation) the arguments are
+// highlighted through to the end. The paren indices are computed on the plain string
+// before any colour codes are added.
+func (av *ApprovalBoxView) highlightSummary(summary string) string {
 	dimColor := av.styleProvider.GetThemeColor("dim")
-	summary := formatting.TruncateText(av.toolCallSummary(tc), av.summaryBudget())
 
 	open := strings.IndexByte(summary, '(')
-	closeParen := strings.LastIndexByte(summary, ')')
-	if open < 0 || closeParen <= open+1 {
+	if open < 0 || open+1 >= len(summary) {
 		return av.styleProvider.RenderWithColor(summary, dimColor)
+	}
+
+	closeParen := strings.LastIndexByte(summary, ')')
+	if closeParen <= open {
+		closeParen = len(summary)
 	}
 
 	accentColor := av.styleProvider.GetThemeColor("accent")

--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -10,8 +10,10 @@ import (
 
 	sdk "github.com/inference-gateway/sdk"
 
+	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	formatting "github.com/inference-gateway/cli/internal/formatting"
+	hints "github.com/inference-gateway/cli/internal/ui/hints"
 	styles "github.com/inference-gateway/cli/internal/ui/styles"
 )
 
@@ -42,11 +44,12 @@ const (
 )
 
 type ApprovalBoxView struct {
-	width         int
-	height        int
-	styleProvider *styles.Provider
-	stateManager  domain.ApprovalUIManager
-	toolFormatter domain.ToolFormatter
+	width            int
+	height           int
+	styleProvider    *styles.Provider
+	stateManager     domain.ApprovalUIManager
+	toolFormatter    domain.ToolFormatter
+	keyHintFormatter *hints.Formatter
 
 	// active is the approval state the form was built for; a mismatch with
 	// the StateManager (cleared externally) marks the form stale.
@@ -109,6 +112,23 @@ func NewApprovalBoxView(styleProvider *styles.Provider, stateManager domain.Appr
 		stateManager:  stateManager,
 		toolFormatter: toolFormatter,
 	}
+}
+
+func (av *ApprovalBoxView) SetKeyHintFormatter(formatter *hints.Formatter) {
+	av.keyHintFormatter = formatter
+}
+
+// expandKey is the configured key for expand/collapse (ctrl+o by default), so the
+// hints track the user's keybindings instead of hardcoding the default.
+func (av *ApprovalBoxView) expandKey() string {
+	if av.keyHintFormatter == nil {
+		return "ctrl+o"
+	}
+	if key := av.keyHintFormatter.GetKeyOnly(
+		config.ActionID(config.NamespaceTools, "toggle_tool_expansion")); key != "" {
+		return key
+	}
+	return "ctrl+o"
 }
 
 func (av *ApprovalBoxView) SetWidth(width int) {
@@ -239,14 +259,14 @@ func (av *ApprovalBoxView) renderSummary(tc *sdk.ChatCompletionMessageToolCall) 
 	// pathologically long command ever blows out the box.
 	if av.expanded && !fits {
 		return av.highlightSummary(formatting.WrapText(full, budget)) + "\n" +
-			av.styleProvider.RenderDimText("(ctrl+o to collapse)")
+			av.styleProvider.RenderDimText(fmt.Sprintf("(%s to collapse)", av.expandKey()))
 	}
 
 	line := av.highlightSummary(oneLine)
 	if fits {
 		return line
 	}
-	return line + "\n" + av.styleProvider.RenderDimText("(ctrl+o to expand)")
+	return line + "\n" + av.styleProvider.RenderDimText(fmt.Sprintf("(%s to expand)", av.expandKey()))
 }
 
 // highlightSummary renders the name and parentheses dim and the inner arguments in
@@ -315,7 +335,7 @@ func (av *ApprovalBoxView) capLines(s string) string {
 	if !av.expanded {
 		hidden := len(lines) - limit
 		hint := av.styleProvider.RenderDimText(
-			fmt.Sprintf("… %d more lines (ctrl+o to expand, full diff shown after approval)", hidden),
+			fmt.Sprintf("… %d more lines (%s to expand, full diff shown after approval)", hidden, av.expandKey()),
 		)
 		return strings.Join(lines[:limit], "\n") + "\n" + hint
 	}
@@ -326,8 +346,8 @@ func (av *ApprovalBoxView) capLines(s string) string {
 	}
 	window := strings.Join(lines[av.scrollOffset:av.scrollOffset+limit], "\n")
 	hint := av.styleProvider.RenderDimText(
-		fmt.Sprintf("↑/↓ scroll · lines %d-%d of %d (ctrl+o to collapse)",
-			av.scrollOffset+1, av.scrollOffset+limit, len(lines)),
+		fmt.Sprintf("↑/↓ scroll · lines %d-%d of %d (%s to collapse)",
+			av.scrollOffset+1, av.scrollOffset+limit, len(lines), av.expandKey()),
 	)
 	return window + "\n" + hint
 }

--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -250,13 +250,6 @@ func (av *ApprovalBoxView) renderSummary(tc *sdk.ChatCompletionMessageToolCall) 
 	oneLine := formatting.TruncateText(full, budget)
 	fits := oneLine == full
 
-	// ctrl+o (ToggleExpanded) soft-wraps the full argument list instead of the
-	// truncated one-liner, so a long command can be reviewed in full before
-	// approving — mirroring the diff-preview expansion. wordwrap is ANSI-aware and
-	// the terminal keeps the accent colour active across wrapped lines, so we can
-	// colour first and wrap after.
-	// ponytail: unbounded height when expanded; route through capLines() if a
-	// pathologically long command ever blows out the box.
 	if av.expanded && !fits {
 		return av.highlightSummary(formatting.WrapText(full, budget)) + "\n" +
 			av.styleProvider.RenderDimText(fmt.Sprintf("(%s to collapse)", av.expandKey()))


### PR DESCRIPTION
## Summary

Two fixes to the approval-box tool-call summary (follow-up to #882).

**1. Highlight survives truncation.** The arg highlight split the summary at the first `(` and last `)`, but when a long command was truncated the closing `)` was cut off, so `LastIndexByte` returned -1 and the whole line fell back to all-dim. Now a missing `)` highlights the arguments through to the end of the truncated string — so the highlight is consistent instead of "sometimes works, sometimes not".

**2. `ctrl+o` expands the args.** For non-diff tools the summary was always a truncated one-liner regardless of the expanded state. `ctrl+o` (already wired to the approval box for diff previews) now soft-wraps the full argument list so a long command can be reviewed in full before approving. Collapsed shows a `(ctrl+o to expand)` hint when truncated; expanded shows `(ctrl+o to collapse)`.

## Testing

`go build ./...`, `go test ./internal/ui/components/`, pre-commit hooks all pass.