### PR TITLE
fix(stt): adopt stt-binaries v0.1.0 release

### DIFF
--- a/internal/stt/binary.go
+++ b/internal/stt/binary.go
@@ -17,8 +17,9 @@ import (
 
 // sttBinariesBase is the release hosting prebuilt static STT binaries
 // (whisper-cli, ffmpeg), published as <base>/<name>-<GOOS>-<GOARCH> plus a
-// checksums.txt with sha256 sums.
-const sttBinariesBase = "https://github.com/inference-gateway/stt-binaries/releases/download/stt-v1"
+// checksums.txt with sha256 sums. Releases are immutable; bump the tag here
+// to adopt a newer stt-binaries release.
+const sttBinariesBase = "https://github.com/inference-gateway/stt-binaries/releases/download/v0.1.0"
 
 // BinaryManager downloads prebuilt STT helper binaries (whisper-cli, ffmpeg)
 // into ~/.infer/bin on demand, mirroring ModelManager for GGML models.


### PR DESCRIPTION
Bumps `sttBinariesBase` from the manual `stt-v1` release to `v0.1.0`, the first release produced by the new semantic-release pipeline (inference-gateway/stt-binaries#7).

**Draft until `v0.1.0` actually exists** — dispatch the Release workflow in stt-binaries first, then verify a downloaded asset runs and mark this ready.

no docs ticket: internal-only constant bump