### PR TITLE
feat(agent): reasoning_effort config + working-offline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,6 +1285,9 @@ and Docker Compose file:
 | [shortcuts](examples/shortcuts/) | Custom `/`-shortcuts wired through config |
 | [web-terminal](examples/web-terminal/) | Browser-based, multi-tab web terminal |
 | [telegram-channel](examples/telegram-channel/) | Driving the agent from a Telegram channel |
+| [working-offline](examples/working-offline/) | Fully offline usage with local models via Ollama or llama.cpp |
+| [postgres-storage](examples/postgres-storage/) | Persisting conversations to PostgreSQL |
+| [a2a-traces](examples/a2a-traces/) | End-to-end OpenTelemetry traces between the CLI and an A2A agent |
 
 ### Basic Workflow
 

--- a/config/config.go
+++ b/config/config.go
@@ -486,6 +486,7 @@ type AgentConfig struct {
 	VerboseTools             bool               `yaml:"verbose_tools" mapstructure:"verbose_tools"`
 	MaxTurns                 int                `yaml:"max_turns" mapstructure:"max_turns"`
 	MaxTokens                int                `yaml:"max_tokens" mapstructure:"max_tokens"`
+	ReasoningEffort          string             `yaml:"reasoning_effort,omitempty" mapstructure:"reasoning_effort"`
 	MaxConcurrentTools       int                `yaml:"max_concurrent_tools" mapstructure:"max_concurrent_tools"`
 }
 
@@ -1189,6 +1190,15 @@ func (c *Config) Validate() error {
 			"invalid tools.safety.approval_behaviour %q: must be one of %q, %q, or %q",
 			c.Tools.Safety.ApprovalBehaviour,
 			ApprovalBehaviourPrompt, ApprovalBehaviourIPC, ApprovalBehaviourBlock,
+		)
+	}
+
+	switch c.Agent.ReasoningEffort {
+	case "", "minimal", "low", "medium", "high":
+	default:
+		return fmt.Errorf(
+			"invalid agent.reasoning_effort %q: must be one of \"minimal\", \"low\", \"medium\", or \"high\"",
+			c.Agent.ReasoningEffort,
 		)
 	}
 

--- a/examples/working-offline/.env.example
+++ b/examples/working-offline/.env.example
@@ -1,0 +1,15 @@
+# Gateway configuration — local providers only, no cloud keys at all.
+SERVER_HOST=0.0.0.0
+SERVER_PORT=8080
+ENVIRONMENT=production
+# Local models load and prefill much slower than cloud APIs — without these
+# the gateway cuts them off (default header timeout 10s, stream timeouts 30s).
+CLIENT_RESPONSE_HEADER_TIMEOUT=300s
+CLIENT_TIMEOUT=600s
+SERVER_WRITE_TIMEOUT=600s
+# Default: Ollama installed natively on the host — containers can't use the
+# GPU (notably on macOS), so a native model server is ~10x faster.
+OLLAMA_API_URL=http://host.docker.internal:11434/v1
+# Fully containerized alternative (CPU-only): docker compose --profile ollama up -d
+# OLLAMA_API_URL=http://ollama:11434/v1
+LLAMACPP_API_URL=http://llamacpp:8080/v1

