### PR TITLE
fix: deliver A2A completion notifications after every headless turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,16 @@ The agent is an **event-driven state machine** (`internal/agent/agent_state_mach
 - Prefer table-driven tests where inputs and expected results vary.
 - SA5011 false positives in tests are suppressed in `.golangci.yml` — `t.Fatal` is recognised as no-return.
 
+### Manual testing against real services
+
+**Never start the gateway or A2A agent containers by hand** (`docker run
+ghcr.io/inference-gateway/inference-gateway`, manual `docker pull`, etc.) when
+manually testing the CLI. `go run . chat` and `go run . agent <prompt>` are
+self-contained: the CLI auto-starts the local gateway and every `run: true`
+agent from `agents.yaml` (pulling images as needed) and tears them down on
+session end. Just run the command; the only manual inputs are the model flag
+(`-m provider/model`) and any `INFER_*` env overrides.
+
 ### Driving the chat TUI via tmux
 
 The chat TUI (Bubble Tea v2) can be exercised end-to-end by running it inside a

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -520,6 +520,7 @@ func (s *AgentSession) execute(taskDescription string, files []string) error {
 
 		if !s.lastResponseHadNoToolCalls() {
 			consecutiveNoToolCalls = 0
+			s.injectDrained(s.bgWaiter.TryDrain())
 			continue
 		}
 
@@ -584,7 +585,12 @@ func (s *AgentSession) waitForBackgroundTasks(ctx context.Context) {
 // as internal user messages on the conversation. Returns the number of
 // messages injected.
 func (s *AgentSession) drainBackgroundResults(ctx context.Context) int {
-	drained := s.bgWaiter.WaitAndDrain(ctx)
+	return s.injectDrained(s.bgWaiter.WaitAndDrain(ctx))
+}
+
+// injectDrained materializes drained background-task payloads as internal user
+// messages on the conversation. Returns the number of messages injected.
+func (s *AgentSession) injectDrained(drained []services.DrainedMessage) int {
 	if len(drained) == 0 {
 		return 0
 	}

--- a/internal/agent/tools/a2a_task.go
+++ b/internal/agent/tools/a2a_task.go
@@ -275,7 +275,7 @@ func (t *A2ASubmitTaskTool) Execute(ctx context.Context, args map[string]any) (*
 			State:      string(submittedTask.Status.State),
 			Success:    true,
 			Message:    fmt.Sprintf("Task delegated to %s and monitoring in background", agentURL),
-			TaskResult: fmt.Sprintf("Task %s delegated successfully. You will be notified automatically when it completes - no need to poll manually.", taskID),
+			TaskResult: fmt.Sprintf("Task %s delegated successfully. The completion notification will be injected into the conversation automatically - do not poll with A2A_QueryTask and do not block on the Wait tool; work on something else or end your turn.", taskID),
 		},
 	}, nil
 }

--- a/internal/services/agent_manager.go
+++ b/internal/services/agent_manager.go
@@ -480,10 +480,6 @@ func (am *AgentManager) startContainer(ctx context.Context, agent config.AgentEn
 	gatewayURL := am.determineGatewayURL()
 	env["A2A_AGENT_CLIENT_BASE_URL"] = gatewayURL
 
-	// ADK's default queue cleanup (120s) purges completed tasks with no age
-	// check, so a query a few minutes after completion gets "task not found".
-	// Match the examples' longer interval; agent environment / .env / host env
-	// still override via the resolution below.
 	if _, ok := env["A2A_QUEUE_CLEANUP_INTERVAL"]; !ok {
 		env["A2A_QUEUE_CLEANUP_INTERVAL"] = "500s"
 	}

--- a/internal/services/agent_manager.go
+++ b/internal/services/agent_manager.go
@@ -480,6 +480,14 @@ func (am *AgentManager) startContainer(ctx context.Context, agent config.AgentEn
 	gatewayURL := am.determineGatewayURL()
 	env["A2A_AGENT_CLIENT_BASE_URL"] = gatewayURL
 
+	// ADK's default queue cleanup (120s) purges completed tasks with no age
+	// check, so a query a few minutes after completion gets "task not found".
+	// Match the examples' longer interval; agent environment / .env / host env
+	// still override via the resolution below.
+	if _, ok := env["A2A_QUEUE_CLEANUP_INTERVAL"]; !ok {
+		env["A2A_QUEUE_CLEANUP_INTERVAL"] = "500s"
+	}
+
 	if agent.ArtifactsURL != "" {
 		env["A2A_ARTIFACTS_ENABLED"] = "true"
 		env["A2A_ARTIFACTS_SERVER_HOST"] = "0.0.0.0"

--- a/internal/services/background_tasks_waiter.go
+++ b/internal/services/background_tasks_waiter.go
@@ -79,6 +79,17 @@ func (w *BackgroundTasksWaiter) HasPendingTasks() bool {
 	return w.registry.HasPending()
 }
 
+// TryDrain drains whatever is already on the queue without blocking. Batch mode
+// calls this after every turn so a completion that landed while the model was
+// busy calling tools (e.g. blocked inside a Wait) is injected at the next turn
+// boundary instead of starving until a no-tool-call turn.
+func (w *BackgroundTasksWaiter) TryDrain() []DrainedMessage {
+	if !w.enabled {
+		return nil
+	}
+	return w.drainQueue()
+}
+
 // WaitAndDrain polls until background tasks complete and the queue has
 // results, or the per-session timeout fires. Returns drained payloads.
 // Returns nil if disabled or no work was pending.

--- a/internal/services/background_tasks_waiter_test.go
+++ b/internal/services/background_tasks_waiter_test.go
@@ -196,7 +196,6 @@ func TestBackgroundTasksWaiter_TryDrainDoesNotBlock(t *testing.T) {
 		t.Fatalf("expected 1 drained message, got %d", len(got))
 	}
 
-	// Empty queue: returns immediately with nothing, even with tasks pending.
 	empty := &domainmocks.FakeMessageQueue{}
 	empty.IsEmptyReturns(true)
 	w2 := services.NewBackgroundTasksWaiter(minimalA2AConfig(5), "session-1", registry, empty, nil)

--- a/internal/services/background_tasks_waiter_test.go
+++ b/internal/services/background_tasks_waiter_test.go
@@ -172,3 +172,35 @@ func TestBackgroundTasksWaiter_HasPendingAcrossTaskTypes(t *testing.T) {
 		t.Errorf("expected HasPending to be consulted")
 	}
 }
+
+func TestBackgroundTasksWaiter_TryDrainDoesNotBlock(t *testing.T) {
+	registry := &domainmocks.FakeBackgroundTaskRegistry{}
+	registry.HasPendingReturns(true) // pending work must NOT make TryDrain wait
+
+	queue := &domainmocks.FakeMessageQueue{}
+	queued := &domain.QueuedMessage{
+		Message: sdk.Message{
+			Role:    sdk.User,
+			Content: sdk.NewMessageContent("[A2A Task Completed: A2A_SubmitTask]\n\nTask ID: task-1"),
+		},
+		RequestID: "req-1",
+	}
+	queue.DequeueReturnsOnCall(0, queued)
+	queue.DequeueReturnsOnCall(1, nil)
+	queue.IsEmptyReturnsOnCall(0, false)
+	queue.IsEmptyReturnsOnCall(1, true)
+
+	w := services.NewBackgroundTasksWaiter(minimalA2AConfig(5), "session-1", registry, queue, nil)
+
+	if got := w.TryDrain(); len(got) != 1 {
+		t.Fatalf("expected 1 drained message, got %d", len(got))
+	}
+
+	// Empty queue: returns immediately with nothing, even with tasks pending.
+	empty := &domainmocks.FakeMessageQueue{}
+	empty.IsEmptyReturns(true)
+	w2 := services.NewBackgroundTasksWaiter(minimalA2AConfig(5), "session-1", registry, empty, nil)
+	if got := w2.TryDrain(); got != nil {
+		t.Errorf("expected nil from TryDrain on empty queue, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the headless A2A completion-notification starvation seen in infer-action run 30717431413: the browser-agent completed its task in 14s and the CLI's poller retrieved `TASK_STATE_COMPLETED` seconds later, but the model never received the notification and burned 15m56s to the job timeout.

**Root cause:** in `infer agent` mode, `drainBackgroundResults` only ran after a turn with **no tool calls**. A model waiting for an A2A result naturally waits by calling tools — in that run a `Wait(120s)`, then a `Wait(300s)` — so the queued completion was never injected: `Wait` times out → model polls/resubmits → more tool calls → starvation. (Chat mode is unaffected; its `CheckingQueue` state drains between turns, which is why local chat testing worked.)

**Fix:** add `BackgroundTasksWaiter.TryDrain()` (non-blocking) and call it after every tool-calling turn in the headless loop, so completions land at the next turn boundary. The blocking wait on quiet turns is unchanged.

Also:
- **`A2A_QUEUE_CLEANUP_INTERVAL=500s`** (overridable via agent env/.env/host env) on agent containers `startContainer` — ADK's 120s default purges completed tasks with no age check, which produced the run's late `A2A_QueryTask` → "task not found" (the task had completed successfully 5 minutes earlier).
- **Stronger `A2A_SubmitTask` result text**: the completion will be injected automatically — do not poll with `A2A_QueryTask` and do not block on the `Wait` tool.
- **AGENTS.md**: `infer chat` / `infer agent` auto-start the gateway and `run: true` agents — never start them manually when testing.

## Verification

- `task test` and `task lint` green; new unit test `TestBackgroundTasksWaiter_TryDrainDoesNotBlock`.
- Headless e2e against the real browser-agent (`go run . agent -m deepseek/deepseek-v4-flash`, full screenshot task): submit once → `✅ A2A Task Completed` notification injected ~14s later → WebFetch downloaded the 901.5 KB artifact to `~/.infer/tmp/` → exit 0.

## Cross-repo impact

- **infer-action**: after release + version-pin bump, CI browser-agent runs should complete instead of hitting `timeout-minutes`.
- **ADK** (follow-ups, not in this PR): age-based completed-task retention instead of the unconditional 120s purge; no OTLP logs exporter exists yet (agent logs can't stream to a collector).

no docs ticket: internal-only fix (restores the behaviour the tool output already promised).
