### PR TITLE
fix(cmd): degrade colors on non-TTY output and add --no-colors flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	fang "charm.land/fang/v2"
+	colorprofile "github.com/charmbracelet/colorprofile"
 	cobra "github.com/spf13/cobra"
 	viper "github.com/spf13/viper"
 
@@ -29,6 +30,12 @@ var rootCmd = &cobra.Command{
 	Long: `A powerful command-line interface for managing and interacting with
 the Inference Gateway. This CLI provides tools for configuration,
 deployment, monitoring, and management of inference services.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		noColors, _ := cmd.Flags().GetBool("no-colors")
+		if noColors || colorprofile.Detect(os.Stdout, os.Environ()) < colorprofile.ANSI {
+			disableOutputColors()
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Welcome to the Inference Gateway CLI!")
 		fmt.Println("Use 'infer chat' to start interactive chat or --help to see available commands.")
@@ -46,6 +53,9 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().Bool("no-colors", false,
+		"disable ANSI colors in command output (colors are also auto-disabled "+
+			"when stdout is not a terminal or NO_COLOR is set)")
 	rootCmd.PersistentFlags().String("tools-bash-allow-append", "",
 		"comma/newline-separated commands added to the bash allow-list in every mode "+
 			"(standard, plan, auto); INFER_TOOLS_BASH_ALLOW_APPEND takes precedence")

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -6,15 +6,17 @@ import (
 	lipgloss "charm.land/lipgloss/v2"
 	table "charm.land/lipgloss/v2/table"
 
+	telemetry "github.com/inference-gateway/cli/internal/telemetry"
 	colors "github.com/inference-gateway/cli/internal/ui/styles/colors"
 	icons "github.com/inference-gateway/cli/internal/ui/styles/icons"
 )
 
 // Shared styling for non-TUI `infer ... list` command output. These draw from
 // the static CLI palette (internal/ui/styles/colors) so list commands render
-// consistently without needing an interactive theme session. lipgloss degrades
-// colour automatically when stdout is not a TTY (e.g. piped), while the table
-// borders still render as box-drawing characters.
+// consistently without needing an interactive theme session. lipgloss v2 does
+// NOT degrade colour on a non-TTY stdout (it always emits the style's escape
+// sequences), so disableOutputColors resets these vars when colour is off;
+// the table borders still render as box-drawing characters either way.
 var (
 	listTitleStyle  = lipgloss.NewStyle().Bold(true).Foreground(colors.AccentColor.GetLipglossColor())
 	listLabelStyle  = lipgloss.NewStyle().Bold(true).Foreground(colors.HeaderColor.GetLipglossColor())
@@ -23,6 +25,20 @@ var (
 	tableBodyCell   = lipgloss.NewStyle().Padding(0, 1)
 	tableBorderInk  = lipgloss.NewStyle().Foreground(colors.BorderColor.GetLipglossColor())
 )
+
+// disableOutputColors strips every SGR-emitting attribute (colour and bold)
+// from the shared command-output styles, keeping only layout (cell padding),
+// so piped/redirected output and --no-colors runs contain no escape sequences.
+// Must run before any command renders (wired into rootCmd.PersistentPreRun).
+func disableOutputColors() {
+	listTitleStyle = lipgloss.NewStyle()
+	listLabelStyle = lipgloss.NewStyle()
+	listHintStyle = lipgloss.NewStyle()
+	tableHeaderCell = lipgloss.NewStyle().Padding(0, 1)
+	tableBodyCell = lipgloss.NewStyle().Padding(0, 1)
+	tableBorderInk = lipgloss.NewStyle()
+	traceTreeStyle = telemetry.TreeStyle{}
+}
 
 // newListTable returns a lipgloss table pre-styled for command-line list
 // output: a rounded border in the palette's border colour, a bold accent

--- a/cmd/table_test.go
+++ b/cmd/table_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	telemetry "github.com/inference-gateway/cli/internal/telemetry"
+)
+
+// disableOutputColors must leave no ANSI escape sequences in any shared
+// command-output rendering path (tables, titles, hints, fields, trace trees).
+func TestDisableOutputColorsStripsEscapes(t *testing.T) {
+	disableOutputColors()
+
+	span := &telemetry.TraceSpan{Name: "chat", DurationMs: 3000}
+	outputs := map[string]string{
+		"table": newListTable("Tool", "Calls").Row("Bash", "54").Render(),
+		"title": listTitle("Tool Calls"),
+		"field": listField("Session", "abc"),
+		"hint":  listHint("legend"),
+		"tree":  telemetry.RenderTraceTree([]*telemetry.TraceSpan{span}, traceTreeStyle),
+	}
+	for name, out := range outputs {
+		if strings.Contains(out, "\x1b") {
+			t.Errorf("%s output still contains ANSI escapes: %q", name, out)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/BurntSushi/xgbutil v0.0.0-20190907113008-ad855c713046
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/aymanbagabas/go-udiff v0.4.1
+	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260602025833-85a30b5e440a
@@ -70,7 +71,6 @@ require (
 	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect


### PR DESCRIPTION
## Summary

Fixes the mojibake reported in inference-gateway/infer-action#214: the `Traces`/`Stats` sections that infer-action embeds into its result comment were full of raw ANSI escape sequences (`�[1;38;2;122;162;247m…`), because `infer traces` / `infer stats` emit truecolor escapes even when stdout is a pipe.

This is not a unicode issue — the box-drawing table borders render fine. lipgloss v2 always emits a style's escape sequences regardless of the output target (the old comment in `cmd/table.go` claiming it "degrades colour automatically when stdout is not a TTY" was lipgloss v1 behavior), so any scripted consumer capturing command output gets the escapes verbatim.

## Changes

- **Auto-detection**: a root `PersistentPreRun` checks stdout's color profile via `github.com/charmbracelet/colorprofile` (already in the module graph, now a direct dependency). Piped/redirected output, `NO_COLOR`, and `TERM=dumb` all degrade to plain text — scripted consumers need no flags.
- **`--no-colors` persistent flag** to force plain output explicitly.
- `disableOutputColors()` in `cmd/table.go` neutralizes the shared command-output styles (`listTitleStyle`, `listLabelStyle`, `listHintStyle`, table header/body/border) plus `traceTreeStyle`, which every styled non-TUI command (`stats`, `traces`, `mcp`, `skills`, `plugins`, `agents`, `conversations`) routes through — one choke point, no per-callsite edits. Cell padding and box-drawing borders are unchanged, so table layout is identical.
- Test asserting tables, titles, fields, hints, and trace trees contain no `\x1b` after disabling.

## Verification

- `./infer stats | cat -v` — zero escape sequences (auto-detect path)
- `./infer stats --no-colors` under a PTY — clean
- interactive TTY output remains colored
- `task test`, `task lint`, pre-commit hooks all pass

## Cross-repo follow-up

- **inference-gateway/infer-action**: bump the pinned CLI version once this releases — its report step pipes stdout, so the auto-detection fixes infer-action#214 with no action-side change; that bump PR can close the issue.
