### PR TITLE
refactor(tests): table-drive remaining internal/ui component tests

### DIFF
--- a/internal/ui/components/approval_box_view_test.go
+++ b/internal/ui/components/approval_box_view_test.go
@@ -96,24 +96,80 @@ func TestApprovalBox_EmptyWhenNoPendingCall(t *testing.T) {
 	}
 }
 
-func TestApprovalBox_FramesSummaryAndButtons(t *testing.T) {
-	sm := approvalStateManager(approvalStateWith("Read", `{"file_path":"/x/y.txt"}`))
+// TestApprovalBox_SummaryRendering covers the one-liner summary path: framing,
+// formatter fallbacks, and narrow-width truncation.
+func TestApprovalBox_SummaryRendering(t *testing.T) {
+	const longPath = "/very/long/path/to/some/deeply/nested/file/name/that/keeps/going.txt"
 
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
-	av.SetWidth(80)
-	_ = av.Begin()
-	out := av.Render()
+	cases := []struct {
+		name         string
+		toolName     string
+		arguments    string
+		nilFormatter bool
+		width        int
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:      "frames summary and buttons",
+			toolName:  "Read",
+			arguments: `{"file_path":"/x/y.txt"}`,
+			width:     80,
+			wantContains: []string{
+				"Approval required",
+				"Read(file_path=/x/y.txt)",
+				"Approve",
+				"╭", "╰",
+			},
+		},
+		{
+			name:         "nil formatter falls back to name",
+			toolName:     "Read",
+			arguments:    `{"file_path":"/x/y.txt"}`,
+			nilFormatter: true,
+			width:        80,
+			wantContains: []string{"Read(...)"},
+		},
+		{
+			name:         "unparseable args fall back",
+			toolName:     "Bash",
+			arguments:    `not json`,
+			width:        80,
+			wantContains: []string{"Bash(...)"},
+		},
+		{
+			name:         "truncates long summary on narrow width",
+			toolName:     "Read",
+			arguments:    fmt.Sprintf(`{"file_path":%q}`, longPath),
+			width:        34,
+			wantContains: []string{"..."},
+			wantAbsent:   []string{longPath},
+		},
+	}
 
-	// The inline select shows only the focused option (← Approve →).
-	for _, want := range []string{
-		"Approval required",
-		"Read(file_path=/x/y.txt)",
-		"Approve",
-		"╭", "╰",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("approval box render missing %q\n---\n%s", want, out)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := approvalStateManager(approvalStateWith(tc.toolName, tc.arguments))
+			var formatter domain.ToolFormatter = argsAwareToolFormatter{}
+			if tc.nilFormatter {
+				formatter = nil
+			}
+			av := NewApprovalBoxView(createMockStyleProvider(), sm, formatter)
+			av.SetWidth(tc.width)
+			_ = av.Begin()
+			out := av.Render()
+
+			for _, want := range tc.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("approval box render missing %q\n---\n%s", want, out)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Errorf("approval box render should not contain %q\n---\n%s", absent, out)
+				}
+			}
+		})
 	}
 }
 
@@ -140,99 +196,6 @@ func TestApprovalBox_SelectEmitsResponseEvent(t *testing.T) {
 		cmd = av.Forward(msg)
 	}
 	t.Fatal("expected a ToolApprovalResponseEvent after enter")
-}
-
-func TestApprovalBox_NilFormatterFallsBackToName(t *testing.T) {
-	sm := approvalStateManager(approvalStateWith("Read", `{"file_path":"/x/y.txt"}`))
-
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, nil)
-	av.SetWidth(80)
-	_ = av.Begin()
-	out := av.Render()
-
-	if !strings.Contains(out, "Read(...)") {
-		t.Errorf("expected nil-formatter fallback to render \"Read(...)\", got:\n%s", out)
-	}
-}
-
-func TestApprovalBox_UnparseableArgsFallBack(t *testing.T) {
-	sm := approvalStateManager(approvalStateWith("Bash", `not json`))
-
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
-	av.SetWidth(80)
-	_ = av.Begin()
-	out := av.Render()
-
-	if !strings.Contains(out, "Bash(...)") {
-		t.Errorf("expected unparseable-args fallback to render \"Bash(...)\", got:\n%s", out)
-	}
-}
-
-func TestApprovalBox_TruncatesLongSummaryOnNarrowWidth(t *testing.T) {
-	longPath := "/very/long/path/to/some/deeply/nested/file/name/that/keeps/going.txt"
-	sm := approvalStateManager(approvalStateWith("Read", fmt.Sprintf(`{"file_path":%q}`, longPath)))
-
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
-	av.SetWidth(34)
-	_ = av.Begin()
-	out := av.Render()
-
-	if strings.Contains(out, longPath) {
-		t.Errorf("expected long summary to be truncated on a narrow box, but full path is present:\n%s", out)
-	}
-	if !strings.Contains(out, "...") {
-		t.Errorf("expected truncation ellipsis in narrow box, got:\n%s", out)
-	}
-}
-
-// TestApprovalBox_RendersEditDiff asserts the file-mutating tools show a colored
-// diff of the change (file path + old/new content) instead of the one-liner, so the
-// user can see what they are approving before approving.
-func TestApprovalBox_RendersEditDiff(t *testing.T) {
-	args := `{"file_path":"/x/y.txt","old_string":"OLD_CONTENT","new_string":"NEW_CONTENT"}`
-	sm := approvalStateManager(approvalStateWith("Edit", args))
-
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
-	av.SetWidth(80)
-	_ = av.Begin()
-	out := stripANSI(av.Render())
-
-	if !strings.Contains(out, "/x/y.txt") {
-		t.Errorf("expected the diff preview to show the file path, got:\n%s", out)
-	}
-	if !strings.Contains(out, "NEW_CONTENT") {
-		t.Errorf("expected the diff preview to show the new content, got:\n%s", out)
-	}
-	if strings.Contains(out, "Edit(") {
-		t.Errorf("expected a diff preview, not the one-liner summary, got:\n%s", out)
-	}
-}
-
-// TestApprovalBox_CapsLongDiffWithHint asserts a large edit is height-capped (so it
-// cannot push the conversation/input off-screen) and that the omitted tail is
-// summarised with a "more lines" hint.
-func TestApprovalBox_CapsLongDiffWithHint(t *testing.T) {
-	var b strings.Builder
-	for i := 0; i < 80; i++ {
-		fmt.Fprintf(&b, "LINE_%02d\n", i)
-	}
-	args := fmt.Sprintf(`{"file_path":"/x/y.txt","old_string":"","new_string":%q}`, b.String())
-
-	sm := approvalStateManager(approvalStateWith("Edit", args))
-
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
-	av.SetWidth(80)
-	av.SetHeight(24) // previewLineLimit -> 12
-
-	_ = av.Begin()
-	out := stripANSI(av.Render())
-
-	if !strings.Contains(out, "more lines") {
-		t.Errorf("expected a truncation hint for a long diff, got:\n%s", out)
-	}
-	if strings.Contains(out, "LINE_79") {
-		t.Errorf("expected the tail of a long diff to be capped away, but LINE_79 is present:\n%s", out)
-	}
 }
 
 // TestApprovalBox_ExpandScrollsToDiffTail asserts ctrl+o (ToggleExpanded) opens a
@@ -310,25 +273,6 @@ func TestApprovalBox_IsActiveFalseAfterExternalClear(t *testing.T) {
 	}
 }
 
-// TestApprovalBox_DiffToolIgnoresFormatter asserts the diff path does not depend on
-// the tool formatter (a nil formatter still yields a diff, not the name fallback).
-func TestApprovalBox_DiffToolIgnoresFormatter(t *testing.T) {
-	args := `{"file_path":"/x/y.txt","old_string":"OLD","new_string":"NEW"}`
-	sm := approvalStateManager(approvalStateWith("Edit", args))
-
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, nil)
-	av.SetWidth(80)
-	_ = av.Begin()
-	out := stripANSI(av.Render())
-
-	if strings.Contains(out, "Edit(") {
-		t.Errorf("expected a diff even with a nil formatter, got summary:\n%s", out)
-	}
-	if !strings.Contains(out, "/x/y.txt") {
-		t.Errorf("expected the diff preview to render the file path, got:\n%s", out)
-	}
-}
-
 // contextSnippet is a 9-line block with a single changed middle line, so a diff
 // renders one hunk whose context width (2 vs 3 lines) is observable: at 2 lines
 // only charlie/delta and foxtrot/golf survive; at 3 lines bravo/hotel show too.
@@ -337,51 +281,96 @@ const (
 	newContextSnippet = "alpha\nbravo\ncharlie\ndelta\necho_NEW\nfoxtrot\ngolf\nhotel\nindia"
 )
 
