### PR TITLE
feat(bash): allow mkdir and ln in the read-only baseline

### DIFF
--- a/config/bash_allowedlist_test.go
+++ b/config/bash_allowedlist_test.go
@@ -224,6 +224,26 @@ func TestIsBashCommandAllowed_GhProject(t *testing.T) {
 	}
 }
 
+func TestIsBashCommandAllowed_MkdirLn(t *testing.T) {
+	cfg := DefaultConfig()
+
+	// Non-destructive scaffolding (create dirs, create symlinks) is in the mode.all
+	// baseline - allowed even in read-only plan mode.
+	allowed := []string{
+		"mkdir .claude",
+		"mkdir -p .claude/skills",
+		"ln -s AGENTS.md CLAUDE.md",
+		"ln -s ../.agents/skills .claude/skills",
+	}
+	for _, mode := range []string{"plan", "standard"} {
+		for _, cmd := range allowed {
+			if !cfg.IsBashCommandAllowed(cmd, mode) {
+				t.Errorf("expected %q to be allowed in %s mode", cmd, mode)
+			}
+		}
+	}
+}
+
 func TestIsBashCommandAllowed_FindActions(t *testing.T) {
 	cfg := DefaultConfig()
 

--- a/config/bash_allowedlist_test.go
+++ b/config/bash_allowedlist_test.go
@@ -227,8 +227,6 @@ func TestIsBashCommandAllowed_GhProject(t *testing.T) {
 func TestIsBashCommandAllowed_MkdirLn(t *testing.T) {
 	cfg := DefaultConfig()
 
-	// Non-destructive scaffolding (create dirs, create symlinks) is in the mode.all
-	// baseline - allowed even in read-only plan mode.
 	allowed := []string{
 		"mkdir .claude",
 		"mkdir -p .claude/skills",

--- a/config/config.go
+++ b/config/config.go
@@ -833,6 +833,7 @@ func DefaultConfig() *Config { //nolint:funlen
 						`echo( .*)?`, `ls( .*)?`, `pwd( .*)?`, `tree( .*)?`,
 						`wc( .*)?`, `sort( .*)?`, `uniq( .*)?`, `head( .*)?`, `tail( .*)?`,
 						`task( .*)?`, `make( .*)?`, `find( .*)?`, `sleep( .*)?`,
+						`mkdir( .*)?`, `ln( .*)?`,
 						`git status( .*)?`,
 						`git branch( --show-current)?( -[alrvd])?`,
 						`git log( .*)?`, `git diff( .*)?`, `git remote( -v)?`, `git show( .*)?`,


### PR DESCRIPTION
Add `mkdir` and `ln` to the every-mode bash allow-list baseline (`tools.bash.mode.all.allow` in `config/config.go`).

## Why

Both are non-destructive scaffolding commands. Without them, a headless `infer agent` cannot create directories or symlinks — e.g. `ln -s AGENTS.md CLAUDE.md` or `ln -s ../.agents/skills .claude/skills` — even when explicitly instructed to. Agents were hitting `command not allowed: ln -s ...` and stopping early on project-init tasks. `mkdir`/`ln` sit naturally alongside the existing benign baseline entries (`find`, `task`, `make`).

The clean-command guard still applies (no substitution, chaining, redirects, or dangerous find actions), and the CLI baseline is the single source of truth — `infer-action` and the org reusable workflow inherit this automatically, no downstream config change needed.

## Change

```
 `task( .*)?`, `make( .*)?`, `find( .*)?`, `sleep( .*)?`,
+`mkdir( .*)?`, `ln( .*)?`,
 `git status( .*)?`,
```

## Test

Added `TestIsBashCommandAllowed_MkdirLn` covering `mkdir`/`mkdir -p` and both symlink forms in plan + standard modes. `go test ./config/` passes.