### PR TITLE
fix(a2a): always allow WebFetch to configured agent hosts

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -467,6 +467,10 @@ tools:
       ttl: 3600  # 1 hour
 ```
 
+Hosts of configured A2A agents (each agent's `url` and `artifacts_url`, on any port) are always
+fetchable when A2A is enabled, regardless of `allowed_domains` - registering an agent is the trust
+decision, and the A2A tools instruct the model to download artifact URLs with WebFetch.
+
 ---
 
 ## Media Tools

--- a/internal/agent/tools/web_fetch.go
+++ b/internal/agent/tools/web_fetch.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 	"unicode/utf8"
 
+	sdk "github.com/inference-gateway/sdk"
+
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
-	sdk "github.com/inference-gateway/sdk"
 )
 
 // WebFetchTool handles content fetching operations
@@ -276,6 +278,10 @@ func (t *WebFetchTool) validateURL(url string) error {
 
 // validateURLDomain checks if URL domain is in allowed list
 func (t *WebFetchTool) validateURLDomain(url string) error {
+	if t.isConfiguredAgentHost(url) {
+		return nil
+	}
+
 	for _, domain := range t.config.Tools.WebFetch.AllowedDomains {
 		if strings.Contains(url, domain) {
 			return nil
@@ -283,6 +289,42 @@ func (t *WebFetchTool) validateURLDomain(url string) error {
 	}
 
 	return fmt.Errorf("domain not allowed")
+}
+
+// isConfiguredAgentHost reports whether url points at the host of a configured
+// A2A agent (its endpoint or artifacts server). Registering an agent is the
+// trust decision: the A2A tools instruct the model to WebFetch artifact
+// Download URLs, so those hosts must stay fetchable regardless of how
+// tools.web_fetch.allowed_domains is overridden. Ports are ignored because
+// locally-run agents get their host ports reassigned on collision.
+func (t *WebFetchTool) isConfiguredAgentHost(rawURL string) bool {
+	if !t.config.A2A.Enabled {
+		return false
+	}
+
+	target, err := url.Parse(rawURL)
+	if err != nil || target.Hostname() == "" {
+		return false
+	}
+
+	bases := append([]string{}, t.config.A2A.Agents...)
+	if agents, err := config.LoadAgents(config.ResolveAgentsPath()); err == nil {
+		for _, agent := range agents.ListEntries() {
+			bases = append(bases, agent.URL, agent.ArtifactsURL)
+		}
+	}
+
+	for _, base := range bases {
+		if base == "" {
+			continue
+		}
+		if u, err := url.Parse(base); err == nil && u.Hostname() != "" &&
+			strings.EqualFold(u.Hostname(), target.Hostname()) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // FormatResult formats tool execution results for different contexts

--- a/internal/agent/tools/web_fetch_test.go
+++ b/internal/agent/tools/web_fetch_test.go
@@ -386,3 +386,64 @@ func TestFetchTool_Execute_ChannelImageDisplayHint(t *testing.T) {
 		t.Error("raw binary bytes leaked into Content")
 	}
 }
+
+func TestFetchTool_Validate_ConfiguredAgentHosts(t *testing.T) {
+	newCfg := func(a2aEnabled bool, agents []string) *config.Config {
+		return &config.Config{
+			A2A: config.A2AConfig{Enabled: a2aEnabled, Agents: agents},
+			Tools: config.ToolsConfig{
+				Enabled: true,
+				WebFetch: config.WebFetchToolConfig{
+					Enabled:        true,
+					AllowedDomains: []string{"github.com"},
+				},
+			},
+		}
+	}
+
+	writeAgentsYAML := func(t *testing.T, content string) {
+		t.Helper()
+		if err := os.MkdirAll(".infer", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(".infer/agents.yaml", []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("agent host from a2a.agents is allowed on any port", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		writeAgentsYAML(t, "agents: []\n")
+		tool := NewWebFetchTool(newCfg(true, []string{"http://localhost:8083"}))
+		if err := tool.Validate(map[string]any{"url": "http://localhost:8084/artifacts/shot.png"}); err != nil {
+			t.Fatalf("expected artifact URL to be allowed, got: %v", err)
+		}
+	})
+
+	t.Run("artifacts_url host from agents.yaml is allowed", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		writeAgentsYAML(t, "agents:\n  - name: browser-agent\n    url: http://localhost:8083\n    artifacts_url: http://artifacts.internal:8084\n")
+		tool := NewWebFetchTool(newCfg(true, nil))
+		if err := tool.Validate(map[string]any{"url": "http://artifacts.internal:8084/shot.png"}); err != nil {
+			t.Fatalf("expected artifacts_url host to be allowed, got: %v", err)
+		}
+	})
+
+	t.Run("a2a disabled falls back to the allow-list", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		writeAgentsYAML(t, "agents: []\n")
+		tool := NewWebFetchTool(newCfg(false, []string{"http://localhost:8083"}))
+		if err := tool.Validate(map[string]any{"url": "http://localhost:8084/artifacts/shot.png"}); err == nil {
+			t.Fatal("expected URL to be blocked when a2a is disabled")
+		}
+	})
+
+	t.Run("unrelated host stays blocked", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		writeAgentsYAML(t, "agents: []\n")
+		tool := NewWebFetchTool(newCfg(true, []string{"http://localhost:8083"}))
+		if err := tool.Validate(map[string]any{"url": "https://evil.example.com/localhost"}); err == nil {
+			t.Fatal("expected unrelated host to be blocked")
+		}
+	})
+}

--- a/internal/services/agent_manager.go
+++ b/internal/services/agent_manager.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	gotenv "github.com/subosito/gotenv"
 
 	client "github.com/inference-gateway/adk/client"
 
@@ -18,7 +21,6 @@ import (
 	logger "github.com/inference-gateway/cli/internal/logger"
 	telemetry "github.com/inference-gateway/cli/internal/telemetry"
 	utils "github.com/inference-gateway/cli/internal/utils"
-	gotenv "github.com/subosito/gotenv"
 )
 
 const (
@@ -456,6 +458,7 @@ func (am *AgentManager) startContainer(ctx context.Context, agent config.AgentEn
 		"--add-host", "host.docker.internal:host-gateway",
 	}
 
+	artifactsURL := agent.ArtifactsURL
 	if agent.ArtifactsURL != "" {
 		artifactsBasePort := am.extractPortFromURL(agent.ArtifactsURL)
 		if artifactsBasePort <= 0 {
@@ -463,6 +466,10 @@ func (am *AgentManager) startContainer(ctx context.Context, agent config.AgentEn
 		}
 		artifactsPort := config.FindAvailablePort(artifactsBasePort)
 		args = append(args, "-p", fmt.Sprintf("%d:8081", artifactsPort))
+		// Keep the announced base URL in sync with the actually-assigned host
+		// port, otherwise the Download URLs the agent embeds in artifact
+		// metadata point at the configured (stale) port after a collision.
+		artifactsURL = setURLPort(agent.ArtifactsURL, artifactsPort)
 		logger.Info("assigned artifacts port", "session", am.sessionID, "agent", agent.Name, "port", artifactsPort)
 	}
 
@@ -480,7 +487,7 @@ func (am *AgentManager) startContainer(ctx context.Context, agent config.AgentEn
 		env["A2A_ARTIFACTS_ENABLE"] = "true"
 		env["A2A_ARTIFACTS_SERVER_HOST"] = "0.0.0.0"
 		env["A2A_ARTIFACTS_SERVER_PORT"] = "8081"
-		env["A2A_ARTIFACTS_STORAGE_BASE_URL"] = agent.ArtifactsURL
+		env["A2A_ARTIFACTS_STORAGE_BASE_URL"] = artifactsURL
 	}
 
 	resolvedEnv := make(map[string]string)
@@ -656,6 +663,17 @@ func (am *AgentManager) determineGatewayURL() string {
 		gatewayURL = strings.TrimSuffix(gatewayURL, "/") + "/v1"
 	}
 	return gatewayURL
+}
+
+// setURLPort returns rawURL with its port replaced (or added). On a URL it
+// cannot parse it returns rawURL unchanged.
+func setURLPort(rawURL string, port int) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return rawURL
+	}
+	u.Host = fmt.Sprintf("%s:%d", u.Hostname(), port)
+	return u.String()
 }
 
 // extractPortFromURL extracts the port number from an agent URL

--- a/internal/services/agent_manager.go
+++ b/internal/services/agent_manager.go
@@ -466,9 +466,6 @@ func (am *AgentManager) startContainer(ctx context.Context, agent config.AgentEn
 		}
 		artifactsPort := config.FindAvailablePort(artifactsBasePort)
 		args = append(args, "-p", fmt.Sprintf("%d:8081", artifactsPort))
-		// Keep the announced base URL in sync with the actually-assigned host
-		// port, otherwise the Download URLs the agent embeds in artifact
-		// metadata point at the configured (stale) port after a collision.
 		artifactsURL = setURLPort(agent.ArtifactsURL, artifactsPort)
 		logger.Info("assigned artifacts port", "session", am.sessionID, "agent", agent.Name, "port", artifactsPort)
 	}

--- a/internal/services/agent_manager_test.go
+++ b/internal/services/agent_manager_test.go
@@ -153,3 +153,21 @@ LOG_LEVEL=debug
 	require.Equal(t, "debug", envMap["LOG_LEVEL"])
 	require.Len(t, envMap, 3)
 }
+
+func TestSetURLPort(t *testing.T) {
+	cases := []struct {
+		in   string
+		port int
+		want string
+	}{
+		{"http://localhost:8084", 9090, "http://localhost:9090"},
+		{"http://localhost", 8081, "http://localhost:8081"},
+		{"https://artifacts.internal:8084/base", 9090, "https://artifacts.internal:9090/base"},
+		{"::not a url::", 9090, "::not a url::"},
+	}
+	for _, c := range cases {
+		if got := setURLPort(c.in, c.port); got != c.want {
+			t.Errorf("setURLPort(%q, %d) = %q, want %q", c.in, c.port, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #980.

On A2A task completion the A2A tools instruct the model to download artifacts via WebFetch, but WebFetch's `tools.web_fetch.allowed_domains` check hard-blocked those Download URLs whenever the list was overridden (the override replaces the default, silently dropping `localhost`). Registering an agent is the trust decision, so configured agent hosts are now always fetchable:

- `validateURLDomain` first consults `isConfiguredAgentHost`: when A2A is enabled, any URL whose hostname matches a configured agent's `url` or `artifacts_url` (from `a2a.agents` and `agents.yaml`) is allowed regardless of `allowed_domains`. Matching is hostname-level and ignores ports, because locally-run agents get their host ports reassigned on collision.
- Related wrinkle from the issue: `A2A_ARTIFACTS_STORAGE_BASE_URL` is now rewritten with the actually-assigned host port (`setURLPort`), so the Download URLs the agent embeds in artifact metadata stay reachable after a port collision.

## Changes

- `internal/agent/tools/web_fetch.go` - agent-host exemption in URL validation.
- `internal/services/agent_manager.go` - announced artifacts base URL follows the assigned host port.
- `internal/agent/tools/web_fetch_test.go` - four new `Validate` cases (agent host allowed on any port, `artifacts_url` from `agents.yaml`, blocked when A2A disabled, unrelated host still blocked), each running from a temp dir so the machine's userspace `~/.infer/agents.yaml` cannot leak into resolution.
- `internal/services/agent_manager_test.go` - `setURLPort` table test.
- `docs/tools-reference.md` - note on the exemption under the WebFetch section.

## Cross-repo impact

- `inference-gateway/infer-action`: no change needed - once this ships in a release, bumping the action's pinned CLI version makes A2A artifact downloads land in `.infer/tmp`, where the action's artifact collection picks them up (context: inference-gateway/infer-action#262).

## Verification

- `task test` green (including the new cases), `task lint` 0 issues, pre-commit hook (fmt, lint, mod-tidy) passes.