-// TestApprovalBox_EditDiffUsesTwoContextLines asserts the snippet-fallback path
-// (the target file does not exist, so old_string/new_string are diffed directly)
-// is tightened to 2 context lines: the 2 nearest unchanged lines on each side
-// remain while the 3rd-out lines (and beyond) are trimmed.
-func TestApprovalBox_EditDiffUsesTwoContextLines(t *testing.T) {
-	args := fmt.Sprintf(`{"file_path":"/x/y.txt","old_string":%q,"new_string":%q}`, oldContextSnippet, newContextSnippet)
-
-	sm := approvalStateManager(approvalStateWith("Edit", args))
-
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
-	av.SetWidth(120)
-	av.SetHeight(60)
-	_ = av.Begin()
-	out := stripANSI(av.Render())
-
-	for _, want := range []string{"charlie", "delta", "foxtrot", "golf", "echo_NEW"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("expected the Edit approval diff to keep 2 context lines incl %q:\n%s", want, out)
-		}
+// TestApprovalBox_DiffRendering covers the diff-preview path for file-mutating
+// tools: diff instead of summary, formatter independence, context-line widths,
+// and the height cap with its "more lines" hint.
+func TestApprovalBox_DiffRendering(t *testing.T) {
+	var longNew strings.Builder
+	for i := 0; i < 80; i++ {
+		fmt.Fprintf(&longNew, "LINE_%02d\n", i)
 	}
-	for _, absent := range []string{"bravo", "hotel", "alpha", "india"} {
-		if strings.Contains(out, absent) {
-			t.Fatalf("expected the Edit approval diff to trim context beyond 2 lines, but %q is present:\n%s", absent, out)
-		}
+
+	cases := []struct {
+		name         string
+		toolName     string
+		arguments    string
+		nilFormatter bool
+		width        int
+		height       int
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "renders edit diff",
+			toolName:     "Edit",
+			arguments:    `{"file_path":"/x/y.txt","old_string":"OLD_CONTENT","new_string":"NEW_CONTENT"}`,
+			width:        80,
+			wantContains: []string{"/x/y.txt", "NEW_CONTENT"},
+			wantAbsent:   []string{"Edit("},
+		},
+		{
+			name:         "diff tool ignores formatter",
+			toolName:     "Edit",
+			arguments:    `{"file_path":"/x/y.txt","old_string":"OLD","new_string":"NEW"}`,
+			nilFormatter: true,
+			width:        80,
+			wantContains: []string{"/x/y.txt"},
+			wantAbsent:   []string{"Edit("},
+		},
+		{
+			name:         "edit diff uses two context lines",
+			toolName:     "Edit",
+			arguments:    fmt.Sprintf(`{"file_path":"/x/y.txt","old_string":%q,"new_string":%q}`, oldContextSnippet, newContextSnippet),
+			width:        120,
+			height:       60,
+			wantContains: []string{"charlie", "delta", "foxtrot", "golf", "echo_NEW"},
+			wantAbsent:   []string{"bravo", "hotel", "alpha", "india"},
+		},
+		{
+			name:         "multiedit keeps three context lines",
+			toolName:     "MultiEdit",
+			arguments:    fmt.Sprintf(`{"file_path":"/x/y.txt","edits":[{"old_string":%q,"new_string":%q}]}`, oldContextSnippet, newContextSnippet),
+			width:        120,
+			height:       60,
+			wantContains: []string{"bravo", "hotel", "echo_NEW"},
+		},
+		{
+			name:         "caps long diff with hint",
+			toolName:     "Edit",
+			arguments:    fmt.Sprintf(`{"file_path":"/x/y.txt","old_string":"","new_string":%q}`, longNew.String()),
+			width:        80,
+			height:       24,
+			wantContains: []string{"more lines"},
+			wantAbsent:   []string{"LINE_79"},
+		},
 	}
-}
 
-// TestApprovalBox_MultiEditKeepsThreeContext locks in that only Edit was tightened:
-// the MultiEdit approval preview still renders the default 3 context lines (so the
-// 3rd-out lines bravo/hotel remain visible).
-func TestApprovalBox_MultiEditKeepsThreeContext(t *testing.T) {
-	args := fmt.Sprintf(`{"file_path":"/x/y.txt","edits":[{"old_string":%q,"new_string":%q}]}`, oldContextSnippet, newContextSnippet)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := approvalStateManager(approvalStateWith(tc.toolName, tc.arguments))
+			var formatter domain.ToolFormatter = argsAwareToolFormatter{}
+			if tc.nilFormatter {
+				formatter = nil
+			}
+			av := NewApprovalBoxView(createMockStyleProvider(), sm, formatter)
+			av.SetWidth(tc.width)
+			if tc.height > 0 {
+				av.SetHeight(tc.height)
+			}
+			_ = av.Begin()
+			out := stripANSI(av.Render())
 
-	sm := approvalStateManager(approvalStateWith("MultiEdit", args))
-
-	av := NewApprovalBoxView(createMockStyleProvider(), sm, argsAwareToolFormatter{})
-	av.SetWidth(120)
-	av.SetHeight(60)
-	_ = av.Begin()
-	out := stripANSI(av.Render())
-
-	for _, want := range []string{"bravo", "hotel", "echo_NEW"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("expected the MultiEdit approval diff to keep the default 3 context lines incl %q:\n%s", want, out)
-		}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected diff render to contain %q, got:\n%s", want, out)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Errorf("expected diff render to not contain %q, got:\n%s", absent, out)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/ui/components/conversation_view_test.go
+++ b/internal/ui/components/conversation_view_test.go
@@ -384,51 +384,120 @@ func TestConversationView_Render(t *testing.T) {
 	}
 }
 
-func TestBackgroundTaskDisplay_SubmittedCreatesEntry(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
+func TestBackgroundTaskDisplay_A2AEventHandlers(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
 
-	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
-		TaskID:    "task-1",
-		AgentName: "weather-agent",
-	}, nil)
+	cases := []struct {
+		name           string
+		events         func(cv *ConversationView)
+		wantAgentName  string
+		wantAgentURL   string
+		wantState      string
+		wantMessage    string
+		wantErrorMsg   string
+		wantIsTerminal *bool
+	}{
+		{
+			name: "submitted creates entry",
+			events: func(cv *ConversationView) {
+				cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+					TaskID:    "task-1",
+					AgentName: "weather-agent",
+				}, nil)
+			},
+			wantAgentName:  "weather-agent",
+			wantState:      "submitted",
+			wantIsTerminal: boolPtr(false),
+		},
+		{
+			name: "submitted captures agent url",
+			events: func(cv *ConversationView) {
+				cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+					TaskID:   "task-1",
+					AgentURL: "http://localhost:8081",
+				}, nil)
+			},
+			wantAgentURL: "http://localhost:8081",
+			wantState:    "submitted",
+		},
+		{
+			name: "status update captures agent url",
+			events: func(cv *ConversationView) {
+				cv.handleA2ATaskStatusUpdate(domain.A2ATaskStatusUpdateEvent{
+					TaskID:   "task-1",
+					AgentURL: "http://localhost:8081",
+					Status:   "TASK_STATE_WORKING",
+				}, nil)
+			},
+			wantAgentURL: "http://localhost:8081",
+		},
+		{
+			name: "status update changes state",
+			events: func(cv *ConversationView) {
+				cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+					TaskID:    "task-1",
+					AgentName: "weather-agent",
+				}, nil)
+				cv.handleA2ATaskStatusUpdate(domain.A2ATaskStatusUpdateEvent{
+					TaskID:  "task-1",
+					Status:  "working",
+					Message: "fetching forecast",
+				}, nil)
+			},
+			wantAgentName: "weather-agent",
+			wantState:     "working",
+			wantMessage:   "fetching forecast",
+		},
+		{
+			name: "failed captures error",
+			events: func(cv *ConversationView) {
+				cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
+					TaskID:    "task-1",
+					AgentName: "weather-agent",
+				}, nil)
+				cv.handleA2ATaskFailed(domain.A2ATaskFailedEvent{
+					TaskID: "task-1",
+					Error:  "connection refused",
+					Result: domain.ToolExecutionResult{
+						ToolName: "A2A_SubmitTask",
+						Success:  false,
+					},
+				}, nil)
+			},
+			wantState:      "failed",
+			wantErrorMsg:   "connection refused",
+			wantIsTerminal: boolPtr(true),
+		},
+	}
 
-	display, ok := cv.backgroundTasks["task-1"]
-	if !ok {
-		t.Fatal("expected backgroundTasks to contain entry for task-1")
-	}
-	if display.AgentName != "weather-agent" {
-		t.Errorf("expected AgentName 'weather-agent', got %q", display.AgentName)
-	}
-	if display.State != "submitted" {
-		t.Errorf("expected State 'submitted', got %q", display.State)
-	}
-	if display.IsTerminal {
-		t.Error("expected IsTerminal to be false on submission")
-	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cv := NewConversationView(createMockStyleProvider())
+			tc.events(cv)
 
-func TestBackgroundTaskDisplay_StatusUpdateChangesState(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-
-	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
-		TaskID:    "task-1",
-		AgentName: "weather-agent",
-	}, nil)
-	cv.handleA2ATaskStatusUpdate(domain.A2ATaskStatusUpdateEvent{
-		TaskID:  "task-1",
-		Status:  "working",
-		Message: "fetching forecast",
-	}, nil)
-
-	display := cv.backgroundTasks["task-1"]
-	if display.State != "working" {
-		t.Errorf("expected State 'working', got %q", display.State)
-	}
-	if display.Message != "fetching forecast" {
-		t.Errorf("expected Message 'fetching forecast', got %q", display.Message)
-	}
-	if display.AgentName != "weather-agent" {
-		t.Errorf("expected AgentName preserved as 'weather-agent', got %q", display.AgentName)
+			display, ok := cv.backgroundTasks["task-1"]
+			if !ok {
+				t.Fatal("expected backgroundTasks to contain entry for task-1")
+			}
+			if tc.wantAgentName != "" && display.AgentName != tc.wantAgentName {
+				t.Errorf("expected AgentName %q, got %q", tc.wantAgentName, display.AgentName)
+			}
+			if tc.wantAgentURL != "" && display.AgentURL != tc.wantAgentURL {
+				t.Errorf("expected AgentURL %q, got %q", tc.wantAgentURL, display.AgentURL)
+			}
+			if tc.wantState != "" && display.State != tc.wantState {
+				t.Errorf("expected State %q, got %q", tc.wantState, display.State)
+			}
+			if tc.wantMessage != "" && display.Message != tc.wantMessage {
+				t.Errorf("expected Message %q, got %q", tc.wantMessage, display.Message)
+			}
+			if tc.wantErrorMsg != "" && display.ErrorMsg != tc.wantErrorMsg {
+				t.Errorf("expected ErrorMsg %q, got %q", tc.wantErrorMsg, display.ErrorMsg)
+			}
+			if tc.wantIsTerminal != nil && display.IsTerminal != *tc.wantIsTerminal {
+				t.Errorf("expected IsTerminal %v, got %v", *tc.wantIsTerminal, display.IsTerminal)
+			}
+		})
 	}
 }
 
@@ -541,64 +610,85 @@ func TestBackgroundTaskDisplay_CompletedCapturesExecutionStats(t *testing.T) {
 	}
 }
 
-func TestBackgroundTaskDisplay_CompletedWithoutMetadataRendersBareName(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-	out := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
-		TaskID:     "t1",
-		AgentName:  "old-agent",
-		State:      "completed",
-		IsTerminal: true,
-	}, 0)
-	if !strings.Contains(out, "Agent(old-agent=completed)") {
-		t.Errorf("expected 'Agent(old-agent=completed)' header, got %q", out)
-	}
-	if strings.Contains(out, "\n") {
-		t.Errorf("expected single-line output when no metadata to show, got %q", out)
-	}
-}
-
-func TestBackgroundTaskDisplay_CompletedUsesLastBranchWhenOnlyOneDetail(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-	out := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
-		TaskID:     "t1",
-		AgentName:  "x",
-		State:      "completed",
-		UsageJSON:  `{"total_tokens":10}`,
-		IsTerminal: true,
-	}, 0)
-	if !strings.Contains(out, "└── usage=") {
-		t.Errorf("expected single detail to use └── branch, got %q", out)
-	}
-	if strings.Contains(out, "├──") {
-		t.Errorf("did not expect ├── branch with only one detail, got %q", out)
-	}
-}
-
-func TestBackgroundTaskDisplay_FailedCapturesError(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-
-	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
-		TaskID:    "task-1",
-		AgentName: "weather-agent",
-	}, nil)
-	cv.handleA2ATaskFailed(domain.A2ATaskFailedEvent{
-		TaskID: "task-1",
-		Error:  "connection refused",
-		Result: domain.ToolExecutionResult{
-			ToolName: "A2A_SubmitTask",
-			Success:  false,
+func TestBackgroundTaskDisplay_RenderLineVariants(t *testing.T) {
+	cases := []struct {
+		name         string
+		display      *BackgroundTaskDisplay
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name: "completed without metadata renders bare name",
+			display: &BackgroundTaskDisplay{
+				TaskID:     "t1",
+				AgentName:  "old-agent",
+				State:      "completed",
+				IsTerminal: true,
+			},
+			wantContains: []string{"Agent(old-agent=completed)"},
+			wantAbsent:   []string{"\n"},
 		},
-	}, nil)
+		{
+			name: "completed uses last branch when only one detail",
+			display: &BackgroundTaskDisplay{
+				TaskID:     "t1",
+				AgentName:  "x",
+				State:      "completed",
+				UsageJSON:  `{"total_tokens":10}`,
+				IsTerminal: true,
+			},
+			wantContains: []string{"└── usage="},
+			wantAbsent:   []string{"├──"},
+		},
+		{
+			name: "falls back to shortened url",
+			display: &BackgroundTaskDisplay{
+				TaskID:   "t1",
+				AgentURL: "http://localhost:8081",
+				State:    "working",
+			},
+			wantContains: []string{"Agent(localhost:8081=working...)"},
+			wantAbsent:   []string{"http://"},
+		},
+		{
+			name: "omits model when unknown",
+			display: &BackgroundTaskDisplay{
+				TaskID:    "t1",
+				AgentName: "browser-agent",
+				State:     "working",
+				Model:     "",
+				StartedAt: time.Now().Add(-5 * time.Second),
+			},
+			wantContains: []string{"Agent(browser-agent=working...) 5s"},
+			wantAbsent:   []string{"model=", ","},
+		},
+		{
+			name: "formats elapsed minutes",
+			display: &BackgroundTaskDisplay{
+				TaskID:    "t1",
+				AgentName: "x",
+				State:     "working",
+				StartedAt: time.Now().Add(-83 * time.Second),
+			},
+			wantContains: []string{"1m23s"},
+		},
+	}
 
-	display := cv.backgroundTasks["task-1"]
-	if display.State != "failed" {
-		t.Errorf("expected State 'failed', got %q", display.State)
-	}
-	if display.ErrorMsg != "connection refused" {
-		t.Errorf("expected ErrorMsg 'connection refused', got %q", display.ErrorMsg)
-	}
-	if !display.IsTerminal {
-		t.Error("expected IsTerminal to be true after failure")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cv := NewConversationView(createMockStyleProvider())
+			line := cv.renderBackgroundTaskLine(tc.display, 0)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(line, want) {
+					t.Errorf("expected line to contain %q, got %q", want, line)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(line, absent) {
+					t.Errorf("expected line to not contain %q, got %q", absent, line)
+				}
+			}
+		})
 	}
 }
 
