### PR TITLE
feat(a2a): stream agent image pull progress and color-code readiness indicator

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -264,6 +264,11 @@ func (c *ServiceContainer) initializeAgentManager() {
 		})
 	})
 
+	c.agentManager.SetPullProgressCallback(func(name string, done, total int) {
+		c.stateManager.UpdateAgentPullProgress(name, done, total)
+		c.uiNotifier.Notify(domain.AgentStatusUpdateEvent{AgentName: name, State: domain.AgentStatePullingImage})
+	})
+
 	ctx := context.Background()
 	if err := c.agentManager.StartAgents(ctx); err != nil {
 		logger.Warn("failed to start agents in background", "error", err)

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -132,4 +132,7 @@ type AgentManager interface {
 
 	// SetStatusCallback sets the callback function for agent status updates
 	SetStatusCallback(callback func(agentName string, state AgentState, message string, url string, image string))
+
+	// SetPullProgressCallback sets the callback function for image pull progress updates
+	SetPullProgressCallback(callback func(agentName string, done, total int))
 }

--- a/internal/domain/container_runtime.go
+++ b/internal/domain/container_runtime.go
@@ -15,8 +15,9 @@ type ContainerRuntime interface {
 	RunContainer(ctx context.Context, opts RunContainerOptions) (containerID string, err error)
 	StopContainer(ctx context.Context, containerIDOrName string) error
 
-	// Image operations
-	PullImage(ctx context.Context, image string) error
+	// Image operations. The optional progress callback receives layer counts
+	// as the pull advances.
+	PullImage(ctx context.Context, image string, progress func(done, total int)) error
 
 	// Container inspection
 	GetContainerHealth(ctx context.Context, containerIDOrName string) (HealthStatus, error)

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -1037,14 +1037,16 @@ type AgentReadinessState struct {
 
 // AgentStatus represents the status of an individual A2A agent
 type AgentStatus struct {
-	Name      string     `json:"name"`
-	URL       string     `json:"url"`
-	Image     string     `json:"image"`
-	State     AgentState `json:"state"`
-	Message   string     `json:"message,omitempty"`
-	StartTime time.Time  `json:"start_time"`
-	ReadyTime *time.Time `json:"ready_time,omitempty"`
-	Error     string     `json:"error,omitempty"`
+	Name        string     `json:"name"`
+	URL         string     `json:"url"`
+	Image       string     `json:"image"`
+	State       AgentState `json:"state"`
+	Message     string     `json:"message,omitempty"`
+	StartTime   time.Time  `json:"start_time"`
+	ReadyTime   *time.Time `json:"ready_time,omitempty"`
+	Error       string     `json:"error,omitempty"`
+	LayersDone  int        `json:"layers_done,omitempty"`
+	LayersTotal int        `json:"layers_total,omitempty"`
 }
 
 // MCPServerStatus represents the status of MCP server connections
@@ -1143,6 +1145,16 @@ func (s *ApplicationState) UpdateAgentStatus(name string, state AgentState, mess
 		now := time.Now()
 		agent.ReadyTime = &now
 		s.agentReadiness.ReadyAgents++
+	}
+}
+
+// UpdateAgentPullProgress updates the image pull layer counts for a specific agent
+func (s *ApplicationState) UpdateAgentPullProgress(name string, done, total int) {
+	if s.agentReadiness == nil {
+		return
+	}
+	if agent, exists := s.agentReadiness.Agents[name]; exists {
+		agent.LayersDone, agent.LayersTotal = done, total
 	}
 }
 

--- a/internal/services/agent_manager.go
+++ b/internal/services/agent_manager.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -26,17 +25,18 @@ const (
 
 // AgentManager manages the lifecycle of A2A agent containers (local and external)
 type AgentManager struct {
-	sessionID        domain.SessionID
-	config           *config.Config
-	agentsConfig     *config.AgentsConfig
-	containerRuntime domain.ContainerRuntime
-	containers       map[string]string
-	assignedPorts    map[string]int
-	externalAgents   map[string]string
-	isRunning        bool
-	statusCallback   func(agentName string, state domain.AgentState, message string, url string, image string)
-	containersMutex  sync.Mutex
-	a2aAgentService  domain.A2AAgentService
+	sessionID            domain.SessionID
+	config               *config.Config
+	agentsConfig         *config.AgentsConfig
+	containerRuntime     domain.ContainerRuntime
+	containers           map[string]string
+	assignedPorts        map[string]int
+	externalAgents       map[string]string
+	isRunning            bool
+	statusCallback       func(agentName string, state domain.AgentState, message string, url string, image string)
+	pullProgressCallback func(agentName string, done, total int)
+	containersMutex      sync.Mutex
+	a2aAgentService      domain.A2AAgentService
 }
 
 // NewAgentManager creates a new agent manager
@@ -62,6 +62,18 @@ func (am *AgentManager) SetStatusCallback(callback func(agentName string, state 
 func (am *AgentManager) notifyStatus(agentName string, state domain.AgentState, message string, url string, image string) {
 	if am.statusCallback != nil {
 		am.statusCallback(agentName, state, message, url, image)
+	}
+}
+
+// SetPullProgressCallback sets the callback function for image pull progress updates
+func (am *AgentManager) SetPullProgressCallback(callback func(agentName string, done, total int)) {
+	am.pullProgressCallback = callback
+}
+
+// notifyPullProgress calls the pull progress callback if set
+func (am *AgentManager) notifyPullProgress(agentName string, done, total int) {
+	if am.pullProgressCallback != nil {
+		am.pullProgressCallback(agentName, done, total)
 	}
 }
 
@@ -186,7 +198,7 @@ func (am *AgentManager) StartAgent(ctx context.Context, agent config.AgentEntry)
 	}
 
 	am.notifyStatus(agent.Name, domain.AgentStatePullingImage, fmt.Sprintf("Pulling image: %s", agent.OCI), agent.URL, agent.OCI)
-	if err := am.pullImage(ctx, agent.OCI); err != nil {
+	if err := am.pullImage(ctx, agent); err != nil {
 		logger.Warn("failed to pull agent image, attempting to use local image", "name", agent.Name, "error", err)
 	}
 
@@ -253,16 +265,13 @@ func (am *AgentManager) StopAgent(ctx context.Context, agentName string) error {
 	return nil
 }
 
-// pullImage pulls the OCI image for an agent
-func (am *AgentManager) pullImage(ctx context.Context, image string) error {
-	cmd := exec.CommandContext(ctx, "docker", "pull", image)
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker pull failed: %w", err)
+// pullImage pulls the OCI image for an agent, streaming layer progress
+func (am *AgentManager) pullImage(ctx context.Context, agent config.AgentEntry) error {
+	progress := func(done, total int) { am.notifyPullProgress(agent.Name, done, total) }
+	if am.containerRuntime != nil {
+		return am.containerRuntime.PullImage(ctx, agent.OCI, progress)
 	}
-	return nil
+	return runPullCommand(ctx, "docker", agent.OCI, progress)
 }
 
 // startContainer starts the agent container

--- a/internal/services/docker_runtime.go
+++ b/internal/services/docker_runtime.go
@@ -209,14 +209,9 @@ func (dr *DockerRuntime) StopContainer(ctx context.Context, containerIDOrName st
 	return nil
 }
 
-// PullImage pulls a Docker image
-func (dr *DockerRuntime) PullImage(ctx context.Context, image string) error {
-	cmd := exec.CommandContext(ctx, "docker", "pull", image)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("docker pull failed: %w, output: %s", err, string(output))
-	}
-	return nil
+// PullImage pulls a Docker image, reporting layer progress via the optional callback
+func (dr *DockerRuntime) PullImage(ctx context.Context, image string, progress func(done, total int)) error {
+	return runPullCommand(ctx, "docker", image, progress)
 }
 
 // GetContainerHealth returns the health status of a container

--- a/internal/services/podman_runtime.go
+++ b/internal/services/podman_runtime.go
@@ -209,14 +209,9 @@ func (pr *PodmanRuntime) StopContainer(ctx context.Context, containerIDOrName st
 	return nil
 }
 
-// PullImage pulls a Podman image
-func (pr *PodmanRuntime) PullImage(ctx context.Context, image string) error {
-	cmd := exec.CommandContext(ctx, "podman", "pull", image)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("podman pull failed: %w, output: %s", err, string(output))
-	}
-	return nil
+// PullImage pulls a Podman image, reporting layer progress via the optional callback
+func (pr *PodmanRuntime) PullImage(ctx context.Context, image string, progress func(done, total int)) error {
+	return runPullCommand(ctx, "podman", image, progress)
 }
 
 // GetContainerHealth returns the health status of a container

--- a/internal/services/pull_progress.go
+++ b/internal/services/pull_progress.go
@@ -53,7 +53,6 @@ func (p *pullProgress) parse(line string) (done, total int, changed bool) {
 }
 
 func (p *pullProgress) recordDockerLine(id, status string) {
-	// A hex-looking tag produces "<tag>: Pulling from <repo>" — not a layer.
 	if strings.HasPrefix(status, "Pulling from") {
 		return
 	}

--- a/internal/services/pull_progress.go
+++ b/internal/services/pull_progress.go
@@ -1,0 +1,108 @@
+package services
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+
+	logger "github.com/inference-gateway/cli/internal/logger"
+)
+
+// dockerLayerRe matches docker's non-TTY per-layer output: "<layer-id>: <status>".
+var dockerLayerRe = regexp.MustCompile(`^([0-9a-f]{10,64}): (.+)$`)
+
+// podmanBlobRe matches podman's "Copying blob <id> ..." output lines.
+var podmanBlobRe = regexp.MustCompile(`^Copying blob (\S+)`)
+
+// pullProgress counts image layers from docker/podman non-TTY pull output.
+// ponytail: heuristic layer counting; docker gives real totals, podman only
+// emits done-lines so the bar jumps — good enough to show liveness.
+type pullProgress struct {
+	layers    map[string]bool // layer id -> completed
+	lastDone  int
+	lastTotal int
+}
+
+func newPullProgress() *pullProgress {
+	return &pullProgress{layers: make(map[string]bool), lastDone: -1, lastTotal: -1}
+}
+
+// parse consumes one output line and returns the current layer counts plus
+// whether they changed since the last call.
+func (p *pullProgress) parse(line string) (done, total int, changed bool) {
+	if m := dockerLayerRe.FindStringSubmatch(line); m != nil {
+		p.recordDockerLine(m[1], m[2])
+	} else if m := podmanBlobRe.FindStringSubmatch(line); m != nil {
+		p.recordLayer(m[1], strings.HasSuffix(line, " done"))
+	}
+
+	for _, completed := range p.layers {
+		if completed {
+			done++
+		}
+	}
+	total = len(p.layers)
+	changed = done != p.lastDone || total != p.lastTotal
+	p.lastDone, p.lastTotal = done, total
+	return done, total, changed
+}
+
+func (p *pullProgress) recordDockerLine(id, status string) {
+	// A hex-looking tag produces "<tag>: Pulling from <repo>" — not a layer.
+	if strings.HasPrefix(status, "Pulling from") {
+		return
+	}
+	p.recordLayer(id, status == "Pull complete" || status == "Already exists")
+}
+
+func (p *pullProgress) recordLayer(id string, completed bool) {
+	if completed {
+		p.layers[id] = true
+	} else if _, seen := p.layers[id]; !seen {
+		p.layers[id] = false
+	}
+}
+
+// runPullCommand streams `<binary> pull <image>` output, reporting layer
+// progress via the optional progress callback.
+func runPullCommand(ctx context.Context, binary, image string, progress func(done, total int)) error {
+	cmd := exec.CommandContext(ctx, binary, "pull", image)
+
+	pipeReader, pipeWriter := io.Pipe()
+	cmd.Stdout = pipeWriter
+	cmd.Stderr = pipeWriter
+
+	pp := newPullProgress()
+	var lastLine string
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		scanner := bufio.NewScanner(pipeReader)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			lastLine = line
+			if done, total, changed := pp.parse(line); changed && progress != nil {
+				progress(done, total)
+			}
+		}
+		if scanErr := scanner.Err(); scanErr != nil {
+			logger.Debug("pull output scan ended with error", "binary", binary, "error", scanErr)
+		}
+	})
+
+	err := cmd.Run()
+	_ = pipeWriter.Close()
+	wg.Wait()
+
+	if err != nil {
+		return fmt.Errorf("%s pull failed: %w, output: %s", binary, err, lastLine)
+	}
+	return nil
+}

--- a/internal/services/pull_progress_test.go
+++ b/internal/services/pull_progress_test.go
@@ -1,0 +1,84 @@
+package services
+
+import "testing"
+
+func TestPullProgress_Parse(t *testing.T) {
+	tests := []struct {
+		name      string
+		lines     []string
+		wantDone  int
+		wantTotal int
+	}{
+		{
+			name: "docker fresh pull",
+			lines: []string{
+				"latest: Pulling from library/nginx",
+				"e1caac4eb9d2: Pulling fs layer",
+				"88a3f2f760d3: Pulling fs layer",
+				"e1caac4eb9d2: Verifying Checksum",
+				"e1caac4eb9d2: Download complete",
+				"e1caac4eb9d2: Pull complete",
+				"88a3f2f760d3: Already exists",
+				"Digest: sha256:abcdef",
+				"Status: Downloaded newer image for nginx:latest",
+			},
+			wantDone:  2,
+			wantTotal: 2,
+		},
+		{
+			name:      "docker hex-looking tag header is not a layer",
+			lines:     []string{"deadbeef01: Pulling from repo/image"},
+			wantDone:  0,
+			wantTotal: 0,
+		},
+		{
+			name: "podman pull",
+			lines: []string{
+				"Trying to pull docker.io/library/nginx:latest...",
+				"Getting image source signatures",
+				"Copying blob 1f7ce2fa46ab done",
+				"Copying blob aabbccddeeff",
+				"Copying config 605c77e624 done",
+				"Writing manifest to image destination",
+			},
+			wantDone:  1,
+			wantTotal: 2,
+		},
+		{
+			name:      "garbage lines are ignored",
+			lines:     []string{"random noise", "another: thing that is not hex"},
+			wantDone:  0,
+			wantTotal: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPullProgress()
+			var done, total int
+			for _, line := range tt.lines {
+				done, total, _ = p.parse(line)
+			}
+			if done != tt.wantDone || total != tt.wantTotal {
+				t.Errorf("got done=%d total=%d, want done=%d total=%d", done, total, tt.wantDone, tt.wantTotal)
+			}
+		})
+	}
+}
+
+func TestPullProgress_ReportsOnlyOnChange(t *testing.T) {
+	p := newPullProgress()
+
+	if _, _, changed := p.parse("e1caac4eb9d2: Pulling fs layer"); !changed {
+		t.Fatal("first layer registration should report a change")
+	}
+	if _, _, changed := p.parse("e1caac4eb9d2: Downloading"); changed {
+		t.Error("a status update that does not affect counts should not report a change")
+	}
+	if _, _, changed := p.parse("e1caac4eb9d2: Pull complete"); !changed {
+		t.Error("layer completion should report a change")
+	}
+	if _, _, changed := p.parse("e1caac4eb9d2: Pull complete"); changed {
+		t.Error("repeated completion should not report a change")
+	}
+}

--- a/internal/services/state_manager.go
+++ b/internal/services/state_manager.go
@@ -615,6 +615,14 @@ func (sm *StateManager) UpdateAgentStatus(name string, state domain.AgentState, 
 	sm.state.UpdateAgentStatus(name, state, message, url, image)
 }
 
+// UpdateAgentPullProgress updates the image pull layer counts for a specific agent
+func (sm *StateManager) UpdateAgentPullProgress(name string, done, total int) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	sm.state.UpdateAgentPullProgress(name, done, total)
+}
+
 // SetAgentError sets an error for a specific agent
 func (sm *StateManager) SetAgentError(name string, err error) {
 	sm.mutex.Lock()

--- a/internal/ui/components/a2a_agents_view.go
+++ b/internal/ui/components/a2a_agents_view.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"maps"
 	"slices"
+	"strings"
 
 	key "charm.land/bubbles/v2/key"
 	list "charm.land/bubbles/v2/list"
@@ -143,6 +144,12 @@ func (m *A2AAgentsViewImpl) agentItems() ([]list.Item, int, int) {
 		} else if status.Message != "" {
 			item.detail = status.Message
 		}
+		// Docker errors can span multiple lines; flatten so each agent stays
+		// a single row in the list.
+		item.detail = strings.Join(strings.Fields(item.detail), " ")
+		if status.State == domain.AgentStatePullingImage && status.LayersTotal > 0 {
+			item.detail = fmt.Sprintf("%s (%d/%d layers)", item.detail, status.LayersDone, status.LayersTotal)
+		}
 		items = append(items, item)
 	}
 	return items, readiness.ReadyAgents, readiness.TotalAgents
@@ -161,6 +168,8 @@ func (m *A2AAgentsViewImpl) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if handled, cmd := m.handleKey(msg); handled {
 			return m, cmd
 		}
+	case domain.AgentStatusUpdateEvent:
+		return m, m.refreshItems()
 	}
 
 	var cmd tea.Cmd
