### PR TITLE
fix(tui): render approval buttons as solid high-contrast buttons

### DIFF
--- a/internal/ui/components/approval_box_view.go
+++ b/internal/ui/components/approval_box_view.go
@@ -178,7 +178,7 @@ func (av *ApprovalBoxView) Begin() tea.Cmd {
 	).
 		WithShowHelp(false).
 		WithWidth(av.summaryBudget()).
-		WithTheme(huhTheme(av.styleProvider))
+		WithTheme(approvalHuhTheme(av.styleProvider))
 	return av.form.Init()
 }
 

--- a/internal/ui/components/approval_box_view_test.go
+++ b/internal/ui/components/approval_box_view_test.go
@@ -8,10 +8,14 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
 
 	sdk "github.com/inference-gateway/sdk"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
+	styles "github.com/inference-gateway/cli/internal/ui/styles"
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+	uimocks "github.com/inference-gateway/cli/tests/mocks/ui"
 )
 
 // argsAwareToolFormatter is a domain.ToolFormatter whose FormatToolCall renders
@@ -61,6 +65,26 @@ func approvalStateManager(s *domain.ApprovalUIState) *domain.ApplicationState {
 		st.SetupApprovalUIState(s.PendingToolCall, nil)
 	}
 	return st
+}
+
+// TestApprovalHuhTheme_SelectedOptionIsButton asserts the focused option is styled
+// as a solid button (accent background, bold) rather than bare accent text.
+func TestApprovalHuhTheme_SelectedOptionIsButton(t *testing.T) {
+	const accent = "#5f5fff"
+	fakeTheme := &uimocks.FakeTheme{}
+	fakeTheme.GetAccentColorReturns(accent)
+	fakeThemeService := &domainmocks.FakeThemeService{}
+	fakeThemeService.GetCurrentThemeReturns(fakeTheme)
+	p := styles.NewProvider(fakeThemeService)
+
+	s := approvalHuhTheme(p).Theme(true)
+
+	if got := s.Focused.SelectedOption.GetBackground(); got != lipgloss.Color(accent) {
+		t.Errorf("selected option should have the accent background %q, got %v", accent, got)
+	}
+	if !s.Focused.SelectedOption.GetBold() {
+		t.Error("selected option button should be bold")
+	}
 }
 
 func TestApprovalBox_EmptyWhenNoPendingCall(t *testing.T) {

--- a/internal/ui/components/huh_theme.go
+++ b/internal/ui/components/huh_theme.go
@@ -53,3 +53,24 @@ func huhTheme(p *styles.Provider) huh.Theme {
 		return t
 	})
 }
+
+// approvalHuhTheme is huhTheme with the inline Select's focused option styled as
+// a solid button (accent background, white text) so the approval CTA stands out.
+func approvalHuhTheme(p *styles.Provider) huh.Theme {
+	base := huhTheme(p)
+	return huh.ThemeFunc(func(isDark bool) *huh.Styles {
+		t := base.Theme(isDark)
+		if p == nil {
+			return t
+		}
+		accent := lipgloss.Color(p.GetThemeColor("accent"))
+		button := t.Focused.SelectedOption.
+			Foreground(lipgloss.Color("15")).
+			Background(accent).
+			Bold(true).
+			Padding(0, 1)
+		t.Focused.SelectedOption = button
+		t.Blurred.SelectedOption = button
+		return t
+	})
+}


### PR DESCRIPTION
Closes #883

## What

The Approve/Reject/Auto-Approve inline select rendered its focused option as thin accent text that was easy to miss (the background-highlighted buttons were lost in the huh/v2 migration).

Style the focused option as a solid button — accent background, white text, bold, padded — via a scoped `approvalHuhTheme`, so the CTA stands out. Scoped to the approval form so other selects (file picker, wizards) keep their plain look, using huh's own `SelectedOption` style (library convention).

## Before / After

Before: `‹ Approve ›` in bare accent text.
After: `‹ ` **Approve** ` ›` as a solid accent button with white text.

## Test

`TestApprovalHuhTheme_SelectedOptionIsButton` asserts the focused option carries the accent background and bold.