@@ -822,68 +912,78 @@ func TestBackgroundTaskDisplay_NormalizesStateString(t *testing.T) {
 	}
 }
 
-func TestBackgroundTaskDisplay_StatusUpdateCapturesAgentURL(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-
-	cv.handleA2ATaskStatusUpdate(domain.A2ATaskStatusUpdateEvent{
-		TaskID:   "task-1",
-		AgentURL: "http://localhost:8081",
-		Status:   "TASK_STATE_WORKING",
-	}, nil)
-
-	display := cv.backgroundTasks["task-1"]
-	if display.AgentURL != "http://localhost:8081" {
-		t.Errorf("expected AgentURL captured from status update, got %q", display.AgentURL)
+func TestBackgroundTaskDisplay_RenderLineResolverAndWidth(t *testing.T) {
+	cases := []struct {
+		name          string
+		display       *BackgroundTaskDisplay
+		width         int
+		resolver      func(string) string
+		wantContains  []string
+		checkMaxWidth bool
+	}{
+		{
+			name: "agent name resolver used",
+			display: &BackgroundTaskDisplay{
+				TaskID:   "t1",
+				AgentURL: "http://localhost:8081",
+				State:    "working",
+			},
+			resolver: func(url string) string {
+				if url == "http://localhost:8081" {
+					return "weather-agent"
+				}
+				return ""
+			},
+			wantContains: []string{"Agent(weather-agent=working...)"},
+		},
+		{
+			name: "resolver falls back to shortened url",
+			display: &BackgroundTaskDisplay{
+				TaskID:   "t1",
+				AgentURL: "http://localhost:9090",
+				State:    "working",
+			},
+			resolver:     func(_ string) string { return "" },
+			wantContains: []string{"Agent(localhost:9090=working...)"},
+		},
+		{
+			name: "truncates long model",
+			display: &BackgroundTaskDisplay{
+				TaskID:    "t1",
+				AgentName: "browser-agent",
+				State:     "working",
+				Model:     "extremely-long-vendor-name/very-verbose-model-identifier-v42-flash-preview-experimental",
+				StartedAt: time.Now().Add(-3 * time.Second),
+			},
+			width: 60,
+			wantContains: []string{
+				"Agent(browser-agent=working..., model=",
+				"...) 3s",
+				"browser-agent",
+				"working...",
+			},
+			checkMaxWidth: true,
+		},
 	}
-}
 
-func TestBackgroundTaskDisplay_SubmittedCapturesAgentURL(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-
-	cv.handleA2ATaskSubmitted(domain.A2ATaskSubmittedEvent{
-		TaskID:   "task-1",
-		AgentURL: "http://localhost:8081",
-	}, nil)
-
-	display := cv.backgroundTasks["task-1"]
-	if display.AgentURL != "http://localhost:8081" {
-		t.Errorf("expected AgentURL captured from submitted event, got %q", display.AgentURL)
-	}
-	if display.State != "submitted" {
-		t.Errorf("expected default state 'submitted', got %q", display.State)
-	}
-}
-
-func TestBackgroundTaskDisplay_AgentNameResolverUsed(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-	cv.SetAgentNameResolver(func(url string) string {
-		if url == "http://localhost:8081" {
-			return "weather-agent"
-		}
-		return ""
-	})
-
-	line := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
-		TaskID:   "t1",
-		AgentURL: "http://localhost:8081",
-		State:    "working",
-	}, 0)
-	if !strings.Contains(line, "Agent(weather-agent=working...)") {
-		t.Errorf("expected resolver-mapped name, got %q", line)
-	}
-}
-
-func TestBackgroundTaskDisplay_AgentNameResolverFallsBackToShortenedURL(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-	cv.SetAgentNameResolver(func(_ string) string { return "" })
-
-	line := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
-		TaskID:   "t1",
-		AgentURL: "http://localhost:9090",
-		State:    "working",
-	}, 0)
-	if !strings.Contains(line, "Agent(localhost:9090=working...)") {
-		t.Errorf("expected fallback to shortened URL when resolver returns empty, got %q", line)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cv := NewConversationView(createMockStyleProvider())
+			if tc.resolver != nil {
+				cv.SetAgentNameResolver(tc.resolver)
+			}
+			line := cv.renderBackgroundTaskLine(tc.display, tc.width)
+			if tc.checkMaxWidth {
+				if got := lipgloss.Width(line); got > tc.width {
+					t.Errorf("expected visible width <= %d, got %d for line %q", tc.width, got, line)
+				}
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(line, want) {
+					t.Errorf("expected line to contain %q, got %q", want, line)
+				}
+			}
+		})
 	}
 }
 
@@ -921,21 +1021,6 @@ func TestBackgroundTaskDisplay_ShortenAgentURLDropsScheme(t *testing.T) {
 				t.Errorf("shortenAgentURL(%q) = %q, want %q", c.raw, got, c.want)
 			}
 		})
-	}
-}
-
-func TestBackgroundTaskDisplay_FallsBackToShortenedURL(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-	line := cv.renderBackgroundTaskLine(&BackgroundTaskDisplay{
-		TaskID:   "t1",
-		AgentURL: "http://localhost:8081",
-		State:    "working",
-	}, 0)
-	if strings.Contains(line, "http://") {
-		t.Errorf("expected scheme stripped from fallback URL, got %q", line)
-	}
-	if !strings.Contains(line, "Agent(localhost:8081=working...)") {
-		t.Errorf("expected shortened URL, got %q", line)
 	}
 }
 
@@ -983,29 +1068,6 @@ func TestBackgroundTaskDisplay_RenderLine_IncludesModelAndElapsed(t *testing.T) 
 	}
 }
 
-func TestBackgroundTaskDisplay_RenderLine_OmitsModelWhenUnknown(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-
-	display := &BackgroundTaskDisplay{
-		TaskID:    "t1",
-		AgentName: "browser-agent",
-		State:     "working",
-		Model:     "",
-		StartedAt: time.Now().Add(-5 * time.Second),
-	}
-	line := cv.renderBackgroundTaskLine(display, 0)
-
-	if !strings.Contains(line, "Agent(browser-agent=working...) 5s") {
-		t.Errorf("expected no-model form 'Agent(browser-agent=working...) 5s', got %q", line)
-	}
-	if strings.Contains(line, "model=") {
-		t.Errorf("expected no 'model=' segment when model is unknown, got %q", line)
-	}
-	if strings.Contains(line, ",") {
-		t.Errorf("expected no trailing comma artefact when model is unknown, got %q", line)
-	}
-}
-
 func TestBackgroundTaskDisplay_RenderLine_FreezesElapsedOnTerminal(t *testing.T) {
 	cv := NewConversationView(createMockStyleProvider())
 
@@ -1036,51 +1098,6 @@ func TestBackgroundTaskDisplay_RenderLine_FreezesElapsedOnTerminal(t *testing.T)
 	}
 	if strings.Contains(line2, "43s") {
 		t.Errorf("expected elapsed to NOT tick past 42s after terminal transition, got %q", line2)
-	}
-}
-
-func TestBackgroundTaskDisplay_RenderLine_FormatElapsedMinutes(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-
-	display := &BackgroundTaskDisplay{
-		TaskID:    "t1",
-		AgentName: "x",
-		State:     "working",
-		StartedAt: time.Now().Add(-83 * time.Second),
-	}
-	line := cv.renderBackgroundTaskLine(display, 0)
-	if !strings.Contains(line, "1m23s") {
-		t.Errorf("expected elapsed '1m23s' for 83s, got %q", line)
-	}
-}
-
-func TestBackgroundTaskDisplay_RenderLine_TruncatesLongModel(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-
-	display := &BackgroundTaskDisplay{
-		TaskID:    "t1",
-		AgentName: "browser-agent",
-		State:     "working",
-		Model:     "extremely-long-vendor-name/very-verbose-model-identifier-v42-flash-preview-experimental",
-		StartedAt: time.Now().Add(-3 * time.Second),
-	}
-	const width = 60
-	line := cv.renderBackgroundTaskLine(display, width)
-
-	if got := lipgloss.Width(line); got > width {
-		t.Errorf("expected visible width <= %d, got %d for line %q", width, got, line)
-	}
-	if !strings.Contains(line, "Agent(browser-agent=working..., model=") {
-		t.Errorf("expected name and state preserved with model prefix, got %q", line)
-	}
-	if !strings.Contains(line, "...) 3s") {
-		t.Errorf("expected truncated model ending with '...) 3s', got %q", line)
-	}
-	if !strings.Contains(line, "browser-agent") {
-		t.Errorf("expected name preserved verbatim, got %q", line)
-	}
-	if !strings.Contains(line, "working...") {
-		t.Errorf("expected state preserved verbatim, got %q", line)
 	}
 }
 
@@ -1256,40 +1273,54 @@ func approvalEntry(status domain.ToolApprovalStatus) domain.ConversationEntry {
 	}
 }
 
