### PR TITLE
feat(telemetry): add infer traces command and /traces shortcut

### DIFF
--- a/cmd/traces.go
+++ b/cmd/traces.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	lipgloss "charm.land/lipgloss/v2"
+	cobra "github.com/spf13/cobra"
+
+	config "github.com/inference-gateway/cli/config"
+	telemetry "github.com/inference-gateway/cli/internal/telemetry"
+	colors "github.com/inference-gateway/cli/internal/ui/styles/colors"
+)
+
+var tracesCmd = &cobra.Command{
+	Use:   "traces [session-id]",
+	Short: "Render a session's span tree from local telemetry",
+	Long: `Render the span tree of a session (root session span -> LLM turns -> tool
+calls) with per-span durations, read from the local per-session trace file under
+<config-dir>/telemetry. With no argument the most recent session is shown.
+
+Traces are recorded locally (no prompt/response content) when telemetry.enabled
+is true; no OTLP collector is required to view them.
+
+Examples:
+  # Span tree of the most recent session
+  infer traces
+
+  # A specific session
+  infer traces 1783977086-aac06edf
+
+  # Sessions that have trace files
+  infer traces --list
+
+  # Structured output
+  infer traces --format json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runTraces,
+}
+
+func init() {
+	tracesCmd.Flags().Bool("list", false, "List sessions that have trace files instead of rendering a tree")
+	tracesCmd.Flags().StringP("format", "f", "text", "Output format (text, json)")
+	rootCmd.AddCommand(tracesCmd)
+}
+
+func runTraces(cmd *cobra.Command, args []string) error {
+	list, _ := cmd.Flags().GetBool("list")
+	format, _ := cmd.Flags().GetString("format")
+	dir := config.TelemetryDir()
+
+	sessions, err := telemetry.TraceSessions(dir)
+	if err != nil {
+		return fmt.Errorf("failed to list trace sessions: %w", err)
+	}
+
+	if list {
+		return renderTraceSessions(sessions, format)
+	}
+
+	var session string
+	switch {
+	case len(args) == 1:
+		session = args[0]
+	case len(sessions) > 0:
+		session = sessions[0].ID
+	default:
+		fmt.Println("No traces recorded yet.")
+		fmt.Println()
+		fmt.Println(listHint("Traces accumulate as you use `infer chat` / `infer agent` (when telemetry.enabled)."))
+		return nil
+	}
+
+	roots, err := telemetry.LoadTraceTree(dir, session)
+	if err != nil {
+		return fmt.Errorf("failed to load trace for session %s: %w", session, err)
+	}
+
+	if format == "json" {
+		return printJSON(map[string]any{"session": session, "spans": roots})
+	}
+	if len(roots) == 0 {
+		fmt.Printf("No spans recorded for session %s.\n", session)
+		return nil
+	}
+	fmt.Println(listField("Session", session))
+	fmt.Println()
+	fmt.Print(telemetry.RenderTraceTree(roots, traceTreeStyle))
+	return nil
+}
+
+// traceTreeStyle colors the span tree from the static CLI palette: dim
+// connectors, accent durations, red error markers.
+var traceTreeStyle = telemetry.TreeStyle{
+	Enumerator: listHintStyle,
+	Duration:   listTitleStyle,
+	Error:      lipgloss.NewStyle().Foreground(colors.ErrorColor.GetLipglossColor()),
+}
+
+func renderTraceSessions(sessions []telemetry.TraceSession, format string) error {
+	if format == "json" {
+		return printJSON(sessions)
+	}
+	if len(sessions) == 0 {
+		fmt.Println("No traces recorded yet.")
+		return nil
+	}
+	fmt.Println(listTitle("Trace Sessions"))
+	fmt.Println()
+	t := newListTable("Session", "Modified")
+	for _, s := range sessions {
+		t.Row(s.ID, s.Modified.Format("2006-01-02 15:04:05"))
+	}
+	fmt.Println(t.Render())
+	return nil
+}
+
+func printJSON(v any) error {
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal output: %w", err)
+	}
+	fmt.Println(string(out))
+	return nil
+}

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -576,6 +576,7 @@ func (c *ServiceContainer) registerDefaultCommands() {
 	c.shortcutRegistry.Register(shortcuts.NewExplorerShortcut())
 	c.shortcutRegistry.Register(shortcuts.NewReleaseNotesShortcut())
 	c.shortcutRegistry.Register(shortcuts.NewStatsShortcut())
+	c.shortcutRegistry.Register(shortcuts.NewTracesShortcut())
 
 	if persistentRepo, ok := c.conversationRepo.(*services.PersistentConversationRepository); ok {
 		c.shortcutRegistry.Register(shortcuts.NewConversationSelectShortcut(persistentRepo))

--- a/internal/shortcuts/traces.go
+++ b/internal/shortcuts/traces.go
@@ -1,0 +1,86 @@
+package shortcuts
+
+import (
+	"context"
+	"fmt"
+
+	lipgloss "charm.land/lipgloss/v2"
+
+	config "github.com/inference-gateway/cli/config"
+	telemetry "github.com/inference-gateway/cli/internal/telemetry"
+	colors "github.com/inference-gateway/cli/internal/ui/styles/colors"
+)
+
+// traceTreeStyle colors the span tree from the static CLI palette: dim
+// connectors, accent durations, red error markers.
+var traceTreeStyle = telemetry.TreeStyle{
+	Enumerator: lipgloss.NewStyle().Foreground(colors.DimColor.GetLipglossColor()),
+	Duration:   lipgloss.NewStyle().Bold(true).Foreground(colors.AccentColor.GetLipglossColor()),
+	Error:      lipgloss.NewStyle().Foreground(colors.ErrorColor.GetLipglossColor()),
+}
+
+// TracesShortcut renders a session's span tree from the local per-session
+// trace file, matching the `infer traces` output.
+type TracesShortcut struct{}
+
+// NewTracesShortcut creates a new TracesShortcut.
+func NewTracesShortcut() *TracesShortcut {
+	return &TracesShortcut{}
+}
+
+func (s *TracesShortcut) GetName() string { return "traces" }
+
+func (s *TracesShortcut) GetDescription() string {
+	return "Show a session's span tree from local telemetry"
+}
+
+func (s *TracesShortcut) GetUsage() string { return "/traces [session-id]" }
+
+func (s *TracesShortcut) CanExecute(args []string) bool {
+	return len(args) <= 1
+}
+
+func (s *TracesShortcut) Execute(ctx context.Context, args []string) (ShortcutResult, error) {
+	dir := config.TelemetryDir()
+
+	var session string
+	if len(args) > 0 {
+		session = args[0]
+	} else {
+		sessions, err := telemetry.TraceSessions(dir)
+		if err != nil {
+			return ShortcutResult{
+				Output:  fmt.Sprintf("Failed to list trace sessions: %v", err),
+				Success: false,
+			}, nil
+		}
+		if len(sessions) == 0 {
+			return ShortcutResult{
+				Output:  "No traces recorded yet.",
+				Success: true,
+			}, nil
+		}
+		session = sessions[0].ID
+	}
+
+	roots, err := telemetry.LoadTraceTree(dir, session)
+	if err != nil {
+		return ShortcutResult{
+			Output:  fmt.Sprintf("Failed to load trace for session %s: %v", session, err),
+			Success: false,
+		}, nil
+	}
+	if len(roots) == 0 {
+		return ShortcutResult{
+			Output:  fmt.Sprintf("No spans recorded for session %s.", session),
+			Success: true,
+		}, nil
+	}
+
+	output := fmt.Sprintf("Traces: %s\n\n%s", session, telemetry.RenderTraceTree(roots, traceTreeStyle))
+
+	return ShortcutResult{
+		Output:  output,
+		Success: true,
+	}, nil
+}

--- a/internal/shortcuts/traces_test.go
+++ b/internal/shortcuts/traces_test.go
@@ -1,0 +1,96 @@
+package shortcuts
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTestTrace writes a minimal two-span session trace file for the given
+// session id under home/.infer/telemetry.
+func writeTestTrace(t *testing.T, home, session string) {
+	t.Helper()
+	dir := filepath.Join(home, ".infer", "telemetry")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := `{"Name":"execute_tool Bash","StartTime":"2026-01-01T00:00:01Z","EndTime":"2026-01-01T00:00:03Z","SpanContext":{"SpanID":"bb"},"Parent":{"SpanID":"aa"},"Status":{"Code":"Unset","Description":""}}
+{"Name":"session","StartTime":"2026-01-01T00:00:00Z","EndTime":"2026-01-01T00:00:10Z","SpanContext":{"SpanID":"aa"},"Parent":{"SpanID":"0000000000000000"},"Attributes":[{"Key":"infer.agent.mode","Value":{"Value":"standard"}},{"Key":"infer.run.outcome","Value":{"Value":"success"}}],"Status":{"Code":"Unset","Description":""}}
+`
+	if err := os.WriteFile(filepath.Join(dir, session+"-traces.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTracesShortcut_Execute(t *testing.T) {
+	tests := []struct {
+		name        string
+		sessions    []string
+		args        []string
+		wantSuccess bool
+		wantOutput  []string
+	}{
+		{
+			name:        "empty store",
+			wantSuccess: true,
+			wantOutput:  []string{"No traces recorded yet."},
+		},
+		{
+			name:        "most recent session by default",
+			sessions:    []string{"sess-1"},
+			wantSuccess: true,
+			wantOutput:  []string{"Traces: sess-1", "session (standard, success)", "╰──", "execute_tool Bash"},
+		},
+		{
+			name:        "explicit session id",
+			sessions:    []string{"sess-1"},
+			args:        []string{"sess-1"},
+			wantSuccess: true,
+			wantOutput:  []string{"Traces: sess-1"},
+		},
+		{
+			name:        "unknown session id fails",
+			sessions:    []string{"sess-1"},
+			args:        []string{"nope"},
+			wantSuccess: false,
+			wantOutput:  []string{"Failed to load trace for session nope"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			for _, s := range tt.sessions {
+				writeTestTrace(t, home, s)
+			}
+
+			res, err := NewTracesShortcut().Execute(context.Background(), tt.args)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if res.Success != tt.wantSuccess {
+				t.Fatalf("Success=%v, want %v (output: %q)", res.Success, tt.wantSuccess, res.Output)
+			}
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(res.Output, want) {
+					t.Errorf("output missing %q, got: %q", want, res.Output)
+				}
+			}
+		})
+	}
+}
+
+func TestTracesShortcut_CanExecute(t *testing.T) {
+	s := NewTracesShortcut()
+	if !s.CanExecute(nil) {
+		t.Error("expected /traces to accept no arguments")
+	}
+	if !s.CanExecute([]string{"sess-1"}) {
+		t.Error("expected /traces to accept one argument")
+	}
+	if s.CanExecute([]string{"a", "b"}) {
+		t.Error("expected /traces to reject two arguments")
+	}
+}

--- a/internal/telemetry/traces.go
+++ b/internal/telemetry/traces.go
@@ -1,0 +1,246 @@
+package telemetry
+
+import (
+	"bufio"
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	lipgloss "charm.land/lipgloss/v2"
+	tree "charm.land/lipgloss/v2/tree"
+)
+
+// TraceSession identifies one session with a non-empty local trace file
+// (<dir>/<id>-traces.jsonl).
+type TraceSession struct {
+	ID       string    `json:"id"`
+	Modified time.Time `json:"modified"`
+}
+
+// TraceSessions lists sessions with non-empty trace files under dir, newest
+// first. Empty files (sessions that recorded no spans) are skipped.
+func TraceSessions(dir string) ([]TraceSession, error) {
+	files, err := filepath.Glob(filepath.Join(dir, "*-traces.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	var out []TraceSession
+	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil || info.Size() == 0 {
+			continue
+		}
+		out = append(out, TraceSession{
+			ID:       strings.TrimSuffix(filepath.Base(f), "-traces.jsonl"),
+			Modified: info.ModTime(),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Modified.After(out[j].Modified) })
+	return out, nil
+}
+
+// TraceSpan is one node of a session's span tree.
+type TraceSpan struct {
+	Name       string            `json:"name"`
+	Start      time.Time         `json:"start"`
+	DurationMs float64           `json:"duration_ms"`
+	Error      string            `json:"error,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+	Children   []*TraceSpan      `json:"children,omitempty"`
+}
+
+// traceLine is a minimal decode of one stdouttrace span stub line (the format
+// written by the per-session trace file processor).
+type traceLine struct {
+	Name        string
+	StartTime   time.Time
+	EndTime     time.Time
+	SpanContext struct{ SpanID string }
+	Parent      struct{ SpanID string }
+	Attributes  []otlpAttr
+	Status      struct {
+		Code        string
+		Description string
+	}
+}
+
+// LoadTraceTree reads a session's trace file and assembles the span tree.
+// Spans whose parent is not in the file (the root, or orphans from a partial
+// file) become roots; siblings are ordered by start time. Malformed lines are
+// skipped best-effort.
+func LoadTraceTree(dir, session string) ([]*TraceSpan, error) {
+	fh, err := os.Open(filepath.Join(dir, session+"-traces.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = fh.Close() }()
+
+	type parented struct {
+		span   *TraceSpan
+		parent string
+	}
+	var nodes []parented
+	byID := map[string]*TraceSpan{}
+
+	scanner := bufio.NewScanner(fh)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		var tl traceLine
+		if json.Unmarshal(scanner.Bytes(), &tl) != nil || tl.Name == "" {
+			continue
+		}
+		span := &TraceSpan{
+			Name:       tl.Name,
+			Start:      tl.StartTime,
+			DurationMs: float64(tl.EndTime.Sub(tl.StartTime).Microseconds()) / 1000,
+			Attributes: attrMap(tl.Attributes),
+		}
+		errType := span.Attributes["error.type"]
+		if tl.Status.Code == "Error" {
+			span.Error = cmp.Or(errType, tl.Status.Description, "error")
+		} else {
+			span.Error = errType
+		}
+		byID[tl.SpanContext.SpanID] = span
+		nodes = append(nodes, parented{span, tl.Parent.SpanID})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	var roots []*TraceSpan
+	orphans := map[string][]*TraceSpan{}
+	for _, n := range nodes {
+		switch p := byID[n.parent]; {
+		case p != nil && p != n.span:
+			p.Children = append(p.Children, n.span)
+		case strings.Trim(n.parent, "0") == "":
+			roots = append(roots, n.span)
+		default:
+			orphans[n.parent] = append(orphans[n.parent], n.span)
+		}
+	}
+	for _, kids := range orphans {
+		root := &TraceSpan{Name: "session (in progress)", Children: kids}
+		end := time.Time{}
+		for i, k := range kids {
+			if i == 0 || k.Start.Before(root.Start) {
+				root.Start = k.Start
+			}
+			if kEnd := k.Start.Add(time.Duration(k.DurationMs * float64(time.Millisecond))); kEnd.After(end) {
+				end = kEnd
+			}
+		}
+		root.DurationMs = float64(end.Sub(root.Start).Microseconds()) / 1000
+		roots = append(roots, root)
+	}
+	sortSpans(roots)
+	return roots, nil
+}
+
+func sortSpans(spans []*TraceSpan) {
+	sort.Slice(spans, func(i, j int) bool { return spans[i].Start.Before(spans[j].Start) })
+	for _, s := range spans {
+		sortSpans(s.Children)
+	}
+}
+
+func attrMap(attrs []otlpAttr) map[string]string {
+	if len(attrs) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(attrs))
+	for _, a := range attrs {
+		m[a.Key] = fmt.Sprintf("%v", a.Value.Value)
+	}
+	return m
+}
+
+// TreeStyle colorizes the rendered tree segments. The zero value renders
+// plain text, which suits markdown/code-fence output.
+type TreeStyle struct {
+	Enumerator lipgloss.Style // tree connector glyphs
+	Duration   lipgloss.Style
+	Error      lipgloss.Style // the [error: ...] marker
+}
+
+// enumeratorWidth is the rendered width of one tree indent level ("├── ").
+const enumeratorWidth = 4
+
+// RenderTraceTree renders the span tree via lipgloss/v2/tree with durations
+// right-aligned in a column:
+//
+//	session (standard, success)          42.1s
+//	├── chat deepseek/deepseek-v4-flash   3.2s
+//	╰── execute_tool Bash                27.5s
+//
+// Failed spans carry a trailing [error: <type>] marker.
+func RenderTraceTree(roots []*TraceSpan, style TreeStyle) string {
+	width := 0
+	var measure func(s *TraceSpan, depth int)
+	measure = func(s *TraceSpan, depth int) {
+		width = max(width, depth*enumeratorWidth+lipgloss.Width(spanLabel(s)))
+		for _, c := range s.Children {
+			measure(c, depth+1)
+		}
+	}
+	for _, r := range roots {
+		measure(r, 0)
+	}
+
+	var node func(s *TraceSpan, depth int) *tree.Tree
+	node = func(s *TraceSpan, depth int) *tree.Tree {
+		label := spanLabel(s)
+		pad := strings.Repeat(" ", width-depth*enumeratorWidth-lipgloss.Width(label)+2)
+		value := label + pad + style.Duration.Render(fmt.Sprintf("%7s", formatSpanDuration(s.DurationMs)))
+		if s.Error != "" {
+			value += style.Error.Render(" [error: " + s.Error + "]")
+		}
+		n := tree.Root(value)
+		for _, c := range s.Children {
+			n.Child(node(c, depth+1))
+		}
+		return n
+	}
+
+	var b strings.Builder
+	for _, r := range roots {
+		b.WriteString(node(r, 0).
+			Enumerator(tree.RoundedEnumerator).
+			EnumeratorStyle(style.Enumerator.PaddingRight(1)).
+			IndenterStyle(style.Enumerator.PaddingRight(1)).
+			String())
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// spanLabel decorates the session root with its agent mode and run outcome,
+// mirroring the resource-level facts a reader wants at the top of the tree.
+func spanLabel(s *TraceSpan) string {
+	mode, outcome := s.Attributes["infer.agent.mode"], s.Attributes["infer.run.outcome"]
+	if mode != "" && outcome != "" {
+		return fmt.Sprintf("%s (%s, %s)", s.Name, mode, outcome)
+	}
+	return s.Name
+}
+
+// formatSpanDuration renders a span duration compactly: 117µs, 41ms, 3.2s, 1m32s.
+func formatSpanDuration(ms float64) string {
+	d := time.Duration(ms * float64(time.Millisecond))
+	switch {
+	case d < time.Millisecond:
+		return fmt.Sprintf("%dµs", d.Microseconds())
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	default:
+		return d.Round(time.Second).String()
+	}
+}

--- a/internal/telemetry/traces_test.go
+++ b/internal/telemetry/traces_test.go
@@ -1,0 +1,225 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLoadTraceTree_EndToEnd records a real session -> LLM turn -> failing
+// tool trace through the Recorder and asserts the loaded tree shape, so the
+// viewer stays in lock-step with the writer's format.
+func TestLoadTraceTree_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	rec := New(Options{Enabled: true, Dir: dir, SessionID: "sess-v"})
+	if rec == nil {
+		t.Fatal("expected a recorder when enabled")
+	}
+
+	endSession := rec.StartSession("standard")
+	turnCtx, turnSpan := rec.StartLLMTurnSpan(rec.SpanContext(context.Background()), "openai/gpt-4o")
+	toolCtx, toolSpan := rec.startToolSpan(turnCtx, "Bash")
+	SetSpanError(toolCtx, errors.New("boom"))
+	toolSpan.End()
+	turnSpan.End()
+	endSession(RunSuccess)
+	rec.Shutdown(context.Background())
+
+	roots, err := LoadTraceTree(dir, "sess-v")
+	if err != nil {
+		t.Fatalf("LoadTraceTree: %v", err)
+	}
+	if len(roots) != 1 || roots[0].Name != "session" {
+		t.Fatalf("roots=%+v, want single session root", roots)
+	}
+	session := roots[0]
+	if len(session.Children) != 1 || session.Children[0].Name != "chat openai/gpt-4o" {
+		t.Fatalf("session children=%+v, want one chat span", session.Children)
+	}
+	turn := session.Children[0]
+	if len(turn.Children) != 1 || turn.Children[0].Name != "execute_tool Bash" {
+		t.Fatalf("turn children=%+v, want one tool span", turn.Children)
+	}
+	if turn.Children[0].Error == "" {
+		t.Fatal("failed tool span must carry an error")
+	}
+
+	rendered := RenderTraceTree(roots, TreeStyle{})
+	for _, want := range []string{"session (standard, success)", "╰── chat openai/gpt-4o", "╰── execute_tool Bash", "[error:"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered tree missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestLoadTraceTree(t *testing.T) {
+	line := func(name, spanID, parentID, start, end, status string) string {
+		return `{"Name":"` + name + `","StartTime":"` + start + `","EndTime":"` + end +
+			`","SpanContext":{"SpanID":"` + spanID + `"},"Parent":{"SpanID":"` + parentID +
+			`"},"Status":{"Code":"` + status + `","Description":""}}`
+	}
+	tests := []struct {
+		name      string
+		lines     []string
+		wantRoots []string
+		wantErr   bool
+	}{
+		{
+			name: "children sorted by start time under parent",
+			lines: []string{
+				line("late", "cc", "aa", "2026-01-01T00:00:05Z", "2026-01-01T00:00:06Z", "Unset"),
+				line("early", "bb", "aa", "2026-01-01T00:00:01Z", "2026-01-01T00:00:02Z", "Unset"),
+				line("session", "aa", "0000000000000000", "2026-01-01T00:00:00Z", "2026-01-01T00:00:10Z", "Unset"),
+			},
+			wantRoots: []string{"session"},
+		},
+		{
+			name: "orphans grouped under a synthetic in-progress root",
+			lines: []string{
+				line("chat m", "bb", "ffff", "2026-01-01T00:00:01Z", "2026-01-01T00:00:02Z", "Unset"),
+				line("execute_tool Read", "cc", "ffff", "2026-01-01T00:00:03Z", "2026-01-01T00:00:04Z", "Unset"),
+			},
+			wantRoots: []string{"session (in progress)"},
+		},
+		{
+			name: "malformed lines skipped",
+			lines: []string{
+				"not json",
+				line("session", "aa", "0000000000000000", "2026-01-01T00:00:00Z", "2026-01-01T00:00:10Z", "Unset"),
+			},
+			wantRoots: []string{"session"},
+		},
+		{
+			name:    "missing file errors",
+			lines:   nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.lines != nil {
+				content := strings.Join(tt.lines, "\n") + "\n"
+				if err := os.WriteFile(filepath.Join(dir, "s1-traces.jsonl"), []byte(content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			roots, err := LoadTraceTree(dir, "s1")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			var names []string
+			for _, r := range roots {
+				names = append(names, r.Name)
+			}
+			if strings.Join(names, ",") != strings.Join(tt.wantRoots, ",") {
+				t.Fatalf("roots=%v, want %v", names, tt.wantRoots)
+			}
+			if tt.name == "children sorted by start time under parent" {
+				kids := roots[0].Children
+				if len(kids) != 2 || kids[0].Name != "early" || kids[1].Name != "late" {
+					t.Fatalf("children=%+v, want early then late", kids)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadTraceTree_ErrorStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantError string
+	}{
+		{
+			name:      "error.type wins",
+			line:      `{"Name":"s","SpanContext":{"SpanID":"aa"},"Parent":{"SpanID":"00"},"Attributes":[{"Key":"error.type","Value":{"Value":"tool_error"}}],"Status":{"Code":"Error","Description":"boom"}}`,
+			wantError: "tool_error",
+		},
+		{
+			name:      "status description fallback",
+			line:      `{"Name":"s","SpanContext":{"SpanID":"aa"},"Parent":{"SpanID":"00"},"Status":{"Code":"Error","Description":"boom"}}`,
+			wantError: "boom",
+		},
+		{
+			name:      "unset status is not an error",
+			line:      `{"Name":"s","SpanContext":{"SpanID":"aa"},"Parent":{"SpanID":"00"},"Status":{"Code":"Unset","Description":""}}`,
+			wantError: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "s1-traces.jsonl"), []byte(tt.line+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			roots, err := LoadTraceTree(dir, "s1")
+			if err != nil || len(roots) != 1 {
+				t.Fatalf("roots=%v err=%v, want one root", roots, err)
+			}
+			if roots[0].Error != tt.wantError {
+				t.Fatalf("Error=%q, want %q", roots[0].Error, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestTraceSessions(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, content string, mtime time.Time) {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	base := time.Now().Add(-time.Hour)
+	write("old-traces.jsonl", "{}\n", base)
+	write("new-traces.jsonl", "{}\n", base.Add(time.Minute))
+	write("empty-traces.jsonl", "", base)
+	write("metrics.jsonl", "{}\n", base) // metric file, not a trace file
+
+	sessions, err := TraceSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ids []string
+	for _, s := range sessions {
+		ids = append(ids, s.ID)
+	}
+	if strings.Join(ids, ",") != "new,old" {
+		t.Fatalf("sessions=%v, want [new old] (newest first, empty and metric files skipped)", ids)
+	}
+}
+
+func TestFormatSpanDuration(t *testing.T) {
+	tests := []struct {
+		ms   float64
+		want string
+	}{
+		{0, "0µs"},
+		{0.117, "117µs"},
+		{9, "9ms"},
+		{999, "999ms"},
+		{3200, "3.2s"},
+		{42100, "42.1s"},
+		{92000, "1m32s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := formatSpanDuration(tt.ms); got != tt.want {
+				t.Fatalf("formatSpanDuration(%v)=%q, want %q", tt.ms, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #903.

PR #901 (towards #893) records the traces signal locally — every session writes a per-session `~/.infer/telemetry/<session>-traces.jsonl` with a `session` root span, `chat <model>` spans per LLM turn, and `execute_tool <name>` spans per tool call — but nothing in the CLI rendered them. This adds a local span-tree viewer, paired the same way `infer stats` / `/stats` are.

## What's included

- **`infer traces [session-id]`** renders the span tree of a session (root → LLM turns → tool calls) with per-span durations from the local trace file; with no argument it picks the most recent session. `--list` enumerates sessions that have trace files, `--format json` emits the tree as structured output (span names, start times, fractional-ms durations, attributes, children).
- **`/traces [session-id]`** chat shortcut renders the same tree inside the chat TUI, colored from the static CLI palette (dim connectors, accent durations, red error markers). The output is deliberately plain text rather than markdown: the chat markdown renderer intentionally bypasses glamour for content containing box-drawing characters, so fenced/heading markup would display raw.
- **Error visibility**: spans with error status or an `error.type` attribute carry a trailing `[error: <type>]` marker, rendered red in the CLI.
- **Live sessions**: spans export as they end, so a running session's file has no `session` root yet. Orphan spans sharing a missing parent are grouped under a synthetic `session (in progress)` root, so mid-session `/traces` still renders a proper tree instead of a flat list.
- **Duration fidelity**: durations are kept at microsecond precision (`162µs`, `41ms`, `3.4s`, `1m32s`) instead of truncating sub-millisecond tool spans to `0ms`.

```text
session (standard, success)                38.8s
├── chat ollama_cloud/deepseek-v4-flash     3.4s
├── execute_tool Read                      162µs
├── execute_tool Read                      137µs
╰── chat ollama_cloud/deepseek-v4-flash     8.1s
```

## Implementation notes

- The tree is rendered via `charm.land/lipgloss/v2/tree` with a `TreeStyle` of `lipgloss.Style` values; the zero value renders plain, which is what the shortcut's non-TTY-safe paths rely on. Widths are measured with `lipgloss.Width` and durations are right-aligned across the whole tree.
- `LoadTraceTree` links spans purely by `Parent.SpanID`, order-independent, so once subprocess span ingestion lands (#904) child-process spans appear under their tool span with no viewer changes.
- Read-only over the existing stdouttrace stub format already exercised by `internal/telemetry/tracer_test.go`; works fully offline, no OTLP endpoint required, and displays no prompt/response content beyond existing span names/attributes.

## Testing

- Table-driven unit tests for tree assembly (sorting, orphan grouping, malformed lines, error-status precedence), session listing, and duration formatting, plus an end-to-end test that records a real session → LLM turn → failing tool trace through the `Recorder` and asserts the loaded tree, keeping the viewer in lock-step with the writer's format.
- Shortcut tests for empty store, default-to-latest, explicit session id, and unknown session.
- Verified live in the chat TUI (tmux + mock gateway) and against real recorded sessions via the built binary.

## Follow-ups

- `[DOCS]` issue against inference-gateway/docs for the new command/shortcut (CLI reference + shortcuts page).
- #904 ingestion must persist received OTLP spans into the parent session's file in the stdouttrace stub format with hex span ids for parent linking to work.