### PR TITLE
fix: make host.docker.internal resolvable for agent containers (Linux CI)

### DIFF
--- a/internal/services/agent_manager.go
+++ b/internal/services/agent_manager.go
@@ -453,6 +453,7 @@ func (am *AgentManager) startContainer(ctx context.Context, agent config.AgentEn
 		"--network", networkName,
 		"-p", fmt.Sprintf("%d:%s", assignedPort, containerPort),
 		"--rm",
+		"--add-host", "host.docker.internal:host-gateway",
 	}
 
 	if agent.ArtifactsURL != "" {


### PR DESCRIPTION
## Problem

When `infer agent` runs headless (e.g. in a GitHub Actions Linux runner via `infer-action`) and delegates to a `--run` A2A agent such as `documentation-agent`, the agent container starts but **cannot reach its LLM**, so the submitted task never resolves. Reproduced on a real CI run delegating to `documentation-agent`: the task submits, then the agent fails to answer.

## Root cause

1. The gateway defaults to `StandaloneBinary: true` (`config/config.go`), so `GatewayManager` starts the inference-gateway as a **binary on the host**, on `localhost:8080`.
2. Agents run as **Docker containers**. `determineGatewayURL()` (`internal/services/agent_manager.go`) rewrites `localhost` → `host.docker.internal`, so the container is handed `A2A_AGENT_CLIENT_BASE_URL=http://host.docker.internal:8080/v1`.
3. But `startContainer` built the `docker run` args without `--add-host=host.docker.internal:host-gateway`. On **Linux** `host.docker.internal` does not resolve inside a container (it's a Docker-Desktop-only convenience), so the agent's outbound LLM call fails DNS resolution.

`host.docker.internal` was emitted in exactly one place with no matching `--add-host` anywhere in the tree.

## Fix

Add `--add-host host.docker.internal:host-gateway` to the agent container's `docker run` args. `host-gateway` is Docker's built-in token for the host (Docker 20.10+); Podman supports the same flag. It is a no-op on Docker Desktop (already provided) and on the container-mode gateway path (agents reach the gateway via its docker DNS name, never `host.docker.internal`), so it's safe unconditionally.

## Verification

- `gofmt` clean; `go build`/`go vet ./internal/services/` pass on the Linux build set.
- Networking behavior is best confirmed by a real run: trigger an A2A delegation on a Linux runner and confirm `A2A_SubmitTask` is followed by the agent returning a real answer, with no DNS/"cannot reach" error in the agent logs.

## Follow-up (separate)

If a run enables gateway auth (`gateway.api_key` set), the agent container still gets no `A2A_AGENT_CLIENT_API_KEY` and its gateway calls would 401 — same `startContainer` neighborhood, out of scope here since the default leaves auth off.