@@ -216,8 +225,16 @@ func (m *A2AAgentsViewImpl) SetHeight(height int) {
 func (m *A2AAgentsViewImpl) Reset() {
 	m.cancelled = false
 	m.list.ResetFilter()
-	items, ready, total := m.agentItems()
-	m.list.SetItems(items)
+	m.refreshItems()
 	m.list.Select(0)
+}
+
+// refreshItems rebuilds the rows and title from the latest agent readiness
+// without touching the user's selection or filter, so the open view stays
+// live while agents pull and start (AgentStatusUpdateEvent).
+func (m *A2AAgentsViewImpl) refreshItems() tea.Cmd {
+	items, ready, total := m.agentItems()
+	cmd := m.list.SetItems(items)
 	m.list.Title = fmt.Sprintf("A2A Agents (%d/%d ready)", ready, total)
+	return cmd
 }

--- a/internal/ui/components/a2a_agents_view.go
+++ b/internal/ui/components/a2a_agents_view.go
@@ -144,8 +144,6 @@ func (m *A2AAgentsViewImpl) agentItems() ([]list.Item, int, int) {
 		} else if status.Message != "" {
 			item.detail = status.Message
 		}
-		// Docker errors can span multiple lines; flatten so each agent stays
-		// a single row in the list.
 		item.detail = strings.Join(strings.Fields(item.detail), " ")
 		if status.State == domain.AgentStatePullingImage && status.LayersTotal > 0 {
 			item.detail = fmt.Sprintf("%s (%d/%d layers)", item.detail, status.LayersDone, status.LayersTotal)

--- a/internal/ui/components/a2a_agents_view_test.go
+++ b/internal/ui/components/a2a_agents_view_test.go
@@ -131,3 +131,30 @@ func TestA2AAgentsView_ResetRefreshesReadiness(t *testing.T) {
 		t.Errorf("Reset should re-read agent state, got %+v", got)
 	}
 }
+
+func TestA2AAgentsView_LiveUpdatesOnAgentStatusEvent(t *testing.T) {
+	view, stateManager := newA2AAgentsViewForTest(&domain.AgentReadinessState{
+		TotalAgents: 1,
+		ReadyAgents: 0,
+		Agents:      map[string]*domain.AgentStatus{"writer": {Name: "writer", State: domain.AgentStatePullingImage, Message: "Pulling image: img"}},
+	})
+
+	stateManager.UpdateAgentPullProgress("writer", 3, 7)
+	model, _ := view.Update(domain.AgentStatusUpdateEvent{AgentName: "writer", State: domain.AgentStatePullingImage})
+	view = model.(*A2AAgentsViewImpl)
+
+	if got := view.list.Items()[0].(a2aAgentItem); got.detail != "Pulling image: img (3/7 layers)" {
+		t.Errorf("event should refresh pull progress in the detail, got %+v", got)
+	}
+
+	stateManager.UpdateAgentStatus("writer", domain.AgentStateReady, "", "", "")
+	model, _ = view.Update(domain.AgentStatusUpdateEvent{AgentName: "writer", State: domain.AgentStateReady})
+	view = model.(*A2AAgentsViewImpl)
+
+	if view.list.Title != "A2A Agents (1/1 ready)" {
+		t.Errorf("title = %q, want the refreshed readiness", view.list.Title)
+	}
+	if got := view.list.Items()[0].(a2aAgentItem); got.state != "ready" {
+		t.Errorf("event should re-read agent state, got %+v", got)
+	}
+}

--- a/internal/ui/components/input_status_bar.go
+++ b/internal/ui/components/input_status_bar.go
@@ -44,6 +44,7 @@ type indicatorPart struct {
 	text     string
 	action   ui.StatusIndicatorAction
 	selected bool
+	color    string
 }
 
 // NewInputStatusBar creates a new input status bar
@@ -290,15 +291,26 @@ func (isb *InputStatusBar) renderIndicatorLine(parts []indicatorPart, dimColor s
 		texts[i] = part.text
 	}
 
-	if !isb.focused {
+	hasColor := false
+	for _, part := range parts {
+		if part.color != "" {
+			hasColor = true
+			break
+		}
+	}
+
+	if !isb.focused && !hasColor {
 		return isb.styleProvider.RenderWithColor(strings.Join(texts, " • "), dimColor)
 	}
 
 	styled := make([]string, len(parts))
 	for i, part := range parts {
-		if part.selected {
+		switch {
+		case part.selected:
 			styled[i] = isb.styleProvider.RenderSelectedIndicator(texts[i])
-		} else {
+		case part.color != "":
+			styled[i] = isb.styleProvider.RenderWithColor(texts[i], part.color)
+		default:
 			styled[i] = isb.styleProvider.RenderWithColor(texts[i], dimColor)
 		}
 	}
@@ -343,7 +355,7 @@ func (isb *InputStatusBar) buildIndicatorParts(currentModel string) []indicatorP
 
 	if isb.shouldShowIndicator("a2a_agents") {
 		if agentsPart := isb.buildA2AAgentsIndicator(); agentsPart != "" {
-			parts = append(parts, indicatorPart{text: agentsPart, action: ui.StatusIndicatorActionA2AAgents})
+			parts = append(parts, indicatorPart{text: agentsPart, action: ui.StatusIndicatorActionA2AAgents, color: isb.a2aIndicatorColor()})
 		}
 	}
 
@@ -591,6 +603,27 @@ func (isb *InputStatusBar) buildA2AAgentsIndicator() string {
 	}
 	if readiness := isb.stateManager.GetAgentReadiness(); readiness != nil && readiness.TotalAgents > 0 {
 		return fmt.Sprintf("A2A: %d/%d", readiness.ReadyAgents, readiness.TotalAgents)
+	}
+	return ""
+}
+
+// a2aIndicatorColor color-codes the A2A segment: green once all agents are
+// ready, red when any agent failed, empty (dim) while starting up.
+func (isb *InputStatusBar) a2aIndicatorColor() string {
+	if isb.stateManager == nil || isb.styleProvider == nil {
+		return ""
+	}
+	readiness := isb.stateManager.GetAgentReadiness()
+	if readiness == nil || readiness.TotalAgents == 0 {
+		return ""
+	}
+	if readiness.ReadyAgents >= readiness.TotalAgents {
+		return isb.styleProvider.GetThemeColor("success")
+	}
+	for _, agent := range readiness.Agents {
+		if agent.State == domain.AgentStateFailed {
+			return isb.styleProvider.GetThemeColor("error")
+		}
 	}
 	return ""
 }

--- a/internal/ui/components/input_status_bar_test.go
+++ b/internal/ui/components/input_status_bar_test.go
@@ -966,3 +966,70 @@ func TestInputStatusBar_SelectedPillWidthForcesWrap(t *testing.T) {
 		t.Fatalf("the selected pill's padding must count toward the line width, got %d line(s)", len(groups))
 	}
 }
+
+func agentStartupProvider() *styles.Provider {
+	fakeTheme := &uimocks.FakeTheme{}
+	fakeTheme.GetDimColorReturns("#888888")
+	fakeTheme.GetSuccessColorReturns("#9ece6a")
+	fakeTheme.GetErrorColorReturns("#f7768e")
+	fakeTheme.GetAccentColorReturns("#ff9e64")
+	themeService := &domainmocks.FakeThemeService{}
+	themeService.GetCurrentThemeReturns(fakeTheme)
+	return styles.NewProvider(themeService)
+}
+
+func TestInputStatusBar_A2AIndicatorColor(t *testing.T) {
+	provider := agentStartupProvider()
+
+	tests := []struct {
+		name  string
+		setup func() *domain.ApplicationState
+		want  string
+	}{
+		{
+			name:  "no readiness state has no color",
+			setup: domain.NewApplicationState,
+			want:  "",
+		},
+		{
+			name: "startup in progress has no color",
+			setup: func() *domain.ApplicationState {
+				st := domain.NewApplicationState()
+				st.InitializeAgentReadiness(1)
+				st.UpdateAgentStatus("agent-a", domain.AgentStatePullingImage, "", "", "")
+				return st
+			},
+			want: "",
+		},
+		{
+			name: "all ready is green",
+			setup: func() *domain.ApplicationState {
+				st := domain.NewApplicationState()
+				st.InitializeAgentReadiness(1)
+				st.UpdateAgentStatus("agent-a", domain.AgentStateReady, "", "", "")
+				return st
+			},
+			want: "#9ece6a",
+		},
+		{
+			name: "any failed is red",
+			setup: func() *domain.ApplicationState {
+				st := domain.NewApplicationState()
+				st.InitializeAgentReadiness(2)
+				st.UpdateAgentStatus("agent-a", domain.AgentStateReady, "", "", "")
+				st.UpdateAgentStatus("agent-b", domain.AgentStateFailed, "", "", "")
+				return st
+			},
+			want: "#f7768e",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusBar := &InputStatusBar{stateManager: tt.setup(), styleProvider: provider}
+			if got := statusBar.a2aIndicatorColor(); got != tt.want {
+				t.Errorf("a2aIndicatorColor() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #542.

During local A2A agent startup the only feedback was a flat, dim `A2A: n/m` segment - the image pull discarded all of its output, so the user had no idea whether an agent was downloading, stuck, or failed. This PR makes agent startup observable while keeping the main chat view clean:

- **Main view**: the `A2A: n/m` indicator is now color-coded - green once all agents are ready, red while any agent has failed, dim during normal startup. Nothing else is added to the main view.
- **Expanded view** (indicator or `/a2a`): now **live-updates** on `AgentStatusUpdateEvent` instead of only rebuilding when opened. During a pull the agent row shows layer-count progress (`Pulling image: python:3.12 (3/7 layers)`) advancing in place; state transitions (`pulling image` -> `starting` -> `waiting` -> `ready`/`failed`) and the `(n/m ready)` title update without reopening. Multi-line docker errors are flattened so a failed agent stays a single row.
- **Pull path fix**: `AgentManager.pullImage` previously shelled out to a hardcoded `docker pull` with stdout/stderr sent to `io.Discard`, bypassing the `ContainerRuntime` abstraction entirely (Podman users got `docker` for pulls). It now routes through `ContainerRuntime.PullImage`, which streams output through a new layer-counting parser (`internal/services/pull_progress.go`) shared by the Docker and Podman runtimes.

## How it works

Non-TTY `docker pull` emits one line per layer state change (`<id>: Pulling fs layer` / `Already exists` / `Pull complete`); podman emits `Copying blob <id> ... done`. The parser counts registered vs completed layers and fires a callback only when the counts change (no throttling timer needed). Progress flows over the existing push pipeline - `SetPullProgressCallback` -> `StateManager.UpdateAgentPullProgress` (new `LayersDone`/`LayersTotal` fields on `AgentStatus`) -> the existing `AgentStatusUpdateEvent` re-render. No new event types, no polling.

## Testing

- Table-driven parser tests: docker fresh pull, `Already exists`, podman output, garbage lines, changed-only firing.
- A2A agents view test for live updates (`TestA2AAgentsView_LiveUpdatesOnAgentStatusEvent`) and status bar test for the indicator color decision (`TestInputStatusBar_A2AIndicatorColor`).
- Verified end-to-end against real docker pulls by driving `infer chat` in tmux: captured the layer counts advancing live in the open `/a2a` view, the indicator turning red on a failed agent and green when all agents were ready, and the flattened single-row failure details.
- `task build`, `task test`, `task lint` all clean; no mock regeneration needed (`ContainerRuntime.PullImage` had no callers or fakes).

## Follow-up

- #932 - recurring liveness probes for A2A agents (remote agents are currently probed once at startup and never again; observed while testing this change).
