### PR TITLE
feat: route anthropic models through gateway /v1/messages via removable adapter

### DIFF
--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -674,7 +674,7 @@ func seededRepo(t *testing.T, pricing domain.PricingService, model string, n, pr
 	t.Helper()
 	repo := services.NewInMemoryConversationRepository(nil, pricing)
 	for range n {
-		if err := repo.AddTokenUsage(model, prompt, completion, total, 0); err != nil {
+		if err := repo.AddTokenUsage(model, prompt, completion, total, 0, 0); err != nil {
 			t.Fatalf("AddTokenUsage: %v", err)
 		}
 	}
@@ -1401,7 +1401,7 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("AddMessage: %v", err)
 		}
-		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0); err != nil {
+		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0, 0); err != nil {
 			t.Fatalf("AddTokenUsage: %v", err)
 		}
 
@@ -1458,7 +1458,7 @@ func TestMaybeRolloverInLoop(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("AddMessage: %v", err)
 		}
-		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0); err != nil {
+		if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0, 0); err != nil {
 			t.Fatalf("AddTokenUsage: %v", err)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/inference-gateway/adk v0.25.0
-	github.com/inference-gateway/sdk v1.28.0
+	github.com/inference-gateway/sdk v1.29.0
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/lib/pq v1.12.3
 	github.com/metoro-io/mcp-golang v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inference-gateway/adk v0.25.0 h1:nHigJA7zs9uU80jI1zqJxVWLGMd9JfKKN9F8PXuosxk=
 github.com/inference-gateway/adk v0.25.0/go.mod h1:yiSyuDpKKp/mYAvgQ4lYn3UR688MQ27YqFATkJTEbdM=
-github.com/inference-gateway/sdk v1.28.0 h1:+YjmwYtqtbk2aA1c9nLoKhifeBQ1qockT/JTBFHSfUI=
-github.com/inference-gateway/sdk v1.28.0/go.mod h1:ZcrZj2pGquVpGUakHx/MEcjPsbJTS1VX067bONi+F7k=
+github.com/inference-gateway/sdk v1.29.0 h1:jalVp5Fai5jGRcbEIVmWTCt29YcbZwmbp0KVcYhpNNU=
+github.com/inference-gateway/sdk v1.29.0/go.mod h1:ZcrZj2pGquVpGUakHx/MEcjPsbJTS1VX067bONi+F7k=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jezek/xgb v1.3.0 h1:Wa1pn4GVtcmNVAVB6/pnQVJ7xPFZVZ/W1Tc27msDhgI=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -757,6 +757,15 @@ func (s *AgentServiceImpl) GetMetrics(requestID string) *domain.ChatMetrics {
 }
 
 // storeIterationMetricsInput holds the data needed for token usage polyfill calculation
+// cacheCreationTokenSource is implemented by clients that report Anthropic
+// cache-creation (cache-write) tokens out of band, since the OpenAI-shaped
+// usage struct has no field for them. The /v1/messages adapter
+// (internal/infra/adapters.AnthropicMessages) is the one implementation;
+// the interface lives here because this package is its consumer.
+type cacheCreationTokenSource interface {
+	TakeCacheCreationTokens() int
+}
+
 type storeIterationMetricsInput struct {
 	inputMessages   []sdk.Message
 	outputContent   string
@@ -807,18 +816,24 @@ func (s *AgentServiceImpl) storeIterationMetrics(
 		s.conversationRepo.AddCachedTokens(cached)
 	}
 
+	cacheWrite := 0
+	if src, ok := s.client.(cacheCreationTokenSource); ok {
+		cacheWrite = src.TakeCacheCreationTokens()
+	}
+
 	if err := s.conversationRepo.AddTokenUsage(
 		model,
 		int(effectiveUsage.PromptTokens),
 		int(effectiveUsage.CompletionTokens),
 		int(effectiveUsage.TotalTokens),
 		cached,
+		cacheWrite,
 	); err != nil {
 		logger.Error("failed to add token usage to session", "error", err)
 	}
 
 	if s.recorder != nil {
-		s.recorder.RecordUsage(model, int(effectiveUsage.PromptTokens), int(effectiveUsage.CompletionTokens), cached)
+		s.recorder.RecordUsage(model, int(effectiveUsage.PromptTokens), int(effectiveUsage.CompletionTokens), cached, cacheWrite)
 	}
 	telemetry.SetSpanUsage(ctx, int(effectiveUsage.PromptTokens), int(effectiveUsage.CompletionTokens))
 

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -19,6 +19,7 @@ import (
 	audio "github.com/inference-gateway/cli/internal/audio"
 	clipboardtext "github.com/inference-gateway/cli/internal/clipboard/text"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	adapters "github.com/inference-gateway/cli/internal/infra/adapters"
 	memory "github.com/inference-gateway/cli/internal/infra/memory"
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
 	logger "github.com/inference-gateway/cli/internal/logger"
@@ -401,7 +402,10 @@ func (c *ServiceContainer) initializeDomainServices() {
 
 	c.githubIssueService = githubissues.New()
 
-	agentClient := c.createRawSDKClient()
+	// The adapter reroutes Anthropic models through the gateway's native
+	// /v1/messages endpoint for prompt caching; unwrap it to fall back to
+	// /v1/chat/completions for every provider.
+	agentClient := adapters.NewAnthropicMessages(c.createRawSDKClient())
 	agentImpl := agent.NewAgent(
 		agentClient,
 		c.toolService,

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -13,6 +13,8 @@ import (
 
 	sdk "github.com/inference-gateway/sdk"
 
+	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
+
 	config "github.com/inference-gateway/cli/config"
 	agent "github.com/inference-gateway/cli/internal/agent"
 	tools "github.com/inference-gateway/cli/internal/agent/tools"
@@ -23,7 +25,6 @@ import (
 	memory "github.com/inference-gateway/cli/internal/infra/memory"
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
 	logger "github.com/inference-gateway/cli/internal/logger"
-	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
 	services "github.com/inference-gateway/cli/internal/services"
 	a2acoord "github.com/inference-gateway/cli/internal/services/a2acoord"
 	approvalcoord "github.com/inference-gateway/cli/internal/services/approvalcoord"
@@ -402,9 +403,6 @@ func (c *ServiceContainer) initializeDomainServices() {
 
 	c.githubIssueService = githubissues.New()
 
-	// The adapter reroutes Anthropic models through the gateway's native
-	// /v1/messages endpoint for prompt caching; unwrap it to fall back to
-	// /v1/chat/completions for every provider.
 	agentClient := adapters.NewAnthropicMessages(c.createRawSDKClient())
 	agentImpl := agent.NewAgent(
 		agentClient,

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -156,12 +156,13 @@ const (
 
 // SessionTokenStats tracks accumulated token usage across a session
 type SessionTokenStats struct {
-	TotalInputTokens  int `json:"total_input_tokens"`
-	TotalOutputTokens int `json:"total_output_tokens"`
-	TotalTokens       int `json:"total_tokens"`
-	RequestCount      int `json:"request_count"`
-	LastInputTokens   int `json:"last_input_tokens"`
-	TotalCachedTokens int `json:"total_cached_tokens"`
+	TotalInputTokens      int `json:"total_input_tokens"`
+	TotalOutputTokens     int `json:"total_output_tokens"`
+	TotalTokens           int `json:"total_tokens"`
+	RequestCount          int `json:"request_count"`
+	LastInputTokens       int `json:"last_input_tokens"`
+	TotalCachedTokens     int `json:"total_cached_tokens"`
+	TotalCacheWriteTokens int `json:"total_cache_write_tokens"`
 }
 
 // MessageRepository handles CRUD operations for conversation messages
@@ -178,7 +179,7 @@ type MessageRepository interface {
 
 // TokenUsageRepository handles token usage tracking
 type TokenUsageRepository interface {
-	AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens int) error
+	AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens, cacheWriteTokens int) error
 	AddCachedTokens(tokens int)
 	GetSessionTokens() SessionTokenStats
 	GetSessionCostStats() SessionCostStats

--- a/internal/domain/pricing.go
+++ b/internal/domain/pricing.go
@@ -40,9 +40,10 @@ type PricingService interface {
 	GetOutputPrice(model string) float64
 
 	// CalculateCost computes the total cost for a given number of input and
-	// output tokens. cachedTokens is the cached subset of inputTokens, billed
-	// at the gateway's cache-read rate when known (full input rate otherwise).
-	CalculateCost(model string, inputTokens, outputTokens, cachedTokens int) (inputCost, outputCost, totalCost float64)
+	// output tokens. cachedTokens and cacheWriteTokens are the cache-read and
+	// cache-creation subsets of inputTokens, billed at the gateway's
+	// cache-read/cache-write rates when known (full input rate otherwise).
+	CalculateCost(model string, inputTokens, outputTokens, cachedTokens, cacheWriteTokens int) (inputCost, outputCost, totalCost float64)
 
 	// RequiresPro reports whether the model is gated behind a paid Pro
 	// subscription (e.g. some Ollama Cloud models). Resolves custom prices

--- a/internal/handlers/chat_handler_test.go
+++ b/internal/handlers/chat_handler_test.go
@@ -398,7 +398,7 @@ func TestFormatMetricsWithoutSessionTokens(t *testing.T) {
 		nil, // toolCoordinator
 	)
 
-	err := conversationRepo.AddTokenUsage("test-model", 100, 50, 150, 0)
+	err := conversationRepo.AddTokenUsage("test-model", 100, 50, 150, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to add token usage: %v", err)
 	}

--- a/internal/handlers/chat_message_processor_test.go
+++ b/internal/handlers/chat_message_processor_test.go
@@ -465,7 +465,7 @@ func TestChatMessageProcessor_processChatMessage_AsyncRolloverPath(t *testing.T)
 		Time:    time.Now(),
 	}))
 
-	require.NoError(t, repo.AddTokenUsage("moonshot/moonshot-v1-8k", 25000, 100, 25100, 0))
+	require.NoError(t, repo.AddTokenUsage("moonshot/moonshot-v1-8k", 25000, 100, 25100, 0, 0))
 
 	mockModel := &mocks.FakeModelService{}
 	mockModel.GetCurrentModelReturns("moonshot/moonshot-v1-8k")

--- a/internal/infra/adapters/anthropic_messages.go
+++ b/internal/infra/adapters/anthropic_messages.go
@@ -1,0 +1,759 @@
+// Package adapters bridges external SDK surfaces to the shapes the agent
+// consumes.
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	logger "github.com/inference-gateway/cli/internal/logger"
+)
+
+// defaultMaxTokens guards the mandatory Messages API max_tokens field when no
+// value was configured via WithOptions.
+const defaultMaxTokens = 4096
+
+// AnthropicMessages is a removable sdk.Client decorator that reroutes agent
+// traffic for the Anthropic provider to the gateway's native /v1/messages
+// endpoint, enabling prompt caching via cache_control breakpoints (system
+// prompt, last tool, and a rolling conversation breakpoint). Anthropic SSE
+// events are translated back into OpenAI-shaped chat-completion chunks, so
+// the agent's streaming pipeline is unaware of the endpoint switch. Every
+// other provider - and every non-generate method - delegates to the wrapped
+// client untouched. To remove the adapter, delete this package, unwrap the
+// client in the container, and drop the TakeCacheCreationTokens read in
+// storeIterationMetrics.
+type AnthropicMessages struct {
+	inner sdk.Client
+	opts  *sdk.CreateChatCompletionRequest
+	tools *[]sdk.ChatCompletionTool
+
+	// cacheCreation carries cache-write tokens from the last Anthropic
+	// response to storeIterationMetrics, which cannot read them from the
+	// OpenAI-shaped usage (it has no cache-creation field).
+	// ponytail: one slot per adapter - fine while the agent runs one request
+	// at a time (the same assumption the shared WithOptions mutation makes);
+	// move to per-request plumbing if that ever changes.
+	cacheCreation atomic.Int64
+}
+
+var _ sdk.Client = (*AnthropicMessages)(nil)
+
+// NewAnthropicMessages wraps the raw SDK client with Anthropic /v1/messages
+// routing.
+func NewAnthropicMessages(inner sdk.Client) *AnthropicMessages {
+	return &AnthropicMessages{inner: inner}
+}
+
+// TakeCacheCreationTokens returns the cache-write token count of the last
+// completed Anthropic request and resets it.
+func (a *AnthropicMessages) TakeCacheCreationTokens() int {
+	return int(a.cacheCreation.Swap(0))
+}
+
+// The builder methods capture what the Messages translation needs and return
+// the adapter itself - returning the inner client would let subsequent calls
+// in a builder chain bypass the adapter.
+
+func (a *AnthropicMessages) WithAuthToken(token string) sdk.Client {
+	a.inner.WithAuthToken(token)
+	return a
+}
+
+func (a *AnthropicMessages) WithTools(tools *[]sdk.ChatCompletionTool) sdk.Client {
+	a.tools = tools
+	a.inner.WithTools(tools)
+	return a
+}
+
+func (a *AnthropicMessages) WithOptions(options *sdk.CreateChatCompletionRequest) sdk.Client {
+	a.opts = options
+	a.inner.WithOptions(options)
+	return a
+}
+
+func (a *AnthropicMessages) WithHeaders(headers map[string]string) sdk.Client {
+	a.inner.WithHeaders(headers)
+	return a
+}
+
+func (a *AnthropicMessages) WithHeader(name, value string) sdk.Client {
+	a.inner.WithHeader(name, value)
+	return a
+}
+
+func (a *AnthropicMessages) WithMiddlewareOptions(options *sdk.MiddlewareOptions) sdk.Client {
+	a.inner.WithMiddlewareOptions(options)
+	return a
+}
+
+func (a *AnthropicMessages) ListModels(ctx context.Context, include ...sdk.ListModelsParamsInclude) (*sdk.ListModelsResponse, error) {
+	return a.inner.ListModels(ctx, include...)
+}
+
+func (a *AnthropicMessages) ListProviderModels(ctx context.Context, provider sdk.Provider, include ...sdk.ListModelsParamsInclude) (*sdk.ListModelsResponse, error) {
+	return a.inner.ListProviderModels(ctx, provider, include...)
+}
+
+func (a *AnthropicMessages) ListTools(ctx context.Context) (*sdk.ListToolsResponse, error) {
+	return a.inner.ListTools(ctx)
+}
+
+func (a *AnthropicMessages) HealthCheck(ctx context.Context) error {
+	return a.inner.HealthCheck(ctx)
+}
+
+func (a *AnthropicMessages) CreateMessage(ctx context.Context, provider sdk.Provider, request sdk.CreateMessagesRequest) (*sdk.MessagesResponse, error) {
+	return a.inner.CreateMessage(ctx, provider, request)
+}
+
+func (a *AnthropicMessages) CreateMessageStream(ctx context.Context, provider sdk.Provider, request sdk.CreateMessagesRequest) (<-chan sdk.SSEvent, error) {
+	return a.inner.CreateMessageStream(ctx, provider, request)
+}
+
+// GenerateContent routes Anthropic requests through /v1/messages and
+// translates the response back into the chat-completions shape.
+func (a *AnthropicMessages) GenerateContent(ctx context.Context, provider sdk.Provider, model string, messages []sdk.Message) (*sdk.CreateChatCompletionResponse, error) {
+	if provider != sdk.Anthropic {
+		return a.inner.GenerateContent(ctx, provider, model, messages)
+	}
+
+	resp, err := a.inner.CreateMessage(ctx, provider, a.buildMessagesRequest(model, messages))
+	if err != nil {
+		return nil, fmt.Errorf("anthropic /v1/messages request failed (the gateway must support the Messages API): %w", err)
+	}
+
+	return a.translateResponse(resp), nil
+}
+
+// GenerateContentStream routes Anthropic requests through /v1/messages and
+// translates the native Anthropic SSE events into chat-completion chunks.
+func (a *AnthropicMessages) GenerateContentStream(ctx context.Context, provider sdk.Provider, model string, messages []sdk.Message) (<-chan sdk.SSEvent, error) {
+	if provider != sdk.Anthropic {
+		return a.inner.GenerateContentStream(ctx, provider, model, messages)
+	}
+
+	in, err := a.inner.CreateMessageStream(ctx, provider, a.buildMessagesRequest(model, messages))
+	if err != nil {
+		return nil, fmt.Errorf("anthropic /v1/messages request failed (the gateway must support the Messages API): %w", err)
+	}
+
+	out := make(chan sdk.SSEvent, 8)
+	go a.translateStream(ctx, in, out, model)
+	return out, nil
+}
+
+// translateStream converts the Anthropic event stream to chat-completion
+// chunks. The cache-creation side channel is only written on a cleanly
+// finished stream so a cancelled turn can't leak its value into the next
+// request's metrics.
+func (a *AnthropicMessages) translateStream(ctx context.Context, in <-chan sdk.SSEvent, out chan<- sdk.SSEvent, model string) {
+	defer close(out)
+
+	t := &streamTranslator{model: model, toolIndex: map[int]int{}}
+	for event := range in {
+		for _, translated := range t.translate(event) {
+			select {
+			case out <- translated:
+			case <-ctx.Done():
+				for range in {
+				}
+				return
+			}
+		}
+	}
+
+	a.cacheCreation.Store(t.usage.cacheCreation)
+}
+
+// buildMessagesRequest maps the agent's chat-completions payload onto the
+// Anthropic Messages API, placing the three cache_control breakpoints:
+// system prompt, last tool, and the rolling conversation breakpoint.
+func (a *AnthropicMessages) buildMessagesRequest(model string, messages []sdk.Message) sdk.CreateMessagesRequest {
+	req := sdk.CreateMessagesRequest{
+		Model:     model,
+		MaxTokens: a.maxTokens(),
+		Messages:  buildMessages(messages),
+	}
+
+	if system := systemPrompt(messages); system != "" {
+		var union sdk.CreateMessagesRequest_System
+		_ = union.FromCreateMessagesRequestSystem1([]sdk.MessagesTextBlock{{
+			Type:         sdk.MessagesTextBlockTypeText,
+			Text:         system,
+			CacheControl: ephemeral(),
+		}})
+		req.System = &union
+	}
+
+	if tools := a.buildTools(); len(tools) > 0 {
+		req.Tools = &tools
+	}
+
+	return req
+}
+
+func (a *AnthropicMessages) maxTokens() int {
+	if a.opts != nil && a.opts.MaxTokens != nil && *a.opts.MaxTokens > 0 {
+		return *a.opts.MaxTokens
+	}
+	return defaultMaxTokens
+}
+
+// buildTools converts the OpenAI tool definitions to Anthropic tools. The
+// last tool carries the cache breakpoint - tool order is deterministic
+// (sorted by name), so the prefix stays byte-stable across turns.
+func (a *AnthropicMessages) buildTools() []sdk.MessagesTool {
+	if a.tools == nil || len(*a.tools) == 0 {
+		return nil
+	}
+
+	tools := make([]sdk.MessagesTool, 0, len(*a.tools))
+	for _, t := range *a.tools {
+		tool := sdk.MessagesTool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			InputSchema: sdk.FunctionParameters{"type": "object"},
+		}
+		if t.Function.Parameters != nil {
+			tool.InputSchema = *t.Function.Parameters
+		}
+		tools = append(tools, tool)
+	}
+
+	tools[len(tools)-1].CacheControl = ephemeral()
+	return tools
+}
+
+// systemPrompt extracts the leading system message, which the Messages API
+// takes as a dedicated top-level field.
+func systemPrompt(messages []sdk.Message) string {
+	if len(messages) > 0 && messages[0].Role == sdk.System {
+		return messageText(messages[0])
+	}
+	return ""
+}
+
+// stagedMessage is the intermediate representation used while grouping and
+// merging messages, before sealing the content blocks into their unions.
+type stagedMessage struct {
+	role   sdk.MessagesMessageRole
+	blocks []sdk.MessagesRequestContentBlock
+	// volatile marks, per block, content the rolling cache breakpoint must
+	// skip (the <system-reminder> tail changes every turn).
+	volatile []bool
+}
+
+// buildMessages converts the conversation (minus the hoisted system prompt)
+// into Anthropic messages: tool calls become tool_use blocks, tool results
+// become tool_result blocks on user turns, and adjacent same-role messages
+// are merged into one legal turn.
+func buildMessages(messages []sdk.Message) []sdk.MessagesMessage {
+	staged := stageMessages(messages)
+	applyRollingCacheControl(staged)
+
+	out := make([]sdk.MessagesMessage, 0, len(staged))
+	for _, m := range staged {
+		var content sdk.MessagesMessage_Content
+		if err := content.FromMessagesMessageContent1(m.blocks); err != nil {
+			logger.Error("failed to seal anthropic message content", "error", err)
+			continue
+		}
+		out = append(out, sdk.MessagesMessage{Role: m.role, Content: content})
+	}
+	return out
+}
+
+func stageMessages(messages []sdk.Message) []*stagedMessage {
+	var staged []*stagedMessage
+
+	appendBlocks := func(role sdk.MessagesMessageRole, volatile bool, blocks ...sdk.MessagesRequestContentBlock) {
+		if len(blocks) == 0 {
+			return
+		}
+		flags := make([]bool, len(blocks))
+		for i := range flags {
+			flags[i] = volatile
+		}
+		if n := len(staged); n > 0 && staged[n-1].role == role {
+			staged[n-1].blocks = append(staged[n-1].blocks, blocks...)
+			staged[n-1].volatile = append(staged[n-1].volatile, flags...)
+			return
+		}
+		staged = append(staged, &stagedMessage{role: role, blocks: blocks, volatile: flags})
+	}
+
+	for i, msg := range messages {
+		switch msg.Role {
+		case sdk.System:
+			if i == 0 {
+				continue // hoisted into the top-level system field
+			}
+			if text := messageText(msg); text != "" {
+				appendBlocks(sdk.MessagesMessageRoleUser, isVolatile(text), textBlock(text))
+			}
+		case sdk.User:
+			if text := messageText(msg); text != "" {
+				appendBlocks(sdk.MessagesMessageRoleUser, isVolatile(text), textBlock(text))
+			}
+		case sdk.Assistant:
+			blocks, text := assistantBlocks(msg)
+			appendBlocks(sdk.MessagesMessageRoleAssistant, isVolatile(text), blocks...)
+		case sdk.Tool:
+			if msg.ToolCallID == nil {
+				continue
+			}
+			appendBlocks(sdk.MessagesMessageRoleUser, false, toolResultBlock(*msg.ToolCallID, messageText(msg)))
+		}
+	}
+
+	return staged
+}
+
+// assistantBlocks maps an assistant message to text + tool_use blocks.
+// Reasoning is intentionally dropped: replaying unsigned thinking is
+// rejected by Anthropic, and extended thinking is out of scope here.
+func assistantBlocks(msg sdk.Message) ([]sdk.MessagesRequestContentBlock, string) {
+	var blocks []sdk.MessagesRequestContentBlock
+
+	text := messageText(msg)
+	if text != "" {
+		blocks = append(blocks, textBlock(text))
+	}
+
+	if msg.ToolCalls != nil {
+		for _, tc := range *msg.ToolCalls {
+			blocks = append(blocks, toolUseBlock(tc))
+		}
+	}
+
+	return blocks, text
+}
+
+// isVolatile reports whether text is injected per-turn CLI content the
+// rolling cache breakpoint must skip.
+func isVolatile(text string) bool {
+	return strings.Contains(text, "<system-reminder>")
+}
+
+// applyRollingCacheControl sets the rolling cache breakpoint on the newest
+// non-volatile block, so the growing conversation prefix caches
+// incrementally across turns while the <system-reminder> tail (merged into
+// the last user message) stays outside the cached prefix.
+func applyRollingCacheControl(staged []*stagedMessage) {
+	for i := len(staged) - 1; i >= 0; i-- {
+		m := staged[i]
+		for j := len(m.blocks) - 1; j >= 0; j-- {
+			if m.volatile[j] {
+				continue
+			}
+			m.blocks[j] = blockWithCacheControl(m.blocks[j])
+			return
+		}
+	}
+}
+
+// blockWithCacheControl returns the block with cache_control set, going
+// through JSON because the union's raw payload is not directly editable.
+func blockWithCacheControl(block sdk.MessagesRequestContentBlock) sdk.MessagesRequestContentBlock {
+	raw, err := block.MarshalJSON()
+	if err != nil {
+		return block
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return block
+	}
+	fields["cache_control"] = map[string]any{"type": string(sdk.Ephemeral)}
+
+	patched, err := json.Marshal(fields)
+	if err != nil {
+		return block
+	}
+
+	var out sdk.MessagesRequestContentBlock
+	if err := out.UnmarshalJSON(patched); err != nil {
+		return block
+	}
+	return out
+}
+
+func ephemeral() *sdk.CacheControl {
+	return &sdk.CacheControl{Type: sdk.Ephemeral}
+}
+
+// messageText extracts the text of a message: plain string content, or the
+// concatenated text parts of multimodal content (non-text parts have no
+// Messages-path mapping and are dropped).
+func messageText(msg sdk.Message) string {
+	if text, err := msg.Content.AsMessageContent0(); err == nil {
+		return text
+	}
+
+	parts, err := msg.Content.AsMessageContent1()
+	if err != nil {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, part := range parts {
+		if tp, err := part.AsTextContentPart(); err == nil && tp.Text != "" {
+			b.WriteString(tp.Text)
+		}
+	}
+	return b.String()
+}
+
+func textBlock(text string) sdk.MessagesRequestContentBlock {
+	var block sdk.MessagesRequestContentBlock
+	_ = block.FromMessagesTextBlock(sdk.MessagesTextBlock{
+		Type: sdk.MessagesTextBlockTypeText,
+		Text: text,
+	})
+	return block
+}
+
+func toolUseBlock(tc sdk.ChatCompletionMessageToolCall) sdk.MessagesRequestContentBlock {
+	input := map[string]any{}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &input); err != nil || input == nil {
+		input = map[string]any{}
+	}
+
+	var block sdk.MessagesRequestContentBlock
+	_ = block.FromMessagesToolUseBlock(sdk.MessagesToolUseBlock{
+		ID:    tc.ID,
+		Name:  tc.Function.Name,
+		Input: input,
+		Type:  sdk.MessagesToolUseBlockTypeToolUse,
+	})
+	return block
+}
+
+func toolResultBlock(toolUseID, text string) sdk.MessagesRequestContentBlock {
+	var content sdk.MessagesToolResultBlock_Content
+	_ = content.FromMessagesToolResultBlockContent0(text)
+
+	var block sdk.MessagesRequestContentBlock
+	_ = block.FromMessagesToolResultBlock(sdk.MessagesToolResultBlock{
+		ToolUseID: toolUseID,
+		Content:   &content,
+		Type:      sdk.ToolResult,
+	})
+	return block
+}
+
+// anthropicUsage accumulates Anthropic usage across message_start and
+// message_delta events.
+type anthropicUsage struct {
+	input         int64
+	output        int64
+	cacheRead     int64
+	cacheCreation int64
+}
+
+func (u *anthropicUsage) absorb(usage sdk.MessagesUsage) {
+	if usage.InputTokens > 0 {
+		u.input = usage.InputTokens
+	}
+	if usage.OutputTokens > 0 {
+		u.output = usage.OutputTokens
+	}
+	if usage.CacheReadInputTokens != nil && *usage.CacheReadInputTokens > 0 {
+		u.cacheRead = *usage.CacheReadInputTokens
+	}
+	if usage.CacheCreationInputTokens != nil && *usage.CacheCreationInputTokens > 0 {
+		u.cacheCreation = *usage.CacheCreationInputTokens
+	}
+}
+
+// toCompletionUsage synthesizes OpenAI-shaped usage: prompt_tokens covers
+// the full input (Anthropic's input_tokens excludes cached tokens), and
+// cache reads surface as prompt_tokens_details.cached_tokens so the
+// existing display and cost paths work unchanged.
+func (u anthropicUsage) toCompletionUsage() sdk.CompletionUsage {
+	prompt := u.input + u.cacheRead + u.cacheCreation
+	usage := sdk.CompletionUsage{
+		PromptTokens:     prompt,
+		CompletionTokens: u.output,
+		TotalTokens:      prompt + u.output,
+	}
+
+	if u.cacheRead > 0 {
+		cached := u.cacheRead
+		usage.PromptTokensDetails = &struct {
+			AudioTokens  *int64 `json:"audio_tokens,omitempty"`
+			CachedTokens *int64 `json:"cached_tokens,omitempty"`
+		}{CachedTokens: &cached}
+	}
+
+	return usage
+}
+
+// streamTranslator converts one Anthropic SSE stream into chat-completion
+// chunks, tracking the block-index-to-tool-index mapping (Anthropic indexes
+// over all content blocks, the tool-call accumulator over tool calls only).
+type streamTranslator struct {
+	model      string
+	toolIndex  map[int]int
+	usage      anthropicUsage
+	stopReason string
+}
+
+func (t *streamTranslator) translate(event sdk.SSEvent) []sdk.SSEvent {
+	if event.Event == nil || event.Data == nil {
+		return []sdk.SSEvent{event} // transport errors pass through untouched
+	}
+
+	var ev sdk.MessagesStreamEvent
+	if err := json.Unmarshal(*event.Data, &ev); err != nil {
+		logger.Error("failed to unmarshal anthropic stream event",
+			"error", err,
+			"raw_data", string(*event.Data))
+		return nil
+	}
+
+	switch ev.Type {
+	case sdk.MessagesStreamEventTypeMessageStart:
+		if ev.Message != nil {
+			t.usage.absorb(ev.Message.Usage)
+		}
+		return nil
+	case sdk.MessagesStreamEventTypeContentBlockStart:
+		return t.translateBlockStart(ev)
+	case sdk.MessagesStreamEventTypeContentBlockDelta:
+		return t.translateDelta(ev)
+	case sdk.MessagesStreamEventTypeMessageDelta:
+		if ev.Usage != nil {
+			t.usage.absorb(*ev.Usage)
+		}
+		if ev.Delta != nil && ev.Delta.StopReason != nil {
+			t.stopReason = *ev.Delta.StopReason
+		}
+		return nil
+	case sdk.MessagesStreamEventTypeMessageStop:
+		return t.finishEvents()
+	case sdk.MessagesStreamEventTypeError:
+		return []sdk.SSEvent{{Data: event.Data}} // nil Event: the agent treats it as broken transport and reconnects
+	default: // ping, content_block_stop
+		return nil
+	}
+}
+
+func (t *streamTranslator) translateBlockStart(ev sdk.MessagesStreamEvent) []sdk.SSEvent {
+	if ev.ContentBlock == nil || ev.Index == nil {
+		return nil
+	}
+
+	tu, ok := asToolUse(*ev.ContentBlock)
+	if !ok {
+		return nil
+	}
+
+	idx := len(t.toolIndex)
+	t.toolIndex[*ev.Index] = idx
+
+	id := tu.ID
+	toolType := string(sdk.Function)
+	return t.chunk(sdk.ChatCompletionStreamResponseDelta{
+		ToolCalls: &[]sdk.ChatCompletionMessageToolCallChunk{{
+			Index:    idx,
+			ID:       &id,
+			Type:     &toolType,
+			Function: &sdk.ChatCompletionMessageToolCallFunction{Name: tu.Name},
+		}},
+	})
+}
+
+func (t *streamTranslator) translateDelta(ev sdk.MessagesStreamEvent) []sdk.SSEvent {
+	d := ev.Delta
+	if d == nil || d.Type == nil {
+		return nil
+	}
+
+	switch *d.Type {
+	case "text_delta":
+		if d.Text == nil || *d.Text == "" {
+			return nil
+		}
+		return t.chunk(sdk.ChatCompletionStreamResponseDelta{Content: *d.Text})
+	case "thinking_delta":
+		if d.Thinking == nil || *d.Thinking == "" {
+			return nil
+		}
+		return t.chunk(sdk.ChatCompletionStreamResponseDelta{ReasoningContent: d.Thinking})
+	case "input_json_delta":
+		if d.PartialJSON == nil || *d.PartialJSON == "" || ev.Index == nil {
+			return nil
+		}
+		idx, ok := t.toolIndex[*ev.Index]
+		if !ok {
+			return nil
+		}
+		return t.chunk(sdk.ChatCompletionStreamResponseDelta{
+			ToolCalls: &[]sdk.ChatCompletionMessageToolCallChunk{{
+				Index:    idx,
+				Function: &sdk.ChatCompletionMessageToolCallFunction{Arguments: *d.PartialJSON},
+			}},
+		})
+	default:
+		return nil
+	}
+}
+
+// finishEvents emits the finish-reason chunk followed by a usage-only chunk,
+// mirroring the stream_options.include_usage shape of the OpenAI path.
+func (t *streamTranslator) finishEvents() []sdk.SSEvent {
+	finish := chatChunk(sdk.CreateChatCompletionStreamResponse{
+		ID:     "anthropic-messages",
+		Object: "chat.completion.chunk",
+		Model:  t.model,
+		Choices: []sdk.ChatCompletionStreamChoice{{
+			FinishReason: mapStopReason(t.stopReason),
+		}},
+	})
+
+	usage := t.usage.toCompletionUsage()
+	usageChunk := chatChunk(sdk.CreateChatCompletionStreamResponse{
+		ID:      "anthropic-messages",
+		Object:  "chat.completion.chunk",
+		Model:   t.model,
+		Choices: []sdk.ChatCompletionStreamChoice{},
+		Usage:   &usage,
+	})
+
+	return []sdk.SSEvent{finish, usageChunk}
+}
+
+func (t *streamTranslator) chunk(delta sdk.ChatCompletionStreamResponseDelta) []sdk.SSEvent {
+	return []sdk.SSEvent{chatChunk(sdk.CreateChatCompletionStreamResponse{
+		ID:      "anthropic-messages",
+		Object:  "chat.completion.chunk",
+		Model:   t.model,
+		Choices: []sdk.ChatCompletionStreamChoice{{Delta: delta}},
+	})}
+}
+
+func chatChunk(resp sdk.CreateChatCompletionStreamResponse) sdk.SSEvent {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		logger.Error("failed to marshal translated stream chunk", "error", err)
+		data = []byte("{}")
+	}
+	event := sdk.ContentDelta
+	return sdk.SSEvent{Event: &event, Data: &data}
+}
+
+func mapStopReason(reason string) sdk.FinishReason {
+	switch reason {
+	case string(sdk.MessagesResponseStopReasonToolUse):
+		return sdk.ToolCalls
+	case string(sdk.MessagesResponseStopReasonMaxTokens):
+		return sdk.Length
+	default: // end_turn, stop_sequence, refusal, or absent
+		return sdk.Stop
+	}
+}
+
+// translateResponse converts a non-streaming Messages response into the
+// chat-completions shape used by the sync Run path.
+func (a *AnthropicMessages) translateResponse(resp *sdk.MessagesResponse) *sdk.CreateChatCompletionResponse {
+	var text, thinking strings.Builder
+	var toolCalls []sdk.ChatCompletionMessageToolCall
+
+	for _, block := range resp.Content {
+		switch blockType(block) {
+		case "text":
+			if tb, err := block.AsMessagesTextBlock(); err == nil {
+				text.WriteString(tb.Text)
+			}
+		case "thinking":
+			if th, err := block.AsMessagesThinkingBlock(); err == nil {
+				thinking.WriteString(th.Thinking)
+			}
+		case "tool_use":
+			if tu, err := block.AsMessagesToolUseBlock(); err == nil {
+				toolCalls = append(toolCalls, toToolCall(tu))
+			}
+		}
+	}
+
+	message := sdk.Message{
+		Role:    sdk.Assistant,
+		Content: sdk.NewMessageContent(text.String()),
+	}
+	if reasoning := thinking.String(); reasoning != "" {
+		r := reasoning
+		message.Reasoning = &r
+		message.ReasoningContent = &r
+	}
+	if len(toolCalls) > 0 {
+		message.ToolCalls = &toolCalls
+	}
+
+	var u anthropicUsage
+	u.absorb(resp.Usage)
+	a.cacheCreation.Store(u.cacheCreation)
+	usage := u.toCompletionUsage()
+
+	return &sdk.CreateChatCompletionResponse{
+		ID:     resp.ID,
+		Object: "chat.completion",
+		Model:  resp.Model,
+		Choices: []sdk.ChatCompletionChoice{{
+			Index:        0,
+			Message:      message,
+			FinishReason: mapStopReason(string(resp.StopReason)),
+		}},
+		Usage: &usage,
+	}
+}
+
+func toToolCall(tu sdk.MessagesToolUseBlock) sdk.ChatCompletionMessageToolCall {
+	args, err := json.Marshal(tu.Input)
+	if err != nil {
+		args = []byte("{}")
+	}
+	return sdk.ChatCompletionMessageToolCall{
+		ID:   tu.ID,
+		Type: sdk.Function,
+		Function: sdk.ChatCompletionMessageToolCallFunction{
+			Name:      tu.Name,
+			Arguments: string(args),
+		},
+	}
+}
+
+// blockType reads the discriminating type field of a response content block;
+// the generated As* accessors don't validate it themselves.
+func blockType(block sdk.MessagesResponseContentBlock) string {
+	raw, err := block.MarshalJSON()
+	if err != nil {
+		return ""
+	}
+	var probe struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return ""
+	}
+	return probe.Type
+}
+
+// asToolUse returns the tool_use payload of a content block, verifying the
+// discriminator first.
+func asToolUse(block sdk.MessagesResponseContentBlock) (sdk.MessagesToolUseBlock, bool) {
+	if blockType(block) != string(sdk.MessagesToolUseBlockTypeToolUse) {
+		return sdk.MessagesToolUseBlock{}, false
+	}
+	tu, err := block.AsMessagesToolUseBlock()
+	if err != nil {
+		return sdk.MessagesToolUseBlock{}, false
+	}
+	return tu, true
+}

--- a/internal/infra/adapters/anthropic_messages_test.go
+++ b/internal/infra/adapters/anthropic_messages_test.go
@@ -1,0 +1,352 @@
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	mocksdk "github.com/inference-gateway/cli/tests/mocks/sdk"
+)
+
+// requestShape mirrors the JSON the gateway receives, for mapping assertions.
+type requestShape struct {
+	Model     string `json:"model"`
+	MaxTokens int    `json:"max_tokens"`
+	System    []struct {
+		Text         string         `json:"text"`
+		CacheControl map[string]any `json:"cache_control"`
+	} `json:"system"`
+	Tools []struct {
+		Name         string         `json:"name"`
+		InputSchema  map[string]any `json:"input_schema"`
+		CacheControl map[string]any `json:"cache_control"`
+	} `json:"tools"`
+	Messages []struct {
+		Role    string           `json:"role"`
+		Content []map[string]any `json:"content"`
+	} `json:"messages"`
+}
+
+func decodeRequest(t *testing.T, req sdk.CreateMessagesRequest) requestShape {
+	t.Helper()
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	var shape requestShape
+	require.NoError(t, json.Unmarshal(data, &shape))
+	return shape
+}
+
+func textMessage(role sdk.MessageRole, text string) sdk.Message {
+	return sdk.Message{Role: role, Content: sdk.NewMessageContent(text)}
+}
+
+func conversationFixture() []sdk.Message {
+	args := `{"path":"a"}`
+	toolCalls := []sdk.ChatCompletionMessageToolCall{
+		{ID: "call_1", Type: sdk.Function, Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Read", Arguments: args}},
+		{ID: "call_2", Type: sdk.Function, Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Bash", Arguments: "not-json"}},
+	}
+	reasoning := "internal thoughts"
+	assistant := sdk.Message{
+		Role:             sdk.Assistant,
+		Content:          sdk.NewMessageContent("I'll check"),
+		Reasoning:        &reasoning,
+		ReasoningContent: &reasoning,
+		ToolCalls:        &toolCalls,
+	}
+	call1, call2 := "call_1", "call_2"
+	return []sdk.Message{
+		textMessage(sdk.System, "You are helpful"),
+		textMessage(sdk.User, "Turn 1"),
+		assistant,
+		{Role: sdk.Tool, ToolCallID: &call1, Content: sdk.NewMessageContent("data 1")},
+		{Role: sdk.Tool, ToolCallID: &call2, Content: sdk.NewMessageContent("data 2")},
+		textMessage(sdk.User, "Turn 2"),
+		textMessage(sdk.User, "<system-reminder>volatile tail</system-reminder>"),
+	}
+}
+
+func TestBuildMessagesRequest(t *testing.T) {
+	toolDesc := "read a file"
+	params := sdk.FunctionParameters{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string"}}}
+	tools := []sdk.ChatCompletionTool{
+		{Type: sdk.Function, Function: sdk.FunctionObject{Name: "Bash"}},
+		{Type: sdk.Function, Function: sdk.FunctionObject{Name: "Read", Description: &toolDesc, Parameters: &params}},
+	}
+	maxTokens := 2048
+
+	adapter := NewAnthropicMessages(&mocksdk.FakeClient{})
+	adapter.WithOptions(&sdk.CreateChatCompletionRequest{MaxTokens: &maxTokens}).WithTools(&tools)
+
+	shape := decodeRequest(t, adapter.buildMessagesRequest("claude-sonnet-4-5", conversationFixture()))
+
+	assert.Equal(t, "claude-sonnet-4-5", shape.Model)
+	assert.Equal(t, 2048, shape.MaxTokens)
+
+	require.Len(t, shape.System, 1)
+	assert.Equal(t, "You are helpful", shape.System[0].Text)
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, shape.System[0].CacheControl)
+
+	require.Len(t, shape.Tools, 2)
+	assert.Equal(t, "Bash", shape.Tools[0].Name)
+	assert.Nil(t, shape.Tools[0].CacheControl)
+	assert.Equal(t, map[string]any{"type": "object"}, shape.Tools[0].InputSchema)
+	assert.Equal(t, "Read", shape.Tools[1].Name)
+	assert.NotNil(t, shape.Tools[1].CacheControl, "last tool carries the cache breakpoint")
+	assert.Contains(t, shape.Tools[1].InputSchema, "properties")
+
+	require.Len(t, shape.Messages, 3)
+
+	assert.Equal(t, "user", shape.Messages[0].Role)
+	require.Len(t, shape.Messages[0].Content, 1)
+	assert.Equal(t, "Turn 1", shape.Messages[0].Content[0]["text"])
+
+	assistant := shape.Messages[1]
+	assert.Equal(t, "assistant", assistant.Role)
+	require.Len(t, assistant.Content, 3)
+	assert.Equal(t, "text", assistant.Content[0]["type"])
+	assert.Equal(t, "I'll check", assistant.Content[0]["text"])
+	assert.Equal(t, "tool_use", assistant.Content[1]["type"])
+	assert.Equal(t, "call_1", assistant.Content[1]["id"])
+	assert.Equal(t, map[string]any{"path": "a"}, assistant.Content[1]["input"])
+	assert.Equal(t, "tool_use", assistant.Content[2]["type"])
+	assert.Equal(t, map[string]any{}, assistant.Content[2]["input"], "unparseable arguments fall back to an empty object")
+	assert.Nil(t, assistant.Content[2]["cache_control"])
+
+	user := shape.Messages[2]
+	assert.Equal(t, "user", user.Role)
+	require.Len(t, user.Content, 4, "tool results + user text + volatile tail merge into one user turn")
+	assert.Equal(t, "tool_result", user.Content[0]["type"])
+	assert.Equal(t, "call_1", user.Content[0]["tool_use_id"])
+	assert.Equal(t, "data 1", user.Content[0]["content"])
+	assert.Equal(t, "tool_result", user.Content[1]["type"])
+	assert.Equal(t, "Turn 2", user.Content[2]["text"])
+	assert.NotNil(t, user.Content[2]["cache_control"], "rolling breakpoint lands on the newest non-volatile block")
+	assert.Nil(t, user.Content[3]["cache_control"], "the volatile tail must not eat a cache slot")
+}
+
+func TestBuildMessagesRequestDefaults(t *testing.T) {
+	adapter := NewAnthropicMessages(&mocksdk.FakeClient{})
+
+	shape := decodeRequest(t, adapter.buildMessagesRequest("claude-sonnet-4-5", []sdk.Message{
+		textMessage(sdk.User, "hi"),
+	}))
+
+	assert.Equal(t, defaultMaxTokens, shape.MaxTokens)
+	assert.Empty(t, shape.System)
+	assert.Empty(t, shape.Tools)
+	require.Len(t, shape.Messages, 1)
+	assert.NotNil(t, shape.Messages[0].Content[0]["cache_control"], "sole user message takes the rolling breakpoint")
+}
+
+func anthropicEvent(payload string) sdk.SSEvent {
+	event := sdk.ContentDelta
+	data := []byte(payload)
+	return sdk.SSEvent{Event: &event, Data: &data}
+}
+
+func collectChunks(t *testing.T, out <-chan sdk.SSEvent) []sdk.CreateChatCompletionStreamResponse {
+	t.Helper()
+	var chunks []sdk.CreateChatCompletionStreamResponse
+	for event := range out {
+		require.NotNil(t, event.Event)
+		require.NotNil(t, event.Data)
+		var chunk sdk.CreateChatCompletionStreamResponse
+		require.NoError(t, json.Unmarshal(*event.Data, &chunk))
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func TestGenerateContentStreamTranslation(t *testing.T) {
+	in := make(chan sdk.SSEvent, 20)
+	fake := &mocksdk.FakeClient{}
+	fake.CreateMessageStreamReturns(in, nil)
+	adapter := NewAnthropicMessages(fake)
+
+	out, err := adapter.GenerateContentStream(context.Background(), sdk.Anthropic, "claude-sonnet-4-5", []sdk.Message{textMessage(sdk.User, "hi")})
+	require.NoError(t, err)
+	assert.Equal(t, 1, fake.CreateMessageStreamCallCount())
+	assert.Equal(t, 0, fake.GenerateContentStreamCallCount())
+
+	for _, payload := range []string{
+		`{"type":"message_start","message":{"id":"msg_1","model":"claude-sonnet-4-5","role":"assistant","type":"message","content":[],"stop_reason":null,"usage":{"input_tokens":10,"output_tokens":0,"cache_read_input_tokens":120,"cache_creation_input_tokens":100}}}`,
+		`{"type":"ping"}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hello"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"path\":"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\"a\"}"}}`,
+		`{"type":"content_block_stop","index":2}`,
+		`{"type":"content_block_start","index":3,"content_block":{"type":"tool_use","id":"toolu_2","name":"Bash","input":{}}}`,
+		`{"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"{}"}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":10,"output_tokens":25}}`,
+		`{"type":"message_stop"}`,
+	} {
+		in <- anthropicEvent(payload)
+	}
+	close(in)
+
+	chunks := collectChunks(t, out)
+	require.Len(t, chunks, 9)
+
+	require.NotNil(t, chunks[0].Choices[0].Delta.ReasoningContent)
+	assert.Equal(t, "hmm", *chunks[0].Choices[0].Delta.ReasoningContent)
+
+	assert.Equal(t, "Hello", chunks[1].Choices[0].Delta.Content)
+
+	firstTool := (*chunks[2].Choices[0].Delta.ToolCalls)[0]
+	assert.Equal(t, 0, firstTool.Index)
+	assert.Equal(t, "toolu_1", *firstTool.ID)
+	assert.Equal(t, "Read", firstTool.Function.Name)
+
+	assert.Equal(t, `{"path":`, (*chunks[3].Choices[0].Delta.ToolCalls)[0].Function.Arguments)
+	assert.Equal(t, `"a"}`, (*chunks[4].Choices[0].Delta.ToolCalls)[0].Function.Arguments)
+
+	secondTool := (*chunks[5].Choices[0].Delta.ToolCalls)[0]
+	assert.Equal(t, 1, secondTool.Index, "anthropic block index 3 remaps to tool index 1")
+	assert.Equal(t, "toolu_2", *secondTool.ID)
+
+	assert.Equal(t, 1, (*chunks[6].Choices[0].Delta.ToolCalls)[0].Index)
+
+	finish := chunks[7]
+	require.Len(t, finish.Choices, 1)
+	assert.Equal(t, sdk.ToolCalls, finish.Choices[0].FinishReason)
+
+	usageChunk := chunks[8]
+	assert.Empty(t, usageChunk.Choices)
+	require.NotNil(t, usageChunk.Usage)
+	assert.Equal(t, int64(230), usageChunk.Usage.PromptTokens, "input + cache read + cache creation")
+	assert.Equal(t, int64(25), usageChunk.Usage.CompletionTokens)
+	assert.Equal(t, int64(255), usageChunk.Usage.TotalTokens)
+	require.NotNil(t, usageChunk.Usage.PromptTokensDetails)
+	assert.Equal(t, int64(120), *usageChunk.Usage.PromptTokensDetails.CachedTokens)
+
+	assert.Equal(t, 100, adapter.TakeCacheCreationTokens())
+	assert.Equal(t, 0, adapter.TakeCacheCreationTokens(), "side channel resets after read")
+}
+
+func TestGenerateContentStreamPassthrough(t *testing.T) {
+	fake := &mocksdk.FakeClient{}
+	inner := make(chan sdk.SSEvent)
+	close(inner)
+	fake.GenerateContentStreamReturns(inner, nil)
+	adapter := NewAnthropicMessages(fake)
+
+	messages := []sdk.Message{textMessage(sdk.User, "hi")}
+	_, err := adapter.GenerateContentStream(context.Background(), sdk.Openai, "gpt-4o", messages)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, fake.GenerateContentStreamCallCount())
+	assert.Equal(t, 0, fake.CreateMessageStreamCallCount())
+	_, provider, model, gotMessages := fake.GenerateContentStreamArgsForCall(0)
+	assert.Equal(t, sdk.Openai, provider)
+	assert.Equal(t, "gpt-4o", model)
+	assert.Equal(t, messages, gotMessages)
+}
+
+func TestBuilderChainKeepsAdapterOutermost(t *testing.T) {
+	fake := &mocksdk.FakeClient{}
+	adapter := NewAnthropicMessages(fake)
+	maxTokens := 512
+	tools := []sdk.ChatCompletionTool{{Type: sdk.Function, Function: sdk.FunctionObject{Name: "Read"}}}
+
+	chained := adapter.
+		WithOptions(&sdk.CreateChatCompletionRequest{MaxTokens: &maxTokens}).
+		WithMiddlewareOptions(&sdk.MiddlewareOptions{SkipMCP: true}).
+		WithTools(&tools).
+		WithAuthToken("token").
+		WithHeader("X-Test", "1").
+		WithHeaders(map[string]string{"X-Other": "2"})
+
+	require.Same(t, adapter, chained, "builder chain must never leak the inner client")
+	assert.Equal(t, 1, fake.WithOptionsCallCount())
+	assert.Equal(t, 1, fake.WithMiddlewareOptionsCallCount())
+	assert.Equal(t, 1, fake.WithToolsCallCount())
+
+	in := make(chan sdk.SSEvent)
+	close(in)
+	fake.CreateMessageStreamReturns(in, nil)
+	_, err := chained.GenerateContentStream(context.Background(), sdk.Anthropic, "claude-sonnet-4-5", []sdk.Message{textMessage(sdk.User, "hi")})
+	require.NoError(t, err)
+
+	_, _, request := fake.CreateMessageStreamArgsForCall(0)
+	assert.Equal(t, 512, request.MaxTokens, "options captured through the chain")
+	require.NotNil(t, request.Tools)
+	assert.Len(t, *request.Tools, 1)
+}
+
+func responseBlock(t *testing.T, payload string) sdk.MessagesResponseContentBlock {
+	t.Helper()
+	var block sdk.MessagesResponseContentBlock
+	require.NoError(t, block.UnmarshalJSON([]byte(payload)))
+	return block
+}
+
+func TestGenerateContentSyncTranslation(t *testing.T) {
+	fake := &mocksdk.FakeClient{}
+	cacheRead, cacheCreation := int64(40), int64(60)
+	fake.CreateMessageReturns(&sdk.MessagesResponse{
+		ID:    "msg_1",
+		Model: "claude-sonnet-4-5",
+		Role:  sdk.MessagesResponseRoleAssistant,
+		Content: []sdk.MessagesResponseContentBlock{
+			responseBlock(t, `{"type":"thinking","thinking":"pondering","signature":"sig"}`),
+			responseBlock(t, `{"type":"text","text":"All done"}`),
+			responseBlock(t, `{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"a"}}`),
+		},
+		StopReason: sdk.MessagesResponseStopReasonToolUse,
+		Usage: sdk.MessagesUsage{
+			InputTokens:              10,
+			OutputTokens:             5,
+			CacheReadInputTokens:     &cacheRead,
+			CacheCreationInputTokens: &cacheCreation,
+		},
+	}, nil)
+	adapter := NewAnthropicMessages(fake)
+
+	resp, err := adapter.GenerateContent(context.Background(), sdk.Anthropic, "claude-sonnet-4-5", []sdk.Message{textMessage(sdk.User, "hi")})
+	require.NoError(t, err)
+	assert.Equal(t, 0, fake.GenerateContentCallCount())
+
+	require.Len(t, resp.Choices, 1)
+	choice := resp.Choices[0]
+	content, err := choice.Message.Content.AsMessageContent0()
+	require.NoError(t, err)
+	assert.Equal(t, "All done", content)
+	require.NotNil(t, choice.Message.ReasoningContent)
+	assert.Equal(t, "pondering", *choice.Message.ReasoningContent)
+	require.NotNil(t, choice.Message.ToolCalls)
+	toolCall := (*choice.Message.ToolCalls)[0]
+	assert.Equal(t, "toolu_1", toolCall.ID)
+	assert.Equal(t, "Read", toolCall.Function.Name)
+	assert.JSONEq(t, `{"path":"a"}`, toolCall.Function.Arguments)
+	assert.Equal(t, sdk.ToolCalls, choice.FinishReason)
+
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, int64(110), resp.Usage.PromptTokens)
+	require.NotNil(t, resp.Usage.PromptTokensDetails)
+	assert.Equal(t, int64(40), *resp.Usage.PromptTokensDetails.CachedTokens)
+	assert.Equal(t, 60, adapter.TakeCacheCreationTokens())
+}
+
+func TestGenerateContentSyncPassthrough(t *testing.T) {
+	fake := &mocksdk.FakeClient{}
+	fake.GenerateContentReturns(&sdk.CreateChatCompletionResponse{}, nil)
+	adapter := NewAnthropicMessages(fake)
+
+	_, err := adapter.GenerateContent(context.Background(), sdk.Openai, "gpt-4o", []sdk.Message{textMessage(sdk.User, "hi")})
+	require.NoError(t, err)
+	assert.Equal(t, 1, fake.GenerateContentCallCount())
+	assert.Equal(t, 0, fake.CreateMessageCallCount())
+}

--- a/internal/mockgateway/messages.go
+++ b/internal/mockgateway/messages.go
@@ -1,0 +1,215 @@
+package mockgateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	sdk "github.com/inference-gateway/sdk"
+)
+
+// handleMessages serves POST /v1/messages, the Anthropic-native endpoint the
+// CLI's AnthropicMessages adapter targets. Scenarios are shared with the
+// chat-completions endpoint via resolveMessages; the turn is rendered as
+// native Anthropic SSE (message_start .. message_stop, no [DONE] sentinel;
+// the stream ends when the response body closes) or as a sync
+// MessagesResponse. Stall and Malformed injection are not supported here:
+// they exercise OpenAI-stream reconnect paths the adapter never takes.
+func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
+	var req sdk.CreateMessagesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"type":"error","error":{"type":"invalid_request_error","message":"invalid request body"}}`, http.StatusBadRequest)
+		return
+	}
+
+	name, step, turn := s.defs.resolveMessages(&req)
+	stream := req.Stream != nil && *req.Stream
+	w.Header().Set("X-Mockgateway-Scenario", name)
+	w.Header().Set("X-Mockgateway-Step", fmt.Sprintf("%d", step))
+	s.record(Recorded{
+		Endpoint:     r.URL.Path,
+		Provider:     r.URL.Query().Get("provider"),
+		Model:        req.Model,
+		Scenario:     name,
+		Step:         step,
+		Stream:       stream,
+		MessagesBody: &req,
+	})
+
+	if turn.Error != nil && s.consumeFailure(name, step, turn.Error) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(turn.Error.Status)
+		_, _ = fmt.Fprint(w, `{"type":"error","error":{"type":"api_error","message":"injected"}}`)
+		return
+	}
+
+	if stream {
+		s.renderMessagesStream(w, r, req.Model, step, turn)
+		return
+	}
+	s.renderMessagesSync(w, r, req.Model, step, turn)
+}
+
+// messagesUsage splits a turn's OpenAI-shaped usage into Anthropic semantics:
+// input_tokens excludes cache reads and writes, so the adapter's
+// input+read+write synthesis lands back on the scenario's PromptTokens and
+// the same scenario numbers hold on both endpoints.
+func (t Turn) messagesUsage() (input, output, cacheRead, cacheWrite int64) {
+	u := Usage{PromptTokens: 10, CompletionTokens: 5}
+	if t.Usage != nil {
+		u = *t.Usage
+	}
+	return max(u.PromptTokens-u.CachedTokens-u.CacheWriteTokens, 0), u.CompletionTokens, u.CachedTokens, u.CacheWriteTokens
+}
+
+func (t Turn) messagesStopReason() string {
+	if len(t.ToolCalls) > 0 {
+		return "tool_use"
+	}
+	return "end_turn"
+}
+
+func (s *Server) renderMessagesStream(w http.ResponseWriter, r *http.Request, model string, step int, turn Turn) {
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "mockgateway: streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+
+	sw := &streamWriter{w: w, fl: fl, ctx: r.Context(), model: model, delay: turn.DelayMs}
+	input, output, cacheRead, cacheWrite := turn.messagesUsage()
+
+	if !sw.event(map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": "msg-mock", "type": "message", "role": "assistant", "model": model,
+			"content": []any{}, "stop_reason": nil,
+			"usage": map[string]any{
+				"input_tokens": input, "output_tokens": 0,
+				"cache_read_input_tokens": cacheRead, "cache_creation_input_tokens": cacheWrite,
+			},
+		},
+	}) {
+		return
+	}
+
+	index := 0
+	if turn.Reasoning != "" {
+		if !sw.textBlock(index, "thinking", "thinking_delta", "thinking", turn.Reasoning, turn.ChunkSize) {
+			return
+		}
+		index++
+	}
+	if turn.Content != "" {
+		if !sw.textBlock(index, "text", "text_delta", "text", turn.Content, turn.ChunkSize) {
+			return
+		}
+		index++
+	}
+	for i, tc := range turn.ToolCalls {
+		if !sw.toolUseBlock(index, fmt.Sprintf("call_%d_%d", step, i), tc.Name, tc.argsJSON, turn.ChunkSize) {
+			return
+		}
+		index++
+	}
+
+	if !sw.event(map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": turn.messagesStopReason()},
+		"usage": map[string]any{"output_tokens": output},
+	}) {
+		return
+	}
+	sw.event(map[string]any{"type": "message_stop"})
+}
+
+// textBlock streams one text or thinking content block: start, per-chunk
+// deltas, stop.
+func (sw *streamWriter) textBlock(index int, blockType, deltaType, deltaField, text string, chunkSize int) bool {
+	start := map[string]any{
+		"type":          "content_block_start",
+		"index":         index,
+		"content_block": map[string]any{"type": blockType, blockType: ""},
+	}
+	if !sw.event(start) {
+		return false
+	}
+	for _, c := range chunks(text, chunkSize) {
+		if !sw.event(map[string]any{
+			"type":  "content_block_delta",
+			"index": index,
+			"delta": map[string]any{"type": deltaType, deltaField: c},
+		}) {
+			return false
+		}
+	}
+	return sw.event(map[string]any{"type": "content_block_stop", "index": index})
+}
+
+// toolUseBlock streams one tool_use content block with at least two
+// input_json_delta fragments (via argFragments) so the adapter's partial-JSON
+// accumulation is always exercised.
+func (sw *streamWriter) toolUseBlock(index int, id, name, argsJSON string, chunkSize int) bool {
+	if !sw.event(map[string]any{
+		"type":          "content_block_start",
+		"index":         index,
+		"content_block": map[string]any{"type": "tool_use", "id": id, "name": name, "input": map[string]any{}},
+	}) {
+		return false
+	}
+	for _, frag := range argFragments(argsJSON, chunkSize) {
+		if !sw.event(map[string]any{
+			"type":  "content_block_delta",
+			"index": index,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": frag},
+		}) {
+			return false
+		}
+	}
+	return sw.event(map[string]any{"type": "content_block_stop", "index": index})
+}
+
+// event marshals one Anthropic stream event and writes it as an SSE data frame.
+func (sw *streamWriter) event(v map[string]any) bool {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return false
+	}
+	return sw.raw(string(b))
+}
+
+func (s *Server) renderMessagesSync(w http.ResponseWriter, r *http.Request, model string, step int, turn Turn) {
+	if !wait(r.Context(), turn.DelayMs) {
+		return
+	}
+
+	blocks := make([]map[string]any, 0, len(turn.ToolCalls)+2)
+	if turn.Reasoning != "" {
+		blocks = append(blocks, map[string]any{"type": "thinking", "thinking": turn.Reasoning, "signature": ""})
+	}
+	if turn.Content != "" {
+		blocks = append(blocks, map[string]any{"type": "text", "text": turn.Content})
+	}
+	for i, tc := range turn.ToolCalls {
+		var input map[string]any
+		if err := json.Unmarshal([]byte(tc.argsJSON), &input); err != nil {
+			input = map[string]any{}
+		}
+		blocks = append(blocks, map[string]any{
+			"type": "tool_use", "id": fmt.Sprintf("call_%d_%d", step, i), "name": tc.Name, "input": input,
+		})
+	}
+
+	input, output, cacheRead, cacheWrite := turn.messagesUsage()
+	writeJSON(w, map[string]any{
+		"id": "msg-mock", "type": "message", "role": "assistant", "model": model,
+		"content":     blocks,
+		"stop_reason": turn.messagesStopReason(),
+		"usage": map[string]any{
+			"input_tokens": input, "output_tokens": output,
+			"cache_read_input_tokens": cacheRead, "cache_creation_input_tokens": cacheWrite,
+		},
+	})
+}

--- a/internal/mockgateway/messages_test.go
+++ b/internal/mockgateway/messages_test.go
@@ -1,0 +1,139 @@
+package mockgateway
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sdk "github.com/inference-gateway/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+// postMessages sends a /v1/messages request built from raw JSON so the test
+// does not depend on the SDK's union builders.
+func postMessages(t *testing.T, baseURL string, body map[string]any) *http.Response {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	resp, err := http.Post(baseURL+"/v1/messages?provider=anthropic", "application/json", bytes.NewReader(b))
+	require.NoError(t, err)
+	return resp
+}
+
+func messagesBody(prompt string, assistants int, stream bool) map[string]any {
+	messages := []map[string]any{{"role": "user", "content": prompt}}
+	for i := 0; i < assistants; i++ {
+		messages = append(messages, map[string]any{"role": "assistant", "content": "ok"})
+		messages = append(messages, map[string]any{
+			"role":    "user",
+			"content": []map[string]any{{"type": "tool_result", "tool_use_id": "call_0_0", "content": "result"}},
+		})
+	}
+	return map[string]any{
+		"model":      "claude-sonnet-4-5",
+		"max_tokens": 4096,
+		"stream":     stream,
+		"messages":   messages,
+	}
+}
+
+func readMessagesEvents(t *testing.T, body *http.Response) []sdk.MessagesStreamEvent {
+	t.Helper()
+	var events []sdk.MessagesStreamEvent
+	scanner := bufio.NewScanner(body.Body)
+	for scanner.Scan() {
+		payload, ok := strings.CutPrefix(scanner.Text(), "data: ")
+		if !ok {
+			continue
+		}
+		var ev sdk.MessagesStreamEvent
+		require.NoError(t, json.Unmarshal([]byte(payload), &ev), "non-JSON frame: %s", payload)
+		events = append(events, ev)
+	}
+	require.NoError(t, scanner.Err())
+	return events
+}
+
+// TestMessagesStream drives the anthropic-cache scenario's first turn over
+// native SSE: thinking block, tool_use block with multi-fragment
+// input_json_delta, Anthropic usage split (input excludes cache writes), and
+// termination via message_stop with no [DONE] sentinel.
+func TestMessagesStream(t *testing.T) {
+	srv := New(Default())
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postMessages(t, ts.URL, messagesBody("exercise the anthropic cache", 0, true))
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "anthropic-cache", resp.Header.Get("X-Mockgateway-Scenario"))
+
+	events := readMessagesEvents(t, resp)
+	types := make([]string, len(events))
+	for i, ev := range events {
+		types[i] = string(ev.Type)
+	}
+
+	require.Equal(t, "message_start", types[0])
+	u := events[0].Message.Usage
+	require.Equal(t, int64(130), u.InputTokens, "input_tokens must exclude cache reads and writes")
+	require.Equal(t, int64(100), *u.CacheCreationInputTokens)
+	require.Equal(t, int64(0), *u.CacheReadInputTokens)
+
+	require.Equal(t, "message_stop", types[len(types)-1])
+	require.Equal(t, "message_delta", types[len(types)-2])
+	require.Equal(t, "tool_use", *events[len(events)-2].Delta.StopReason)
+	require.Equal(t, int64(25), events[len(events)-2].Usage.OutputTokens)
+
+	var thinking, args strings.Builder
+	jsonFragments := 0
+	for _, ev := range events {
+		if ev.Type != "content_block_delta" {
+			continue
+		}
+		switch *ev.Delta.Type {
+		case "thinking_delta":
+			thinking.WriteString(*ev.Delta.Thinking)
+		case "input_json_delta":
+			args.WriteString(*ev.Delta.PartialJSON)
+			jsonFragments++
+		}
+	}
+	require.Equal(t, "Deciding which file to inspect first.", thinking.String())
+	require.JSONEq(t, `{"file_path":"a.txt"}`, args.String())
+	require.GreaterOrEqual(t, jsonFragments, 2, "argument accumulation must be exercised")
+
+	recorded := srv.Requests()
+	require.Len(t, recorded, 1)
+	require.Equal(t, "/v1/messages", recorded[0].Endpoint)
+	require.NotNil(t, recorded[0].MessagesBody)
+	require.Equal(t, "anthropic", recorded[0].Provider)
+}
+
+// TestMessagesSync exercises the second turn (tool_result-only user messages
+// must not re-anchor the scenario) via the sync JSON path.
+func TestMessagesSync(t *testing.T) {
+	ts := httptest.NewServer(New(Default()))
+	defer ts.Close()
+
+	resp := postMessages(t, ts.URL, messagesBody("exercise the anthropic cache", 1, false))
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "1", resp.Header.Get("X-Mockgateway-Step"))
+
+	var msg sdk.MessagesResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&msg))
+	require.Equal(t, "end_turn", string(msg.StopReason))
+	require.Equal(t, int64(140), msg.Usage.InputTokens)
+	require.Equal(t, int64(120), *msg.Usage.CacheReadInputTokens)
+	require.Equal(t, int64(12), msg.Usage.OutputTokens)
+
+	require.Len(t, msg.Content, 1)
+	text, err := msg.Content[0].AsMessagesTextBlock()
+	require.NoError(t, err)
+	require.Equal(t, "Cache exercised.", text.Text)
+}

--- a/internal/mockgateway/mockgateway.go
+++ b/internal/mockgateway/mockgateway.go
@@ -23,24 +23,32 @@ import (
 	sdk "github.com/inference-gateway/sdk"
 )
 
-// DefaultModel is the single model the mock advertises on /v1/models. Model
+// DefaultModel is the primary model the mock advertises on /v1/models. Model
 // ids carry the provider prefix; request bodies arrive with it stripped.
 const DefaultModel = "openai/gpt-4o"
+
+// AnthropicModel is the Anthropic model the mock advertises; the CLI routes
+// it through POST /v1/messages (native Anthropic SSE) instead of
+// /v1/chat/completions.
+const AnthropicModel = "anthropic/claude-sonnet-4-5"
 
 // Metadata advertised for DefaultModel on /v1/models. The real gateway only
 // includes these fields when ?include=context_window,pricing is set; the mock
 // always serves them (the CLI always asks).
 const (
-	DefaultContextWindow = 128000
-	DefaultInputPrice    = "0.0000025"  // per token → $2.50 per MTok
-	DefaultOutputPrice   = "0.00001"    // per token → $10.00 per MTok
-	DefaultCachePrice    = "0.00000025" // per token → $0.25 per MTok
+	DefaultContextWindow   = 128000
+	DefaultInputPrice      = "0.0000025"   // per token → $2.50 per MTok
+	DefaultOutputPrice     = "0.00001"     // per token → $10.00 per MTok
+	DefaultCachePrice      = "0.00000025"  // per token → $0.25 per MTok
+	DefaultCacheWritePrice = "0.000003125" // per token → $3.125 per MTok (1.25x input)
 )
 
 const defaultChunkSize = 16
 
-// Recorded captures one /v1/chat/completions request for test assertions.
+// Recorded captures one LLM request for test assertions.
 type Recorded struct {
+	// Endpoint is the request path (/v1/chat/completions or /v1/messages).
+	Endpoint string
 	// Provider is the ?provider= query parameter sent by the SDK.
 	Provider string
 	// Model is the request-body model (provider prefix already stripped).
@@ -51,8 +59,10 @@ type Recorded struct {
 	Step int
 	// Stream reports whether the request asked for SSE.
 	Stream bool
-	// Body is the full decoded request.
+	// Body is the full decoded request for /v1/chat/completions.
 	Body sdk.CreateChatCompletionRequest
+	// MessagesBody is the full decoded request for /v1/messages.
+	MessagesBody *sdk.CreateMessagesRequest
 }
 
 // Server is an http.Handler implementing the inference-gateway API surface
@@ -81,21 +91,32 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/chat/completions":
 		s.handleCompletions(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/v1/messages":
+		s.handleMessages(w, r)
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/models":
 		cachePrice := DefaultCachePrice
+		cacheWritePrice := DefaultCacheWritePrice
+		pricing := sdk.Pricing{
+			InputPerToken:      DefaultInputPrice,
+			OutputPerToken:     DefaultOutputPrice,
+			CacheReadPerToken:  &cachePrice,
+			CacheWritePerToken: &cacheWritePrice,
+			Currency:           "USD",
+			Source:             sdk.PricingSourceProvider,
+		}
+		contextWindow := sdk.ContextWindow{Tokens: DefaultContextWindow, Source: sdk.ContextWindowSourceProvider}
 		writeJSON(w, sdk.ListModelsResponse{
 			Object: "list",
-			Data: []sdk.Model{{
-				ID: DefaultModel, Object: "model", OwnedBy: "openai", ServedBy: "openai",
-				ContextWindow: &sdk.ContextWindow{Tokens: DefaultContextWindow, Source: sdk.ContextWindowSourceProvider},
-				Pricing: &sdk.Pricing{
-					InputPerToken:     DefaultInputPrice,
-					OutputPerToken:    DefaultOutputPrice,
-					CacheReadPerToken: &cachePrice,
-					Currency:          "USD",
-					Source:            sdk.PricingSourceProvider,
+			Data: []sdk.Model{
+				{
+					ID: DefaultModel, Object: "model", OwnedBy: "openai", ServedBy: "openai",
+					ContextWindow: &contextWindow, Pricing: &pricing,
 				},
-			}},
+				{
+					ID: AnthropicModel, Object: "model", OwnedBy: "anthropic", ServedBy: "anthropic",
+					ContextWindow: &contextWindow, Pricing: &pricing,
+				},
+			},
 		})
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/health":
 		writeJSON(w, map[string]string{"status": "ok"})
@@ -116,6 +137,7 @@ func (s *Server) handleCompletions(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Mockgateway-Scenario", name)
 	w.Header().Set("X-Mockgateway-Step", fmt.Sprintf("%d", step))
 	s.record(Recorded{
+		Endpoint: r.URL.Path,
 		Provider: r.URL.Query().Get("provider"),
 		Model:    req.Model,
 		Scenario: name,

--- a/internal/mockgateway/mockgateway_test.go
+++ b/internal/mockgateway/mockgateway_test.go
@@ -73,7 +73,7 @@ func readFrames(t *testing.T, body io.Reader) ([]sdk.CreateChatCompletionStreamR
 
 func TestDefaultScenariosAreValid(t *testing.T) {
 	defs := Default()
-	require.Len(t, defs.Scenarios, 19)
+	require.Len(t, defs.Scenarios, 20)
 	require.Equal(t, "Done.", defs.Fallback.Content)
 }
 
@@ -187,8 +187,9 @@ func TestModelsAndHealthEndpoints(t *testing.T) {
 
 	var models sdk.ListModelsResponse
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&models))
-	require.Len(t, models.Data, 1)
+	require.Len(t, models.Data, 2)
 	require.Equal(t, DefaultModel, models.Data[0].ID)
+	require.Equal(t, AnthropicModel, models.Data[1].ID)
 
 	health, err := http.Get(ts.URL + "/v1/health")
 	require.NoError(t, err)

--- a/internal/mockgateway/scenario.go
+++ b/internal/mockgateway/scenario.go
@@ -82,11 +82,14 @@ type ToolCall struct {
 	argsJSON string
 }
 
-// Usage overrides the token usage reported for a turn.
+// Usage overrides the token usage reported for a turn. CacheWriteTokens is
+// only surfaced on the /v1/messages endpoint (cache_creation_input_tokens);
+// the OpenAI-shaped usage has no field for it.
 type Usage struct {
 	PromptTokens     int64 `yaml:"prompt_tokens"`
 	CompletionTokens int64 `yaml:"completion_tokens"`
 	CachedTokens     int64 `yaml:"cached_tokens"`
+	CacheWriteTokens int64 `yaml:"cache_write_tokens"`
 }
 
 // ErrorInject makes a turn answer with HTTP Status for the first Times
@@ -231,6 +234,53 @@ func (f *ScenarioFile) resolve(req *sdk.CreateChatCompletionRequest) (string, in
 		return sc.Name, step, f.Fallback
 	}
 	return "", step, f.Fallback
+}
+
+// resolveMessages resolves a /v1/messages request against the same scenario
+// library by projecting the Anthropic messages onto the chat-completions
+// shape resolve understands: text is extracted from string content or text
+// blocks, and tool_result-only user messages are dropped so they can't
+// anchor a scenario.
+func (f *ScenarioFile) resolveMessages(req *sdk.CreateMessagesRequest) (string, int, Turn) {
+	projected := make([]sdk.Message, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		text := messagesText(m.Content)
+		if m.Role == sdk.MessagesMessageRoleUser && text == "" {
+			continue
+		}
+		role := sdk.User
+		if m.Role == sdk.MessagesMessageRoleAssistant {
+			role = sdk.Assistant
+		}
+		projected = append(projected, sdk.Message{Role: role, Content: sdk.NewMessageContent(text)})
+	}
+	return f.resolve(&sdk.CreateChatCompletionRequest{Messages: projected})
+}
+
+// messagesText extracts the concatenated text of an Anthropic message
+// content union: a bare string or the text blocks of a block array.
+// <system-reminder> blocks are skipped: the adapter merges the volatile tail
+// into the same user message as the prompt, and including it would make
+// anchorUserMessage reject the whole message.
+func messagesText(c sdk.MessagesMessage_Content) string {
+	if s, err := c.AsMessagesMessageContent0(); err == nil {
+		return s
+	}
+
+	blocks, err := c.AsMessagesMessageContent1()
+	if err != nil {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, block := range blocks {
+		tb, err := block.AsMessagesTextBlock()
+		if err != nil || tb.Type != sdk.MessagesTextBlockTypeText || strings.Contains(tb.Text, "<system-reminder>") {
+			continue
+		}
+		b.WriteString(tb.Text)
+	}
+	return b.String()
 }
 
 // jobNoticeRe matches the background-job completion notices the supervisor

--- a/internal/mockgateway/scenarios.yaml
+++ b/internal/mockgateway/scenarios.yaml
@@ -105,6 +105,16 @@ scenarios:
       - content: "Usage reported."
         usage: { prompt_tokens: 100, completion_tokens: 42, cached_tokens: 64 }
 
+  - name: anthropic-cache
+    match: '(?i)exercise the anthropic cache'
+    turns:
+      - reasoning: "Deciding which file to inspect first."
+        tool_calls:
+          - { name: Read, args: { file_path: "a.txt" } }
+        usage: { prompt_tokens: 230, completion_tokens: 25, cache_write_tokens: 100 }
+      - content: "Cache exercised."
+        usage: { prompt_tokens: 260, completion_tokens: 12, cached_tokens: 120 }
+
   - name: read-missing
     match: '(?i)read the missing file'
     turns:

--- a/internal/services/conversation.go
+++ b/internal/services/conversation.go
@@ -411,7 +411,7 @@ func (r *InMemoryConversationRepository) filterHiddenMessages() []domain.Convers
 
 // AddTokenUsage adds token usage from a single API call to session totals with model tracking.
 // The model parameter is required for cost tracking. Use empty string for unknown models.
-func (r *InMemoryConversationRepository) AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens int) error {
+func (r *InMemoryConversationRepository) AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens, cacheWriteTokens int) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -420,12 +420,13 @@ func (r *InMemoryConversationRepository) AddTokenUsage(model string, inputTokens
 	r.sessionStats.TotalTokens += totalTokens
 	r.sessionStats.RequestCount++
 	r.sessionStats.LastInputTokens = inputTokens
+	r.sessionStats.TotalCacheWriteTokens += max(cacheWriteTokens, 0)
 
 	if r.pricingService == nil || model == "" {
 		return nil
 	}
 
-	inputCost, outputCost, totalCost := r.pricingService.CalculateCost(model, inputTokens, outputTokens, cachedTokens)
+	inputCost, outputCost, totalCost := r.pricingService.CalculateCost(model, inputTokens, outputTokens, cachedTokens, cacheWriteTokens)
 
 	if r.costStats.PerModelStats == nil {
 		r.costStats.PerModelStats = make(map[string]*domain.ModelCostStats)

--- a/internal/services/conversation_optimizer_test.go
+++ b/internal/services/conversation_optimizer_test.go
@@ -391,7 +391,7 @@ func TestOptimizeMessages_LastInputTokensTrigger(t *testing.T) {
 
 	t.Run("fires when LastInputTokens above threshold", func(t *testing.T) {
 		repo := services.NewInMemoryConversationRepository(nil, nil)
-		require.NoError(t, repo.AddTokenUsage(model, 7000, 100, 7100, 0))
+		require.NoError(t, repo.AddTokenUsage(model, 7000, 100, 7100, 0, 0))
 
 		mockClient := createMockSDKClient(t, "Summary text")
 		optimizer := services.NewConversationOptimizer(services.OptimizerConfig{
@@ -423,7 +423,7 @@ func TestOptimizeMessages_LastInputTokensTrigger(t *testing.T) {
 
 	t.Run("does not fire when LastInputTokens below threshold", func(t *testing.T) {
 		repo := services.NewInMemoryConversationRepository(nil, nil)
-		require.NoError(t, repo.AddTokenUsage(model, 1000, 100, 1100, 0))
+		require.NoError(t, repo.AddTokenUsage(model, 1000, 100, 1100, 0, 0))
 
 		mockClient := createMockSDKClient(t, "Summary text")
 		optimizer := services.NewConversationOptimizer(services.OptimizerConfig{
@@ -464,7 +464,7 @@ func TestOptimizeMessages_NoAutoCompactForUnknownModel(t *testing.T) {
 	model := "ollama_cloud/some-unlisted-model"
 
 	repo := services.NewInMemoryConversationRepository(nil, nil)
-	require.NoError(t, repo.AddTokenUsage(model, 500000, 100, 500100, 0))
+	require.NoError(t, repo.AddTokenUsage(model, 500000, 100, 500100, 0, 0))
 
 	mockClient := createMockSDKClient(t, "Summary text")
 	optimizer := services.NewConversationOptimizer(services.OptimizerConfig{

--- a/internal/services/conversation_session_tokens_test.go
+++ b/internal/services/conversation_session_tokens_test.go
@@ -97,7 +97,6 @@ func TestAddTokenUsageForwardsCachedTokensToPricing(t *testing.T) {
 	pricing := &domainmocks.FakePricingService{}
 	repo := NewInMemoryConversationRepository(nil, pricing)
 
-	// 3000 prompt tokens, 2400 of them served from cache.
 	if err := repo.AddTokenUsage("test-model", 3000, 100, 3100, 2400, 0); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}

--- a/internal/services/conversation_session_tokens_test.go
+++ b/internal/services/conversation_session_tokens_test.go
@@ -15,7 +15,7 @@ func TestSessionTokenTracking(t *testing.T) {
 		t.Errorf("Expected zero stats initially, got %+v", stats)
 	}
 
-	err := repo.AddTokenUsage("test-model", 100, 50, 150, 0)
+	err := repo.AddTokenUsage("test-model", 100, 50, 150, 0, 0)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -32,7 +32,7 @@ func TestSessionTokenTracking(t *testing.T) {
 		t.Errorf("Expected %+v, got %+v", expected, stats)
 	}
 
-	err = repo.AddTokenUsage("test-model", 200, 75, 275, 0)
+	err = repo.AddTokenUsage("test-model", 200, 75, 275, 0, 0)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -98,14 +98,14 @@ func TestAddTokenUsageForwardsCachedTokensToPricing(t *testing.T) {
 	repo := NewInMemoryConversationRepository(nil, pricing)
 
 	// 3000 prompt tokens, 2400 of them served from cache.
-	if err := repo.AddTokenUsage("test-model", 3000, 100, 3100, 2400); err != nil {
+	if err := repo.AddTokenUsage("test-model", 3000, 100, 3100, 2400, 0); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 
 	if got := pricing.CalculateCostCallCount(); got != 1 {
 		t.Fatalf("CalculateCost called %d times, want 1", got)
 	}
-	_, in, out, cached := pricing.CalculateCostArgsForCall(0)
+	_, in, out, cached, _ := pricing.CalculateCostArgsForCall(0)
 	if in != 3000 || out != 100 || cached != 2400 {
 		t.Errorf("CalculateCost args = in %d, out %d, cached %d; want 3000/100/2400 (cached must not be dropped to 0)", in, out, cached)
 	}
@@ -114,7 +114,7 @@ func TestAddTokenUsageForwardsCachedTokensToPricing(t *testing.T) {
 func TestSessionTokensWithZeroValues(t *testing.T) {
 	repo := NewInMemoryConversationRepository(nil, nil)
 
-	err := repo.AddTokenUsage("test-model", 0, 0, 0, 0)
+	err := repo.AddTokenUsage("test-model", 0, 0, 0, 0, 0)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/internal/services/persistent_conversation.go
+++ b/internal/services/persistent_conversation.go
@@ -372,7 +372,7 @@ func (r *PersistentConversationRepository) DeleteMessagesAfterIndex(index int) e
 }
 
 // AddTokenUsage wraps the in-memory implementation with persistence and auto-save
-func (r *PersistentConversationRepository) AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens int) error {
+func (r *PersistentConversationRepository) AddTokenUsage(model string, inputTokens, outputTokens, totalTokens, cachedTokens, cacheWriteTokens int) error {
 	r.metadataMutex.RLock()
 	needsInit := r.autoSave && r.conversationID == ""
 	r.metadataMutex.RUnlock()
@@ -411,7 +411,7 @@ func (r *PersistentConversationRepository) AddTokenUsage(model string, inputToke
 		r.metadataMutex.Unlock()
 	}
 
-	if err := r.InMemoryConversationRepository.AddTokenUsage(model, inputTokens, outputTokens, totalTokens, cachedTokens); err != nil {
+	if err := r.InMemoryConversationRepository.AddTokenUsage(model, inputTokens, outputTokens, totalTokens, cachedTokens, cacheWriteTokens); err != nil {
 		return err
 	}
 

--- a/internal/services/persistent_conversation_test.go
+++ b/internal/services/persistent_conversation_test.go
@@ -285,7 +285,7 @@ func TestPersistentConversationRepository_TokenTracking(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Token Usage Tracking", func(t *testing.T) {
-		err := repo.AddTokenUsage("test-model", 50, 75, 125, 0)
+		err := repo.AddTokenUsage("test-model", 50, 75, 125, 0, 0)
 		assert.NoError(t, err)
 
 		stats := repo.GetSessionTokens()
@@ -294,7 +294,7 @@ func TestPersistentConversationRepository_TokenTracking(t *testing.T) {
 		assert.Equal(t, 125, stats.TotalTokens)
 		assert.Equal(t, 1, stats.RequestCount)
 
-		err = repo.AddTokenUsage("test-model", 30, 45, 75, 0)
+		err = repo.AddTokenUsage("test-model", 30, 45, 75, 0, 0)
 		assert.NoError(t, err)
 
 		stats = repo.GetSessionTokens()

--- a/internal/services/pricing_service.go
+++ b/internal/services/pricing_service.go
@@ -14,9 +14,10 @@ import (
 // gatewayPrice is a per-model price from /v1/models?include=pricing,
 // converted from per-token decimal strings to per-MTok floats at ingest.
 type gatewayPrice struct {
-	inputPerMTok     float64
-	outputPerMTok    float64
-	cacheReadPerMTok *float64
+	inputPerMTok      float64
+	outputPerMTok     float64
+	cacheReadPerMTok  *float64
+	cacheWritePerMTok *float64
 }
 
 var (
@@ -57,6 +58,12 @@ func parseGatewayPricing(p *sdk.Pricing) (gatewayPrice, bool) {
 			price.cacheReadPerMTok = &perMTok
 		}
 	}
+	if p.CacheWritePerToken != nil {
+		if cacheWrite, err := strconv.ParseFloat(*p.CacheWritePerToken, 64); err == nil {
+			perMTok := cacheWrite * 1e6
+			price.cacheWritePerMTok = &perMTok
+		}
+	}
 	return price, true
 }
 
@@ -90,15 +97,15 @@ func (p *PricingServiceImpl) IsEnabled() bool {
 
 // resolvePricing returns the input/output price for a model and whether it's known.
 // Custom prices win, then gateway-reported prices; anything else is unknown.
-// cacheRead is per-MTok when the gateway reports a cache-read rate, nil otherwise.
-func (p *PricingServiceImpl) resolvePricing(model string) (input, output float64, cacheRead *float64, ok bool) {
+// cacheRead/cacheWrite are per-MTok when the gateway reports the rate, nil otherwise.
+func (p *PricingServiceImpl) resolvePricing(model string) (input, output float64, cacheRead, cacheWrite *float64, ok bool) {
 	if customPrice, exists := p.config.CustomPrices[model]; exists {
-		return customPrice.InputPricePerMToken, customPrice.OutputPricePerMToken, nil, true
+		return customPrice.InputPricePerMToken, customPrice.OutputPricePerMToken, nil, nil, true
 	}
 	if price, exists := gatewayPriceFor(model); exists {
-		return price.inputPerMTok, price.outputPerMTok, price.cacheReadPerMTok, true
+		return price.inputPerMTok, price.outputPerMTok, price.cacheReadPerMTok, price.cacheWritePerMTok, true
 	}
-	return 0.0, 0.0, nil, false
+	return 0.0, 0.0, nil, nil, false
 }
 
 // resolveRequiresPro returns whether a model is gated behind a Pro subscription.
@@ -129,7 +136,7 @@ func (p *PricingServiceImpl) GetInputPrice(model string) float64 {
 	if !p.config.Enabled {
 		return 0.0
 	}
-	input, _, _, _ := p.resolvePricing(model)
+	input, _, _, _, _ := p.resolvePricing(model)
 	return input
 }
 
@@ -139,29 +146,38 @@ func (p *PricingServiceImpl) GetOutputPrice(model string) float64 {
 	if !p.config.Enabled {
 		return 0.0
 	}
-	_, output, _, _ := p.resolvePricing(model)
+	_, output, _, _, _ := p.resolvePricing(model)
 	return output
 }
 
 // CalculateCost computes the total cost for a given number of input, output
-// and cached-prompt tokens. cachedTokens is the cached subset of inputTokens;
-// it is billed at the gateway's cache-read rate when known, otherwise at the
+// and cached-prompt tokens. cachedTokens and cacheWriteTokens are the
+// cache-read and cache-creation subsets of inputTokens; they are billed at
+// the gateway's cache-read/cache-write rates when known, otherwise at the
 // full input rate. Returns inputCost, outputCost, and totalCost in USD (or
 // configured currency).
-func (p *PricingServiceImpl) CalculateCost(model string, inputTokens, outputTokens, cachedTokens int) (inputCost, outputCost, totalCost float64) {
+func (p *PricingServiceImpl) CalculateCost(model string, inputTokens, outputTokens, cachedTokens, cacheWriteTokens int) (inputCost, outputCost, totalCost float64) {
 	if !p.config.Enabled {
 		return 0.0, 0.0, 0.0
 	}
 
-	inputPrice, outputPrice, cacheReadPrice, _ := p.resolvePricing(model)
+	inputPrice, outputPrice, cacheReadPrice, cacheWritePrice, _ := p.resolvePricing(model)
 
 	cached := min(max(cachedTokens, 0), inputTokens)
-	cacheRate := inputPrice
+	written := min(max(cacheWriteTokens, 0), inputTokens-cached)
+
+	cacheReadRate := inputPrice
 	if cacheReadPrice != nil {
-		cacheRate = *cacheReadPrice
+		cacheReadRate = *cacheReadPrice
+	}
+	cacheWriteRate := inputPrice
+	if cacheWritePrice != nil {
+		cacheWriteRate = *cacheWritePrice
 	}
 
-	inputCost = (float64(inputTokens-cached)*inputPrice + float64(cached)*cacheRate) / 1_000_000.0
+	inputCost = (float64(inputTokens-cached-written)*inputPrice +
+		float64(cached)*cacheReadRate +
+		float64(written)*cacheWriteRate) / 1_000_000.0
 	outputCost = (float64(outputTokens) / 1_000_000.0) * outputPrice
 	totalCost = inputCost + outputCost
 
@@ -178,7 +194,7 @@ func (p *PricingServiceImpl) FormatModelPricing(model string) string {
 		return ""
 	}
 
-	inputPrice, outputPrice, _, ok := p.resolvePricing(model)
+	inputPrice, outputPrice, _, _, ok := p.resolvePricing(model)
 	if !ok {
 		return ""
 	}

--- a/internal/services/pricing_service_test.go
+++ b/internal/services/pricing_service_test.go
@@ -334,7 +334,7 @@ func TestPricingService_LocalProvidersUnknown(t *testing.T) {
 	} {
 		t.Run(model, func(t *testing.T) {
 			assert.Empty(t, service.FormatModelPricing(model))
-			_, _, total := service.CalculateCost(model, 100000, 50000, 0)
+			_, _, total := service.CalculateCost(model, 100000, 50000, 0, 0)
 			assert.Zero(t, total)
 			assert.False(t, service.RequiresPro(model))
 		})
@@ -405,7 +405,7 @@ func TestPricingService_CalculateCost_CachedTokens(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			in, _, total := service.CalculateCost(tt.model, tt.input, tt.output, tt.cached)
+			in, _, total := service.CalculateCost(tt.model, tt.input, tt.output, tt.cached, 0)
 			assert.InDelta(t, tt.wantInput, in, 1e-9)
 			assert.InDelta(t, tt.wantTotal, total, 1e-9)
 		})
@@ -450,7 +450,7 @@ func TestPricingService_CalculateCost(t *testing.T) {
 
 	service := NewPricingService(cfg)
 
-	inputCost, outputCost, totalCost := service.CalculateCost("test-model", 100000, 50000, 0)
+	inputCost, outputCost, totalCost := service.CalculateCost("test-model", 100000, 50000, 0, 0)
 
 	expectedInputCost := (100000.0 / 1_000_000.0) * 10.00       // $1.00
 	expectedOutputCost := (50000.0 / 1_000_000.0) * 20.00       // $1.00

--- a/internal/services/session_rollover_manager_test.go
+++ b/internal/services/session_rollover_manager_test.go
@@ -185,7 +185,7 @@ func addBigMessages(t *testing.T, repo *PersistentConversationRepository, n int)
 
 func addTokenUsage(t *testing.T, repo *PersistentConversationRepository, model string, input, output, total int) {
 	t.Helper()
-	if err := repo.AddTokenUsage(model, input, output, total, 0); err != nil {
+	if err := repo.AddTokenUsage(model, input, output, total, 0, 0); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 }
@@ -445,7 +445,7 @@ func TestMaybeRollover_FiresAndReturnsNewID(t *testing.T) {
 	originalID := repo.GetCurrentConversationID()
 
 	addUserMessage(t, repo, "hi", time.Now())
-	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0); err != nil {
+	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0, 0); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 
@@ -492,7 +492,7 @@ func TestMaybeRollover_PerformRolloverErrorReturnsFalse(t *testing.T) {
 	if err := repo.AddMessage(hidden); err != nil {
 		t.Fatalf("AddMessage: %v", err)
 	}
-	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0); err != nil {
+	if err := repo.AddTokenUsage("moonshot/moonshot-v1-8k", 7000, 100, 7100, 0, 0); err != nil {
 		t.Fatalf("AddTokenUsage: %v", err)
 	}
 

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -75,9 +75,9 @@ const (
 )
 
 // CostFunc returns the input, output, and total cost for a model's token counts
-// (wraps domain.PricingService.CalculateCost). cached is the cached-prompt
-// subset of prompt tokens. Pass nil to skip cost.
-type CostFunc func(model string, prompt, completion, cached int) (input, output, total float64)
+// (wraps domain.PricingService.CalculateCost). cached and cacheWrite are the
+// cache-read and cache-creation subsets of prompt tokens. Pass nil to skip cost.
+type CostFunc func(model string, prompt, completion, cached, cacheWrite int) (input, output, total float64)
 
 // Options configures a Recorder. Dir + SessionID locate the per-process local
 // file; OTLP* enable the optional remote export.
@@ -355,10 +355,10 @@ func (r *Recorder) initInstruments(meter metric.Meter) error {
 }
 
 // RecordUsage records one request's token usage (gen_ai.client.token.usage, one
-// datapoint per token type) and the derived infer.client.cost split. cached is
-// the cached-prompt subset of prompt tokens; its datapoint is only emitted when
-// non-zero.
-func (r *Recorder) RecordUsage(model string, prompt, completion, cached int) {
+// datapoint per token type) and the derived infer.client.cost split. cached and
+// cacheWrite are the cache-read and cache-creation subsets of prompt tokens;
+// their datapoints are only emitted when non-zero.
+func (r *Recorder) RecordUsage(model string, prompt, completion, cached, cacheWrite int) {
 	if r == nil {
 		return
 	}
@@ -373,9 +373,12 @@ func (r *Recorder) RecordUsage(model string, prompt, completion, cached int) {
 	if cached > 0 {
 		r.tokenUsage.Record(ctx, int64(cached), metric.WithAttributes(r.withConv(append(base, attribute.String("gen_ai.token.type", "cache_read")))...))
 	}
+	if cacheWrite > 0 {
+		r.tokenUsage.Record(ctx, int64(cacheWrite), metric.WithAttributes(r.withConv(append(base, attribute.String("gen_ai.token.type", "cache_write")))...))
+	}
 
 	if r.cost != nil {
-		in, out, _ := r.cost(model, prompt, completion, cached)
+		in, out, _ := r.cost(model, prompt, completion, cached, cacheWrite)
 		m := attribute.String("gen_ai.request.model", model)
 		r.costCounter.Add(ctx, in, metric.WithAttributes(r.withConv([]attribute.KeyValue{m, attribute.String("infer.cost.type", "input")})...))
 		r.costCounter.Add(ctx, out, metric.WithAttributes(r.withConv([]attribute.KeyValue{m, attribute.String("infer.cost.type", "output")})...))

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -14,7 +14,7 @@ import (
 // format + stats parsing in one path.
 func TestRecordExportAndAggregate(t *testing.T) {
 	dir := t.TempDir()
-	cost := func(_ string, _, _, _ int) (float64, float64, float64) { return 0.01, 0.02, 0.03 }
+	cost := func(_ string, _, _, _, _ int) (float64, float64, float64) { return 0.01, 0.02, 0.03 }
 	rec := New(Options{Enabled: true, Dir: dir, SessionID: "sess-1", Cost: cost})
 	if rec == nil {
 		t.Fatal("expected a recorder when enabled")
@@ -23,7 +23,7 @@ func TestRecordExportAndAggregate(t *testing.T) {
 	rec.RecordTool("Read", ToolError, ErrTypeTool, 12*time.Millisecond)
 	rec.RecordTool("Read", ToolSuccess, "", 8*time.Millisecond)
 	rec.RecordTool("Bash", ToolRejected, "", 3*time.Millisecond)
-	rec.RecordUsage("deepseek/deepseek-chat", 100, 42, 30)
+	rec.RecordUsage("deepseek/deepseek-chat", 100, 42, 30, 0)
 	rec.RecordSession("standard", RunSuccess, time.Second)
 
 	rec.Shutdown(context.Background())
@@ -71,7 +71,7 @@ func TestAggregateFiltersByConversation(t *testing.T) {
 	recA := New(Options{Enabled: true, Dir: dir, SessionID: "sess-a"})
 	recA.SetConversationID("conv-a")
 	recA.RecordTool("Read", ToolSuccess, "", 5*time.Millisecond)
-	recA.RecordUsage("model-x", 100, 20, 0)
+	recA.RecordUsage("model-x", 100, 20, 0, 0)
 	recA.Shutdown(context.Background())
 
 	recB := New(Options{Enabled: true, Dir: dir, SessionID: "sess-b"})
@@ -145,7 +145,7 @@ func TestNewDisabledReturnsNil(t *testing.T) {
 	}
 	var r *Recorder
 	r.RecordTool("X", ToolSuccess, "", 0)
-	r.RecordUsage("m", 1, 2, 0)
+	r.RecordUsage("m", 1, 2, 0, 0)
 	r.RecordSession("standard", RunSuccess, 0)
 	r.Shutdown(context.Background())
 }

--- a/tests/integration/agent_gateway_test.go
+++ b/tests/integration/agent_gateway_test.go
@@ -19,10 +19,11 @@ import (
 
 	sdk "github.com/inference-gateway/sdk"
 
+	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
+
 	config "github.com/inference-gateway/cli/config"
 	container "github.com/inference-gateway/cli/internal/container"
 	domain "github.com/inference-gateway/cli/internal/domain"
-	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
 	models "github.com/inference-gateway/cli/internal/models"
 	services "github.com/inference-gateway/cli/internal/services"
 	streamevent "github.com/inference-gateway/cli/internal/streamevent"

--- a/tests/integration/agent_gateway_test.go
+++ b/tests/integration/agent_gateway_test.go
@@ -77,7 +77,7 @@ func newEnvWithScenarios(t *testing.T, defs *mockgateway.ScenarioFile, mutate ..
 
 	models, err := c.GetModelService().ListModels(context.Background())
 	require.NoError(t, err, "mock /v1/models must serve the real ModelService")
-	require.Equal(t, []string{mockgateway.DefaultModel}, models)
+	require.Equal(t, []string{mockgateway.DefaultModel, mockgateway.AnthropicModel}, models)
 	require.NoError(t, c.GetModelService().SelectModel(mockgateway.DefaultModel))
 
 	return &env{container: c, gateway: gw}
@@ -591,11 +591,11 @@ func TestModelMetadataFromGateway(t *testing.T) {
 	require.Equal(t, mockgateway.DefaultContextWindow, window)
 
 	pricing := services.NewPricingService(&config.PricingConfig{Enabled: true})
-	in, out, total := pricing.CalculateCost(mockgateway.DefaultModel, 1_000_000, 1_000_000, 0)
+	in, out, total := pricing.CalculateCost(mockgateway.DefaultModel, 1_000_000, 1_000_000, 0, 0)
 	require.InDelta(t, 2.5, in, 1e-9)
 	require.InDelta(t, 10.0, out, 1e-9)
 	require.InDelta(t, 12.5, total, 1e-9)
 
-	in, _, _ = pricing.CalculateCost(mockgateway.DefaultModel, 1_000_000, 0, 1_000_000)
+	in, _, _ = pricing.CalculateCost(mockgateway.DefaultModel, 1_000_000, 0, 1_000_000, 0)
 	require.InDelta(t, 0.25, in, 1e-9, "cached tokens must bill at the cache-read rate")
 }

--- a/tests/integration/agent_messages_test.go
+++ b/tests/integration/agent_messages_test.go
@@ -11,9 +11,10 @@ import (
 
 	sdk "github.com/inference-gateway/sdk"
 
+	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
+
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
-	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
 	services "github.com/inference-gateway/cli/internal/services"
 )
 

--- a/tests/integration/agent_messages_test.go
+++ b/tests/integration/agent_messages_test.go
@@ -1,0 +1,209 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	mockgateway "github.com/inference-gateway/cli/internal/mockgateway"
+	services "github.com/inference-gateway/cli/internal/services"
+)
+
+// newAnthropicEnv is newEnv pointed at the mock's Anthropic model, so the
+// AnthropicMessages adapter routes the agent through POST /v1/messages.
+func newAnthropicEnv(t *testing.T) *env {
+	t.Helper()
+	e := newEnv(t, func(cfg *config.Config) {
+		cfg.Agent.Model = mockgateway.AnthropicModel
+		cfg.Prompts.Agent.SystemPrompt = "You are a test agent."
+	})
+	require.NoError(t, e.container.GetModelService().SelectModel(mockgateway.AnthropicModel))
+	return e
+}
+
+func (e *env) runAnthropicStream(ctx context.Context, t *testing.T, prompt string) result {
+	t.Helper()
+	req := &domain.AgentRequest{
+		RequestID: fmt.Sprintf("req-%s", strings.ReplaceAll(t.Name(), "/", "-")),
+		Model:     mockgateway.AnthropicModel,
+		Messages:  []sdk.Message{userMessage(t, prompt)},
+	}
+	events, err := e.container.GetAgentService().RunWithStream(ctx, req)
+	require.NoError(t, err)
+	return drain(t, events)
+}
+
+// messagesBodies returns the recorded /v1/messages request bodies, failing if
+// any recorded request went to another endpoint.
+func (e *env) messagesBodies(t *testing.T) []sdk.CreateMessagesRequest {
+	t.Helper()
+	reqs := e.gateway.Requests()
+	bodies := make([]sdk.CreateMessagesRequest, len(reqs))
+	for i, r := range reqs {
+		require.Equal(t, "/v1/messages", r.Endpoint, "anthropic model must never hit /v1/chat/completions")
+		require.Equal(t, "anthropic", r.Provider)
+		require.NotNil(t, r.MessagesBody)
+		bodies[i] = *r.MessagesBody
+	}
+	return bodies
+}
+
+// cacheControlCount counts cache_control markers in the marshaled request:
+// system block + last tool + the rolling conversation breakpoint.
+func cacheControlCount(t *testing.T, req sdk.CreateMessagesRequest) int {
+	t.Helper()
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+	return strings.Count(string(b), `"cache_control"`)
+}
+
+// TestMessagesToolLoop is the end-to-end acceptance check for issue #942: the
+// agent drives a full tool round-trip over the native Anthropic endpoint -
+// thinking and text deltas reach the TUI event stream, tool arguments
+// reassemble from input_json_delta fragments, tool results return as
+// tool_result blocks, and every request carries the three cache_control
+// breakpoints with the volatile <system-reminder> tail left uncached.
+func TestMessagesToolLoop(t *testing.T) {
+	e := newAnthropicEnv(t)
+	e.writeFixtures(t, "a.txt")
+
+	res := e.runAnthropicStream(context.Background(), t, "exercise the anthropic cache")
+
+	require.Empty(t, res.errs)
+	require.Equal(t, "Cache exercised.", res.content())
+	require.Equal(t, "Deciding which file to inspect first.", res.reasoning())
+
+	bodies := e.messagesBodies(t)
+	require.Len(t, bodies, 2, "tool round-trip must trigger exactly one follow-up request")
+
+	for i, body := range bodies {
+		require.Equal(t, "claude-sonnet-4-5", body.Model, "provider prefix must be stripped (request %d)", i)
+		require.Equal(t, 3, cacheControlCount(t, body), "system + last tool + rolling breakpoint (request %d)", i)
+
+		require.NotNil(t, body.System, "system prompt must ride the top-level system field (request %d)", i)
+		require.NotNil(t, body.Tools, "tools must be present (request %d)", i)
+		tools := *body.Tools
+		require.NotEmpty(t, tools)
+		require.NotNil(t, tools[len(tools)-1].CacheControl, "last tool carries a breakpoint (request %d)", i)
+		for _, tool := range tools[:len(tools)-1] {
+			require.Nil(t, tool.CacheControl)
+		}
+	}
+
+	followUp := bodies[1]
+	toolResult := findToolResult(t, followUp, "call_0_0")
+	require.Contains(t, toolResultText(t, toolResult), "fixture content")
+
+	lastBlocks := requestBlocks(t, followUp.Messages[len(followUp.Messages)-1])
+	tail, err := lastBlocks[len(lastBlocks)-1].AsMessagesTextBlock()
+	require.NoError(t, err)
+	require.Contains(t, tail.Text, "<system-reminder>")
+	require.Nil(t, tail.CacheControl, "the volatile tail must never consume a cache breakpoint")
+}
+
+// TestMessagesTokenAccounting checks that Anthropic cache usage lands in the
+// session stats with OpenAI semantics: prompt tokens are the synthesized
+// input+read+write totals, cache reads accumulate as cached tokens and cache
+// writes into the new TotalCacheWriteTokens counter.
+func TestMessagesTokenAccounting(t *testing.T) {
+	e := newAnthropicEnv(t)
+	e.writeFixtures(t, "a.txt")
+
+	res := e.runAnthropicStream(context.Background(), t, "exercise the anthropic cache")
+	require.Empty(t, res.errs)
+
+	stats := e.container.GetConversationRepository().GetSessionTokens()
+	require.Equal(t, 490, stats.TotalInputTokens, "230 + 260 synthesized prompt tokens")
+	require.Equal(t, 37, stats.TotalOutputTokens, "25 + 12 completion tokens")
+	require.Equal(t, 120, stats.TotalCachedTokens, "turn-2 cache read must accumulate")
+	require.Equal(t, 100, stats.TotalCacheWriteTokens, "turn-1 cache write must accumulate")
+	require.Equal(t, 2, stats.RequestCount)
+}
+
+// TestMessagesCacheWritePricing verifies the gateway-advertised
+// cache_write_per_token rate flows into cost calculation.
+func TestMessagesCacheWritePricing(t *testing.T) {
+	newAnthropicEnv(t)
+
+	pricing := services.NewPricingService(&config.PricingConfig{Enabled: true})
+	in, _, _ := pricing.CalculateCost(mockgateway.AnthropicModel, 1_000_000, 0, 0, 1_000_000)
+	require.InDelta(t, 3.125, in, 1e-9, "cache writes must bill at the cache-write rate")
+
+	in, _, _ = pricing.CalculateCost(mockgateway.AnthropicModel, 1_000_000, 0, 400_000, 600_000)
+	require.InDelta(t, 0.4*0.25+0.6*3.125, in, 1e-9, "mixed read/write must bill each bucket at its rate")
+}
+
+// TestMessagesSyncRun covers the non-streaming (headless) path over
+// /v1/messages.
+func TestMessagesSyncRun(t *testing.T) {
+	e := newAnthropicEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
+	defer cancel()
+
+	resp, err := e.container.GetAgentService().Run(ctx, &domain.AgentRequest{
+		RequestID: "req-messages-sync",
+		Model:     mockgateway.AnthropicModel,
+		Messages:  []sdk.Message{userMessage(t, "say hello")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Hello! How can I help?", resp.Content)
+	require.NotNil(t, resp.Usage)
+	require.EqualValues(t, 15, resp.Usage.TotalTokens)
+
+	reqs := e.gateway.Requests()
+	require.Len(t, reqs, 1)
+	require.False(t, reqs[0].Stream, "AgentService.Run must use the non-streaming path")
+	require.Equal(t, "/v1/messages", reqs[0].Endpoint)
+}
+
+func requestBlocks(t *testing.T, m sdk.MessagesMessage) []sdk.MessagesRequestContentBlock {
+	t.Helper()
+	blocks, err := m.Content.AsMessagesMessageContent1()
+	require.NoError(t, err, "expected block-array content")
+	return blocks
+}
+
+func findToolResult(t *testing.T, req sdk.CreateMessagesRequest, toolUseID string) sdk.MessagesToolResultBlock {
+	t.Helper()
+	for _, m := range req.Messages {
+		if m.Role != sdk.MessagesMessageRoleUser {
+			continue
+		}
+		blocks, err := m.Content.AsMessagesMessageContent1()
+		if err != nil {
+			continue
+		}
+		for _, b := range blocks {
+			if tr, err := b.AsMessagesToolResultBlock(); err == nil &&
+				tr.Type == sdk.ToolResult && tr.ToolUseID == toolUseID {
+				return tr
+			}
+		}
+	}
+	t.Fatalf("no tool_result block for %s", toolUseID)
+	return sdk.MessagesToolResultBlock{}
+}
+
+func toolResultText(t *testing.T, tr sdk.MessagesToolResultBlock) string {
+	t.Helper()
+	require.NotNil(t, tr.Content)
+	if s, err := tr.Content.AsMessagesToolResultBlockContent0(); err == nil {
+		return s
+	}
+	blocks, err := tr.Content.AsMessagesToolResultBlockContent1()
+	require.NoError(t, err)
+	var b strings.Builder
+	for _, tb := range blocks {
+		b.WriteString(tb.Text)
+	}
+	return b.String()
+}

--- a/tests/mocks/domain/fake_conversation_repository.go
+++ b/tests/mocks/domain/fake_conversation_repository.go
@@ -26,7 +26,7 @@ type FakeConversationRepository struct {
 	addMessageReturnsOnCall map[int]struct {
 		result1 error
 	}
-	AddTokenUsageStub        func(string, int, int, int, int) error
+	AddTokenUsageStub        func(string, int, int, int, int, int) error
 	addTokenUsageMutex       sync.RWMutex
 	addTokenUsageArgsForCall []struct {
 		arg1 string
@@ -34,6 +34,7 @@ type FakeConversationRepository struct {
 		arg3 int
 		arg4 int
 		arg5 int
+		arg6 int
 	}
 	addTokenUsageReturns struct {
 		result1 error
@@ -327,7 +328,7 @@ func (fake *FakeConversationRepository) AddMessageReturnsOnCall(i int, result1 e
 	}{result1}
 }
 
-func (fake *FakeConversationRepository) AddTokenUsage(arg1 string, arg2 int, arg3 int, arg4 int, arg5 int) error {
+func (fake *FakeConversationRepository) AddTokenUsage(arg1 string, arg2 int, arg3 int, arg4 int, arg5 int, arg6 int) error {
 	fake.addTokenUsageMutex.Lock()
 	ret, specificReturn := fake.addTokenUsageReturnsOnCall[len(fake.addTokenUsageArgsForCall)]
 	fake.addTokenUsageArgsForCall = append(fake.addTokenUsageArgsForCall, struct {
@@ -336,13 +337,14 @@ func (fake *FakeConversationRepository) AddTokenUsage(arg1 string, arg2 int, arg
 		arg3 int
 		arg4 int
 		arg5 int
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg6 int
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.AddTokenUsageStub
 	fakeReturns := fake.addTokenUsageReturns
-	fake.recordInvocation("AddTokenUsage", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("AddTokenUsage", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.addTokenUsageMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1
@@ -356,17 +358,17 @@ func (fake *FakeConversationRepository) AddTokenUsageCallCount() int {
 	return len(fake.addTokenUsageArgsForCall)
 }
 
-func (fake *FakeConversationRepository) AddTokenUsageCalls(stub func(string, int, int, int, int) error) {
+func (fake *FakeConversationRepository) AddTokenUsageCalls(stub func(string, int, int, int, int, int) error) {
 	fake.addTokenUsageMutex.Lock()
 	defer fake.addTokenUsageMutex.Unlock()
 	fake.AddTokenUsageStub = stub
 }
 
-func (fake *FakeConversationRepository) AddTokenUsageArgsForCall(i int) (string, int, int, int, int) {
+func (fake *FakeConversationRepository) AddTokenUsageArgsForCall(i int) (string, int, int, int, int, int) {
 	fake.addTokenUsageMutex.RLock()
 	defer fake.addTokenUsageMutex.RUnlock()
 	argsForCall := fake.addTokenUsageArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeConversationRepository) AddTokenUsageReturns(result1 error) {

--- a/tests/mocks/domain/fake_pricing_service.go
+++ b/tests/mocks/domain/fake_pricing_service.go
@@ -8,13 +8,14 @@ import (
 )
 
 type FakePricingService struct {
-	CalculateCostStub        func(string, int, int, int) (float64, float64, float64)
+	CalculateCostStub        func(string, int, int, int, int) (float64, float64, float64)
 	calculateCostMutex       sync.RWMutex
 	calculateCostArgsForCall []struct {
 		arg1 string
 		arg2 int
 		arg3 int
 		arg4 int
+		arg5 int
 	}
 	calculateCostReturns struct {
 		result1 float64
@@ -84,7 +85,7 @@ type FakePricingService struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakePricingService) CalculateCost(arg1 string, arg2 int, arg3 int, arg4 int) (float64, float64, float64) {
+func (fake *FakePricingService) CalculateCost(arg1 string, arg2 int, arg3 int, arg4 int, arg5 int) (float64, float64, float64) {
 	fake.calculateCostMutex.Lock()
 	ret, specificReturn := fake.calculateCostReturnsOnCall[len(fake.calculateCostArgsForCall)]
 	fake.calculateCostArgsForCall = append(fake.calculateCostArgsForCall, struct {
@@ -92,13 +93,14 @@ func (fake *FakePricingService) CalculateCost(arg1 string, arg2 int, arg3 int, a
 		arg2 int
 		arg3 int
 		arg4 int
-	}{arg1, arg2, arg3, arg4})
+		arg5 int
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.CalculateCostStub
 	fakeReturns := fake.calculateCostReturns
-	fake.recordInvocation("CalculateCost", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("CalculateCost", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.calculateCostMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -112,17 +114,17 @@ func (fake *FakePricingService) CalculateCostCallCount() int {
 	return len(fake.calculateCostArgsForCall)
 }
 
-func (fake *FakePricingService) CalculateCostCalls(stub func(string, int, int, int) (float64, float64, float64)) {
+func (fake *FakePricingService) CalculateCostCalls(stub func(string, int, int, int, int) (float64, float64, float64)) {
 	fake.calculateCostMutex.Lock()
 	defer fake.calculateCostMutex.Unlock()
 	fake.CalculateCostStub = stub
 }
 
-func (fake *FakePricingService) CalculateCostArgsForCall(i int) (string, int, int, int) {
+func (fake *FakePricingService) CalculateCostArgsForCall(i int) (string, int, int, int, int) {
 	fake.calculateCostMutex.RLock()
 	defer fake.calculateCostMutex.RUnlock()
 	argsForCall := fake.calculateCostArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakePricingService) CalculateCostReturns(result1 float64, result2 float64, result3 float64) {


### PR DESCRIPTION
Closes #942

## What

Anthropic models (`anthropic/*`) now reach the gateway through its native `POST /v1/messages` passthrough instead of the OpenAI-compatible `/v1/chat/completions`, enabling Anthropic prompt caching. Built as a removable adapter per the issue's constraint: the endpoint is non-OpenAI-standard, so pulling it out is deleting `internal/infra/adapters/anthropic_messages.go` (+ test) and reverting one line in the container, plus the small cache-write side-channel read in the agent.

## How

- **`AnthropicMessages` adapter** decorates `sdk.Client` at the agent's construction seam (`container.go`). Non-Anthropic providers delegate verbatim. For Anthropic, `GenerateContent`/`GenerateContentStream` build a `CreateMessagesRequest` and translate the native Anthropic SSE events back into OpenAI-shaped chunks, so `processStreamEvent`, tool-call accumulation, `finalizeStream` and the TUI stay byte-identical. All six `With*` builders are overridden so chains never leak the inner client.
- **Cache breakpoints (3 of the 4 slots)**: system prompt block, last tool definition (tool order is already deterministic per #941), and a rolling breakpoint on the newest non-volatile content block - the injected `<system-reminder>` tail is skipped per block so the volatile content never consumes a cache slot.
- **Usage synthesis**: `prompt_tokens = input + cache_read + cache_creation`, `prompt_tokens_details.cached_tokens = cache_read`, so the existing `C.<n>` display works unchanged. Cache-creation tokens flow through a side channel (`TakeCacheCreationTokens`, consumed via a named `cacheCreationTokenSource` interface in the agent) into session stats (`TotalCacheWriteTokens`), cost calculation (billed at the gateway-advertised `cache_write_per_token` rate, fallback to the input rate) and telemetry (`gen_ai.token.type=cache_write`).
- **SDK bumped** v1.28.0 -> v1.29.0 (types-only sync with schemas v0.15.3, brings `CreateMessage`/`CreateMessageStream` types current).
- **Mock gateway** now serves `POST /v1/messages` with native Anthropic SSE (message_start/content_block deltas/message_delta/message_stop, no `[DONE]`), advertises `anthropic/claude-sonnet-4-5` with cache read/write pricing, and ships an `anthropic-cache` scenario - the whole path is hermetically testable.

## Tests

- Adapter unit tests: request mapping (breakpoints, tool_result grouping, adjacent-role merging, volatile-tail skip), stream translation goldens (multi-tool index remapping, usage synthesis, error events), sync translation, passthrough, builder-chain identity.
- `tests/integration/agent_messages_test.go`: full tool loop over real HTTP - thinking/text deltas, fragmented `input_json_delta` reassembly, tool_result round-trip, 3 `cache_control` markers per request with the tail uncached, session token accounting (cached + cache-write), cache-write pricing, sync `Run` path.
- Full suite green: `task test`, `task test:e2e`, `task lint`, `task fmt`.

## Cross-repo impact

None to ship - gateway passthrough, SDK v1.29.0 and schemas are already released. Follow-up: `[DOCS]` note for inference-gateway/docs describing the Anthropic routing and cache accounting.