-func TestRenderPendingToolEntry_ApprovedThemedHeader(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-	cv.SetToolFormatter(&stubToolFormatter{})
-
-	out := cv.renderPendingToolEntry(approvalEntry(domain.ToolApprovalApproved))
-
-	if !strings.Contains(out, "Approved") {
-		t.Errorf("expected Approved label, got %q", out)
+func TestRenderPendingToolEntry(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       domain.ToolApprovalStatus
+		wantContains []string
+		wantAbsent   []string
+		wantEmpty    bool
+	}{
+		{
+			name:         "approved themed header",
+			status:       domain.ToolApprovalApproved,
+			wantContains: []string{"Approved", "Bash"},
+			wantAbsent:   []string{"Tool:", "Arguments:"},
+		},
+		{
+			name:         "rejected themed header",
+			status:       domain.ToolApprovalRejected,
+			wantContains: []string{"Rejected"},
+		},
+		{
+			name:      "pending renders nothing",
+			status:    domain.ToolApprovalPending,
+			wantEmpty: true,
+		},
 	}
-	if !strings.Contains(out, "Bash") {
-		t.Errorf("expected tool name in header, got %q", out)
-	}
 
-	if strings.Contains(out, "Tool:") || strings.Contains(out, "Arguments:") {
-		t.Errorf("approval header should not contain raw Tool:/Arguments: block, got %q", out)
-	}
-}
-
-func TestRenderPendingToolEntry_RejectedThemedHeader(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-	cv.SetToolFormatter(&stubToolFormatter{})
-
-	out := cv.renderPendingToolEntry(approvalEntry(domain.ToolApprovalRejected))
-	if !strings.Contains(out, "Rejected") {
-		t.Errorf("expected Rejected label, got %q", out)
-	}
-}
-
-func TestRenderPendingToolEntry_PendingRendersNothing(t *testing.T) {
-	cv := NewConversationView(createMockStyleProvider())
-	cv.SetToolFormatter(&stubToolFormatter{})
-
-	if out := cv.renderPendingToolEntry(approvalEntry(domain.ToolApprovalPending)); out != "" {
-		t.Errorf("pending approval should render nothing, got %q", out)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cv := NewConversationView(createMockStyleProvider())
+			cv.SetToolFormatter(&stubToolFormatter{})
+			out := cv.renderPendingToolEntry(approvalEntry(tc.status))
+			if tc.wantEmpty {
+				if out != "" {
+					t.Errorf("pending approval should render nothing, got %q", out)
+				}
+				return
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected output to contain %q, got %q", want, out)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(out, absent) {
+					t.Errorf("expected output to not contain %q, got %q", absent, out)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/ui/components/file_explorer_test.go
+++ b/internal/ui/components/file_explorer_test.go
@@ -178,33 +178,33 @@ func TestExplorer_ReanchorAcrossRefresh(t *testing.T) {
 	}
 }
 
-func TestExplorer_TickPicksUpNewFileInExpandedDir(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "dir", "old.txt"), "o")
-
-	e := newTestExplorer(t, root)
-	e.cursor = mustRowIndex(t, e, "dir")
-	e.setExpanded(true)
-
-	writeTestFile(t, filepath.Join(root, "dir", "new.txt"), "n")
-	e.refresh()
-
-	if !explorerHasRow(e, "dir/new.txt") {
-		t.Fatalf("new file in an expanded dir should appear after a tick; rows=%v", rowRels(e))
+func TestExplorer_TickRefreshRespectsExpansion(t *testing.T) {
+	cases := []struct {
+		name        string
+		expandDir   bool
+		wantVisible bool
+	}{
+		{"picks up new file in expanded dir", true, true},
+		{"ignores new file in collapsed dir", false, false},
 	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeTestFile(t, filepath.Join(root, "dir", "old.txt"), "o")
 
-func TestExplorer_TickIgnoresNewFileInCollapsedDir(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "dir", "old.txt"), "o")
+			e := newTestExplorer(t, root)
+			if tc.expandDir {
+				e.cursor = mustRowIndex(t, e, "dir")
+				e.setExpanded(true)
+			}
 
-	e := newTestExplorer(t, root) // dir is collapsed by default
+			writeTestFile(t, filepath.Join(root, "dir", "new.txt"), "n")
+			e.refresh()
 
-	writeTestFile(t, filepath.Join(root, "dir", "new.txt"), "n")
-	e.refresh()
-
-	if explorerHasRow(e, "dir/new.txt") {
-		t.Fatal("a file in a collapsed dir should not be read/shown on refresh")
+			if got := explorerHasRow(e, "dir/new.txt"); got != tc.wantVisible {
+				t.Fatalf("dir/new.txt visible = %v, want %v after refresh; rows=%v", got, tc.wantVisible, rowRels(e))
+			}
+		})
 	}
 }
 
@@ -281,7 +281,7 @@ func TestExplorer_RevealPathExpandsAncestors(t *testing.T) {
 func TestExplorer_FindModeKeyCapture(t *testing.T) {
 	root := t.TempDir()
 	e := newTestExplorer(t, root)
-	e.candidates = []string{} // non-nil so enterFind does not kick off a walk
+	e.candidates = []string{}
 
 	if cmd := e.enterFind(); cmd != nil {
 		t.Fatal("enterFind should not start a walk when candidates are already loaded")
@@ -323,7 +323,6 @@ func TestExplorer_RenderSmoke(t *testing.T) {
 		t.Fatal("render with input row should be non-empty")
 	}
 
-	// Select the file and render the preview pane.
 	e.cursor = mustRowIndex(t, e, "main.go")
 	e.selectedKey = "main.go"
 	e.dirtyPreview = true
@@ -331,7 +330,6 @@ func TestExplorer_RenderSmoke(t *testing.T) {
 		t.Fatalf("preview should show file content; got %q", out)
 	}
 
-	// Find mode render.
 	e.candidates = []string{"main.go", "dir/nested.txt"}
 	e.enterFind()
 	e.findQuery = "main"
@@ -341,23 +339,25 @@ func TestExplorer_RenderSmoke(t *testing.T) {
 	}
 }
 
-func TestExplorer_BinaryPreviewPlaceholder(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "bin"), "abc\x00def")
-
-	e := newTestExplorer(t, root)
-	if out := e.computePreview("bin"); !strings.Contains(out, "Binary or large file") {
-		t.Fatalf("expected binary placeholder, got %q", out)
+func TestExplorer_PreviewPlaceholder(t *testing.T) {
+	cases := []struct {
+		name     string
+		filename string
+		content  string
+	}{
+		{"binary content", "bin", "abc\x00def"},
+		{"oversized content", "big.txt", strings.Repeat("a", explorerMaxPreviewBytes+1)},
 	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeTestFile(t, filepath.Join(root, tc.filename), tc.content)
 
-func TestExplorer_OversizedPreviewPlaceholder(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "big.txt"), strings.Repeat("a", explorerMaxPreviewBytes+1))
-
-	e := newTestExplorer(t, root)
-	if out := e.computePreview("big.txt"); !strings.Contains(out, "Binary or large file") {
-		t.Fatalf("expected oversized placeholder, got %q", out)
+			e := newTestExplorer(t, root)
+			if out := e.computePreview(tc.filename); !strings.Contains(out, "Binary or large file") {
+				t.Fatalf("expected placeholder, got %q", out)
+			}
+		})
 	}
 }
 
@@ -369,7 +369,7 @@ func selectFileForPreview(t *testing.T, e *FileExplorerImpl, rel string) *FileEx
 	e.cursor = mustRowIndex(t, e, rel)
 	e.selectedKey = rel
 	e.dirtyPreview = true
-	e.Render("") // triggers ensurePreview → sets previewLines
+	e.Render("")
 	return e
 }
 
