### PR TITLE
test(memory): fix flaky TestGitBackend TempDir cleanup

### DIFF
--- a/internal/infra/memory/git_test.go
+++ b/internal/infra/memory/git_test.go
@@ -27,9 +27,16 @@ func isolatedGitEnv(t *testing.T) {
 	t.Setenv("GIT_COMMITTER_NAME", "infer-test")
 	t.Setenv("GIT_COMMITTER_EMAIL", "infer-test@example.com")
 	t.Setenv("GIT_TERMINAL_PROMPT", "0")
-	t.Setenv("GIT_CONFIG_COUNT", "1")
+	// Disable git's auto-maintenance: git 2.30+ fetch spawns a detached
+	// `git maintenance run --auto --detach` that keeps writing to .git/objects
+	// after pull returns, racing t.TempDir() cleanup ("unlinkat .git/objects:
+	// directory not empty", #950). gc.auto=0 alone doesn't stop it - the detached
+	// maintenance run is separate - so disable maintenance.auto too.
+	t.Setenv("GIT_CONFIG_COUNT", "2")
 	t.Setenv("GIT_CONFIG_KEY_0", "gc.auto")
 	t.Setenv("GIT_CONFIG_VALUE_0", "0")
+	t.Setenv("GIT_CONFIG_KEY_1", "maintenance.auto")
+	t.Setenv("GIT_CONFIG_VALUE_1", "false")
 }
 
 func mustGit(t *testing.T, dir string, args ...string) string {

--- a/internal/infra/memory/git_test.go
+++ b/internal/infra/memory/git_test.go
@@ -27,11 +27,6 @@ func isolatedGitEnv(t *testing.T) {
 	t.Setenv("GIT_COMMITTER_NAME", "infer-test")
 	t.Setenv("GIT_COMMITTER_EMAIL", "infer-test@example.com")
 	t.Setenv("GIT_TERMINAL_PROMPT", "0")
-	// Disable git's auto-maintenance: git 2.30+ fetch spawns a detached
-	// `git maintenance run --auto --detach` that keeps writing to .git/objects
-	// after pull returns, racing t.TempDir() cleanup ("unlinkat .git/objects:
-	// directory not empty", #950). gc.auto=0 alone doesn't stop it - the detached
-	// maintenance run is separate - so disable maintenance.auto too.
 	t.Setenv("GIT_CONFIG_COUNT", "2")
 	t.Setenv("GIT_CONFIG_KEY_0", "gc.auto")
 	t.Setenv("GIT_CONFIG_VALUE_0", "0")


### PR DESCRIPTION
Closes #950

## Summary

`internal/infra/memory` intermittently failed CI with:

```
--- FAIL: TestGitBackend_PullOnPresent (0.11s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat .../memory/.git/objects: directory not empty
```

## Root cause (confirmed via `GIT_TRACE=1`)

Git 2.30+ `git fetch` (invoked by the backend's `pull --rebase --autostash`) ends by spawning a **detached** background process:

```
git maintenance run --auto --no-quiet --detach
```

`pull` returns immediately while that process keeps writing to `.git/objects/info/`. Go's `t.TempDir()` cleanup then runs `os.RemoveAll` on the memory dir and races the still-writing detached process → `directory not empty`.

The existing `gc.auto=0` does **not** help — it only disables the `gc` task, not the detached maintenance auto-run. `maintenance.auto=false` removes the spawn entirely.

## Change

One line in the shared test helper `isolatedGitEnv` (inherited by both the backend's `run()` and the `mustGit` helpers), so every git test is covered:

```go
GIT_CONFIG_COUNT=2
gc.auto=0            (kept, belt-and-suspenders)
maintenance.auto=false   (new)
```

Test-only — in production the memory dir is persistent, so background maintenance is normal/beneficial. No production code changed.

## Verification

- `go test ./internal/infra/memory/ -run TestGitBackend -count=50` → green (was flaky).
- `GIT_TRACE=1 git pull --rebase ...` with the env set shows no `git maintenance ... --detach` spawn.