### PR TITLE
fix(tui): coalesce streaming re-renders to stop mid-generation scrambling (#888)

### DIFF
--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -118,6 +118,10 @@ type ConversationView struct {
 	streamingReasoningBuffer strings.Builder
 	isStreaming              bool
 	streamingModel           string
+	// streamingDirty marks that new streamed content is waiting to be rendered;
+	// streamingRenderArmed guards the single coalescing render tick (issue #888).
+	streamingDirty       bool
+	streamingRenderArmed bool
 
 	keyHintFormatter *hints.Formatter
 
@@ -504,22 +508,40 @@ func (cv *ConversationView) updateViewportContent() {
 	cv.updateViewportContentFull()
 }
 
-// appendStreamingContent appends content to the streaming buffer and triggers immediate render
+// streamingRenderInterval bounds how often the viewport is rebuilt while an
+// assistant message streams. Deltas arrive far faster than this (a real model
+// emits many tokens/sec); rebuilding + SetContent + GotoBottom on every delta
+// hands the 60fps renderer a fully-reflowed frame per token, which the terminal
+// cannot paint cleanly and shows as mid-stream scrambling (issue #888). We
+// coalesce to ~30fps: visually live, but at most one rebuild per tick.
+const streamingRenderInterval = 33 * time.Millisecond
+
+// streamingRenderTickMsg drives the coalesced streaming re-render loop.
+type streamingRenderTickMsg struct{}
+
+func streamingRenderTick() tea.Cmd {
+	return tea.Tick(streamingRenderInterval, func(time.Time) tea.Msg { return streamingRenderTickMsg{} })
+}
+
+// appendStreamingContent appends a streamed delta and marks the view dirty; the
+// actual rebuild is deferred to the coalescing tick (handleStreamingRenderTick),
+// so a burst of tokens costs one render per tick instead of one render each.
 func (cv *ConversationView) appendStreamingContent(content, reasoning, model string) {
 	cv.isStreaming = true
 	cv.streamingModel = model
 	cv.streamingBuffer.WriteString(content)
 	cv.streamingReasoningBuffer.WriteString(reasoning)
-
-	cv.updateViewportContentFull()
+	cv.streamingDirty = true
 }
 
-// flushStreamingBuffer clears the streaming buffer after completion
+// flushStreamingBuffer clears the streaming buffer after completion. isStreaming
+// flips false so the coalescing render tick stops re-arming on its next fire.
 func (cv *ConversationView) flushStreamingBuffer() {
 	cv.streamingBuffer.Reset()
 	cv.streamingReasoningBuffer.Reset()
 	cv.isStreaming = false
 	cv.streamingModel = ""
+	cv.streamingDirty = false
 }
 
 // renderStreamingContent renders the currently streaming assistant message
@@ -1273,6 +1295,8 @@ func (cv *ConversationView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return cv.handleRemoveSubagent(msg, cmd)
 	case spinner.TickMsg:
 		return cv.handleSpinnerTick(msg, cmd)
+	case streamingRenderTickMsg:
+		return cv.handleStreamingRenderTick(cmd)
 	default:
 		return cv.handleDefaultEvents(msg, cmd)
 	}
@@ -1356,7 +1380,25 @@ func (cv *ConversationView) handleChatStartEvent(cmd tea.Cmd) (tea.Model, tea.Cm
 func (cv *ConversationView) handleStreamingContentEvent(msg domain.StreamingContentEvent, cmd tea.Cmd) (tea.Model, tea.Cmd) {
 	if cv.navigationMode != NavigationModeMessageHistory {
 		cv.appendStreamingContent(msg.Content, msg.ReasoningContent, msg.Model)
+		if !cv.streamingRenderArmed {
+			cv.streamingRenderArmed = true
+			return cv, tea.Batch(cmd, streamingRenderTick())
+		}
 	}
+	return cv, cmd
+}
+
+// handleStreamingRenderTick performs the coalesced viewport rebuild: at most one
+// rebuild per tick while streaming, re-arming until streaming ends (issue #888).
+func (cv *ConversationView) handleStreamingRenderTick(cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	if cv.streamingDirty {
+		cv.streamingDirty = false
+		cv.updateViewportContentFull()
+	}
+	if cv.isStreaming {
+		return cv, tea.Batch(cmd, streamingRenderTick())
+	}
+	cv.streamingRenderArmed = false
 	return cv, cmd
 }
 

--- a/internal/ui/components/conversation_view.go
+++ b/internal/ui/components/conversation_view.go
@@ -118,10 +118,8 @@ type ConversationView struct {
 	streamingReasoningBuffer strings.Builder
 	isStreaming              bool
 	streamingModel           string
-	// streamingDirty marks that new streamed content is waiting to be rendered;
-	// streamingRenderArmed guards the single coalescing render tick (issue #888).
-	streamingDirty       bool
-	streamingRenderArmed bool
+	streamingDirty           bool
+	streamingRenderArmed     bool
 
 	keyHintFormatter *hints.Formatter
 

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -1197,6 +1197,53 @@ func TestConversationView_StreamingLifecycle(t *testing.T) {
 	}
 }
 
+// TestConversationView_StreamingRenderCoalesced pins the issue #888 fix: streamed
+// deltas must not each trigger a full viewport rebuild. Instead they mark the view
+// dirty and a single coalescing tick performs one rebuild, re-arming until the
+// stream ends. Per-token rebuilds are what scrambled the screen mid-generation.
+func TestConversationView_StreamingRenderCoalesced(t *testing.T) {
+	cv := NewConversationView(createMockStyleProvider())
+	cv.SetWidth(100)
+	cv.SetHeight(30)
+
+	const marker = "STREAMED_MARKER"
+
+	_, cmd := cv.handleStreamingContentEvent(domain.StreamingContentEvent{Content: marker + " one "}, nil)
+	if cmd == nil {
+		t.Fatal("first streamed delta should arm the render tick (non-nil cmd)")
+	}
+
+	if _, cmd2 := cv.handleStreamingContentEvent(domain.StreamingContentEvent{Content: "two "}, nil); cmd2 != nil {
+		t.Fatal("subsequent streamed deltas must not arm a second render tick")
+	}
+
+	if strings.Contains(cv.renderedContent, marker) {
+		t.Fatal("streamed content must not be rendered synchronously on every delta")
+	}
+	if !cv.streamingDirty {
+		t.Fatal("streamed content should mark the view dirty")
+	}
+
+	_, tickCmd := cv.handleStreamingRenderTick(nil)
+	if !strings.Contains(cv.renderedContent, marker) {
+		t.Fatal("render tick should rebuild the viewport with the streamed content")
+	}
+	if cv.streamingDirty {
+		t.Fatal("render tick should clear the dirty flag")
+	}
+	if tickCmd == nil {
+		t.Fatal("render tick should re-arm while streaming is active")
+	}
+
+	cv.flushStreamingBuffer()
+	if _, stopCmd := cv.handleStreamingRenderTick(nil); stopCmd != nil {
+		t.Fatal("render tick should stop re-arming once streaming ends")
+	}
+	if cv.streamingRenderArmed {
+		t.Fatal("render tick should disarm once streaming ends")
+	}
+}
+
 func approvalEntry(status domain.ToolApprovalStatus) domain.ConversationEntry {
 	return domain.ConversationEntry{
 		PendingToolCall: &sdk.ChatCompletionMessageToolCall{


### PR DESCRIPTION
## Summary

Fixes #888 — assistant text (notably the reasoning/thinking block) scrambled while generating, then snapped back correct once generation finished.

## Root cause

Every streamed token called `updateViewportContentFull()` — a full viewport-string rebuild + `Viewport.SetContent()` (re-measures every line) + `GotoBottom()`. At a real "flash" model's token rate this handed Bubble Tea's 60fps renderer a fully-reflowed, re-scrolled frame **per token**, which the terminal could not paint cleanly → sub-frame tearing that resolved the instant streaming stopped (completion re-renders once from committed history, which is why it self-healed).

Ruled out during investigation:

- **Not the `` ` `` backtick** — the reasoning path never routes through glamour; it tears with no backtick present.
- **Not a data race** — the streaming buffer is confined to Bubble Tea's single `Update` goroutine, delivered in order via one self-re-arming listener, and self-heals to a correct final frame (a race would corrupt the data permanently).

It was the **render rate**: faster tokens → more distinct fully-reflowed frames per second than the terminal could paint.

## Fix

Decouple token rate from render rate. A streamed delta now only appends to the buffer and marks the view dirty; a self-scheduling `streamingRenderTickMsg` (~33 ms / 30 fps) performs one coalesced rebuild, re-arming while streaming and disarming on completion. Visually live, but at most one rebuild per tick instead of one per token.

All in `internal/ui/components/conversation_view.go` (~30 lines).

## Testing

- New `TestConversationView_StreamingRenderCoalesced`: streamed deltas no longer render per-token (they mark dirty), a single tick performs one rebuild, and the tick disarms once streaming ends.
- `task test` (whole repo), `golangci-lint` (0 issues) and `markdownlint` all green.
- Reproduced and verified against the embedded mock gateway streaming a reasoning block fast in a narrow tmux pane; the fixed binary streams smoothly and the final frame is unchanged.