@@ -400,7 +400,6 @@ func TestExplorer_EnterSelectModeNoFile(t *testing.T) {
 	writeTestFile(t, filepath.Join(root, "main.go"), "package main\n")
 	e := newTestExplorer(t, root)
 
-	// No file selected (cursor on a dir or nothing).
 	e.enterSelectMode()
 	if e.selectMode {
 		t.Fatal("enterSelectMode should be a no-op when no file is previewed")
@@ -414,27 +413,23 @@ func TestExplorer_PreviewCursorMovement(t *testing.T) {
 	selectFileForPreview(t, e, "f.go")
 	e.enterSelectMode()
 
-	// Move down a few lines.
 	e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'})
 	e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'})
 	if e.previewCursor != 2 {
 		t.Fatalf("after 2x nav_down previewCursor = %d, want 2", e.previewCursor)
 	}
 
-	// Move back up.
 	e.Update(tea.KeyPressMsg{Text: "k", Code: 'k'})
 	if e.previewCursor != 1 {
 		t.Fatalf("after nav_up previewCursor = %d, want 1", e.previewCursor)
 	}
 
-	// Clamp at bottom.
 	e.previewCursor = e.previewLines - 1
 	e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'})
 	if e.previewCursor != e.previewLines-1 {
 		t.Fatalf("nav_down at bottom: previewCursor = %d, want %d", e.previewCursor, e.previewLines-1)
 	}
 
-	// Clamp at top.
 	e.previewCursor = 0
 	e.Update(tea.KeyPressMsg{Text: "k", Code: 'k'})
 	if e.previewCursor != 0 {
@@ -456,9 +451,9 @@ func TestExplorer_PreviewCursorKeepsSelectionInView(t *testing.T) {
 	writeTestFile(t, filepath.Join(root, "tall.go"), sb.String())
 
 	e := newTestExplorer(t, root)
-	e.SetHeight(8) // force a short pane (well under the 40-line file); h is read back below
+	e.SetHeight(8)
 	selectFileForPreview(t, e, "tall.go")
-	e.Render("") // apply the short height to the viewport
+	e.Render("")
 
 	h := e.viewport.Height()
 	if h <= 0 || h >= e.previewLines {
@@ -466,12 +461,9 @@ func TestExplorer_PreviewCursorKeepsSelectionInView(t *testing.T) {
 	}
 
 	e.enterSelectMode()
-	e.Update(tea.KeyPressMsg{Text: " ", Code: ' '}) // anchor at the top line
+	e.Update(tea.KeyPressMsg{Text: " ", Code: ' '})
 	anchor := e.selAnchor
 
-	// Drive the cursor to a mid-file line: far enough below the fold to scroll,
-	// but well clear of the bottom clamp (where pin-to-top and keep-in-view would
-	// coincide at maxYOffset and the test couldn't tell them apart).
 	target := e.previewLines / 2
 	for i := 0; i < target; i++ {
 		e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'})
@@ -644,10 +636,8 @@ func TestExplorer_EnterAttachesSelection(t *testing.T) {
 	selectFileForPreview(t, e, "f.go")
 	e.enterSelectMode()
 
-	// Enter attaches the current range immediately (no annotation required),
-	// stays in select mode, and does NOT close the explorer.
-	e.Update(tea.KeyPressMsg{Text: " ", Code: ' '}) // anchor at line 1
-	e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'}) // extend to line 2
+	e.Update(tea.KeyPressMsg{Text: " ", Code: ' '})
+	e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'})
 	e.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	sels := e.Selections()
@@ -720,10 +710,9 @@ func TestExplorer_PreviewHighlightRender(t *testing.T) {
 	selectFileForPreview(t, e, "f.go")
 	e.enterSelectMode()
 
-	// Select lines 2-3 (0-indexed 1-2).
 	e.previewCursor = 1
-	e.Update(tea.KeyPressMsg{Text: " ", Code: ' '}) // anchor at 1
-	e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'}) // cursor → 2
+	e.Update(tea.KeyPressMsg{Text: " ", Code: ' '})
+	e.Update(tea.KeyPressMsg{Text: "j", Code: 'j'})
 
 	out := e.Render("")
 	if !strings.Contains(out, "▌") {
@@ -757,85 +746,86 @@ func TestExplorer_AnnotateModeRenderSmoke(t *testing.T) {
 }
 
 func TestExplorer_FormatAnnotations(t *testing.T) {
-	root := t.TempDir()
-	content := "package main\n\nfunc main() {\n\tprintln(\"hi\")\n}\n"
-	writeTestFile(t, filepath.Join(root, "main.go"), content)
+	three := 3
+	cases := []struct {
+		name            string
+		files           map[string]string
+		sels            []SnippetSelection
+		wantContains    []string
+		wantNotContains []string
+		wantLineCount   *int
+		wantEmpty       bool
+	}{
+		{
+			name:  "single file selected lines with note",
+			files: map[string]string{"main.go": "package main\n\nfunc main() {\n\tprintln(\"hi\")\n}\n"},
+			sels: []SnippetSelection{
+				{File: "main.go", StartLine: 3, EndLine: 5, Annotation: "refactor to use early returns"},
+			},
+			wantContains: []string{
+				"main.go (lines 3-5):",
+				"```go",
+				"func main() {",
+				"println(\"hi\")",
+				"note: refactor to use early returns",
+			},
+			wantNotContains: []string{"package main"},
+		},
+		{
+			name:  "large file emits selected lines only",
+			files: map[string]string{"big.txt": strings.Repeat("line\n", explorerMaxPreviewBytes/5+10)},
+			sels: []SnippetSelection{
+				{File: "big.txt", StartLine: 10, EndLine: 12, Annotation: "fix this"},
+			},
+			wantContains:    []string{"big.txt (lines 10-12):", "note: fix this"},
+			wantNotContains: []string{"### Lines", "(context "},
+			wantLineCount:   &three,
+		},
+		{
+			name:  "multiple files and a missing file",
+			files: map[string]string{"a.go": "a\nb\nc\n", "b.go": "d\ne\nf\n"},
+			sels: []SnippetSelection{
+				{File: "a.go", StartLine: 1, EndLine: 2, Annotation: "first"},
+				{File: "b.go", StartLine: 2, EndLine: 3, Annotation: "second"},
+				{File: "gone.go", StartLine: 1, EndLine: 1, Annotation: "missing"},
+			},
+			wantContains: []string{"a.go", "b.go", "first", "second", "unavailable"},
+		},
+		{
+			name:      "nil selections yield empty output",
+			wantEmpty: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for name, content := range tc.files {
+				writeTestFile(t, filepath.Join(root, name), content)
+			}
 
-	sels := []SnippetSelection{
-		{File: "main.go", StartLine: 3, EndLine: 5, Annotation: "refactor to use early returns"},
-	}
-	out := FormatAnnotations(root, sels)
+			out := FormatAnnotations(root, tc.sels)
 
-	checks := []string{
-		"main.go (lines 3-5):",
-		"```go",
-		"func main() {",
-		"println(\"hi\")",
-		"note: refactor to use early returns",
-	}
-	for _, want := range checks {
-		if !strings.Contains(out, want) {
-			t.Errorf("FormatAnnotations output missing %q\n--- output ---\n%s", want, out)
-		}
-	}
-	// Only the selected lines (3-5) are emitted - not the whole file.
-	if strings.Contains(out, "package main") {
-		t.Errorf("output should not include non-selected line 1 (package main)\n--- output ---\n%s", out)
-	}
-}
-
-func TestExplorer_FormatAnnotationsLargeFileSelectedLinesOnly(t *testing.T) {
-	root := t.TempDir()
-	// A large file: the formatter must still emit ONLY the selected lines, never
-	// the whole file or a context window.
-	content := strings.Repeat("line\n", explorerMaxPreviewBytes/5+10)
-	writeTestFile(t, filepath.Join(root, "big.txt"), content)
-
-	sels := []SnippetSelection{
-		{File: "big.txt", StartLine: 10, EndLine: 12, Annotation: "fix this"},
-	}
-	out := FormatAnnotations(root, sels)
-
-	if !strings.Contains(out, "big.txt (lines 10-12):") {
-		t.Errorf("output should head the snippet with the file + range\n--- output ---\n%s", out)
-	}
-	if !strings.Contains(out, "note: fix this") {
-		t.Errorf("output should contain the note\n--- output ---\n%s", out)
-	}
-	if strings.Contains(out, "### Lines") || strings.Contains(out, "(context ") {
-		t.Errorf("the old windowed/context format must be gone\n--- output ---\n%s", out)
-	}
-	// Exactly the 3 selected lines are emitted (not the whole file).
-	if got := strings.Count(out, "line\n"); got != 3 {
-		t.Errorf("expected exactly 3 selected lines, got %d\n--- output ---\n%s", got, out)
-	}
-}
-
-func TestExplorer_FormatAnnotationsMultiFileAndMissing(t *testing.T) {
-	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "a.go"), "a\nb\nc\n")
-	writeTestFile(t, filepath.Join(root, "b.go"), "d\ne\nf\n")
-
-	sels := []SnippetSelection{
-		{File: "a.go", StartLine: 1, EndLine: 2, Annotation: "first"},
-		{File: "b.go", StartLine: 2, EndLine: 3, Annotation: "second"},
-		{File: "gone.go", StartLine: 1, EndLine: 1, Annotation: "missing"},
-	}
-	out := FormatAnnotations(root, sels)
-
-	if !strings.Contains(out, "a.go") || !strings.Contains(out, "b.go") {
-		t.Errorf("output should list both files\n--- output ---\n%s", out)
-	}
-	if !strings.Contains(out, "first") || !strings.Contains(out, "second") {
-		t.Errorf("output should contain both annotations\n--- output ---\n%s", out)
-	}
-	if !strings.Contains(out, "unavailable") {
-		t.Errorf("output should mention the missing file\n--- output ---\n%s", out)
-	}
-}
-
-func TestExplorer_FormatAnnotationsEmpty(t *testing.T) {
-	if out := FormatAnnotations(t.TempDir(), nil); out != "" {
-		t.Fatalf("FormatAnnotations(nil) = %q, want empty", out)
+			if tc.wantEmpty {
+				if out != "" {
+					t.Fatalf("FormatAnnotations(nil) = %q, want empty", out)
+				}
+				return
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("FormatAnnotations output missing %q\n--- output ---\n%s", want, out)
+				}
+			}
+			for _, unwanted := range tc.wantNotContains {
+				if strings.Contains(out, unwanted) {
+					t.Errorf("output should not contain %q\n--- output ---\n%s", unwanted, out)
+				}
+			}
+			if tc.wantLineCount != nil {
+				if got := strings.Count(out, "line\n"); got != *tc.wantLineCount {
+					t.Errorf("expected exactly %d selected lines, got %d\n--- output ---\n%s", *tc.wantLineCount, got, out)
+				}
+			}
+		})
 	}
 }

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -557,37 +557,41 @@ func TestInputStatusBar_GetContextUsageIndicator(t *testing.T) {
 	}
 }
 
-func TestInputStatusBar_BuildSessionTokensIndicator_FallsBackToEstimator(t *testing.T) {
-	mockRepo := &domainmocks.FakeConversationRepository{}
-	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{TotalInputTokens: 0})
-	mockRepo.GetMessagesReturns([]domain.ConversationEntry{
-		{Message: sdk.Message{Role: sdk.User}},
-	})
-
-	statusBar := &InputStatusBar{
-		conversationRepo: mockRepo,
-		tokenEstimator:   &stubTokenEstimator{estimate: 6643},
+func TestInputStatusBar_FallsBackToEstimator(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*InputStatusBar) string
+		want string
+	}{
+		{
+			name: "session tokens indicator uses estimate",
+			call: func(sb *InputStatusBar) string { return sb.buildSessionTokensIndicator() },
+			want: "T.6643",
+		},
+		{
+			name: "context usage indicator uses estimate",
+			call: func(sb *InputStatusBar) string { return sb.getContextUsageIndicator("deepseek/deepseek-v4-flash") },
+			want: "Context: 0.7%",
+		},
 	}
 
-	if got := statusBar.buildSessionTokensIndicator(); got != "T.6643" {
-		t.Errorf("expected fallback estimate T.6643, got: %s", got)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := &domainmocks.FakeConversationRepository{}
+			mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{TotalInputTokens: 0})
+			mockRepo.GetMessagesReturns([]domain.ConversationEntry{
+				{Message: sdk.Message{Role: sdk.User}},
+			})
 
-func TestInputStatusBar_GetContextUsageIndicator_FallsBackToEstimator(t *testing.T) {
-	mockRepo := &domainmocks.FakeConversationRepository{}
-	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{TotalInputTokens: 0})
-	mockRepo.GetMessagesReturns([]domain.ConversationEntry{
-		{Message: sdk.Message{Role: sdk.User}},
-	})
+			statusBar := &InputStatusBar{
+				conversationRepo: mockRepo,
+				tokenEstimator:   &stubTokenEstimator{estimate: 6643},
+			}
 
-	statusBar := &InputStatusBar{
-		conversationRepo: mockRepo,
-		tokenEstimator:   &stubTokenEstimator{estimate: 6643},
-	}
-
-	if got := statusBar.getContextUsageIndicator("deepseek/deepseek-v4-flash"); got != "Context: 0.7%" {
-		t.Errorf("expected fallback estimator percentage, got: %s", got)
+			if got := tt.call(statusBar); got != tt.want {
+				t.Errorf("expected fallback estimate %s, got: %s", tt.want, got)
+			}
+		})
 	}
 }
 
@@ -624,35 +628,6 @@ func TestInputStatusBar_ShouldShowIndicator_SessionTokens(t *testing.T) {
 				t.Errorf("Expected %v but got %v", tt.expected, result)
 			}
 		})
-	}
-}
-
-func TestInputStatusBar_BuildModelDisplayText_WithSessionTokens(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.Agent.MaxTokens = 8000
-	cfg.Chat.StatusBar.Indicators.SessionTokens = true
-
-	mockRepo := &domainmocks.FakeConversationRepository{}
-	mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{
-		TotalInputTokens: 1234,
-	})
-
-	themeService := &domainmocks.FakeThemeService{}
-	themeService.GetCurrentThemeNameReturns("tokyo-night")
-
-	statusBar := &InputStatusBar{
-		config:           cfg,
-		themeService:     themeService,
-		conversationRepo: mockRepo,
-	}
-
-	result := statusBar.buildModelDisplayText("test-model")
-
-	if result == "" {
-		t.Error("Expected non-empty output when indicators are enabled")
-	}
-	if !strings.Contains(result, "T.1234") {
-		t.Errorf("Expected output to contain 'T.1234', got: %s", result)
 	}
 }
 
