### PR TITLE
fix(agent): discount cached prompt tokens in session cost accumulator

### DIFF
--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -674,7 +674,7 @@ func seededRepo(t *testing.T, pricing domain.PricingService, model string, n, pr
 	t.Helper()
 	repo := services.NewInMemoryConversationRepository(nil, pricing)
 	for range n {
-		if err := repo.AddTokenUsage(model, prompt, completion, total); err != nil {
+		if err := repo.AddTokenUsage(model, prompt, completion, total, 0); err != nil {
 			t.Fatalf("AddTokenUsage: %v", err)
 		}
 	}
@@ -1401,7 +1401,7 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("AddMessage: %v", err)
 		}
-		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
+		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0); err != nil {
 			t.Fatalf("AddTokenUsage: %v", err)
 		}
 
@@ -1458,7 +1458,7 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("AddMessage: %v", err)
 		}
-		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
+		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0); err != nil {
 			t.Fatalf("AddTokenUsage: %v", err)
 		}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -812,6 +812,7 @@ func (s *AgentServiceImpl) storeIterationMetrics(
 		int(effectiveUsage.PromptTokens),
 		int(effectiveUsage.CompletionTokens),
 		int(effectiveUsage.TotalTokens),
+		cached,
 	); err != nil {
 		logger.Error("failed to add token usage to session", "error", err)
 	}

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -178,7 +178,7 @@ type MessageRepository interface {
 
 // TokenUsageRepository handles token usage tracking
 type TokenUsageRepository interface {
-	AddTokenUsage(model string, inputTokens, outputTokens, totalTokens int) error
+	AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens int) error
 	AddCachedTokens(tokens int)
 	GetSessionTokens() SessionTokenStats
 	GetSessionCostStats() SessionCostStats

--- a/internal/handlers/chat_handler_test.go
+++ b/internal/handlers/chat_handler_test.go
@@ -398,7 +398,7 @@ func TestFormatMetricsWithoutSessionTokens(t *testing.T) {
 		nil, // toolCoordinator
 	)
 
-	err := conversationRepo.AddTokenUsage("test-model", 100, 50, 150)
+	err := conversationRepo.AddTokenUsage("test-model", 100, 50, 150, 0)
 	if err != nil {
 		t.Fatalf("Failed to add token usage: %v", err)
 	}

--- a/internal/handlers/chat_message_processor_test.go
+++ b/internal/handlers/chat_message_processor_test.go
@@ -465,7 +465,7 @@ func TestChatMessageProcessor_processChatMessage_AsyncRolloverPath(t *testing.T)
 		Time:    time.Now(),
 	}))
 
-	require.NoError(t, repo.AddTokenUsage("moonshot/moonshot-v1-8k", 25000, 100, 25100))
+	require.NoError(t, repo.AddTokenUsage("moonshot/moonshot-v1-8k", 25000, 100, 25100, 0))
 
 	mockModel := &mocks.FakeModelService{}
 	mockModel.GetCurrentModelReturns("moonshot/moonshot-v1-8k")

--- a/internal/services/conversation.go
+++ b/internal/services/conversation.go
@@ -411,7 +411,7 @@ func (r *InMemoryConversationRepository) filterHiddenMessages() []domain.Convers
 
 // AddTokenUsage adds token usage from a single API call to session totals with model tracking.
 // The model parameter is required for cost tracking. Use empty string for unknown models.
-func (r *InMemoryConversationRepository) AddTokenUsage(model string, inputTokens, outputTokens, totalTokens int) error {
+func (r *InMemoryConversationRepository) AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens int) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -425,7 +425,7 @@ func (r *InMemoryConversationRepository) AddTokenUsage(model string, inputTokens
 		return nil
 	}
 
