### PR TITLE
feat(agents): add --tag flag for OCI image tag selection, remove enable/disable commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ See [Commands Reference](docs/commands-reference.md#configuration-management) fo
 ```bash
 infer agents init                    # Initialize agents configuration
 infer agents add browser-agent       # Add an agent from the registry with defaults
+infer agents add browser-agent --tag lightpanda  # Pick another image tag (engine/version)
 infer agents add custom https://...  # Add a custom agent
 infer agents list                    # List all agents
 ```

--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -35,6 +35,9 @@ Examples:
   # Add a known agent and override the model
   infer agents add browser-agent --model anthropic/claude-4-5-sonnet
 
+  # Pin the image tag of a known agent (browser-agent ships one tag per browser engine)
+  infer agents add browser-agent --tag lightpanda
+
   # Add a remote agent
   infer agents add code-reviewer https://agent.example.com
 
@@ -66,6 +69,14 @@ Examples:
 		model, _ := cmd.Flags().GetString("model")
 		envVars, _ := cmd.Flags().GetStringSlice("environment")
 
+		taggedOCI, err := resolveTagFlag(cmd, name)
+		if err != nil {
+			return err
+		}
+		if taggedOCI != "" {
+			oci = taggedOCI
+		}
+
 		var environment map[string]string
 		if len(envVars) > 0 {
 			environment = make(map[string]string)
@@ -85,7 +96,7 @@ Examples:
 			if !cmd.Flags().Changed("artifacts-url") && defaults.ArtifactsURL != "" {
 				artifactsURL = defaults.ArtifactsURL
 			}
-			if !cmd.Flags().Changed("oci") && defaults.OCI != "" {
+			if oci == "" && defaults.OCI != "" {
 				oci = defaults.OCI
 			}
 			if !cmd.Flags().Changed("run") {
@@ -128,6 +139,9 @@ Examples:
   # Update multiple properties
   infer agents update test-runner --oci ghcr.io/org/test-runner:v2 --model anthropic/claude-4-5-sonnet
 
+  # Switch to another image tag (browser-agent ships one tag per browser engine)
+  infer agents update browser-agent --tag lightpanda
+
   # Add environment variables (replaces existing ones)
   infer agents update analyzer --environment CUSTOM_ENV=value --environment DEBUG=true`,
 	Args: cobra.ExactArgs(1),
@@ -135,8 +149,9 @@ Examples:
 		name := args[0]
 
 		if !cmd.Flags().Changed("url") && !cmd.Flags().Changed("artifacts-url") &&
-			!cmd.Flags().Changed("oci") && !cmd.Flags().Changed("run") &&
-			!cmd.Flags().Changed("model") && !cmd.Flags().Changed("environment") {
+			!cmd.Flags().Changed("oci") && !cmd.Flags().Changed("tag") &&
+			!cmd.Flags().Changed("run") && !cmd.Flags().Changed("model") &&
+			!cmd.Flags().Changed("environment") {
 			return fmt.Errorf("at least one flag must be provided to update the agent")
 		}
 
@@ -146,6 +161,14 @@ Examples:
 		run, _ := cmd.Flags().GetBool("run")
 		model, _ := cmd.Flags().GetString("model")
 		envVars, _ := cmd.Flags().GetStringSlice("environment")
+
+		taggedOCI, err := resolveTagFlag(cmd, name)
+		if err != nil {
+			return err
+		}
+		if taggedOCI != "" {
+			oci = taggedOCI
+		}
 
 		var environment map[string]string
 		if cmd.Flags().Changed("environment") {
@@ -195,26 +218,6 @@ var agentsInitCmd = &cobra.Command{
 	Short: "Initialize the agents.yaml configuration file",
 	Long:  `Initialize a new agents.yaml configuration file with default settings.`,
 	RunE:  initAgents,
-}
-
-var agentsEnableCmd = &cobra.Command{
-	Use:   "enable <name>",
-	Short: "Enable an A2A agent",
-	Long:  `Enable a specific Agent-to-Agent (A2A) agent. Note: You may need to restart your chat session for changes to take effect.`,
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return enableAgent(cmd, args[0])
-	},
-}
-
-var agentsDisableCmd = &cobra.Command{
-	Use:   "disable <name>",
-	Short: "Disable an A2A agent",
-	Long:  `Disable a specific Agent-to-Agent (A2A) agent. Note: You may need to restart your chat session for changes to take effect.`,
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return disableAgent(cmd, args[0])
-	},
 }
 
 // agentsConfigPath returns the agents.yaml path for the current command. Writes
@@ -274,6 +277,19 @@ func extractAgentNameFromURL(url string) string {
 // Known agents consult their metadata; unknown agents are presumed LLM-backed.
 func requiresModel(name string, run bool) bool {
 	return config.AgentRequiresModel(name, run)
+}
+
+// resolveTagFlag turns --tag into a full OCI reference against the agent's
+// default image, or returns an empty string when the flag was not used.
+func resolveTagFlag(cmd *cobra.Command, name string) (string, error) {
+	if !cmd.Flags().Changed("tag") {
+		return "", nil
+	}
+	if cmd.Flags().Changed("oci") {
+		return "", fmt.Errorf("cannot combine --tag with --oci: --tag only replaces the tag of the agent's default image")
+	}
+	tag, _ := cmd.Flags().GetString("tag")
+	return config.ResolveOCITag(name, tag)
 }
 
 func addAgent(cmd *cobra.Command, name, url, artifactsURL, oci string, run bool, model string, environment map[string]string) error {
@@ -347,7 +363,7 @@ func updateAgent(cmd *cobra.Command, name, url, artifactsURL, oci string, run bo
 	if cmd.Flags().Changed("artifacts-url") {
 		agent.ArtifactsURL = artifactsURL
 	}
-	if cmd.Flags().Changed("oci") {
+	if cmd.Flags().Changed("oci") || cmd.Flags().Changed("tag") {
 		agent.OCI = oci
 	}
 	if cmd.Flags().Changed("run") {
@@ -449,7 +465,7 @@ func listAgents(cmd *cobra.Command, args []string) error {
 	fmt.Println(listHint(fmt.Sprintf("%d local, %d external", len(localAgents), len(externalAgents))))
 	fmt.Println()
 
-	agentsTable := newListTable("Source", "Enabled", "Name", "URL", "OCI Image", "Local", "Model", "Env")
+	agentsTable := newListTable("Source", "Name", "URL", "OCI Image", "Local", "Model", "Env")
 	for _, agent := range localAgents {
 		oci := "-"
 		if agent.OCI != "" {
@@ -472,16 +488,15 @@ func listAgents(cmd *cobra.Command, args []string) error {
 			envStr = fmt.Sprintf("%d", len(agent.Environment))
 		}
 
-		agentsTable.Row("yaml", statusIcon(agent.Enabled), agent.Name, agent.URL, oci, runLocally, model, envStr)
+		agentsTable.Row("yaml", agent.Name, agent.URL, oci, runLocally, model, envStr)
 	}
 
 	for _, agent := range externalAgents {
-		agentsTable.Row("env", icons.CheckMark, agent.Name, agent.URL, "-", "-", "-", "-")
+		agentsTable.Row("env", agent.Name, agent.URL, "-", "-", "-", "-")
 	}
 	fmt.Println(agentsTable.Render())
 
 	fmt.Println()
-	fmt.Println(statusLegend())
 	return nil
 }
 
@@ -514,11 +529,6 @@ func showAgent(cmd *cobra.Command, name string) error {
 	fmt.Println(listTitle(fmt.Sprintf("Agent: %s", agent.Name)))
 	fmt.Println()
 
-	status := icons.CheckMark + " enabled"
-	if !agent.Enabled {
-		status = icons.CrossMark + " disabled"
-	}
-	fmt.Println(listField("Status", status))
 	fmt.Println(listField("URL", agent.URL))
 
 	if agent.ArtifactsURL != "" {
@@ -572,60 +582,6 @@ func initAgents(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func enableAgent(cmd *cobra.Command, name string) error {
-	path, err := agentsConfigPath(cmd)
-	if err != nil {
-		return err
-	}
-
-	cfg, err := config.LoadAgents(path)
-	if err != nil {
-		return fmt.Errorf("failed to load agents: %w", err)
-	}
-	agent, err := cfg.ReadEntry(name)
-	if err != nil {
-		return fmt.Errorf("failed to find agent: %w", err)
-	}
-
-	agent.Enabled = true
-	if err := cfg.UpdateEntry(*agent); err != nil {
-		return fmt.Errorf("failed to enable agent: %w", err)
-	}
-
-	fmt.Printf("%s Agent '%s' enabled successfully\n", icons.CheckMarkStyle.Render(icons.CheckMark), name)
-	fmt.Println()
-	fmt.Println("Note: Restart your chat session for changes to take effect.")
-
-	return nil
-}
-
-func disableAgent(cmd *cobra.Command, name string) error {
-	path, err := agentsConfigPath(cmd)
-	if err != nil {
-		return err
-	}
-
-	cfg, err := config.LoadAgents(path)
-	if err != nil {
-		return fmt.Errorf("failed to load agents: %w", err)
-	}
-	agent, err := cfg.ReadEntry(name)
-	if err != nil {
-		return fmt.Errorf("failed to find agent: %w", err)
-	}
-
-	agent.Enabled = false
-	if err := cfg.UpdateEntry(*agent); err != nil {
-		return fmt.Errorf("failed to disable agent: %w", err)
-	}
-
-	fmt.Printf("%s Agent '%s' disabled successfully\n", icons.CheckMarkStyle.Render(icons.CheckMark), name)
-	fmt.Println()
-	fmt.Println("Note: Restart your chat session for changes to take effect.")
-
-	return nil
-}
-
 func init() {
 	agentsCmd.AddCommand(agentsAddCmd)
 	agentsCmd.AddCommand(agentsUpdateCmd)
@@ -633,10 +589,9 @@ func init() {
 	agentsCmd.AddCommand(agentsRemoveCmd)
 	agentsCmd.AddCommand(agentsShowCmd)
 	agentsCmd.AddCommand(agentsInitCmd)
-	agentsCmd.AddCommand(agentsEnableCmd)
-	agentsCmd.AddCommand(agentsDisableCmd)
 
 	agentsAddCmd.Flags().String("oci", "", "OCI image reference for local execution")
+	agentsAddCmd.Flags().String("tag", "", "Image tag for the agent's default image (browser-agent: chromium, firefox, webkit, lightpanda)")
 	agentsAddCmd.Flags().String("artifacts-url", "", "Artifacts server URL")
 	agentsAddCmd.Flags().Bool("run", false, "Run this agent locally with Docker")
 	agentsAddCmd.Flags().String("model", "", "Model to use for the agent (format: provider/model)")
@@ -645,6 +600,7 @@ func init() {
 	agentsUpdateCmd.Flags().String("url", "", "Agent URL")
 	agentsUpdateCmd.Flags().String("artifacts-url", "", "Artifacts server URL")
 	agentsUpdateCmd.Flags().String("oci", "", "OCI image reference for local execution")
+	agentsUpdateCmd.Flags().String("tag", "", "Image tag for the agent's default image (browser-agent: chromium, firefox, webkit, lightpanda)")
 	agentsUpdateCmd.Flags().Bool("run", false, "Run this agent locally with Docker")
 	agentsUpdateCmd.Flags().String("model", "", "Model to use for the agent (format: provider/model)")
 	agentsUpdateCmd.Flags().StringSlice("environment", []string{}, "Environment variables (KEY=VALUE)")

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -2,7 +2,43 @@ package cmd
 
 import (
 	"testing"
+
+	cobra "github.com/spf13/cobra"
 )
+
+func TestResolveTagFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    string
+		args     []string
+		expected string
+		wantErr  bool
+	}{
+		{"no tag flag is a no-op", "browser-agent", nil, "", false},
+		{"tag resolves against the default image", "browser-agent", []string{"--tag", "lightpanda"}, "ghcr.io/inference-gateway/browser-agent:lightpanda", false},
+		{"tag and oci are mutually exclusive", "browser-agent", []string{"--tag", "lightpanda", "--oci", "ghcr.io/org/other:v1"}, "", true},
+		{"tag on an unknown agent", "code-reviewer", []string{"--tag", "latest"}, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("tag", "", "")
+			cmd.Flags().String("oci", "", "")
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("ParseFlags(%v) failed: %v", tt.args, err)
+			}
+
+			got, err := resolveTagFlag(cmd, tt.agent)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveTagFlag(%q) error = %v, wantErr %v", tt.agent, err, tt.wantErr)
+			}
+			if got != tt.expected {
+				t.Errorf("resolveTagFlag(%q) = %q, want %q", tt.agent, got, tt.expected)
+			}
+		})
+	}
+}
 
 func TestRequiresModel(t *testing.T) {
 	tests := []struct {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -902,8 +902,6 @@ func createA2AShortcutsFile(path string) error {
 # - /agents list - List all configured A2A agents
 # - /agents add - Add a new A2A agent
 # - /agents remove - Remove an A2A agent
-# - /agents enable - Enable an A2A agent
-# - /agents disable - Disable an A2A agent
 
 shortcuts:
   - name: agents
@@ -918,10 +916,6 @@ shortcuts:
         description: "Add a new A2A agent (usage: <name> [url] [options])"
       - name: remove
         description: "Remove an A2A agent (usage: <name>)"
-      - name: enable
-        description: "Enable an A2A agent (usage: <name>)"
-      - name: disable
-        description: "Disable an A2A agent (usage: <name>)"
 `
 
 	return os.WriteFile(path, []byte(a2aShortcutsContent), 0644)

--- a/config/agent_defaults.go
+++ b/config/agent_defaults.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"strings"
 )
 
 // AgentDefaults contains default configuration for a known agent type
@@ -32,7 +33,7 @@ var agentBaseDefaults = map[string]struct {
 		ArtifactsPortOffset: 1,
 		OCI:                 "ghcr.io/inference-gateway/browser-agent:latest",
 		Run:                 true,
-		Model:               "deepseek/deepseek-v4-pro",
+		Model:               "deepseek/deepseek-v4-flash",
 		RequiresModel:       true,
 		Environment: map[string]string{
 			"A2A_AGENT_CLIENT_TOOLS_CREATE_ARTIFACT": "true",
@@ -47,23 +48,40 @@ var agentBaseDefaults = map[string]struct {
 		BasePort:      8082,
 		OCI:           "ghcr.io/inference-gateway/google-calendar-agent:latest",
 		Run:           true,
-		Model:         "deepseek/deepseek-v4-pro",
+		Model:         "deepseek/deepseek-v4-flash",
 		RequiresModel: true,
 	},
 	"documentation-agent": {
 		BasePort:      8085,
 		OCI:           "ghcr.io/inference-gateway/documentation-agent:latest",
 		Run:           true,
-		Model:         "deepseek/deepseek-v4-pro",
+		Model:         "deepseek/deepseek-v4-flash",
 		RequiresModel: true,
 	},
 	"n8n-agent": {
 		BasePort:      8086,
 		OCI:           "ghcr.io/inference-gateway/n8n-agent:latest",
 		Run:           true,
-		Model:         "deepseek/deepseek-v4-pro",
+		Model:         "deepseek/deepseek-v4-flash",
 		RequiresModel: true,
 	},
+}
+
+// ResolveOCITag rewrites the tag of a known agent's default OCI reference.
+// browser-agent uses this for its engine variants (chromium, firefox, webkit,
+// lightpanda), which are published as separate image tags; any agent can use it
+// to pin a version.
+func ResolveOCITag(name, tag string) (string, error) {
+	template, ok := agentBaseDefaults[name]
+	if !ok || template.OCI == "" {
+		return "", fmt.Errorf("no default image for '%s' to re-tag; use --oci instead of --tag", name)
+	}
+
+	ref := template.OCI
+	if i := strings.LastIndex(ref, ":"); i > strings.LastIndex(ref, "/") {
+		ref = ref[:i]
+	}
+	return ref + ":" + tag, nil
 }
 
 // isPortAvailable checks if a port is available on localhost

--- a/config/agent_defaults_test.go
+++ b/config/agent_defaults_test.go
@@ -2,6 +2,33 @@ package config
 
 import "testing"
 
+func TestResolveOCITag(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    string
+		tag      string
+		expected string
+		wantErr  bool
+	}{
+		{"browser engine variant", "browser-agent", "lightpanda", "ghcr.io/inference-gateway/browser-agent:lightpanda", false},
+		{"pinned version", "browser-agent", "chromium-0.8.0", "ghcr.io/inference-gateway/browser-agent:chromium-0.8.0", false},
+		{"another known agent", "mock-agent", "0.4.0", "ghcr.io/inference-gateway/mock-agent:0.4.0", false},
+		{"unknown agent", "code-reviewer", "latest", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveOCITag(tt.agent, tt.tag)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveOCITag(%q, %q) error = %v, wantErr %v", tt.agent, tt.tag, err, tt.wantErr)
+			}
+			if got != tt.expected {
+				t.Errorf("ResolveOCITag(%q, %q) = %q, want %q", tt.agent, tt.tag, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestAgentRequiresModel(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/config/agents.go
+++ b/config/agents.go
@@ -24,7 +24,6 @@ type AgentEntry struct {
 	Run          bool              `yaml:"run" mapstructure:"run"`
 	Model        string            `yaml:"model,omitempty" mapstructure:"model,omitempty"`
 	Environment  map[string]string `yaml:"environment,omitempty" mapstructure:"environment,omitempty"`
-	Enabled      bool              `yaml:"enabled" mapstructure:"enabled"`
 }
 
 // DefaultAgentsConfig returns a default agents configuration

--- a/docs/a2a-connections.md
+++ b/docs/a2a-connections.md
@@ -63,18 +63,6 @@ Options:
 /agents remove my-agent
 ```
 
-#### Enable an Agent
-
-```bash
-/agents enable my-agent
-```
-
-#### Disable an Agent
-
-```bash
-/agents disable my-agent
-```
-
 ### Using the A2A Tools
 
 The A2A functionality is exposed through multiple tools that can be used in conversations:
@@ -367,10 +355,6 @@ Enable verbose logging and check for:
 
 # List configured agents
 /agents list
-
-# Enable or disable an agent
-/agents enable code-reviewer
-/agents disable code-reviewer
 ```
 
 ### Code Review Task

--- a/docs/agents-configuration.md
+++ b/docs/agents-configuration.md
@@ -275,7 +275,7 @@ agents:
     artifacts_url: http://localhost:8084
     oci: ghcr.io/inference-gateway/browser-agent:latest
     run: true
-    model: deepseek/deepseek-v4-pro
+    model: deepseek/deepseek-v4-flash
     environment:
       A2A_DEBUG: true
 ```
@@ -283,6 +283,54 @@ agents:
 The artifacts server allows the agent to serve files like screenshots, PDFs, or other generated content.
 When running locally, the CLI will map port 8084 on the host to port 8081 in the container (the standard
 artifacts server port).
+
+### Choosing a browser engine for browser-agent
+
+The browser engine is baked into the browser-agent image at build time, so you pick it by picking the
+image tag. `--tag` swaps the tag on the agent's default image:
+
+```bash
+infer agents add browser-agent --tag lightpanda
+```
+
+**⚠️ Artifacts must be enabled.** The browser-agent returns results (screenshots, extracted
+data, generated files) as **artifacts** served by an internal HTTP server. Without the artifacts
+URL, the agent has no way to deliver them and data is silently lost.
+
+For **known agents** (like `browser-agent`), the CLI auto-computes the artifacts URL from the
+agent's base port + 1 and sets `A2A_AGENT_CLIENT_TOOLS_CREATE_ARTIFACT=true` in the environment.
+The `infer agents add browser-agent` command above already does this — no extra flags needed.
+
+For **custom/unknown agents** that create artifacts, you must pass both flags explicitly:
+
+```bash
+infer agents add my-custom-agent http://localhost:8081 \
+  --artifacts-url http://localhost:8082 \
+  --environment A2A_AGENT_CLIENT_TOOLS_CREATE_ARTIFACT=true
+```
+
+To verify the artifacts URL is set after adding:
+
+```bash
+infer agents show browser-agent
+# Look for "Artifacts URL: http://localhost:8084"
+```
+
+| Tag | Engine | Image size |
+| --- | --- | --- |
+| `latest`, `chromium` | Chromium (default) | 3.03GB |
+| `firefox` | Firefox | 1.74GB |
+| `webkit` | WebKit | 1.95GB |
+| `lightpanda` | Lightpanda | 871MB |
+
+Each tag is also published per release (`chromium-0.8.0`, `lightpanda-0.8.0`, ...), so `--tag` doubles
+as version pinning. Setting `BROWSER_ENGINE` at runtime does not work - the image ships exactly one
+engine and rejects any other value at startup.
+
+Lightpanda drives a bundled browser over CDP instead of launching one per session, which cuts cold-start
+time and image size. The tradeoff is coverage: it implements a subset of the web platform, and it has no
+rendering engine at all, so `take_screenshot` fails. Every skill shipped with browser-agent uses
+screenshots, so choose it only for text and DOM extraction where speed matters.
 
 ### Example 3: Multiple Agents
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -215,6 +215,7 @@ connections to specialized A2A agents for task delegation and distributed proces
 - `--url <url>`: Update agent URL
 - `--model <model>`: Update model for the agent
 - `--oci <image>`: Update OCI image reference
+- `--tag <tag>`: Replace the tag of the agent's default image (known agents only, mutually exclusive with `--oci`)
 - `--artifacts-url <url>`: Update artifacts server URL
 - `--environment <KEY=VALUE>`: Set environment variables
 - `--run`: Enable local execution with Docker
@@ -230,6 +231,12 @@ infer agents add browser-agent
 
 # Add a known agent with custom model
 infer agents add documentation-agent --model "anthropic/claude-4-5-sonnet"
+
+# Add a known agent on a specific image tag (browser-agent ships one tag per browser engine)
+infer agents add browser-agent --tag lightpanda
+
+# Pin a known agent to a released version
+infer agents add browser-agent --tag chromium-0.8.0
 
 # Add a custom remote agent
 infer agents add code-reviewer https://agent.example.com
@@ -248,6 +255,9 @@ infer agents update browser-agent --url http://browser-agent:9090
 
 # Update agent model
 infer agents update browser-agent --model "deepseek/deepseek-v4-pro"
+
+# Switch to another image tag
+infer agents update browser-agent --tag lightpanda
 
 # Update multiple settings
 infer agents update browser-agent --url http://browser-agent:9090 --model "openai/gpt-4"


### PR DESCRIPTION
## Summary

Adds a `--tag` flag to `agents add` and `agents update` that resolves against the agent's default OCI image, making it easy to switch browser engines or pin versions without knowing the full image path.

Also removes the unused `agents enable`/`agents disable` commands and the `Enabled` field from `AgentEntry` — these were never wired to anything functional.

## Changes

- **`--tag` flag** on `agents add` and `agents update` — replaces the tag portion of the agent's default OCI reference (e.g. `--tag lightpanda` → `ghcr.io/inference-gateway/browser-agent:lightpanda`)
- **`ResolveOCITag`** helper in `config/agent_defaults.go` — parses the default image, strips the tag, and appends the requested one
- **Mutual exclusion** — `--tag` and `--oci` cannot be combined; `--tag` only works for known agents with a default image
- **Removed** `agents enable`, `agents disable` commands, the `Enabled` field from `AgentEntry`, and related docs/shortcuts
- **Default model bump** — `deepseek/deepseek-v4-pro` → `deepseek/deepseek-v4-flash` for all known agents
- **Docs** — browser engine table (chromium/firefox/webkit/lightpanda with sizes), tag usage examples, artifacts requirement warning
- **Tests** — `TestResolveTagFlag` and `TestResolveOCITag` with table-driven cases

## Browser engine reference

| Tag | Engine | Size |
|-----|--------|------|
| `latest`, `chromium` | Chromium (default) | 3.03GB |
| `firefox` | Firefox | 1.74GB |
| `webkit` | WebKit | 1.95GB |
| `lightpanda` | Lightpanda | 871MB |

## Usage

```bash
# Add browser-agent with Lightpanda engine
infer agents add browser-agent --tag lightpanda

# Pin to a specific release
infer agents add browser-agent --tag chromium-0.8.0

# Switch an existing agent's engine
infer agents update browser-agent --tag firefox
```