@@ -693,48 +668,84 @@ func TestInputStatusBar_ShouldShowIndicator_GitBranch(t *testing.T) {
 }
 
 func TestInputStatusBar_BuildModelDisplayText(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.Chat.StatusBar.Indicators.Model = false
-	cfg.Chat.StatusBar.Indicators.Theme = false
-	cfg.Chat.StatusBar.Indicators.MaxOutput = false
-	cfg.Chat.StatusBar.Indicators.A2AAgents = false
-	cfg.Chat.StatusBar.Indicators.Tools = false
-	cfg.Chat.StatusBar.Indicators.BackgroundShells = false
-	cfg.Chat.StatusBar.Indicators.MCP = false
-	cfg.Chat.StatusBar.Indicators.ContextUsage = false
-	cfg.Chat.StatusBar.Indicators.SessionTokens = false
-	cfg.Chat.StatusBar.Indicators.GitBranch = false
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T) *InputStatusBar
+		wantEmpty    bool
+		wantContains string
+	}{
+		{
+			name: "all indicators disabled yields empty",
+			setup: func(t *testing.T) *InputStatusBar {
+				cfg := config.DefaultConfig()
+				cfg.Chat.StatusBar.Indicators.Model = false
+				cfg.Chat.StatusBar.Indicators.Theme = false
+				cfg.Chat.StatusBar.Indicators.MaxOutput = false
+				cfg.Chat.StatusBar.Indicators.A2AAgents = false
+				cfg.Chat.StatusBar.Indicators.Tools = false
+				cfg.Chat.StatusBar.Indicators.BackgroundShells = false
+				cfg.Chat.StatusBar.Indicators.MCP = false
+				cfg.Chat.StatusBar.Indicators.ContextUsage = false
+				cfg.Chat.StatusBar.Indicators.SessionTokens = false
+				cfg.Chat.StatusBar.Indicators.GitBranch = false
 
-	statusBar := &InputStatusBar{
-		config: cfg,
+				return &InputStatusBar{config: cfg}
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "all enabled contains model information",
+			setup: func(t *testing.T) *InputStatusBar {
+				cfg := config.DefaultConfig()
+				cfg.Agent.MaxTokens = 8000
+
+				themeService := &domainmocks.FakeThemeService{}
+				themeService.GetCurrentThemeNameReturns("tokyo-night")
+
+				return &InputStatusBar{config: cfg, themeService: themeService}
+			},
+			wantContains: "test-model",
+		},
+		{
+			name: "session tokens indicator included when enabled",
+			setup: func(t *testing.T) *InputStatusBar {
+				cfg := config.DefaultConfig()
+				cfg.Agent.MaxTokens = 8000
+				cfg.Chat.StatusBar.Indicators.SessionTokens = true
+
+				mockRepo := &domainmocks.FakeConversationRepository{}
+				mockRepo.GetSessionTokensReturns(domain.SessionTokenStats{
+					TotalInputTokens: 1234,
+				})
+
+				themeService := &domainmocks.FakeThemeService{}
+				themeService.GetCurrentThemeNameReturns("tokyo-night")
+
+				return &InputStatusBar{config: cfg, themeService: themeService, conversationRepo: mockRepo}
+			},
+			wantContains: "T.1234",
+		},
 	}
 
-	result := statusBar.buildModelDisplayText("test-model")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusBar := tt.setup(t)
 
-	if result != "" {
-		t.Errorf("Expected empty string when all indicators disabled, got: %s", result)
-	}
-}
+			result := statusBar.buildModelDisplayText("test-model")
 
-func TestInputStatusBar_BuildModelDisplayText_AllEnabled(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.Agent.MaxTokens = 8000
-
-	themeService := &domainmocks.FakeThemeService{}
-	themeService.GetCurrentThemeNameReturns("tokyo-night")
-
-	statusBar := &InputStatusBar{
-		config:       cfg,
-		themeService: themeService,
-	}
-
-	result := statusBar.buildModelDisplayText("test-model")
-
-	if result == "" {
-		t.Error("Expected non-empty output when indicators are enabled")
-	}
-	if !strings.Contains(result, "test-model") {
-		t.Error("Expected output to contain model information")
+			if tt.wantEmpty {
+				if result != "" {
+					t.Errorf("Expected empty string when all indicators disabled, got: %s", result)
+				}
+				return
+			}
+			if result == "" {
+				t.Error("Expected non-empty output when indicators are enabled")
+			}
+			if !strings.Contains(result, tt.wantContains) {
+				t.Errorf("Expected output to contain '%s', got: %s", tt.wantContains, result)
+			}
+		})
 	}
 }
 

--- a/internal/ui/components/input_view_test.go
+++ b/internal/ui/components/input_view_test.go
@@ -107,15 +107,85 @@ func TestNewInputView(t *testing.T) {
 	}
 }
 
-func TestInputView_GetInput(t *testing.T) {
-	mockModelService := createMockModelService()
-	iv := NewInputView(mockModelService)
+func TestInputView_GettersAndSetters(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(iv *InputView)
+		got    func(iv *InputView) any
+		want   any
+	}{
+		{
+			name:   "get input returns set text",
+			mutate: func(iv *InputView) { iv.SetText("Hello, world!") },
+			got:    func(iv *InputView) any { return iv.GetInput() },
+			want:   "Hello, world!",
+		},
+		{
+			name:   "set text stores content",
+			mutate: func(iv *InputView) { iv.SetText("New text content") },
+			got:    func(iv *InputView) any { return iv.GetInput() },
+			want:   "New text content",
+		},
+		{
+			name:   "set text moves cursor to end",
+			mutate: func(iv *InputView) { iv.SetText("New text content") },
+			got:    func(iv *InputView) any { return iv.GetCursor() },
+			want:   16,
+		},
+		{
+			name: "get cursor returns position set in text",
+			mutate: func(iv *InputView) {
+				iv.SetText("Hello World")
+				iv.SetCursor(5)
+			},
+			got:  func(iv *InputView) any { return iv.GetCursor() },
+			want: 5,
+		},
+		{
+			name:   "set cursor keeps zero for invalid position",
+			mutate: func(iv *InputView) { iv.SetCursor(15) },
+			got:    func(iv *InputView) any { return iv.GetCursor() },
+			want:   0,
+		},
+		{
+			name: "set cursor moves within text",
+			mutate: func(iv *InputView) {
+				iv.SetText("Hello World")
+				iv.SetCursor(5)
+			},
+			got:  func(iv *InputView) any { return iv.GetCursor() },
+			want: 5,
+		},
+		{
+			name:   "set width updates width",
+			mutate: func(iv *InputView) { iv.SetWidth(120) },
+			got:    func(iv *InputView) any { return iv.width },
+			want:   120,
+		},
+		{
+			name:   "set height updates height",
+			mutate: func(iv *InputView) { iv.SetHeight(8) },
+			got:    func(iv *InputView) any { return iv.height },
+			want:   8,
+		},
+		{
+			name:   "set placeholder updates placeholder",
+			mutate: func(iv *InputView) { iv.SetPlaceholder("Enter your message...") },
+			got:    func(iv *InputView) any { return iv.placeholder },
+			want:   "Enter your message...",
+		},
+	}
 
-	testText := "Hello, world!"
-	iv.SetText(testText)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iv := NewInputView(createMockModelService())
 
-	if iv.GetInput() != testText {
-		t.Errorf("Expected GetInput to return '%s', got '%s'", testText, iv.GetInput())
+			tt.mutate(iv)
+
+			if got := tt.got(iv); got != tt.want {
+				t.Errorf("Expected %v, got %v", tt.want, got)
+			}
+		})
 	}
 }
 
@@ -153,84 +223,6 @@ func TestInputView_AddImageAttachmentTokenHasNoIssueRef(t *testing.T) {
 	}
 	if got := len(iv.GetImageAttachments()); got != 2 {
 		t.Errorf("expected 2 tracked attachments, got %d", got)
-	}
-}
-
-func TestInputView_SetPlaceholder(t *testing.T) {
-	mockModelService := createMockModelService()
-	iv := NewInputView(mockModelService)
-
-	testPlaceholder := "Enter your message..."
-	iv.SetPlaceholder(testPlaceholder)
-
-	if iv.placeholder != testPlaceholder {
-		t.Errorf("Expected placeholder '%s', got '%s'", testPlaceholder, iv.placeholder)
-	}
-}
-
-func TestInputView_GetCursor(t *testing.T) {
-	mockModelService := createMockModelService()
-	iv := NewInputView(mockModelService)
-
-	iv.SetText("Hello World")
-	iv.SetCursor(5)
-
-	if iv.GetCursor() != 5 {
-		t.Errorf("Expected cursor position 5, got %d", iv.GetCursor())
-	}
-}
-
-func TestInputView_SetCursor(t *testing.T) {
-	mockModelService := createMockModelService()
-	iv := NewInputView(mockModelService)
-
-	iv.SetCursor(15)
-	if iv.GetCursor() != 0 {
-		t.Errorf("Expected cursor to remain at 0 for invalid position, got %d", iv.GetCursor())
-	}
-
-	iv.SetText("Hello World")
-	iv.SetCursor(5)
-	if iv.GetCursor() != 5 {
-		t.Errorf("Expected cursor position 5, got %d", iv.GetCursor())
-	}
-}
-
-func TestInputView_SetText(t *testing.T) {
-	mockModelService := createMockModelService()
-	iv := NewInputView(mockModelService)
-
-	testText := "New text content"
-	iv.SetText(testText)
-
-	if iv.GetInput() != testText {
-		t.Errorf("Expected text '%s', got '%s'", testText, iv.GetInput())
-	}
-
-	if iv.GetCursor() != 16 {
-		t.Errorf("Expected cursor at end of text (16), got %d", iv.GetCursor())
-	}
-}
-
-func TestInputView_SetWidth(t *testing.T) {
-	mockModelService := createMockModelService()
-	iv := NewInputView(mockModelService)
-
-	iv.SetWidth(120)
-
-	if iv.width != 120 {
-		t.Errorf("Expected width 120, got %d", iv.width)
-	}
-}
-
-func TestInputView_SetHeight(t *testing.T) {
-	mockModelService := createMockModelService()
-	iv := NewInputView(mockModelService)
-
-	iv.SetHeight(8)
-
-	if iv.height != 8 {
-		t.Errorf("Expected height 8, got %d", iv.height)
 	}
 }
 

--- a/internal/ui/keybinding/config_test.go
+++ b/internal/ui/keybinding/config_test.go
@@ -2,143 +2,145 @@ package keybinding_test
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	config "github.com/inference-gateway/cli/config"
 	keybinding "github.com/inference-gateway/cli/internal/ui/keybinding"
 )
 