-	inputCost, outputCost, totalCost := r.pricingService.CalculateCost(model, inputTokens, outputTokens, 0)
+	inputCost, outputCost, totalCost := r.pricingService.CalculateCost(model, inputTokens, outputTokens, cachedTokens)
 
 	if r.costStats.PerModelStats == nil {
 		r.costStats.PerModelStats = make(map[string]*domain.ModelCostStats)

--- a/internal/services/conversation_optimizer_test.go
+++ b/internal/services/conversation_optimizer_test.go
@@ -391,7 +391,7 @@ func TestOptimizeMessages_LastInputTokensTrigger(t *testing.T) {
 
 	t.Run("fires when LastInputTokens above threshold", func(t *testing.T) {
 		repo := services.NewInMemoryConversationRepository(nil, nil)
-		require.NoError(t, repo.AddTokenUsage(model, 7000, 100, 7100))
+		require.NoError(t, repo.AddTokenUsage(model, 7000, 100, 7100, 0))
 
 		mockClient := createMockSDKClient(t, "Summary text")
 		optimizer := services.NewConversationOptimizer(services.OptimizerConfig{
@@ -423,7 +423,7 @@ func TestOptimizeMessages_LastInputTokensTrigger(t *testing.T) {
 
 	t.Run("does not fire when LastInputTokens below threshold", func(t *testing.T) {
 		repo := services.NewInMemoryConversationRepository(nil, nil)
-		require.NoError(t, repo.AddTokenUsage(model, 1000, 100, 1100))
+		require.NoError(t, repo.AddTokenUsage(model, 1000, 100, 1100, 0))
 
 		mockClient := createMockSDKClient(t, "Summary text")
 		optimizer := services.NewConversationOptimizer(services.OptimizerConfig{
@@ -464,7 +464,7 @@ func TestOptimizeMessages_NoAutoCompactForUnknownModel(t *testing.T) {
 	model := "ollama_cloud/some-unlisted-model"
 
 	repo := services.NewInMemoryConversationRepository(nil, nil)
-	require.NoError(t, repo.AddTokenUsage(model, 500000, 100, 500100))
+	require.NoError(t, repo.AddTokenUsage(model, 500000, 100, 500100, 0))
 
 	mockClient := createMockSDKClient(t, "Summary text")
 	optimizer := services.NewConversationOptimizer(services.OptimizerConfig{

--- a/internal/services/conversation_session_tokens_test.go
+++ b/internal/services/conversation_session_tokens_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	domain "github.com/inference-gateway/cli/internal/domain"
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
 func TestSessionTokenTracking(t *testing.T) {
@@ -14,7 +15,7 @@ func TestSessionTokenTracking(t *testing.T) {
 		t.Errorf("Expected zero stats initially, got %+v", stats)
 	}
 
-	err := repo.AddTokenUsage("test-model", 100, 50, 150)
+	err := repo.AddTokenUsage("test-model", 100, 50, 150, 0)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -31,7 +32,7 @@ func TestSessionTokenTracking(t *testing.T) {
 		t.Errorf("Expected %+v, got %+v", expected, stats)
 	}
 
-	err = repo.AddTokenUsage("test-model", 200, 75, 275)
+	err = repo.AddTokenUsage("test-model", 200, 75, 275, 0)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -88,10 +89,32 @@ func TestAddCachedTokens(t *testing.T) {
 	}
 }
 
+// Regression: AddTokenUsage must forward the per-request cached-token count to
+// CalculateCost so the session cost accumulator (which feeds the session_stats
+// stream line and the /cost shortcut) discounts cache hits - it used to pass a
+// hardcoded 0, inflating cost for cache-heavy runs.
+func TestAddTokenUsageForwardsCachedTokensToPricing(t *testing.T) {
+	pricing := &domainmocks.FakePricingService{}
+	repo := NewInMemoryConversationRepository(nil, pricing)
+
+	// 3000 prompt tokens, 2400 of them served from cache.
+	if err := repo.AddTokenUsage("test-model", 3000, 100, 3100, 2400); err != nil {
+		t.Fatalf("AddTokenUsage: %v", err)
+	}
+
+	if got := pricing.CalculateCostCallCount(); got != 1 {
+		t.Fatalf("CalculateCost called %d times, want 1", got)
+	}
+	_, in, out, cached := pricing.CalculateCostArgsForCall(0)
+	if in != 3000 || out != 100 || cached != 2400 {
+		t.Errorf("CalculateCost args = in %d, out %d, cached %d; want 3000/100/2400 (cached must not be dropped to 0)", in, out, cached)
+	}
+}
+
 func TestSessionTokensWithZeroValues(t *testing.T) {
 	repo := NewInMemoryConversationRepository(nil, nil)
 
-	err := repo.AddTokenUsage("test-model", 0, 0, 0)
+	err := repo.AddTokenUsage("test-model", 0, 0, 0, 0)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/internal/services/persistent_conversation.go
+++ b/internal/services/persistent_conversation.go
@@ -372,7 +372,7 @@ func (r *PersistentConversationRepository) DeleteMessagesAfterIndex(index int) e
 }
 
 // AddTokenUsage wraps the in-memory implementation with persistence and auto-save
-func (r *PersistentConversationRepository) AddTokenUsage(model string, inputTokens, outputTokens, totalTokens int) error {
+func (r *PersistentConversationRepository) AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens int) error {
 	r.metadataMutex.RLock()
 	needsInit := r.autoSave && r.conversationID == ""
 	r.metadataMutex.RUnlock()
@@ -411,7 +411,7 @@ func (r *PersistentConversationRepository) AddTokenUsage(model string, inputToke
 		r.metadataMutex.Unlock()
 	}
 
-	if err := r.InMemoryConversationRepository.AddTokenUsage(model, inputTokens, outputTokens, totalTokens); err != nil {
+	if err := r.InMemoryConversationRepository.AddTokenUsage(model, inputTokens, outputTokens, totalTokens, cachedTokens); err != nil {
 		return err
 	}
 

--- a/internal/services/persistent_conversation_test.go
+++ b/internal/services/persistent_conversation_test.go
@@ -285,7 +285,7 @@ func TestPersistentConversationRepository_TokenTracking(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Token Usage Tracking", func(t *testing.T) {
-		err := repo.AddTokenUsage("test-model", 50, 75, 125)
+		err := repo.AddTokenUsage("test-model", 50, 75, 125, 0)
 		assert.NoError(t, err)
 
 		stats := repo.GetSessionTokens()
@@ -294,7 +294,7 @@ func TestPersistentConversationRepository_TokenTracking(t *testing.T) {
 		assert.Equal(t, 125, stats.TotalTokens)
 		assert.Equal(t, 1, stats.RequestCount)
 
-		err = repo.AddTokenUsage("test-model", 30, 45, 75)
+		err = repo.AddTokenUsage("test-model", 30, 45, 75, 0)
 		assert.NoError(t, err)
 
 		stats = repo.GetSessionTokens()

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -185,7 +185,7 @@ func addBigMessages(t *testing.T, repo *PersistentConversationRepository, n int)
 
 func addTokenUsage(t *testing.T, repo *PersistentConversationRepository, model string, input, output, total int) {
 	t.Helper()
-	if err := repo.AddTokenUsage(model, input, output, total); err != nil {
+	if err := repo.AddTokenUsage(model, input, output, total, 0); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 }
@@ -445,7 +445,7 @@ func TestMaybeRollover_FiresAndReturnsNewID(t *testing.T) {
 	originalID := repo.GetCurrentConversationID()
 
 	addUserMessage(t, repo, "hi", time.Now())
-	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
+	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 
@@ -492,7 +492,7 @@ func TestMaybeRollover_PerformRolloverErrorReturnsFalse(t *testing.T) {
 	if err := repo.AddMessage(hidden); err != nil {
 		t.Fatalf("AddMessage: %v", err)
 	}
-	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100); err != nil {
+	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 

--- a/tests/mocks/domain/fake_conversation_repository.go
+++ b/tests/mocks/domain/fake_conversation_repository.go
@@ -26,13 +26,14 @@ type FakeConversationRepository struct {
 	addMessageReturnsOnCall map[int]struct {
 		result1 error
 	}
-	AddTokenUsageStub        func(string, int, int, int) error
+	AddTokenUsageStub        func(string, int, int, int, int) error
 	addTokenUsageMutex       sync.RWMutex
 	addTokenUsageArgsForCall []struct {
 		arg1 string
 		arg2 int
 		arg3 int
 		arg4 int
+		arg5 int
 	}
 	addTokenUsageReturns struct {
 		result1 error
@@ -326,7 +327,7 @@ func (fake *FakeConversationRepository) AddMessageReturnsOnCall(i int, result1 e
 	}{result1}
 }
 
-func (fake *FakeConversationRepository) AddTokenUsage(arg1 string, arg2 int, arg3 int, arg4 int) error {
+func (fake *FakeConversationRepository) AddTokenUsage(arg1 string, arg2 int, arg3 int, arg4 int, arg5 int) error {
 	fake.addTokenUsageMutex.Lock()
 	ret, specificReturn := fake.addTokenUsageReturnsOnCall[len(fake.addTokenUsageArgsForCall)]
 	fake.addTokenUsageArgsForCall = append(fake.addTokenUsageArgsForCall, struct {
@@ -334,13 +335,14 @@ func (fake *FakeConversationRepository) AddTokenUsage(arg1 string, arg2 int, arg
 		arg2 int
 		arg3 int
 		arg4 int
-	}{arg1, arg2, arg3, arg4})
+		arg5 int
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.AddTokenUsageStub
 	fakeReturns := fake.addTokenUsageReturns
-	fake.recordInvocation("AddTokenUsage", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("AddTokenUsage", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.addTokenUsageMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -354,17 +356,17 @@ func (fake *FakeConversationRepository) AddTokenUsageCallCount() int {
 	return len(fake.addTokenUsageArgsForCall)
 }
 
-func (fake *FakeConversationRepository) AddTokenUsageCalls(stub func(string, int, int, int) error) {
+func (fake *FakeConversationRepository) AddTokenUsageCalls(stub func(string, int, int, int, int) error) {
 	fake.addTokenUsageMutex.Lock()
 	defer fake.addTokenUsageMutex.Unlock()
 	fake.AddTokenUsageStub = stub
 }
 
-func (fake *FakeConversationRepository) AddTokenUsageArgsForCall(i int) (string, int, int, int) {
+func (fake *FakeConversationRepository) AddTokenUsageArgsForCall(i int) (string, int, int, int, int) {
 	fake.addTokenUsageMutex.RLock()
 	defer fake.addTokenUsageMutex.RUnlock()
 	argsForCall := fake.addTokenUsageArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeConversationRepository) AddTokenUsageReturns(result1 error) {


### PR DESCRIPTION
## Problem

The Infer result comment (and the interactive `/cost` shortcut) reported a cost that disagreed with `infer stats` for the same run — e.g. **$0.1192** in the footer vs **$0.022** in the Stats table for a cache-heavy `deepseek/deepseek-v4-flash` run (834,418 prompt tokens, 708,480 of them cached).

## Root cause

The CLI has two cost paths:

- **Correct** — `infer stats` reads telemetry, and `Recorder.RecordUsage` passes the real cached-token count into `CalculateCost`, which bills the cached subset at the gateway's cache-read rate.
- **Wrong** — the session accumulator `InMemoryConversationRepository.AddTokenUsage` called `CalculateCost(model, in, out, 0)` with **`cachedTokens` hardcoded to `0`**, so every prompt token was priced at the full input rate. That inflated `costStats` feeds the `session_stats` stream line (which `infer-action` renders as the footer `Cost:`) and the `/cost` shortcut.

The caller in `internal/agent/agent.go` already computes the per-request `cached` count and already passes it to the telemetry recorder — it just dropped it when calling `AddTokenUsage`.

## Fix

Thread the per-request cached-token count through `AddTokenUsage` (`TokenUsageRepository` interface + in-memory and persistent impls + the agent caller) into `CalculateCost`, so both cost paths agree. `CalculateCost` already clamps `cachedTokens` to `[0, inputTokens]`.

## Tests

- Added `TestAddTokenUsageForwardsCachedTokensToPricing` asserting the cached count reaches `CalculateCost` (fails if it regresses to `0`).
- Updated existing `AddTokenUsage` call sites for the new signature; regenerated the `ConversationRepository` counterfeiter mock.
- `go build ./...`, `task lint`, and the full `go test ./...` suite pass.

## Downstream

`inference-gateway/infer-action` renders whatever the CLI streams and needs no change — it benefits once this ships and its pinned CLI version is bumped.