### PR TITLE
feat(gpu): on-demand GPU provisioning with llama.cpp via RunPod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,6 +1286,7 @@ and Docker Compose file:
 | [web-terminal](examples/web-terminal/) | Browser-based, multi-tab web terminal |
 | [telegram-channel](examples/telegram-channel/) | Driving the agent from a Telegram channel |
 | [working-offline](examples/working-offline/) | Fully offline usage with local models via Ollama or llama.cpp |
+| [gpu-provisioning](examples/gpu-provisioning/) | Renting an on-demand cloud GPU running llama.cpp via `infer gpu` (RunPod) |
 | [postgres-storage](examples/postgres-storage/) | Persisting conversations to PostgreSQL |
 | [a2a-traces](examples/a2a-traces/) | End-to-end OpenTelemetry traces between the CLI and an A2A agent |
 

--- a/cmd/gpu.go
+++ b/cmd/gpu.go
@@ -1,0 +1,327 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+
+	huh "charm.land/huh/v2"
+	cobra "github.com/spf13/cobra"
+
+	provisioner "github.com/inference-gateway/cli/internal/services/provisioner"
+	utils "github.com/inference-gateway/cli/internal/utils"
+)
+
+const (
+	gpuDefaultImage  = "ghcr.io/ggml-org/llama.cpp:server-cuda"
+	gpuDefaultModel  = "ggml-org/gemma-4-E4B-it-GGUF:Q4_0"
+	gpuDefaultDiskGB = 50
+	gpuLlamaPort     = 8080
+)
+
+var gpuCmd = &cobra.Command{
+	Use:   "gpu",
+	Short: "Rent an on-demand cloud GPU running llama.cpp (RunPod)",
+	Long: `Provision, inspect and destroy on-demand GPU instances running a llama.cpp
+server - pay only for the hours used. The instance is exposed through the
+standard llamacpp provider env vars (LLAMACPP_API_URL / LLAMACPP_API_KEY);
+connecting to it is indistinguishable from any other llamacpp backend.
+
+The RunPod API key is management-plane only (create/list/destroy calls). It is
+asked for on first provision and stored as provisioner.api_key in config.yaml.`,
+}
+
+var gpuProvisionCmd = &cobra.Command{
+	Use:   "provision",
+	Short: "Provision a GPU pod running llama.cpp (interactive)",
+	RunE:  gpuProvision,
+}
+
+var gpuListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List instances provisioned by infer",
+	RunE:  gpuList,
+}
+
+var gpuStatusCmd = &cobra.Command{
+	Use:   "status <pod-id>",
+	Short: "Show state, uptime and cost of a pod",
+	Args:  cobra.ExactArgs(1),
+	RunE:  gpuStatus,
+}
+
+var gpuDestroyCmd = &cobra.Command{
+	Use:   "destroy <pod-id>",
+	Short: "Destroy a pod (billing stops)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  gpuDestroy,
+}
+
+func init() {
+	gpuProvisionCmd.Flags().String("gpu-type", "", "GPU type id (skips the interactive picker)")
+	gpuProvisionCmd.Flags().String("model", "", "Hugging Face GGUF to serve, as <repo>:<quant>")
+	gpuProvisionCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+	gpuDestroyCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+
+	gpuCmd.AddCommand(gpuProvisionCmd)
+	gpuCmd.AddCommand(gpuListCmd)
+	gpuCmd.AddCommand(gpuStatusCmd)
+	gpuCmd.AddCommand(gpuDestroyCmd)
+	rootCmd.AddCommand(gpuCmd)
+}
+
+// gpuDriver builds the RunPod driver, prompting for (and persisting) the API
+// key on first use via the same write path as `infer config set`.
+func gpuDriver() (*provisioner.RunPod, error) {
+	key := Cfg.Provisioner.APIKey
+	if key == "" {
+		var err error
+		if key, err = promptAndSaveAPIKey(); err != nil {
+			return nil, err
+		}
+	}
+	return provisioner.NewRunPod(key), nil
+}
+
+func promptAndSaveAPIKey() (string, error) {
+	var key string
+	if err := huh.NewInput().
+		Title("RunPod API key").
+		Description("Management-plane only (create/list/destroy). Stored as provisioner.api_key in ~/.infer/config.yaml.").
+		EchoMode(huh.EchoModePassword).
+		Value(&key).Run(); err != nil {
+		return "", err
+	}
+	if key == "" {
+		return "", fmt.Errorf("a RunPod API key is required (create one at runpod.io/console/user/settings)")
+	}
+	target, path, err := configWriteTarget(false)
+	if err != nil {
+		return "", err
+	}
+	target.Set("provisioner.api_key", key)
+	if err := utils.WriteViperConfigWithIndent(target, 2); err != nil {
+		return "", fmt.Errorf("failed to save API key: %w", err)
+	}
+	fmt.Printf("API key saved to %s\n", path)
+	return key, nil
+}
+
+func gpuProvision(cmd *cobra.Command, args []string) error {
+	drv, err := gpuDriver()
+	if err != nil {
+		return err
+	}
+	ctx := cmd.Context()
+
+	gpuType, _ := cmd.Flags().GetString("gpu-type")
+	model, _ := cmd.Flags().GetString("model")
+	yes, _ := cmd.Flags().GetBool("yes")
+	if gpuType == "" {
+		gpuType = Cfg.Provisioner.GPUType
+	}
+	if model == "" {
+		model = Cfg.Provisioner.Model
+	}
+	if model == "" {
+		model = gpuDefaultModel
+	}
+
+	gpuType, model, cloudType, pricePerHr, err := gpuResolveChoices(cmd.Context(), drv, gpuType, model, yes)
+	if err != nil {
+		return err
+	}
+	if maxHourly := Cfg.Provisioner.MaxHourly; maxHourly > 0 && pricePerHr > maxHourly {
+		return fmt.Errorf("%s costs $%.2f/hr, above provisioner.max_hourly ($%.2f)", gpuType, pricePerHr, maxHourly)
+	}
+
+	if !yes {
+		ok := false
+		if err := huh.NewConfirm().
+			Title(fmt.Sprintf("Provision %s (%s) at ~$%.2f/hr serving %s?", gpuType, cloudType, pricePerHr, model)).
+			Value(&ok).Run(); err != nil || !ok {
+			return fmt.Errorf("provisioning cancelled")
+		}
+	}
+
+	token, err := randomToken()
+	if err != nil {
+		return err
+	}
+	image := Cfg.Provisioner.Image
+	if image == "" {
+		image = gpuDefaultImage
+	}
+	diskGB := Cfg.Provisioner.DiskGB
+	if diskGB == 0 {
+		diskGB = gpuDefaultDiskGB
+	}
+
+	pod, err := drv.Provision(ctx, provisioner.ProvisionRequest{
+		Name:      provisioner.PodNamePrefix + token[:8],
+		GPUTypeID: gpuType,
+		Image:     image,
+		StartCmd: []string{
+			"-hf", model,
+			"--host", "0.0.0.0",
+			"--port", strconv.Itoa(gpuLlamaPort),
+			"--api-key", token,
+			"--jinja",
+		},
+		CloudType: cloudType,
+		DiskGB:    diskGB,
+		Ports:     []string{fmt.Sprintf("%d/http", gpuLlamaPort)},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to provision pod: %w", err)
+	}
+	fmt.Printf("Pod %s created (~$%.2f/hr). Waiting until the model answers...\n", pod.ID, pod.CostPerHr)
+
+	pod, err = drv.WaitReady(ctx, pod.ID, gpuLlamaPort, token, func(msg string) { fmt.Println("• " + msg) })
+	if err != nil {
+		return fmt.Errorf("pod %s did not become ready (destroy it with `infer gpu destroy %s`): %w", pod.ID, pod.ID, err)
+	}
+
+	fmt.Println("\nReady. Point the gateway at it:")
+	fmt.Printf("  LLAMACPP_API_URL=%s/v1\n", pod.ProxyURL(gpuLlamaPort))
+	fmt.Printf("  LLAMACPP_API_KEY=%s\n", token)
+	fmt.Printf("\nWhen done: infer gpu destroy %s\n", pod.ID)
+	return nil
+}
+
+func gpuAskChoices(types []provisioner.GPUType, model string, yes bool) (string, string, error) {
+	var gpuType string
+	if err := huh.NewSelect[string]().Title("GPU type (cheapest first)").Options(gpuTypeOptions(types)...).Value(&gpuType).Run(); err != nil {
+		return "", "", err
+	}
+	if !yes {
+		if err := huh.NewInput().Title("Model (Hugging Face GGUF, <repo>:<quant>)").Value(&model).Run(); err != nil {
+			return "", "", err
+		}
+	}
+	return gpuType, model, nil
+}
+
+func gpuTypeOptions(types []provisioner.GPUType) []huh.Option[string] {
+	opts := make([]huh.Option[string], 0, len(types))
+	for _, t := range types {
+		p := t.CommunityPrice
+		if p == 0 {
+			p = t.SecurePrice
+		}
+		opts = append(opts, huh.NewOption(fmt.Sprintf("%-45s %3d GB  $%.2f/hr", t.DisplayName, t.MemoryInGb, p), t.ID))
+	}
+	return opts
+}
+
+// gpuResolveChoices fills in GPU type, model, cloud type and price from flags,
+// config and the interactive picker (with live pricing, cheapest first).
+func gpuResolveChoices(ctx context.Context, drv *provisioner.RunPod, gpuType, model string, yes bool) (string, string, string, float64, error) {
+	types, err := drv.GPUTypes(ctx)
+	if err != nil {
+		return "", "", "", 0, fmt.Errorf("failed to list GPU types: %w", err)
+	}
+	if gpuType == "" {
+		if gpuType, model, err = gpuAskChoices(types, model, yes); err != nil {
+			return "", "", "", 0, err
+		}
+	}
+	cloudType, pricePerHr := "COMMUNITY", 0.0
+	for _, t := range types {
+		if t.ID == gpuType {
+			pricePerHr = t.CommunityPrice
+			if pricePerHr == 0 {
+				pricePerHr = t.SecurePrice
+				cloudType = "SECURE"
+			}
+		}
+	}
+	if Cfg.Provisioner.CloudType != "" {
+		cloudType = Cfg.Provisioner.CloudType
+	}
+	return gpuType, model, cloudType, pricePerHr, nil
+}
+
+func gpuList(cmd *cobra.Command, args []string) error {
+	drv, err := gpuDriver()
+	if err != nil {
+		return err
+	}
+	pods, err := drv.List(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if len(pods) == 0 {
+		fmt.Println("No infer-provisioned instances.")
+		return nil
+	}
+	fmt.Printf("%-16s %-16s %-10s %-10s %s\n", "ID", "NAME", "STATUS", "$/HR", "UPTIME")
+	for _, p := range pods {
+		fmt.Printf("%-16s %-16s %-10s %-10.2f %s\n", p.ID, p.Name, p.DesiredStatus, p.CostPerHr, podUptime(p))
+	}
+	return nil
+}
+
+func gpuStatus(cmd *cobra.Command, args []string) error {
+	drv, err := gpuDriver()
+	if err != nil {
+		return err
+	}
+	pod, err := drv.Status(cmd.Context(), args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Printf("ID:      %s\nName:    %s\nStatus:  %s\nImage:   %s\nCost:    $%.2f/hr\nUptime:  %s\nURL:     %s/v1\n",
+		pod.ID, pod.Name, pod.DesiredStatus, pod.Image, pod.CostPerHr, podUptime(pod), pod.ProxyURL(gpuLlamaPort))
+	if up := uptimeHours(pod); up > 0 {
+		fmt.Printf("Est. total: $%.2f\n", up*pod.CostPerHr)
+	}
+	return nil
+}
+
+func gpuDestroy(cmd *cobra.Command, args []string) error {
+	drv, err := gpuDriver()
+	if err != nil {
+		return err
+	}
+	if yes, _ := cmd.Flags().GetBool("yes"); !yes {
+		ok := false
+		if err := huh.NewConfirm().Title(fmt.Sprintf("Destroy pod %s?", args[0])).Value(&ok).Run(); err != nil || !ok {
+			return fmt.Errorf("destroy cancelled")
+		}
+	}
+	if err := drv.Destroy(cmd.Context(), args[0]); err != nil {
+		return err
+	}
+	fmt.Printf("Pod %s destroyed; billing stopped.\n", args[0])
+	return nil
+}
+
+func podUptime(p provisioner.Pod) string {
+	if h := uptimeHours(p); h > 0 {
+		return time.Duration(h * float64(time.Hour)).Round(time.Minute).String()
+	}
+	return "-"
+}
+
+func uptimeHours(p provisioner.Pod) float64 {
+	if p.DesiredStatus != "RUNNING" || p.LastStartedAt == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339, p.LastStartedAt)
+	if err != nil {
+		return 0
+	}
+	return time.Since(t).Hours()
+}
+
+func randomToken() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/cmd/gpu.go
+++ b/cmd/gpu.go
@@ -31,7 +31,8 @@ standard llamacpp provider env vars (LLAMACPP_API_URL / LLAMACPP_API_KEY);
 connecting to it is indistinguishable from any other llamacpp backend.
 
 The RunPod API key is management-plane only (create/list/destroy calls). It is
-asked for on first provision and stored as provisioner.api_key in config.yaml.`,
+asked for on first provision and stored as provisioner.runpod.api_key in
+config.yaml, or supplied via INFER_PROVISIONER_RUNPOD_API_KEY.`,
 }
 
 var gpuProvisionCmd = &cobra.Command{
@@ -76,7 +77,7 @@ func init() {
 // gpuDriver builds the RunPod driver, prompting for (and persisting) the API
 // key on first use via the same write path as `infer config set`.
 func gpuDriver() (*provisioner.RunPod, error) {
-	key := Cfg.Provisioner.APIKey
+	key := Cfg.Provisioner.RunPod.APIKey
 	if key == "" {
 		var err error
 		if key, err = promptAndSaveAPIKey(); err != nil {
@@ -90,7 +91,7 @@ func promptAndSaveAPIKey() (string, error) {
 	var key string
 	if err := huh.NewInput().
 		Title("RunPod API key").
-		Description("Management-plane only (create/list/destroy). Stored as provisioner.api_key in ~/.infer/config.yaml.").
+		Description("Management-plane only (create/list/destroy). Stored as provisioner.runpod.api_key in ~/.infer/config.yaml.").
 		EchoMode(huh.EchoModePassword).
 		Value(&key).Run(); err != nil {
 		return "", err
@@ -102,7 +103,7 @@ func promptAndSaveAPIKey() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	target.Set("provisioner.api_key", key)
+	target.Set("provisioner.runpod.api_key", key)
 	if err := utils.WriteViperConfigWithIndent(target, 2); err != nil {
 		return "", fmt.Errorf("failed to save API key: %w", err)
 	}

--- a/cmd/gpu.go
+++ b/cmd/gpu.go
@@ -181,7 +181,8 @@ func gpuProvision(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Pod %s created (~$%.2f/hr). Waiting until the model answers...\n", pod.ID, pod.CostPerHr)
 
-	pod, err = drv.WaitReady(ctx, pod.ID, gpuLlamaPort, token, func(msg string) { fmt.Println("• " + msg) })
+	pod, err = drv.WaitReady(ctx, pod.ID, gpuLlamaPort, token, func(msg string) { fmt.Printf("\r\033[K• %s", msg) })
+	fmt.Println()
 	if err != nil {
 		return fmt.Errorf("pod %s did not become ready (destroy it with `infer gpu destroy %s`): %w", pod.ID, pod.ID, err)
 	}
@@ -195,13 +196,16 @@ func gpuProvision(cmd *cobra.Command, args []string) error {
 
 func gpuAskChoices(types []provisioner.GPUType, model string, yes bool) (string, string, error) {
 	var gpuType string
-	if err := huh.NewSelect[string]().Title("GPU type (cheapest first)").Options(gpuTypeOptions(types)...).Value(&gpuType).Run(); err != nil {
-		return "", "", err
+	fields := []huh.Field{
+		// Height caps the list so the title/filter line stays on screen ("/" to filter).
+		huh.NewSelect[string]().Title("GPU type (cheapest first)").Options(gpuTypeOptions(types)...).Height(15).Value(&gpuType),
 	}
 	if !yes {
-		if err := huh.NewInput().Title("Model (Hugging Face GGUF, <repo>:<quant>)").Value(&model).Run(); err != nil {
-			return "", "", err
-		}
+		fields = append(fields, huh.NewInput().Title("Model (Hugging Face GGUF, <repo>:<quant>)").Value(&model))
+	}
+	// One group so shift+tab navigates back to change an earlier answer.
+	if err := huh.NewForm(huh.NewGroup(fields...)).Run(); err != nil {
+		return "", "", err
 	}
 	return gpuType, model, nil
 }

--- a/cmd/gpu.go
+++ b/cmd/gpu.go
@@ -66,6 +66,7 @@ func init() {
 	gpuProvisionCmd.Flags().String("model", "", "Hugging Face GGUF to serve, as <repo>:<quant>")
 	gpuProvisionCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
 	gpuDestroyCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+	gpuStatusCmd.Flags().Bool("wait", false, "Block until llama.cpp answers, with a progress heartbeat")
 
 	gpuCmd.AddCommand(gpuProvisionCmd)
 	gpuCmd.AddCommand(gpuListCmd)
@@ -183,7 +184,7 @@ func gpuProvision(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Spec: %s (%s), %d GB disk, image %s, model %s\n", gpuType, cloudType, diskGB, image, model)
 	fmt.Println("Waiting until the model answers...")
 
-	pod, err = drv.WaitReady(ctx, pod.ID, gpuLlamaPort, token, func(msg string) { fmt.Printf("\r\033[K• %s", msg) })
+	pod, err = drv.WaitReady(ctx, pod.ID, gpuLlamaPort, gpuHeartbeat)
 	fmt.Println()
 	if err != nil {
 		return fmt.Errorf("pod %s did not become ready (destroy it with `infer gpu destroy %s`): %w", pod.ID, pod.ID, err)
@@ -272,6 +273,8 @@ func gpuList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func gpuHeartbeat(msg string) { fmt.Printf("\r\033[K• %s", msg) }
+
 func gpuStatus(cmd *cobra.Command, args []string) error {
 	drv, err := gpuDriver()
 	if err != nil {
@@ -280,6 +283,14 @@ func gpuStatus(cmd *cobra.Command, args []string) error {
 	pod, err := drv.Status(cmd.Context(), args[0])
 	if err != nil {
 		return err
+	}
+	if wait, _ := cmd.Flags().GetBool("wait"); wait {
+		pod, err = drv.WaitReady(cmd.Context(), pod.ID, gpuLlamaPort, gpuHeartbeat)
+		fmt.Println()
+		if err != nil {
+			return err
+		}
+		fmt.Println("Ready.")
 	}
 	fmt.Printf("ID:      %s\nName:    %s\nStatus:  %s\nImage:   %s\nCost:    $%.2f/hr\nUptime:  %s\nURL:     %s/v1\n",
 		pod.ID, pod.Name, pod.DesiredStatus, pod.Image, pod.CostPerHr, podUptime(pod), pod.ProxyURL(gpuLlamaPort))

--- a/cmd/gpu.go
+++ b/cmd/gpu.go
@@ -179,7 +179,9 @@ func gpuProvision(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to provision pod: %w", err)
 	}
-	fmt.Printf("Pod %s created (~$%.2f/hr). Waiting until the model answers...\n", pod.ID, pod.CostPerHr)
+	fmt.Printf("Pod %s created (~$%.2f/hr)\n", pod.ID, pod.CostPerHr)
+	fmt.Printf("Spec: %s (%s), %d GB disk, image %s, model %s\n", gpuType, cloudType, diskGB, image, model)
+	fmt.Println("Waiting until the model answers...")
 
 	pod, err = drv.WaitReady(ctx, pod.ID, gpuLlamaPort, token, func(msg string) { fmt.Printf("\r\033[K• %s", msg) })
 	fmt.Println()

--- a/config/config.go
+++ b/config/config.go
@@ -416,14 +416,20 @@ type CompactConfig struct {
 // The provider API key is management-plane only (provision/list/destroy); the
 // running pod is reached exclusively through the llamacpp provider env vars.
 type ProvisionerConfig struct {
-	Provider  string  `yaml:"provider,omitempty" mapstructure:"provider"`
-	APIKey    string  `yaml:"api_key,omitempty" mapstructure:"api_key"`
-	GPUType   string  `yaml:"gpu_type,omitempty" mapstructure:"gpu_type"`
-	Model     string  `yaml:"model,omitempty" mapstructure:"model"`
-	Image     string  `yaml:"image,omitempty" mapstructure:"image"`
-	CloudType string  `yaml:"cloud_type,omitempty" mapstructure:"cloud_type"`
-	DiskGB    int     `yaml:"disk_gb,omitempty" mapstructure:"disk_gb"`
-	MaxHourly float64 `yaml:"max_hourly,omitempty" mapstructure:"max_hourly"`
+	Provider  string                  `yaml:"provider,omitempty" mapstructure:"provider"`
+	RunPod    ProvisionerRunPodConfig `yaml:"runpod,omitempty" mapstructure:"runpod"`
+	GPUType   string                  `yaml:"gpu_type,omitempty" mapstructure:"gpu_type"`
+	Model     string                  `yaml:"model,omitempty" mapstructure:"model"`
+	Image     string                  `yaml:"image,omitempty" mapstructure:"image"`
+	CloudType string                  `yaml:"cloud_type,omitempty" mapstructure:"cloud_type"`
+	DiskGB    int                     `yaml:"disk_gb,omitempty" mapstructure:"disk_gb"`
+	MaxHourly float64                 `yaml:"max_hourly,omitempty" mapstructure:"max_hourly"`
+}
+
+// ProvisionerRunPodConfig holds RunPod-specific settings under
+// provisioner.runpod.* (env: INFER_PROVISIONER_RUNPOD_API_KEY).
+type ProvisionerRunPodConfig struct {
+	APIKey string `yaml:"api_key,omitempty" mapstructure:"api_key"`
 }
 
 // WebConfig contains web terminal settings

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	ContextWindows   map[string]int         `yaml:"context_windows" mapstructure:"context_windows"`
 	Compact          CompactConfig          `yaml:"compact" mapstructure:"compact"`
 	Web              WebConfig              `yaml:"web" mapstructure:"web"`
+	Provisioner      ProvisionerConfig      `yaml:"provisioner,omitempty" mapstructure:"provisioner"`
 	ComputerUse      ComputerUseConfig      `yaml:"-" mapstructure:"-"`
 	Channels         ChannelsConfig         `yaml:"-" mapstructure:"-"`
 	Heartbeat        HeartbeatConfig        `yaml:"-" mapstructure:"-"`
@@ -409,6 +410,20 @@ type CompactConfig struct {
 	KeepFirstMessages     int  `yaml:"keep_first_messages" mapstructure:"keep_first_messages"`
 	RolloverOnIdleMinutes int  `yaml:"rollover_on_idle_minutes" mapstructure:"rollover_on_idle_minutes"`
 	SummaryMaxTokens      int  `yaml:"summary_max_tokens" mapstructure:"summary_max_tokens"`
+}
+
+// ProvisionerConfig contains on-demand GPU provisioning settings (issue #939).
+// The provider API key is management-plane only (provision/list/destroy); the
+// running pod is reached exclusively through the llamacpp provider env vars.
+type ProvisionerConfig struct {
+	Provider  string  `yaml:"provider,omitempty" mapstructure:"provider"`
+	APIKey    string  `yaml:"api_key,omitempty" mapstructure:"api_key"`
+	GPUType   string  `yaml:"gpu_type,omitempty" mapstructure:"gpu_type"`
+	Model     string  `yaml:"model,omitempty" mapstructure:"model"`
+	Image     string  `yaml:"image,omitempty" mapstructure:"image"`
+	CloudType string  `yaml:"cloud_type,omitempty" mapstructure:"cloud_type"`
+	DiskGB    int     `yaml:"disk_gb,omitempty" mapstructure:"disk_gb"`
+	MaxHourly float64 `yaml:"max_hourly,omitempty" mapstructure:"max_hourly"`
 }
 
 // WebConfig contains web terminal settings

--- a/examples/gpu-provisioning/.env.example
+++ b/examples/gpu-provisioning/.env.example
@@ -1,0 +1,5 @@
+# Paste the two values printed by `infer gpu provision` when the pod is ready:
+#   LLAMACPP_API_URL=https://<pod-id>-8080.proxy.runpod.net/v1
+#   LLAMACPP_API_KEY=<per-session token>
+LLAMACPP_API_URL=
+LLAMACPP_API_KEY=

--- a/examples/gpu-provisioning/.env.example
+++ b/examples/gpu-provisioning/.env.example
@@ -1,4 +1,9 @@
-# Paste the two values printed by `infer gpu provision` when the pod is ready:
+# RunPod management-plane API key (create/list/destroy). Create one at
+# runpod.io/console/user/settings with graphql Read/Write. Lets you run the
+# provisioning commands containerized: docker compose run --rm cli gpu provision
+INFER_PROVISIONER_RUNPOD_API_KEY=
+
+# Paste the two values printed by `... gpu provision` when the pod is ready:
 #   LLAMACPP_API_URL=https://<pod-id>-8080.proxy.runpod.net/v1
 #   LLAMACPP_API_KEY=<per-session token>
 LLAMACPP_API_URL=

--- a/examples/gpu-provisioning/README.md
+++ b/examples/gpu-provisioning/README.md
@@ -18,7 +18,10 @@ HTTPS proxy URL instead of localhost.
 
 - A [RunPod](https://www.runpod.io) account and API key. The key is
   management-plane only (create/list/destroy calls); the provision form asks
-  for it once and stores it as `provisioner.api_key` in `~/.infer/config.yaml`.
+  for it once and stores it as `provisioner.runpod.api_key` in
+  `~/.infer/config.yaml`. Alternatively set `INFER_PROVISIONER_RUNPOD_API_KEY`
+  (useful in CI) - the form then skips the key question but still asks what
+  to provision.
 - `infer` installed on the host (the provisioning commands run locally).
 - Docker, for the compose path below.
 

--- a/examples/gpu-provisioning/README.md
+++ b/examples/gpu-provisioning/README.md
@@ -16,20 +16,26 @@ HTTPS proxy URL instead of localhost.
 
 ## Prerequisites
 
-- A [RunPod](https://www.runpod.io) account and API key. The key is
-  management-plane only (create/list/destroy calls); the provision form asks
-  for it once and stores it as `provisioner.runpod.api_key` in
-  `~/.infer/config.yaml`. Alternatively set `INFER_PROVISIONER_RUNPOD_API_KEY`
-  (useful in CI) - the form then skips the key question but still asks what
-  to provision.
-- `infer` installed on the host (the provisioning commands run locally).
-- Docker, for the compose path below.
+- A [RunPod](https://www.runpod.io) account and API key (create one at
+  runpod.io/console/user/settings with **graphql Read/Write** - it's
+  management-plane only: create/list/destroy calls).
+- Docker. A host-installed `infer` works too but isn't required.
+
+```bash
+cp .env.example .env   # paste your RunPod API key
+```
 
 ## Provision
 
 ```bash
-infer gpu provision
+docker compose run --rm cli gpu provision
 ```
+
+(Host-installed `infer` instead? `infer gpu provision` - the form asks for the
+API key on first run and stores it as `provisioner.runpod.api_key` in
+`~/.infer/config.yaml`; with `INFER_PROVISIONER_RUNPOD_API_KEY` set, as the
+compose service does, the key question is skipped and the form only asks what
+to provision.)
 
 An interactive form asks what to provision: GPU type (live $/hr pricing,
 cheapest first), model as `<hf-repo>:<quant>` (default
@@ -37,7 +43,7 @@ cheapest first), model as `<hf-repo>:<quant>` (default
 price before anything is created. Non-interactive:
 
 ```bash
-infer gpu provision --gpu-type "NVIDIA GeForce RTX 5090" \
+docker compose run --rm cli gpu provision --gpu-type "NVIDIA GeForce RTX 5090" \
   --model "ggml-org/gemma-4-E4B-it-GGUF:Q4_0" --yes
 ```
 
@@ -52,12 +58,15 @@ Ready. Point the gateway at it:
 When done: infer gpu destroy <pod-id>
 ```
 
+(Provisioned from the container? The key is saved nowhere - it came from
+`.env`; the printed handoff values are all you need to keep.)
+
 ## Connect
 
 **Compose gateway (this directory):**
 
 ```bash
-cp .env.example .env   # paste the two printed values
+# paste the two printed values into .env, then
 docker compose up -d
 
 # Confirm the gateway sees the pod's model
@@ -81,9 +90,9 @@ infer chat
 ## Cost control
 
 ```bash
-infer gpu list           # every infer-provisioned pod, from any session
-infer gpu status <id>    # state, uptime, $/hr, estimated total so far
-infer gpu destroy <id>   # billing stops
+docker compose run --rm cli gpu list           # every infer-provisioned pod, any session
+docker compose run --rm cli gpu status <id>    # state, uptime, $/hr, estimated total
+docker compose run --rm cli gpu destroy <id>   # billing stops
 ```
 
 `list` queries RunPod for pods created by infer (name-prefixed), so a pod

--- a/examples/gpu-provisioning/README.md
+++ b/examples/gpu-provisioning/README.md
@@ -1,0 +1,103 @@
+# GPU provisioning (RunPod)
+
+Rent a serious GPU by the hour, work against it, destroy it when you're done -
+you pay only for the hours the pod exists. RunPod Community Cloud lists an
+RTX A6000 48GB at roughly $0.33/hr and an RTX PRO 6000 Blackwell 96GB at
+roughly $1.69/hr, so occasional heavy sessions cost pocket change compared to
+owning the card.
+
+`infer gpu provision` creates the pod running the official
+`ghcr.io/ggml-org/llama.cpp:server-cuda` image, which downloads the GGUF you
+picked from Hugging Face by itself on boot. To the gateway the pod is just an
+ordinary llamacpp provider: the handoff is the standard `LLAMACPP_API_URL` +
+`LLAMACPP_API_KEY` env vars - the same two the
+[working-offline](../working-offline/) example uses, pointed at the pod's
+HTTPS proxy URL instead of localhost.
+
+## Prerequisites
+
+- A [RunPod](https://www.runpod.io) account and API key. The key is
+  management-plane only (create/list/destroy calls); the provision form asks
+  for it once and stores it as `provisioner.api_key` in `~/.infer/config.yaml`.
+- `infer` installed on the host (the provisioning commands run locally).
+- Docker, for the compose path below.
+
+## Provision
+
+```bash
+infer gpu provision
+```
+
+An interactive form asks what to provision: GPU type (live $/hr pricing,
+cheapest first), model as `<hf-repo>:<quant>` (default
+`ggml-org/gemma-4-E4B-it-GGUF:Q4_0`), then a confirm step showing the GPU and
+price before anything is created. Non-interactive:
+
+```bash
+infer gpu provision --gpu-type "NVIDIA GeForce RTX 5090" \
+  --model "ggml-org/gemma-4-E4B-it-GGUF:Q4_0" --yes
+```
+
+The command streams progress while the pod boots and the model downloads,
+then prints the handoff once the server answers:
+
+```text
+Ready. Point the gateway at it:
+  LLAMACPP_API_URL=https://<pod-id>-8080.proxy.runpod.net/v1
+  LLAMACPP_API_KEY=<per-session token>
+
+When done: infer gpu destroy <pod-id>
+```
+
+## Connect
+
+**Compose gateway (this directory):**
+
+```bash
+cp .env.example .env   # paste the two printed values
+docker compose up -d
+
+# Confirm the gateway sees the pod's model
+curl -s http://localhost:8080/v1/models
+
+docker compose run --rm cli chat
+```
+
+Pick the `llamacpp/...` model in the picker. After editing `.env`, apply it
+with `docker compose up -d inference-gateway --force-recreate`.
+
+**Host-managed gateway (no compose):** with `gateway.run: true` (the default)
+the CLI starts the gateway itself and passes its environment through, so:
+
+```bash
+export LLAMACPP_API_URL=https://<pod-id>-8080.proxy.runpod.net/v1
+export LLAMACPP_API_KEY=<per-session token>
+infer chat
+```
+
+## Cost control
+
+```bash
+infer gpu list           # every infer-provisioned pod, from any session
+infer gpu status <id>    # state, uptime, $/hr, estimated total so far
+infer gpu destroy <id>   # billing stops
+```
+
+`list` queries RunPod for pods created by infer (name-prefixed), so a pod
+forgotten by a previous session is always visible. Set
+`provisioner.max_hourly` in config as a hard price guard - provisioning
+refuses anything above it.
+
+Destroying the pod wipes its container disk, including the downloaded GGUF;
+the next session re-downloads it on boot. That cold start (a few minutes for
+a ~4 GB model) is the accepted trade-off for paying zero while idle.
+
+## Notes
+
+- The pod is reachable only through RunPod's HTTPS proxy
+  (`https://<pod-id>-8080.proxy.runpod.net`) and the llama.cpp server requires
+  the per-session `--api-key` token - never an open port.
+- The proxy has a ~100s idle timeout; streaming responses (the CLI default)
+  are unaffected.
+- Gated Hugging Face models need an `HF_TOKEN` on the pod - not wired up yet;
+  stick to open models like the `ggml-org/*` GGUFs.

--- a/examples/gpu-provisioning/docker-compose.yml
+++ b/examples/gpu-provisioning/docker-compose.yml
@@ -14,7 +14,8 @@ services:
   # One-off interactive CLI: docker compose run --rm cli chat
   # (the profile keeps `up -d` from starting it; `run` activates it anyway)
   cli:
-    image: ghcr.io/inference-gateway/cli:latest
+    image: ghcr.io/inference-gateway/cli:local
+    pull_policy: never
     depends_on:
       - inference-gateway
     env_file:

--- a/examples/gpu-provisioning/docker-compose.yml
+++ b/examples/gpu-provisioning/docker-compose.yml
@@ -1,0 +1,29 @@
+---
+# Gateway + CLI in containers; the model server is a rented RunPod GPU pod
+# created by `infer gpu provision` (see README). The pod endpoint reaches the
+# gateway through the standard llamacpp provider env vars in .env.
+services:
+  inference-gateway:
+    image: ghcr.io/inference-gateway/inference-gateway:latest
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env # LLAMACPP_API_URL + LLAMACPP_API_KEY from `infer gpu provision`
+    restart: unless-stopped
+
+  # One-off interactive CLI: docker compose run --rm cli chat
+  # (the profile keeps `up -d` from starting it; `run` activates it anyway)
+  cli:
+    image: ghcr.io/inference-gateway/cli:latest
+    depends_on:
+      - inference-gateway
+    environment:
+      INFER_GATEWAY_URL: http://inference-gateway:8080 # compose service DNS
+      INFER_GATEWAY_RUN: "false" # compose runs the gateway; don't auto-start one
+    volumes:
+      - cli_data:/home/infer/.infer # persists conversations across runs
+    profiles:
+      - cli
+
+volumes:
+  cli_data:

--- a/examples/gpu-provisioning/docker-compose.yml
+++ b/examples/gpu-provisioning/docker-compose.yml
@@ -5,6 +5,7 @@
 services:
   inference-gateway:
     image: ghcr.io/inference-gateway/inference-gateway:latest
+    pull_policy: always
     ports:
       - "8080:8080"
     env_file:
@@ -14,8 +15,8 @@ services:
   # One-off interactive CLI: docker compose run --rm cli chat
   # (the profile keeps `up -d` from starting it; `run` activates it anyway)
   cli:
-    image: ghcr.io/inference-gateway/cli:local
-    pull_policy: never
+    image: ghcr.io/inference-gateway/cli:latest
+    pull_policy: always
     depends_on:
       - inference-gateway
     env_file:

--- a/examples/gpu-provisioning/docker-compose.yml
+++ b/examples/gpu-provisioning/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     image: ghcr.io/inference-gateway/cli:latest
     depends_on:
       - inference-gateway
+    env_file:
+      - .env # INFER_PROVISIONER_RUNPOD_API_KEY for `run --rm cli gpu ...`
     environment:
       INFER_GATEWAY_URL: http://inference-gateway:8080 # compose service DNS
       INFER_GATEWAY_RUN: "false" # compose runs the gateway; don't auto-start one

--- a/internal/services/provisioner/runpod.go
+++ b/internal/services/provisioner/runpod.go
@@ -181,9 +181,10 @@ func price(t GPUType) float64 {
 	return t.SecurePrice
 }
 
-// WaitReady polls the pod, then the llama.cpp /v1/models endpoint through the
-// proxy until the model answers. report is called with progress lines.
-func (r *RunPod) WaitReady(ctx context.Context, id string, port int, apiKey string, report func(string)) (Pod, error) {
+// WaitReady polls the pod, then the llama.cpp /health endpoint through the
+// proxy until the model answers. /health is unauthenticated in llama.cpp, so
+// this needs no per-session token and works for `gpu status --wait` too.
+func (r *RunPod) WaitReady(ctx context.Context, id string, port int, report func(string)) (Pod, error) {
 	var pod Pod
 	for {
 		var err error
@@ -203,7 +204,7 @@ func (r *RunPod) WaitReady(ctx context.Context, id string, port int, apiKey stri
 	if r.ProxyBase != "" {
 		base = r.ProxyBase
 	}
-	url := base + "/v1/models"
+	url := base + "/health"
 	report("pod running; waiting for llama.cpp to download the model and answer...")
 	start := time.Now()
 	for {
@@ -212,7 +213,6 @@ func (r *RunPod) WaitReady(ctx context.Context, id string, port int, apiKey stri
 		// the probe status: 503 = server up + model downloading/loading.
 		phase := "starting llama.cpp server..."
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		req.Header.Set("Authorization", "Bearer "+apiKey)
 		resp, err := r.Client.Do(req)
 		if err == nil {
 			_, _ = io.Copy(io.Discard, resp.Body)

--- a/internal/services/provisioner/runpod.go
+++ b/internal/services/provisioner/runpod.go
@@ -208,9 +208,6 @@ func (r *RunPod) WaitReady(ctx context.Context, id string, port int, report func
 	report("pod running; waiting for llama.cpp to download the model and answer...")
 	start := time.Now()
 	for {
-		// No download % available: RunPod exposes no log/telemetry API and
-		// llama.cpp doesn't report progress over HTTP. Phase is inferred from
-		// the probe status: 503 = server up + model downloading/loading.
 		phase := "starting llama.cpp server..."
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		resp, err := r.Client.Do(req)

--- a/internal/services/provisioner/runpod.go
+++ b/internal/services/provisioner/runpod.go
@@ -1,0 +1,227 @@
+// Package provisioner rents on-demand GPU instances running llama.cpp and
+// exposes them as a llamacpp provider endpoint (issue #939). RunPod is the
+// first driver; the surface is plain CRUD on instances.
+package provisioner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PodNamePrefix tags every pod created by infer so List can find them.
+const PodNamePrefix = "infer-"
+
+// Pod is the subset of RunPod's Pod object the CLI cares about.
+type Pod struct {
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	Image         string  `json:"image"`
+	DesiredStatus string  `json:"desiredStatus"`
+	CostPerHr     float64 `json:"costPerHr"`
+	LastStartedAt string  `json:"lastStartedAt"`
+}
+
+// ProxyURL is the pod's public HTTPS endpoint for the given internal port.
+func (p Pod) ProxyURL(port int) string {
+	return fmt.Sprintf("https://%s-%d.proxy.runpod.net", p.ID, port)
+}
+
+// GPUType is a rentable GPU with live pricing.
+type GPUType struct {
+	ID             string  `json:"id"`
+	DisplayName    string  `json:"displayName"`
+	MemoryInGb     int     `json:"memoryInGb"`
+	CommunityPrice float64 `json:"communityPrice"`
+	SecurePrice    float64 `json:"securePrice"`
+}
+
+// ProvisionRequest describes the pod to create.
+type ProvisionRequest struct {
+	Name      string
+	GPUTypeID string
+	Image     string
+	StartCmd  []string
+	CloudType string // COMMUNITY or SECURE
+	DiskGB    int
+	Env       map[string]string
+	Ports     []string
+}
+
+// RunPod is the RunPod driver. Base URLs are fields so tests can point at httptest.
+type RunPod struct {
+	APIKey     string
+	RestURL    string // default https://rest.runpod.io/v1
+	GraphQLURL string // default https://api.runpod.io/graphql
+	Client     *http.Client
+}
+
+func NewRunPod(apiKey string) *RunPod {
+	return &RunPod{
+		APIKey:     apiKey,
+		RestURL:    "https://rest.runpod.io/v1",
+		GraphQLURL: "https://api.runpod.io/graphql",
+		Client:     &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (r *RunPod) do(ctx context.Context, method, url string, body any, out any) error {
+	var rd io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		rd = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rd)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+r.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("runpod api: %s %s: %s: %s", method, url, resp.Status, strings.TrimSpace(string(data)))
+	}
+	if out != nil {
+		return json.Unmarshal(data, out)
+	}
+	return nil
+}
+
+// Provision creates a pod. CRUD: create.
+func (r *RunPod) Provision(ctx context.Context, req ProvisionRequest) (Pod, error) {
+	payload := map[string]any{
+		"name":              req.Name,
+		"imageName":         req.Image,
+		"dockerStartCmd":    req.StartCmd,
+		"ports":             req.Ports,
+		"gpuTypeIds":        []string{req.GPUTypeID},
+		"cloudType":         req.CloudType,
+		"containerDiskInGb": req.DiskGB,
+	}
+	if len(req.Env) > 0 {
+		payload["env"] = req.Env
+	}
+	var pod Pod
+	err := r.do(ctx, http.MethodPost, r.RestURL+"/pods", payload, &pod)
+	return pod, err
+}
+
+// List returns pods created by infer (name-prefix filtered). CRUD: read.
+func (r *RunPod) List(ctx context.Context) ([]Pod, error) {
+	var pods []Pod
+	if err := r.do(ctx, http.MethodGet, r.RestURL+"/pods", nil, &pods); err != nil {
+		return nil, err
+	}
+	mine := pods[:0]
+	for _, p := range pods {
+		if strings.HasPrefix(p.Name, PodNamePrefix) {
+			mine = append(mine, p)
+		}
+	}
+	return mine, nil
+}
+
+// Status returns a single pod. CRUD: read.
+func (r *RunPod) Status(ctx context.Context, id string) (Pod, error) {
+	var pod Pod
+	err := r.do(ctx, http.MethodGet, r.RestURL+"/pods/"+id, nil, &pod)
+	return pod, err
+}
+
+// Destroy terminates a pod; billing stops. CRUD: delete.
+func (r *RunPod) Destroy(ctx context.Context, id string) error {
+	return r.do(ctx, http.MethodDelete, r.RestURL+"/pods/"+id, nil, nil)
+}
+
+// GPUTypes returns rentable GPU types with live pricing, cheapest first.
+// This is the one non-REST call (RunPod exposes pricing only via GraphQL).
+func (r *RunPod) GPUTypes(ctx context.Context) ([]GPUType, error) {
+	query := map[string]string{
+		"query": `query { gpuTypes { id displayName memoryInGb communityPrice securePrice } }`,
+	}
+	var out struct {
+		Data struct {
+			GPUTypes []GPUType `json:"gpuTypes"`
+		} `json:"data"`
+	}
+	if err := r.do(ctx, http.MethodPost, r.GraphQLURL, query, &out); err != nil {
+		return nil, err
+	}
+	types := out.Data.GPUTypes[:0]
+	for _, t := range out.Data.GPUTypes {
+		if t.CommunityPrice > 0 || t.SecurePrice > 0 {
+			types = append(types, t)
+		}
+	}
+	sort.Slice(types, func(i, j int) bool { return price(types[i]) < price(types[j]) })
+	return types, nil
+}
+
+func price(t GPUType) float64 {
+	if t.CommunityPrice > 0 {
+		return t.CommunityPrice
+	}
+	return t.SecurePrice
+}
+
+// WaitReady polls the pod, then the llama.cpp /v1/models endpoint through the
+// proxy until the model answers. report is called with progress lines.
+func (r *RunPod) WaitReady(ctx context.Context, id string, port int, apiKey string, report func(string)) (Pod, error) {
+	var pod Pod
+	for {
+		var err error
+		pod, err = r.Status(ctx, id)
+		if err != nil {
+			return pod, err
+		}
+		if pod.DesiredStatus == "RUNNING" {
+			break
+		}
+		report("waiting for pod to start (" + pod.DesiredStatus + ")...")
+		if err := sleep(ctx, 5*time.Second); err != nil {
+			return pod, err
+		}
+	}
+	url := pod.ProxyURL(port) + "/v1/models"
+	report("pod running; waiting for llama.cpp to download the model and answer...")
+	for {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		resp, err := r.Client.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return pod, nil
+			}
+		}
+		if err := sleep(ctx, 10*time.Second); err != nil {
+			return pod, err
+		}
+	}
+}
+
+func sleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/services/provisioner/runpod.go
+++ b/internal/services/provisioner/runpod.go
@@ -59,7 +59,10 @@ type RunPod struct {
 	APIKey     string
 	RestURL    string // default https://rest.runpod.io/v1
 	GraphQLURL string // default https://api.runpod.io/graphql
+	ProxyBase  string // overrides Pod.ProxyURL in WaitReady; tests only
 	Client     *http.Client
+
+	pollInterval time.Duration // WaitReady probe interval; 0 means 10s (short in tests)
 }
 
 func NewRunPod(apiKey string) *RunPod {
@@ -196,9 +199,18 @@ func (r *RunPod) WaitReady(ctx context.Context, id string, port int, apiKey stri
 			return pod, err
 		}
 	}
-	url := pod.ProxyURL(port) + "/v1/models"
+	base := pod.ProxyURL(port)
+	if r.ProxyBase != "" {
+		base = r.ProxyBase
+	}
+	url := base + "/v1/models"
 	report("pod running; waiting for llama.cpp to download the model and answer...")
+	start := time.Now()
 	for {
+		// No download % available: RunPod exposes no log/telemetry API and
+		// llama.cpp doesn't report progress over HTTP. Phase is inferred from
+		// the probe status: 503 = server up + model downloading/loading.
+		phase := "starting llama.cpp server..."
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 		resp, err := r.Client.Do(req)
@@ -208,8 +220,16 @@ func (r *RunPod) WaitReady(ctx context.Context, id string, port int, apiKey stri
 			if resp.StatusCode == http.StatusOK {
 				return pod, nil
 			}
+			if resp.StatusCode == http.StatusServiceUnavailable {
+				phase = "downloading/loading model..."
+			}
 		}
-		if err := sleep(ctx, 10*time.Second); err != nil {
+		report(phase + " (" + time.Since(start).Round(time.Second).String() + " elapsed)")
+		interval := r.pollInterval
+		if interval == 0 {
+			interval = 10 * time.Second
+		}
+		if err := sleep(ctx, interval); err != nil {
 			return pod, err
 		}
 	}

--- a/internal/services/provisioner/runpod_test.go
+++ b/internal/services/provisioner/runpod_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func testDriver(t *testing.T, handler http.Handler) *RunPod {
@@ -94,6 +96,37 @@ func TestGPUTypes(t *testing.T) {
 	}
 	if types[0].ID != "A6000" {
 		t.Fatalf("GPUTypes should sort cheapest first, got %+v", types)
+	}
+}
+
+func TestWaitReadyReportsDownloadPhase(t *testing.T) {
+	probes := 0
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/pods/abc123":
+			_ = json.NewEncoder(w).Encode(Pod{ID: "abc123", DesiredStatus: "RUNNING"})
+		case "/v1/models":
+			probes++
+			if probes == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable) // llama.cpp still loading the model
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	r := testDriver(t, handler)
+	r.ProxyBase = r.RestURL
+	r.pollInterval = time.Millisecond
+
+	var msgs []string
+	if _, err := r.WaitReady(context.Background(), "abc123", 8080, "tok", func(m string) { msgs = append(msgs, m) }); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+	joined := strings.Join(msgs, "\n")
+	if !strings.Contains(joined, "downloading/loading model") || !strings.Contains(joined, "elapsed") {
+		t.Fatalf("expected download-phase heartbeat, got %q", joined)
 	}
 }
 

--- a/internal/services/provisioner/runpod_test.go
+++ b/internal/services/provisioner/runpod_test.go
@@ -1,0 +1,105 @@
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testDriver(t *testing.T, handler http.Handler) *RunPod {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	r := NewRunPod("test-key")
+	r.RestURL = srv.URL
+	r.GraphQLURL = srv.URL + "/graphql"
+	return r
+}
+
+func TestRunPodCRUD(t *testing.T) {
+	var gotAuth, gotMethod, gotPath string
+	var gotBody map[string]any
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotAuth = req.Header.Get("Authorization")
+		gotMethod, gotPath = req.Method, req.URL.Path
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/pods":
+			_ = json.NewDecoder(req.Body).Decode(&gotBody)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(Pod{ID: "abc123", Name: "infer-x", CostPerHr: 1.69})
+		case req.Method == http.MethodGet && req.URL.Path == "/pods":
+			_ = json.NewEncoder(w).Encode([]Pod{
+				{ID: "abc123", Name: "infer-x", DesiredStatus: "RUNNING"},
+				{ID: "other", Name: "someone-elses-pod"},
+			})
+		case req.Method == http.MethodGet && req.URL.Path == "/pods/abc123":
+			_ = json.NewEncoder(w).Encode(Pod{ID: "abc123", DesiredStatus: "RUNNING"})
+		case req.Method == http.MethodDelete && req.URL.Path == "/pods/abc123":
+			w.WriteHeader(http.StatusOK)
+		case req.URL.Path == "/graphql":
+			_, _ = w.Write([]byte(`{"data":{"gpuTypes":[
+				{"id":"H100","displayName":"H100 PCIe","memoryInGb":80,"communityPrice":1.99},
+				{"id":"A6000","displayName":"RTX A6000","memoryInGb":48,"communityPrice":0.33},
+				{"id":"nope","displayName":"unavailable","memoryInGb":8,"communityPrice":0}]}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	r := testDriver(t, handler)
+	ctx := context.Background()
+
+	pod, err := r.Provision(ctx, ProvisionRequest{Name: "infer-x", GPUTypeID: "A6000", Image: "img", DiskGB: 50})
+	if err != nil || pod.ID != "abc123" {
+		t.Fatalf("Provision: pod=%+v err=%v", pod, err)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+	if gotBody["imageName"] != "img" || gotBody["containerDiskInGb"] != float64(50) {
+		t.Fatalf("create body = %v", gotBody)
+	}
+
+	pods, err := r.List(ctx)
+	if err != nil || len(pods) != 1 || pods[0].ID != "abc123" {
+		t.Fatalf("List should filter to infer- prefixed pods, got %+v err=%v", pods, err)
+	}
+
+	if _, err := r.Status(ctx, "abc123"); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+
+	if err := r.Destroy(ctx, "abc123"); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if gotMethod != http.MethodDelete || gotPath != "/pods/abc123" {
+		t.Fatalf("Destroy hit %s %s", gotMethod, gotPath)
+	}
+
+}
+
+func TestGPUTypes(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"gpuTypes":[
+			{"id":"H100","displayName":"H100 PCIe","memoryInGb":80,"communityPrice":1.99},
+			{"id":"A6000","displayName":"RTX A6000","memoryInGb":48,"communityPrice":0.33},
+			{"id":"nope","displayName":"unavailable","memoryInGb":8,"communityPrice":0}]}}`))
+	})
+	r := testDriver(t, handler)
+
+	types, err := r.GPUTypes(context.Background())
+	if err != nil || len(types) != 2 {
+		t.Fatalf("GPUTypes should drop unpriced entries, got %+v err=%v", types, err)
+	}
+	if types[0].ID != "A6000" {
+		t.Fatalf("GPUTypes should sort cheapest first, got %+v", types)
+	}
+}
+
+func TestProxyURL(t *testing.T) {
+	p := Pod{ID: "abc123"}
+	if got := p.ProxyURL(8080); got != "https://abc123-8080.proxy.runpod.net" {
+		t.Fatalf("ProxyURL = %q", got)
+	}
+}

--- a/internal/services/provisioner/runpod_test.go
+++ b/internal/services/provisioner/runpod_test.go
@@ -105,7 +105,7 @@ func TestWaitReadyReportsDownloadPhase(t *testing.T) {
 		switch req.URL.Path {
 		case "/pods/abc123":
 			_ = json.NewEncoder(w).Encode(Pod{ID: "abc123", DesiredStatus: "RUNNING"})
-		case "/v1/models":
+		case "/health":
 			probes++
 			if probes == 1 {
 				w.WriteHeader(http.StatusServiceUnavailable) // llama.cpp still loading the model
@@ -121,7 +121,7 @@ func TestWaitReadyReportsDownloadPhase(t *testing.T) {
 	r.pollInterval = time.Millisecond
 
 	var msgs []string
-	if _, err := r.WaitReady(context.Background(), "abc123", 8080, "tok", func(m string) { msgs = append(msgs, m) }); err != nil {
+	if _, err := r.WaitReady(context.Background(), "abc123", 8080, func(m string) { msgs = append(msgs, m) }); err != nil {
 		t.Fatalf("WaitReady: %v", err)
 	}
 	joined := strings.Join(msgs, "\n")


### PR DESCRIPTION
## Summary

First implementation of #939 - operator mode: rent an on-demand cloud GPU running llama.cpp, work against it, destroy it when done, pay only for hours used.

```bash
infer gpu provision   # interactive form -> provision + deploy + wait ready
infer gpu list        # instances provisioned by infer (name-prefix filtered)
infer gpu status <id> # state, uptime, $/hr, estimated total
infer gpu destroy <id>
```

- **Provision** opens a `huh` form (already a dependency): GPU picker with live pricing cheapest-first (RunPod GraphQL `gpuTypes`), model input (`<repo>:<quant>`), confirm step showing GPU + $/hr. `--gpu-type`/`--model`/`--yes` for non-interactive use. `provisioner.max_hourly` acts as a hard price guard.
- **The pod is just a llamacpp provider**: it runs `ghcr.io/ggml-org/llama.cpp:server-cuda`, which self-downloads the GGUF from Hugging Face on boot (same mechanism as `examples/working-offline`). On ready, the CLI prints `LLAMACPP_API_URL` (RunPod HTTPS proxy) and `LLAMACPP_API_KEY` (per-session random token passed as llama-server `--api-key`) - no new env-var contract, never an open port.
- **RunPod driver** (`internal/services/provisioner/runpod.go`) is plain CRUD on `rest.runpod.io/v1/pods` plus the one GraphQL pricing query; base URLs are injectable, tested against `httptest`.
- **API key** is management-plane only and per-provider: asked once by the form and persisted as `provisioner.runpod.api_key` via the same write path as `infer config set`, or supplied via `INFER_PROVISIONER_RUNPOD_API_KEY` (the form then only asks what to provision).
- New `provisioner` config block: `provider`, `runpod.api_key`, `gpu_type`, `model`, `image`, `cloud_type`, `disk_gb`, `max_hourly`.

Includes a runnable example at `examples/gpu-provisioning/` (working-offline template: README + compose gateway/cli + `.env.example` for the printed `LLAMACPP_*` handoff), linked from the top-level README examples table.

Deferred to follow-ups (tracked in #939): `infer chat --gpu` convenience flag, idle-timeout auto-destroy, additional providers (Vast.ai/Nebius), network-volume model caching.

## Docs ticket draft (for inference-gateway/docs, on request)

**Title:** `[DOCS] Document infer gpu on-demand provisioning (RunPod + llama.cpp)`
**Body:** Document the `infer gpu provision|list|status|destroy` commands, the `provisioner.*` config block, the llamacpp env-var handoff, and cost guardrails (`max_hourly`, destroy semantics). Source: inference-gateway/cli#939 and this PR.