-// TestConfigOverrides tests that keybinding configuration overrides are applied correctly
-func TestConfigOverrides(t *testing.T) {
-	cfg := config.DefaultConfig()
-
-	cfg.Chat.Keybindings.Enabled = true
-	enabled := true
-	cfg.Chat.Keybindings.Bindings = map[string]config.KeyBindingEntry{
-		"mode_cycle_agent_mode": {
-			Keys:    []string{"ctrl+m"},
-			Enabled: &enabled,
-		},
-	}
-
-	registry := keybinding.NewRegistry(cfg)
-
-	action := registry.GetAction("mode_cycle_agent_mode")
-	if action == nil {
-		t.Fatal("Expected mode_cycle_agent_mode action to exist")
-	}
-
-	if len(action.Binding.Keys()) != 1 || action.Binding.Keys()[0] != "ctrl+m" {
-		t.Errorf("Expected keys to be [ctrl+m], got %v", action.Binding.Keys())
-	}
-
-	if !action.Binding.Enabled() {
-		t.Error("Expected action to be enabled")
-	}
+type configOverrideCase struct {
+	name             string
+	nilConfig        bool
+	enabled          bool
+	bindings         map[string]config.KeyBindingEntry
+	action           string
+	wantNil          bool
+	wantKeys         []string
+	wantNonEmptyKeys bool
+	wantEnabled      *bool
+	wantKeyContains  string
 }
 
-// TestConfigDisableAction tests that actions can be disabled via config
-func TestConfigDisableAction(t *testing.T) {
-	cfg := config.DefaultConfig()
+func assertConfigOverride(t *testing.T, action *keybinding.KeyAction, tc configOverrideCase) {
+	t.Helper()
 
-	disabled := false
-	cfg.Chat.Keybindings.Enabled = true
-	cfg.Chat.Keybindings.Bindings = map[string]config.KeyBindingEntry{
-		"tools_toggle_tool_expansion": {
-			Keys:    []string{"ctrl+o"},
-			Enabled: &disabled,
-		},
-	}
-
-	registry := keybinding.NewRegistry(cfg)
-
-	action := registry.GetAction("tools_toggle_tool_expansion")
-	if action == nil {
-		t.Fatal("Expected tools_toggle_tool_expansion action to exist")
-	}
-
-	if action.Binding.Enabled() {
-		t.Error("Expected action to be disabled")
-	}
-}
-
-// TestConfigMultipleKeys tests that multiple keys can be assigned to one action
-func TestConfigMultipleKeys(t *testing.T) {
-	cfg := config.DefaultConfig()
-
-	enabled := true
-	cfg.Chat.Keybindings.Enabled = true
-	cfg.Chat.Keybindings.Bindings = map[string]config.KeyBindingEntry{
-		"chat_enter_key_handler": {
-			Keys:    []string{"ctrl+enter", "enter"},
-			Enabled: &enabled,
-		},
-	}
-
-	registry := keybinding.NewRegistry(cfg)
-
-	action := registry.GetAction("chat_enter_key_handler")
-	if action == nil {
-		t.Fatal("Expected chat_enter_key_handler action to exist")
-	}
-
-	if len(action.Binding.Keys()) != 2 {
-		t.Errorf("Expected 2 keys, got %d", len(action.Binding.Keys()))
-	}
-
-	expectedKeys := map[string]bool{"ctrl+enter": true, "enter": true}
-	for _, key := range action.Binding.Keys() {
-		if !expectedKeys[key] {
-			t.Errorf("Unexpected key: %s", key)
+	if tc.wantKeys != nil {
+		keys := action.Binding.Keys()
+		if len(keys) != len(tc.wantKeys) {
+			t.Errorf("Expected %d keys, got %d", len(tc.wantKeys), len(keys))
+		}
+		expectedKeys := make(map[string]bool, len(tc.wantKeys))
+		for _, key := range tc.wantKeys {
+			expectedKeys[key] = true
+		}
+		for _, key := range keys {
+			if !expectedKeys[key] {
+				t.Errorf("Unexpected key: %s", key)
+			}
 		}
 	}
-}
-
-// TestConfigWithoutOverrides tests that registry works without custom bindings
-func TestConfigWithoutOverrides(t *testing.T) {
-	cfg := config.DefaultConfig()
-	cfg.Chat.Keybindings.Enabled = false
-
-	registry := keybinding.NewRegistry(cfg)
-
-	action := registry.GetAction("global_quit")
-	if action == nil {
-		t.Fatal("Expected global_quit action to exist even without custom bindings")
-	}
-
-	if len(action.Binding.Keys()) == 0 {
+	if tc.wantNonEmptyKeys && len(action.Binding.Keys()) == 0 {
 		t.Error("Expected default keys to be present")
 	}
+	if tc.wantEnabled != nil && action.Binding.Enabled() != *tc.wantEnabled {
+		t.Errorf("Expected enabled=%v, got %v", *tc.wantEnabled, action.Binding.Enabled())
+	}
+	if tc.wantKeyContains != "" && !slices.Contains(action.Binding.Keys(), tc.wantKeyContains) {
+		t.Error("Expected config key to be applied without runtime validation")
+	}
 }
 
-// TestConfigUnknownActionIgnored tests that unknown action IDs are ignored
-func TestConfigUnknownActionIgnored(t *testing.T) {
-	cfg := config.DefaultConfig()
+// TestConfigOverrides tests how keybinding configuration is applied to the registry
+func TestConfigOverrides(t *testing.T) {
+	on, off := true, false
 
-	enabled := true
-	cfg.Chat.Keybindings.Enabled = true
-	cfg.Chat.Keybindings.Bindings = map[string]config.KeyBindingEntry{
-		"nonexistent_action": {
-			Keys:    []string{"ctrl+z"},
-			Enabled: &enabled,
+	tests := []configOverrideCase{
+		{
+			name:    "override replaces keys and keeps action enabled",
+			enabled: true,
+			bindings: map[string]config.KeyBindingEntry{
+				"mode_cycle_agent_mode": {Keys: []string{"ctrl+m"}, Enabled: &on},
+			},
+			action:      "mode_cycle_agent_mode",
+			wantKeys:    []string{"ctrl+m"},
+			wantEnabled: &on,
+		},
+		{
+			name:    "action disabled via config",
+			enabled: true,
+			bindings: map[string]config.KeyBindingEntry{
+				"tools_toggle_tool_expansion": {Keys: []string{"ctrl+o"}, Enabled: &off},
+			},
+			action:      "tools_toggle_tool_expansion",
+			wantEnabled: &off,
+		},
+		{
+			name:    "multiple keys assigned to one action",
+			enabled: true,
+			bindings: map[string]config.KeyBindingEntry{
+				"chat_enter_key_handler": {Keys: []string{"ctrl+enter", "enter"}, Enabled: &on},
+			},
+			action:   "chat_enter_key_handler",
+			wantKeys: []string{"ctrl+enter", "enter"},
+		},
+		{
+			name:             "defaults kept when overrides disabled",
+			enabled:          false,
+			action:           "global_quit",
+			wantNonEmptyKeys: true,
+		},
+		{
+			name:    "unknown action id ignored",
+			enabled: true,
+			bindings: map[string]config.KeyBindingEntry{
+				"nonexistent_action": {Keys: []string{"ctrl+z"}, Enabled: &on},
+			},
+			action:  "nonexistent_action",
+			wantNil: true,
+		},
+		{
+			name:      "nil config falls back to defaults",
+			nilConfig: true,
+			action:    "global_quit",
+		},
+		{
+			name:    "conflicting key applied without runtime validation",
+			enabled: true,
+			bindings: map[string]config.KeyBindingEntry{
+				"mode_cycle_agent_mode": {Keys: []string{"ctrl+c"}, Enabled: &on},
+			},
+			action:          "mode_cycle_agent_mode",
+			wantKeyContains: "ctrl+c",
 		},
 	}
 
-	registry := keybinding.NewRegistry(cfg)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg *config.Config
+			if !tt.nilConfig {
+				cfg = config.DefaultConfig()
+				cfg.Chat.Keybindings.Enabled = tt.enabled
+				if tt.bindings != nil {
+					cfg.Chat.Keybindings.Bindings = tt.bindings
+				}
+			}
 
-	action := registry.GetAction("nonexistent_action")
-	if action != nil {
-		t.Error("Expected unknown action to be ignored, not registered")
-	}
-}
+			registry := keybinding.NewRegistry(cfg)
+			action := registry.GetAction(tt.action)
 
-// TestConfigNilSafe tests that nil config is handled safely
-func TestConfigNilSafe(t *testing.T) {
-	registry := keybinding.NewRegistry(nil)
+			if tt.wantNil {
+				if action != nil {
+					t.Error("Expected unknown action to be ignored, not registered")
+				}
+				return
+			}
+			if action == nil {
+				t.Fatalf("Expected %s action to exist", tt.action)
+			}
 
-	action := registry.GetAction("global_quit")
-	if action == nil {
-		t.Fatal("Expected default bindings to work with nil config")
+			assertConfigOverride(t, action, tt)
+		})
 	}
 }
 
@@ -180,38 +182,5 @@ func TestKeybindingsExcludedFromMainConfigYAML(t *testing.T) {
 	}
 	if got := field.Tag.Get("mapstructure"); got != "-" {
 		t.Errorf("Expected mapstructure tag '-', got %q (viper would unmarshal into the field)", got)
-	}
-}
-
-// TestConfigNoRuntimeValidation tests that conflicts are allowed at runtime (last wins)
-func TestConfigNoRuntimeValidation(t *testing.T) {
-	cfg := config.DefaultConfig()
-
-	enabled := true
-	cfg.Chat.Keybindings.Enabled = true
-	cfg.Chat.Keybindings.Bindings = map[string]config.KeyBindingEntry{
-		"mode_cycle_agent_mode": {
-			Keys:    []string{"ctrl+c"},
-			Enabled: &enabled,
-		},
-	}
-
-	registry := keybinding.NewRegistry(cfg)
-
-	action := registry.GetAction("mode_cycle_agent_mode")
-	if action == nil {
-		t.Fatal("Expected mode_cycle_agent_mode action to exist")
-	}
-
-	hasConfigKey := false
-	for _, key := range action.Binding.Keys() {
-		if key == "ctrl+c" {
-			hasConfigKey = true
-			break
-		}
-	}
-
-	if !hasConfigKey {
-		t.Error("Expected config key to be applied without runtime validation")
 	}
 }

--- a/internal/ui/keybinding/registry_test.go
+++ b/internal/ui/keybinding/registry_test.go
@@ -45,99 +45,128 @@ func newTestContext(currentView domain.ViewState, inputText string) *keybindingm
 	return fake
 }
 
-func TestRegistryCreation(t *testing.T) {
-	registry := keybinding.NewRegistry(nil)
-	if registry == nil {
-		t.Fatal("Expected registry to be created")
+func TestActiveActionMembership(t *testing.T) {
+	tests := []struct {
+		name        string
+		view        domain.ViewState
+		inputText   string
+		actionID    string
+		wantPresent bool
+	}{
+		{
+			name:        "global quit registered in chat view",
+			view:        domain.ViewStateChat,
+			inputText:   "test message",
+			actionID:    "global_quit",
+			wantPresent: true,
+		},
+		{
+			name:        "tool expansion toggle registered in chat view",
+			view:        domain.ViewStateChat,
+			inputText:   "test message",
+			actionID:    "tools_toggle_tool_expansion",
+			wantPresent: true,
+		},
+		{
+			name:        "tool expansion toggle filtered out in model selection view",
+			view:        domain.ViewStateModelSelection,
+			inputText:   "",
+			actionID:    "tools_toggle_tool_expansion",
+			wantPresent: false,
+		},
 	}
 
-	mockContext := newTestContext(domain.ViewStateChat, "test message")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := keybinding.NewRegistry(nil)
+			if registry == nil {
+				t.Fatal("Expected registry to be created")
+			}
 
-	actions := registry.GetActiveActions(mockContext)
+			mockContext := newTestContext(tt.view, tt.inputText)
+			actions := registry.GetActiveActions(mockContext)
+			if tt.wantPresent && len(actions) == 0 {
+				t.Fatal("Expected default actions to be registered")
+			}
 
-	if len(actions) == 0 {
-		t.Fatal("Expected default actions to be registered")
-	}
-
-	foundQuit := false
-	foundToggle := false
-	for _, action := range actions {
-		switch action.ID {
-		case "global_quit":
-			foundQuit = true
-		case "tools_toggle_tool_expansion":
-			foundToggle = true
-		}
-	}
-
-	if !foundQuit {
-		t.Error("Expected 'global_quit' action to be registered")
-	}
-	if !foundToggle {
-		t.Error("Expected 'tools_toggle_tool_expansion' action to be registered")
+			present := false
+			for _, action := range actions {
+				if action.ID == tt.actionID {
+					present = true
+					break
+				}
+			}
+			if present != tt.wantPresent {
+				t.Errorf("Expected %s present=%v in view %v, got %v", tt.actionID, tt.wantPresent, tt.view, present)
+			}
+		})
 	}
 }
 
 func TestKeyResolution(t *testing.T) {
-	registry := keybinding.NewRegistry(nil)
-	mockContext := newTestContext(domain.ViewStateChat, "test message")
-
-	action := registry.ResolveKey("ctrl+c", mockContext)
-	if action == nil {
-		t.Fatal("Expected ctrl+c to resolve to an action")
-	} else if action.ID != "global_quit" {
-		t.Errorf("Expected ctrl+c to resolve to 'global_quit', got %s", action.ID)
+	tests := []struct {
+		name      string
+		inputText string
+		key       string
+		wantID    string
+	}{
+		{
+			name:      "ctrl+c resolves to global quit",
+			inputText: "test message",
+			key:       "ctrl+c",
+			wantID:    "global_quit",
+		},
+		{
+			name:      "ctrl+o resolves to tool expansion toggle",
+			inputText: "test message",
+			key:       "ctrl+o",
+			wantID:    "tools_toggle_tool_expansion",
+		},
+		{
+			name:      "ctrl+r resolves to raw format toggle",
+			inputText: "test message",
+			key:       "ctrl+r",
+			wantID:    "display_toggle_raw_format",
+		},
+		{
+			name:      "ctrl+z resolves to no action",
+			inputText: "test message",
+			key:       "ctrl+z",
+			wantID:    "",
+		},
+		{
+			name:      "enter resolves to enter handler when input is empty",
+			inputText: "",
+			key:       "enter",
+			wantID:    "chat_enter_key_handler",
+		},
+		{
+			name:      "enter resolves to enter handler when input has content",
+			inputText: "hello",
+			key:       "enter",
+			wantID:    "chat_enter_key_handler",
+		},
 	}
 
-	action = registry.ResolveKey("ctrl+o", mockContext)
-	if action == nil {
-		t.Fatal("Expected ctrl+o to resolve to an action")
-	} else if action.ID != "tools_toggle_tool_expansion" {
-		t.Errorf("Expected ctrl+o to resolve to 'tools_toggle_tool_expansion', got %s", action.ID)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := keybinding.NewRegistry(nil)
+			mockContext := newTestContext(domain.ViewStateChat, tt.inputText)
 
-	action = registry.ResolveKey("ctrl+r", mockContext)
-	if action == nil {
-		t.Fatal("Expected ctrl+r to resolve to an action")
-	} else if action.ID != "display_toggle_raw_format" {
-		t.Errorf("Expected ctrl+r to resolve to 'display_toggle_raw_format', got %s", action.ID)
-	}
-
-	action = registry.ResolveKey("ctrl+z", mockContext)
-	if action != nil {
-		t.Errorf("Expected ctrl+z to not resolve to any action, got %s", action.ID)
-	}
-}
-
-func TestViewContextFiltering(t *testing.T) {
-	registry := keybinding.NewRegistry(nil)
-
-	chatContext := newTestContext(domain.ViewStateChat, "test message")
-
-	chatActions := registry.GetActiveActions(chatContext)
-	hasToggleAction := false
-	for _, action := range chatActions {
-		if action.ID == "tools_toggle_tool_expansion" {
-			hasToggleAction = true
-			break
-		}
-	}
-	if !hasToggleAction {
-		t.Error("Expected tools_toggle_tool_expansion to be available in chat view")
-	}
-
-	modelContext := newTestContext(domain.ViewStateModelSelection, "")
-
-	modelActions := registry.GetActiveActions(modelContext)
-	hasToggleActionInModel := false
-	for _, action := range modelActions {
-		if action.ID == "tools_toggle_tool_expansion" {
-			hasToggleActionInModel = true
-			break
-		}
-	}
-	if hasToggleActionInModel {
-		t.Error("Expected tools_toggle_tool_expansion to NOT be available in model selection view")
+			action := registry.ResolveKey(tt.key, mockContext)
+			if tt.wantID == "" {
+				if action != nil {
+					t.Errorf("Expected %s to not resolve to any action, got %s", tt.key, action.ID)
+				}
+				return
+			}
+			if action == nil {
+				t.Fatalf("Expected %s to resolve to an action", tt.key)
+			}
+			if action.ID != tt.wantID {
+				t.Errorf("Expected %s to resolve to '%s', got %s", tt.key, tt.wantID, action.ID)
+			}
+		})
 	}
 }
 
@@ -177,49 +206,24 @@ func TestHelpShortcutGeneration(t *testing.T) {
 		t.Fatal("Expected help shortcuts to be generated")
 	}
 
-	foundQuit := false
-	foundToggle := false
-	foundRaw := false
-	for _, shortcut := range shortcuts {
-		if shortcut.Key == "ctrl+c" && shortcut.Description == "exit application" {
-			foundQuit = true
-		}
-		if shortcut.Key == "ctrl+o" && shortcut.Description == "expand/collapse tool results" {
-			foundToggle = true
-		}
-		if shortcut.Key == "ctrl+r" && shortcut.Description == "toggle raw/rendered markdown" {
-			foundRaw = true
-		}
+	expected := []struct {
+		key         string
+		description string
+	}{
+		{key: "ctrl+c", description: "exit application"},
+		{key: "ctrl+o", description: "expand/collapse tool results"},
+		{key: "ctrl+r", description: "toggle raw/rendered markdown"},
 	}
 
-	if !foundQuit {
-		t.Error("Expected quit shortcut in help")
-	}
-	if !foundToggle {
-		t.Error("Expected toggle shortcut in help")
-	}
-	if !foundRaw {
-		t.Error("Expected raw format shortcut in help (ctrl+r)")
-	}
-}
-
-func TestConditionalKeyBindings(t *testing.T) {
-	registry := keybinding.NewRegistry(nil)
-
-	emptyInputContext := newTestContext(domain.ViewStateChat, "")
-	action := registry.ResolveKey("enter", emptyInputContext)
-	if action == nil {
-		t.Fatal("Expected enter key to resolve to chat_enter_key_handler even when input is empty")
-	} else if action.ID != "chat_enter_key_handler" {
-		t.Errorf("Expected enter to resolve to 'chat_enter_key_handler', got %s", action.ID)
-	}
-
-	nonEmptyInputContext := newTestContext(domain.ViewStateChat, "hello")
-	action = registry.ResolveKey("enter", nonEmptyInputContext)
-	if action == nil {
-		t.Fatal("Expected enter key to resolve to chat_enter_key_handler when input has content")
-	} else if action.ID != "chat_enter_key_handler" {
-		t.Errorf("Expected enter to resolve to 'chat_enter_key_handler', got %s", action.ID)
+	for _, want := range expected {
+		t.Run(want.key, func(t *testing.T) {
+			for _, shortcut := range shortcuts {
+				if shortcut.Key == want.key && shortcut.Description == want.description {
+					return
+				}
+			}
+			t.Errorf("Expected shortcut %q (%s) in help", want.key, want.description)
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #899. Part of #898.

## Summary

Converts the remaining flat test clusters under `internal/ui` to the table-driven
convention (`[]struct` + `t.Run`), finishing the inventory in #899. Behavior-preserving
only: every original assertion survives in a table row or loop body, per-case model
construction stays inside `t.Run`, and each file keeps its dominant assertion style
(all touched files are raw `if`; no testify introduced).

Net diff: **+1019 / −1033 lines** across 7 files.

### Conversions

| File | New tables (originals folded in) |
| --- | --- |
| `conversation_view_test.go` | `TestBackgroundTaskDisplay_A2AEventHandlers` (5 funcs), `TestBackgroundTaskDisplay_RenderLineVariants` (5), `TestBackgroundTaskDisplay_RenderLineResolverAndWidth` (3), `TestRenderPendingToolEntry` (3) |
| `approval_box_view_test.go` | `TestApprovalBox_SummaryRendering` (4), `TestApprovalBox_DiffRendering` (5) |
| `file_explorer_test.go` | `TestExplorer_PreviewPlaceholder` (2), `TestExplorer_FormatAnnotations` (4), `TestExplorer_TickRefreshRespectsExpansion` (2) |
| `input_status_bar_test.go` | `TestInputStatusBar_FallsBackToEstimator` (2), `TestInputStatusBar_BuildModelDisplayText` (3) |
| `keybinding/registry_test.go` | `TestKeyResolution` (2 funcs, 6 rows), `TestActiveActionMembership` (2), `TestHelpShortcutGeneration` (internal table) |
| `keybinding/config_test.go` | `TestConfigOverrides` (7 funcs → 1 table) |
| `input_view_test.go` | `TestInputView_GettersAndSetters` (7 funcs, 9 rows) |

## Deviation from #899 guardrails

Skips, applying the issue's own rule ("no structurally distinct scenario is forced into a
shared table" / "stop where cases stop sharing shape"):

- **`diff_viewer_test.go` — no conversion.** Its 22 tests are distinct behavior flows
  already sharing the `newTestDiffViewer`/`fakeDiffSource` scaffold; the two borderline
  pairs (patch direction, discard gating) assert different observables, and merging them
  would strip coverage.
- **`conversation_view_test.go`**: `RenderLine_IncludesModelAndElapsed` (index-ordering
  assertion), `RenderLine_FreezesElapsedOnTerminal` (`time.Sleep` re-render), the
  `StartedAt` timestamp pair (range predicate), and the model-resolver pair (setup +
  mid-sequence assert) stay flat. The trivial getter trio and `SetWidth`/`SetHeight` pair
  stay flat — closure columns for 2–3 rows read worse than the originals.
- **`file_explorer_test.go`**: expand/collapse/select-mode/annotate/navigation flows stay
  flat per the issue's explicit warning; no "flatten" table exists to build
  (`FlattenRootDirsFirst` is a single instance and `WalkProjectHonorsGitignore` tests a
  different function).
- **`approval_box_view_test.go`**: `EmptyWhenNoPendingCall` (no `Begin`),
  `EditDiffShowsFileContext` (`t.TempDir` setup), and the event/flow tests stay flat.
- **`config_test.go`**: the merged table's assertions moved into an
  `assertConfigOverride` helper (`t.Helper()`) because a single `t.Run` body tripped
  `gocognit` and new `//nolint` is off the table.

## Verification

- `task test` green; `task lint` 0 issues (funlen/gocognit respected, no new `//nolint`).
- `go test -cover` before → after: `internal/ui/components` 54.6% → 54.6%,
  `internal/ui/keybinding` 36.1% → 36.1% — no coverage regression.

no docs ticket: internal-only refactor