--- a/examples/working-offline/README.md
+++ b/examples/working-offline/README.md
@@ -1,0 +1,133 @@
+# Working offline
+
+Run `infer` completely offline against a local model - no cloud provider, no
+API keys, nothing leaves the machine.
+
+The CLI always talks to an Inference Gateway (it needs the gateway's
+provider-prefixed model IDs), so "offline" means: the containerized CLI talks
+to a local gateway, which talks to a local model server - Ollama or llama.cpp,
+your pick. Everything, including the model download, runs in containers; the
+only host requirement is Docker.
+
+## One-time preparation (the only step that needs network)
+
+```bash
+cp .env.example .env   # local provider URLs only - nothing to edit
+```
+
+**Option A - native Ollama (the default):** containers cannot use the GPU
+(notably on macOS), so the default is a model server installed natively on
+the host - it runs on the GPU (Metal on Apple Silicon, roughly 10x faster)
+while the gateway and CLI stay in containers. `.env.example` already points
+the gateway at it via `host.docker.internal`.
+
+```bash
+# Install https://ollama.com (or: brew install ollama), then
+ollama pull qwen3:8b   # small model with solid tool-calling; any tool-capable model works
+docker compose up -d
+```
+
+Prefer native llama.cpp instead? `brew install llama.cpp`, run
+`llama-server -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_0 --alias gemma-4-e4b --jinja -c 16384`,
+and set `LLAMACPP_API_URL=http://host.docker.internal:8080/v1` in `.env`.
+
+**Option B - containerized Ollama (CPU-only):** set
+`OLLAMA_API_URL=http://ollama:11434/v1` in `.env`, then:
+
+```bash
+docker compose --profile ollama up -d
+# Pull the model inside the container, into the ollama_models volume
+docker compose exec ollama ollama pull qwen3:8b
+```
+
+**Option C - containerized llama.cpp (CPU-only):**
+
+```bash
+docker compose --profile llamacpp up -d
+```
+
+The llamacpp container downloads the official
+[Gemma 4 E4B GGUF](https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF)
+(Q4_0, ~4 GB) from Hugging Face by itself on first start and caches it in
+the `llamacpp_cache` volume - no manual download.
+
+To know when the model is ready: the image has a built-in healthcheck, so
+`docker compose ps` shows `(health: starting)` while downloading/loading and
+`(healthy)` once the server can answer. Watch download progress with
+`docker compose logs -f llamacpp`, or poll the gateway - the model appears in
+`curl -s http://localhost:8080/v1/models` only when the server is up.
+
+After editing `.env`, apply it with
+`docker compose up -d inference-gateway --force-recreate`.
+
+The CLI is agentic, so whatever model you choose must support tool calls
+(all of the above do).
+
+## Run offline
+
+```bash
+# Confirm the gateway sees your local model
+curl -s http://localhost:8080/v1/models
+
+# Chat - fully containerized
+docker compose run --rm cli chat
+```
+
+The model picker shows `ollama/qwen3:8b` (options A/B) or
+`llamacpp/gemma-4-e4b` (option C). Ask it to run a tool ("list the files
+here") to see agentic use against the local model.
+
+Expect the first turn to be slow with the containerized backends (B/C): the
+agent's ~8k-token system prompt is processed on the CPU before the first token
+appears (a minute or more, depending on the machine). Follow-up turns reuse
+the prompt cache and respond much faster. The native default (A) runs on the
+GPU and responds in seconds.
+
+A host-installed `infer` works too - from this directory:
+`INFER_GATEWAY_URL=http://localhost:8080 infer chat`.
+
+## Performance tips for local models
+
+Local prefill is the enemy: the agent sends an ~8k-token system prompt + tool
+schemas with every request, so anything that invalidates the model server's
+prompt-prefix cache makes a turn cost a full re-read of that prompt.
+
+- The compose file already sets `INFER_AGENT_CONTEXT_GIT_CONTEXT_ENABLED=false`
+  and `INFER_AGENT_CONTEXT_TREE_ENABLED=false` - these keep the system prompt
+  byte-identical across turns so the cache holds and follow-up turns only pay
+  for your new message. Don't remove them for local backends.
+- The first turn of a session always pays the full prefill - that one is slow
+  by nature; follow-ups should be fast.
+- Set expectations by hardware: agentic use means prefilling thousands of
+  prompt tokens per turn, so a discrete GPU with high memory bandwidth matters
+  more than CPU. On an Apple Silicon laptop (M4 Pro), expect ~1 minute for the
+  first turn with an 8B model - workable for occasional offline use, not for
+  daily driving.
+- Thinking models (like qwen3) spend a long time generating reasoning tokens
+  before answering. Set `INFER_AGENT_REASONING_EFFORT=low` (or `minimal`) on
+  the `cli` service if your backend honors `reasoning_effort`, or pick a
+  non-thinking model.
+
+## What's disabled and why
+
+The CLI is configured entirely through `INFER_*` environment variables on the
+`cli` service in `docker-compose.yml` - no config file. They turn off
+everything that would otherwise reach the network:
+
+| Env var | Why |
+| --- | --- |
+| `INFER_GATEWAY_RUN=false` | Compose runs the gateway; the CLI must not download/start one |
+| `INFER_TOOLS_WEB_SEARCH_ENABLED=false` | Outbound HTTP to search engines |
+| `INFER_TOOLS_WEB_FETCH_ENABLED=false` | Outbound HTTP fetches |
+| `INFER_A2A_ENABLED=false` | Would probe remote agent URLs |
+
+Conversation title generation stays on - it uses the same local model.
+Conversations persist in the `cli_data` volume.
+
+## Truly air-gapped
+
+After the one-time preparation, images, models, and conversations all live in
+local Docker volumes. Disconnect from
+the network entirely and `docker compose run --rm cli chat` keeps working;
+everything survives `docker compose down` (`down -v` wipes the models and
+conversations).

--- a/examples/working-offline/docker-compose.yml
+++ b/examples/working-offline/docker-compose.yml
@@ -1,0 +1,82 @@
+---
+# Everything runs in containers — gateway, model server, model download, and
+# the CLI itself. The only host requirement is Docker.
+#
+# No pull_policy: always here on purpose: images must come from the local
+# cache once you are offline.
+services:
+  inference-gateway:
+    image: ghcr.io/inference-gateway/inference-gateway:latest
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    extra_hosts:
+      - host.docker.internal:host-gateway # reach a native model server on Linux too
+    restart: unless-stopped
+
+  # One-off interactive CLI: docker compose run --rm cli chat
+  # (the profile keeps `up -d` from starting it; `run` activates it anyway)
+  cli:
+    image: ghcr.io/inference-gateway/cli:latest
+    depends_on:
+      - inference-gateway
+    environment:
+      INFER_GATEWAY_URL: http://inference-gateway:8080 # compose service DNS
+      INFER_GATEWAY_RUN: "false" # compose runs the gateway; don't auto-start one
+      INFER_TOOLS_WEB_SEARCH_ENABLED: "false" # offline: no outbound HTTP
+      INFER_TOOLS_WEB_FETCH_ENABLED: "false"
+      INFER_A2A_ENABLED: "false" # would probe remote agent URLs
+      # CPU prefill of the agent's ~8k-token system prompt can take minutes;
+      # don't treat that silence as a stalled stream (default is 30s)
+      INFER_CLIENT_STALL_THRESHOLD_SEC: "300"
+      # Keep the system prompt byte-identical across turns so the model
+      # server's prompt-prefix cache holds — otherwise the ~8k-token prompt
+      # is re-processed from scratch whenever git status or the file tree changes
+      INFER_AGENT_CONTEXT_GIT_CONTEXT_ENABLED: "false"
+      INFER_AGENT_CONTEXT_TREE_ENABLED: "false"
+    volumes:
+      - cli_data:/home/infer/.infer # persists conversations across runs
+    profiles:
+      - cli
+
+  # Backend option A: Ollama. Pull a model once, inside the container:
+  #   docker compose exec ollama ollama pull qwen3:8b
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama_models:/root/.ollama
+    restart: unless-stopped
+    profiles:
+      - ollama
+
+  # Backend option B: llama.cpp. The container downloads the official
+  # Gemma 4 E4B GGUF (~4 GB) from Hugging Face on first start and caches it
+  # in the llamacpp_cache volume; later starts are fully offline.
+  # --jinja enables tool-call templating, required for agentic use.
+  # -c caps the context so the KV cache fits in a default 8 GB Docker VM;
+  # without it llama-server allocates the model's full training context → OOM (exit 137).
+  # Raise it if you give Docker more memory.
+  # -np 1 gives the whole context to one slot — the server defaults to 4
+  # parallel slots, which would leave only 4k per slot, less than the
+  # agent's system prompt.
+  llamacpp:
+    image: ghcr.io/ggml-org/llama.cpp:server
+    command: >
+      -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_0
+      --alias gemma-4-e4b
+      --host 0.0.0.0
+      --port 8080
+      --jinja
+      -c 16384
+      -np 1
+    volumes:
+      - llamacpp_cache:/root/.cache
+    restart: unless-stopped
+    profiles:
+      - llamacpp
+
+volumes:
+  cli_data:
+  ollama_models:
+  llamacpp_cache:

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -32,6 +32,7 @@ type AgentServiceImpl struct {
 	stateManager     stateManager
 	timeoutSeconds   int
 	maxTokens        int
+	reasoningEffort  *sdk.CreateChatCompletionRequestReasoningEffort
 	optimizer        domain.ConversationOptimizer
 	tokenizer        *services.TokenizerService
 	approvalPolicy   domain.ApprovalPolicy
@@ -374,6 +375,7 @@ func NewAgent(
 		stateManager:     stateManager,
 		timeoutSeconds:   timeoutSeconds,
 		maxTokens:        cfg.GetAgentConfig().MaxTokens,
+		reasoningEffort:  reasoningEffortOption(cfg.GetAgentConfig().ReasoningEffort),
 		optimizer:        optimizer,
 		tokenizer:        tokenizer,
 		approvalPolicy:   approvalPolicy,
@@ -385,6 +387,16 @@ func NewAgent(
 		metrics:          make(map[string]*domain.ChatMetrics),
 		toolCallsMap:     make(map[string]*sdk.ChatCompletionMessageToolCall),
 	}
+}
+
+// reasoningEffortOption maps agent.reasoning_effort ("" = unset, validated in
+// Config.Validate) to the SDK's optional request field.
+func reasoningEffortOption(effort string) *sdk.CreateChatCompletionRequestReasoningEffort {
+	if effort == "" {
+		return nil
+	}
+	e := sdk.CreateChatCompletionRequestReasoningEffort(effort)
+	return &e
 }
 
 // SetTelemetryRecorder wires the telemetry recorder so per-request token usage
@@ -433,7 +445,8 @@ func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*
 		providerType := sdk.Provider(provider)
 
 		client := s.client.WithOptions(&sdk.CreateChatCompletionRequest{
-			MaxTokens: &s.maxTokens,
+			MaxTokens:       &s.maxTokens,
+			ReasoningEffort: s.reasoningEffort,
 		}).
 			WithMiddlewareOptions(&sdk.MiddlewareOptions{
 				SkipMCP: true,

--- a/internal/agent/agent_streaming.go
+++ b/internal/agent/agent_streaming.go
@@ -52,7 +52,8 @@ func (a *EventDrivenAgent) startStreaming() {
 
 	client := a.service.client.
 		WithOptions(&sdk.CreateChatCompletionRequest{
-			MaxTokens: &a.service.maxTokens,
+			MaxTokens:       &a.service.maxTokens,
+			ReasoningEffort: a.service.reasoningEffort,
 			StreamOptions: &sdk.ChatCompletionStreamOptions{
 				IncludeUsage: true,
 			},


### PR DESCRIPTION
## What

- **`agent.reasoning_effort`** (`minimal|low|medium|high`, env `INFER_AGENT_REASONING_EFFORT`): passed through the existing `WithOptions` on both the streaming and sync LLM paths via the SDK's `ReasoningEffort` request field (already in the pinned `sdk v1.22.0`). Empty default = no behavior change; invalid values fail config load in `Config.Validate`.
- **`examples/working-offline/`**: run the CLI fully offline — containerized gateway + CLI against a local model server. Native host Ollama is the default (containers can't use the GPU, notably on macOS); containerized Ollama and self-downloading llama.cpp (Gemma 4 E4B) are CPU-only alternatives behind compose profiles. CLI configured purely via `INFER_*` env vars, including prompt-prefix-cache-friendly settings (`git_context`/`tree` disabled so the model server's prompt cache holds across turns). README covers readiness detection, performance expectations by hardware, and a truly-air-gapped mode. Also adds the missing `working-offline`, `postgres-storage`, and `a2a-traces` rows to the root README examples table.

## Why

Local models invert the cloud cost model: prefilling the agent's ~8k-token prompt dominates turn latency, and thinking models spend most of their time on reasoning tokens. Tested end-to-end on an M4 Pro with qwen3:8b on native Ollama (tool calls verified, file written by the agent).

## Verification

- `task build`, `go test ./config/ ./internal/agent/...`, `task lint` — all green
- `docker compose config` validates; live chat + headless smoke tests against the compose gateway
- Invalid `reasoning_effort` value fails fast at config load (verified)

## Cross-repo / docs

- No schema or gateway changes; SDK already carries the field.
- Docs ticket for the new config key to be filed against `inference-gateway/docs`:
  - **Title**: `[DOCS] Document agent.reasoning_effort CLI setting`
  - **Body**: New CLI config `agent.reasoning_effort` (`minimal|low|medium|high`, env `INFER_AGENT_REASONING_EFFORT`) constrains reasoning-model thinking; affected pages: CLI configuration reference. Source PR: this PR.
- Separate gateway finding (not in this PR): non-streaming requests time out after 30s despite `CLIENT_TIMEOUT=600s` — to be filed against `inference-gateway/inference-gateway`.