### PR TITLE
feat: auto-download A2A task artifacts (opt-in) and wait for local agents before headless turns

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -170,7 +170,8 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 	}
 
 	if agentManager := svc.GetAgentManager(); agentManager != nil {
-		waitCtx, waitCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		readyTimeout := time.Duration(cmp.Or(cfg.A2A.AgentsReadyTimeoutSec, 900)) * time.Second
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), readyTimeout)
 		agentManager.WaitForAgentsReady(waitCtx)
 		waitCancel()
 	}

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -170,7 +170,7 @@ For more information, visit: https://github.com/inference-gateway/inference-gate
 	}
 
 	if agentManager := svc.GetAgentManager(); agentManager != nil {
-		readyTimeout := time.Duration(cmp.Or(cfg.A2A.AgentsReadyTimeoutSec, 900)) * time.Second
+		readyTimeout := time.Duration(cmp.Or(cfg.A2A.AgentsReadyTimeoutSec, 600)) * time.Second
 		waitCtx, waitCancel := context.WithTimeout(context.Background(), readyTimeout)
 		agentManager.WaitForAgentsReady(waitCtx)
 		waitCancel()

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -169,6 +169,12 @@ Possible solutions:
 For more information, visit: https://github.com/inference-gateway/inference-gateway`, err)
 	}
 
+	if agentManager := svc.GetAgentManager(); agentManager != nil {
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		agentManager.WaitForAgentsReady(waitCtx)
+		waitCancel()
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.Gateway.Timeout)*time.Second)
 	defer cancel()
 

--- a/config/config.go
+++ b/config/config.go
@@ -571,6 +571,7 @@ type A2AConfig struct {
 	Agents                []string       `yaml:"agents,omitempty" mapstructure:"agents"`
 	LivenessProbeEnabled  bool           `yaml:"liveness_probe_enabled,omitempty" mapstructure:"liveness_probe_enabled,omitempty"`
 	LivenessProbeInterval int            `yaml:"liveness_probe_interval,omitempty" mapstructure:"liveness_probe_interval,omitempty"`
+	AgentsReadyTimeoutSec int            `yaml:"agents_ready_timeout_sec" mapstructure:"agents_ready_timeout_sec"`
 	Cache                 A2ACacheConfig `yaml:"cache" mapstructure:"cache"`
 	Task                  A2ATaskConfig  `yaml:"task" mapstructure:"task"`
 	Tools                 A2AToolsConfig `yaml:"tools" mapstructure:"tools"`
@@ -1100,6 +1101,7 @@ func DefaultConfig() *Config { //nolint:funlen
 			Enabled:               true,
 			LivenessProbeEnabled:  true,
 			LivenessProbeInterval: 30,
+			AgentsReadyTimeoutSec: 900,
 			Cache: A2ACacheConfig{
 				Enabled: true,
 				TTL:     300,

--- a/config/config.go
+++ b/config/config.go
@@ -1101,7 +1101,7 @@ func DefaultConfig() *Config { //nolint:funlen
 			Enabled:               true,
 			LivenessProbeEnabled:  true,
 			LivenessProbeInterval: 30,
-			AgentsReadyTimeoutSec: 900,
+			AgentsReadyTimeoutSec: 600,
 			Cache: A2ACacheConfig{
 				Enabled: true,
 				TTL:     300,

--- a/config/config.go
+++ b/config/config.go
@@ -770,6 +770,7 @@ type A2ATaskConfig struct {
 	BackgroundMonitoring    bool    `yaml:"background_monitoring" mapstructure:"background_monitoring"`
 	CompletedTaskRetention  int     `yaml:"completed_task_retention" mapstructure:"completed_task_retention"`
 	AgentModeMaxWaitSeconds int     `yaml:"agent_mode_max_wait_seconds" mapstructure:"agent_mode_max_wait_seconds"`
+	ArtifactsAutoDownload   bool    `yaml:"artifacts_auto_download" mapstructure:"artifacts_auto_download"`
 }
 
 // A2ACacheConfig contains settings for A2A agent card caching
@@ -1112,6 +1113,7 @@ func DefaultConfig() *Config { //nolint:funlen
 				BackgroundMonitoring:    true,
 				CompletedTaskRetention:  5,
 				AgentModeMaxWaitSeconds: 300,
+				ArtifactsAutoDownload:   false,
 			},
 			Tools: A2AToolsConfig{
 				QueryAgent: QueryAgentToolConfig{

--- a/internal/agent/tools/a2a_task.go
+++ b/internal/agent/tools/a2a_task.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -14,6 +18,7 @@ import (
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	logger "github.com/inference-gateway/cli/internal/logger"
 	telemetry "github.com/inference-gateway/cli/internal/telemetry"
 )
 
@@ -438,6 +443,10 @@ func (t *A2ASubmitTaskTool) handleTaskState(agentURL, _ /* taskID */ string, _ /
 			finalResult = t.extractTextFromParts(currentTask.Status.Message.Parts)
 		}
 
+		if t.config.A2A.Task.ArtifactsAutoDownload {
+			t.downloadArtifacts(&currentTask)
+		}
+
 		result := &domain.ToolExecutionResult{
 			ToolName: "A2A_SubmitTask",
 			Success:  true,
@@ -620,10 +629,18 @@ func (t *A2ASubmitTaskTool) formatA2ATaskData(data any, metadata map[string]stri
 
 	if taskData.Task != nil && len(taskData.Task.Artifacts) > 0 {
 		fmt.Fprintf(&dataContent, "\n\nArtifacts Available: %d\n", len(taskData.Task.Artifacts))
+		downloaded := false
 		for i, artifact := range taskData.Task.Artifacts {
 			t.formatArtifact(&dataContent, i+1, artifact)
+			if artifactLocalPath(artifact) != "" {
+				downloaded = true
+			}
 		}
-		dataContent.WriteString("\nTo download artifacts: Use WebFetch tool with the Download URL from each artifact above.\n")
+		if downloaded {
+			dataContent.WriteString("\nArtifacts marked \"Saved to\" are already downloaded locally - use those paths directly, no need to fetch them.\n")
+		} else {
+			dataContent.WriteString("\nTo download artifacts: Use WebFetch tool with the Download URL from each artifact above.\n")
+		}
 	}
 
 	hasMetadata := len(metadata) > 0
@@ -681,11 +698,6 @@ func (t *A2ASubmitTaskTool) formatArtifact(builder *strings.Builder, index int, 
 	}
 	fmt.Fprintf(builder, "%d. %s (ID: %s)", index, artifactName, artifact.ArtifactID)
 
-	if artifact.Metadata == nil {
-		builder.WriteString("\n")
-		return
-	}
-
 	if artifact.Metadata != nil {
 		if mimeType, ok := (*artifact.Metadata)["mime_type"].(string); ok {
 			fmt.Fprintf(builder, ", Type: %s", mimeType)
@@ -693,11 +705,100 @@ func (t *A2ASubmitTaskTool) formatArtifact(builder *strings.Builder, index int, 
 		if size, ok := (*artifact.Metadata)["size"].(float64); ok {
 			fmt.Fprintf(builder, ", Size: %d bytes", int64(size))
 		}
-		if url, ok := (*artifact.Metadata)["url"].(string); ok {
-			fmt.Fprintf(builder, "\n   Download URL: %s", url)
-		}
+	}
+	if url := artifactDownloadURL(artifact); url != "" {
+		fmt.Fprintf(builder, "\n   Download URL: %s", url)
+	}
+	if path := artifactLocalPath(artifact); path != "" {
+		fmt.Fprintf(builder, "\n   Saved to: %s", path)
 	}
 	builder.WriteString("\n")
+}
+
+// artifactDownloadURL resolves an artifact's download URL: metadata "url"
+// first, then the first file part carrying a URI (agents differ in where
+// they put it).
+func artifactDownloadURL(artifact adk.Artifact) string {
+	if artifact.Metadata != nil {
+		if url, ok := (*artifact.Metadata)["url"].(string); ok && url != "" {
+			return url
+		}
+	}
+	for _, part := range artifact.Parts {
+		if part.File != nil && part.File.FileWithURI != nil && *part.File.FileWithURI != "" {
+			return *part.File.FileWithURI
+		}
+	}
+	return ""
+}
+
+// artifactLocalPath returns the local path recorded by downloadArtifacts, if any.
+func artifactLocalPath(artifact adk.Artifact) string {
+	if artifact.Metadata == nil {
+		return ""
+	}
+	path, _ := (*artifact.Metadata)["local_path"].(string)
+	return path
+}
+
+// downloadArtifacts fetches each artifact of a completed task from its
+// (trusted agent-host) download URL into <configDir>/tmp and records the
+// local path in the artifact's metadata, so the completion notification can
+// point at a file on disk instead of asking the model to WebFetch it.
+// Fail-soft: any failure just leaves that artifact with its URL line.
+func (t *A2ASubmitTaskTool) downloadArtifacts(task *adk.Task) {
+	baseDir := filepath.Join(t.config.GetConfigDir(), "tmp")
+	httpClient := &http.Client{Timeout: 60 * time.Second}
+
+	for i := range task.Artifacts {
+		artifact := &task.Artifacts[i]
+		url := artifactDownloadURL(*artifact)
+		if url == "" || !isTrustedAgentHost(t.config, url) {
+			continue
+		}
+
+		path, err := downloadArtifactFile(httpClient, url, baseDir)
+		if err != nil {
+			logger.Warn("failed to auto-download A2A artifact", "url", url, "error", err)
+			continue
+		}
+
+		if artifact.Metadata == nil {
+			artifact.Metadata = &adk.Struct{}
+		}
+		(*artifact.Metadata)["local_path"] = path
+		logger.Info("auto-downloaded A2A artifact", "url", url, "path", path)
+	}
+}
+
+// downloadArtifactFile GETs url into baseDir and returns the absolute path.
+func downloadArtifactFile(httpClient *http.Client, url, baseDir string) (string, error) {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return "", err
+	}
+	fullPath := filepath.Join(baseDir, filepath.Base(extractFilenameFromURL(url)))
+	file, err := os.Create(fullPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	if _, err := io.Copy(file, resp.Body); err != nil {
+		return "", err
+	}
+
+	if absPath, err := filepath.Abs(fullPath); err == nil {
+		return absPath, nil
+	}
+	return fullPath, nil
 }
 
 // FormatPreview returns a short preview of the result for UI display

--- a/internal/agent/tools/a2a_task_test.go
+++ b/internal/agent/tools/a2a_task_test.go
@@ -2,13 +2,19 @@ package tools
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
-	adk "github.com/inference-gateway/adk/types"
-	config "github.com/inference-gateway/cli/config"
-	domain "github.com/inference-gateway/cli/internal/domain"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
+
+	adk "github.com/inference-gateway/adk/types"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 func TestA2ASubmitTaskTool_Definition(t *testing.T) {
@@ -450,4 +456,135 @@ func TestA2ASubmitTaskTool_ShouldAlwaysExpand(t *testing.T) {
 	tool := NewA2ASubmitTaskTool(cfg, nil, nil)
 
 	assert.False(t, tool.ShouldAlwaysExpand())
+}
+
+func TestArtifactDownloadURL_FallsBackToFilePartURI(t *testing.T) {
+	uri := "http://localhost:8084/artifacts/ctx/art/fullpage.png"
+	name := "fullpage.png"
+
+	tests := []struct {
+		name     string
+		artifact adk.Artifact
+		want     string
+	}{
+		{
+			name: "metadata url wins",
+			artifact: adk.Artifact{
+				ArtifactID: "a1",
+				Metadata:   &adk.Struct{"url": "http://meta-url"},
+				Parts:      []adk.Part{{File: &adk.FilePart{FileWithURI: &uri, Name: name}}},
+			},
+			want: "http://meta-url",
+		},
+		{
+			name: "file part uri fallback",
+			artifact: adk.Artifact{
+				ArtifactID: "a2",
+				Parts:      []adk.Part{{File: &adk.FilePart{FileWithURI: &uri, Name: name}}},
+			},
+			want: uri,
+		},
+		{
+			name:     "no url anywhere",
+			artifact: adk.Artifact{ArtifactID: "a3"},
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, artifactDownloadURL(tt.artifact))
+		})
+	}
+}
+
+func TestA2ASubmitTaskTool_FormatResult_ArtifactSavedTo(t *testing.T) {
+	cfg := &config.Config{}
+	tool := NewA2ASubmitTaskTool(cfg, nil, nil)
+	name := "shot.png"
+
+	result := &domain.ToolExecutionResult{
+		ToolName: "A2A_SubmitTask",
+		Success:  true,
+		Data: A2ASubmitTaskResult{
+			TaskID:  "task-1",
+			State:   string(adk.TaskStateCompleted),
+			Success: true,
+			Task: &adk.Task{
+				ID: "task-1",
+				Artifacts: []adk.Artifact{{
+					ArtifactID: "a1",
+					Name:       &name,
+					Metadata: &adk.Struct{
+						"url":        "http://localhost:8084/artifacts/shot.png",
+						"local_path": "/home/user/.infer/tmp/shot.png",
+					},
+				}},
+			},
+		},
+	}
+
+	formatted := tool.FormatResult(result, domain.FormatterLLM)
+	assert.Contains(t, formatted, "Download URL: http://localhost:8084/artifacts/shot.png")
+	assert.Contains(t, formatted, "Saved to: /home/user/.infer/tmp/shot.png")
+	assert.Contains(t, formatted, "already downloaded locally")
+	assert.NotContains(t, formatted, "Use WebFetch tool")
+}
+
+func TestA2ASubmitTaskTool_DownloadArtifacts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("png-bytes"))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{A2A: config.A2AConfig{Enabled: true, Agents: []string{server.URL}}}
+	cfg.SetConfigDir(t.TempDir())
+	tool := NewA2ASubmitTaskTool(cfg, nil, nil)
+
+	trustedURL := server.URL + "/artifacts/shot.png"
+	task := &adk.Task{
+		ID: "task-1",
+		Artifacts: []adk.Artifact{
+			{ArtifactID: "trusted", Metadata: &adk.Struct{"url": trustedURL}},
+			{ArtifactID: "untrusted", Metadata: &adk.Struct{"url": "http://not-an-agent.example.com/x.png"}},
+		},
+	}
+
+	tool.downloadArtifacts(task)
+
+	savedPath := artifactLocalPath(task.Artifacts[0])
+	require.NotEmpty(t, savedPath)
+	content, err := os.ReadFile(savedPath)
+	require.NoError(t, err)
+	assert.Equal(t, "png-bytes", string(content))
+
+	assert.Empty(t, artifactLocalPath(task.Artifacts[1]))
+}
+
+func TestA2ASubmitTaskTool_HandleTaskState_NoDownloadByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("png-bytes"))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{A2A: config.A2AConfig{Enabled: true, Agents: []string{server.URL}}}
+	cfg.SetConfigDir(t.TempDir())
+	tool := NewA2ASubmitTaskTool(cfg, nil, nil)
+
+	task := adk.Task{
+		ID:     "task-1",
+		Status: adk.TaskStatus{State: adk.TaskStateCompleted},
+		Artifacts: []adk.Artifact{
+			{ArtifactID: "a1", Metadata: &adk.Struct{"url": server.URL + "/artifacts/shot.png"}},
+		},
+	}
+	state := &domain.TaskPollingState{TaskID: "task-1", StartedAt: time.Now()}
+
+	done, result := tool.handleTaskState(server.URL, "task-1", 1, state, task, "")
+	require.True(t, done)
+	require.NotNil(t, result)
+
+	submit, ok := result.Data.(A2ASubmitTaskResult)
+	require.True(t, ok)
+	assert.Empty(t, artifactLocalPath(submit.Task.Artifacts[0]))
 }

--- a/internal/agent/tools/web_fetch.go
+++ b/internal/agent/tools/web_fetch.go
@@ -120,7 +120,7 @@ func (t *WebFetchTool) Execute(ctx context.Context, args map[string]any) (*domai
 	isBinary := isBinaryContent(fetchResult.ContentType, fetchResult.Content)
 
 	if download || isBinary {
-		filename := t.extractFilenameFromURL(url)
+		filename := extractFilenameFromURL(url)
 		savedPath, saveErr := t.saveToFile(fetchResult, filename)
 		if saveErr != nil {
 			result.Error = fmt.Sprintf("failed to save file: %v", saveErr)
@@ -278,7 +278,7 @@ func (t *WebFetchTool) validateURL(url string) error {
 
 // validateURLDomain checks if URL domain is in allowed list
 func (t *WebFetchTool) validateURLDomain(url string) error {
-	if t.isConfiguredAgentHost(url) {
+	if isTrustedAgentHost(t.config, url) {
 		return nil
 	}
 
@@ -291,14 +291,14 @@ func (t *WebFetchTool) validateURLDomain(url string) error {
 	return fmt.Errorf("domain not allowed")
 }
 
-// isConfiguredAgentHost reports whether url points at the host of a configured
+// isTrustedAgentHost reports whether url points at the host of a configured
 // A2A agent (its endpoint or artifacts server). Registering an agent is the
 // trust decision: the A2A tools instruct the model to WebFetch artifact
 // Download URLs, so those hosts must stay fetchable regardless of how
 // tools.web_fetch.allowed_domains is overridden. Ports are ignored because
 // locally-run agents get their host ports reassigned on collision.
-func (t *WebFetchTool) isConfiguredAgentHost(rawURL string) bool {
-	if !t.config.A2A.Enabled {
+func isTrustedAgentHost(cfg *config.Config, rawURL string) bool {
+	if !cfg.A2A.Enabled {
 		return false
 	}
 
@@ -307,7 +307,7 @@ func (t *WebFetchTool) isConfiguredAgentHost(rawURL string) bool {
 		return false
 	}
 
-	bases := append([]string{}, t.config.A2A.Agents...)
+	bases := append([]string{}, cfg.A2A.Agents...)
 	if agents, err := config.LoadAgents(config.ResolveAgentsPath()); err == nil {
 		for _, agent := range agents.ListEntries() {
 			bases = append(bases, agent.URL, agent.ArtifactsURL)
@@ -499,8 +499,9 @@ func (t *WebFetchTool) ShouldAlwaysExpand() bool {
 	return false
 }
 
-// extractFilenameFromURL extracts a safe filename from a URL
-func (t *WebFetchTool) extractFilenameFromURL(url string) string {
+// extractFilenameFromURL extracts a safe filename from a URL; shared with the
+// A2A artifact auto-download path.
+func extractFilenameFromURL(url string) string {
 	parts := strings.Split(url, "/")
 	filename := "download"
 

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -130,6 +130,10 @@ type AgentManager interface {
 	// StartAgents starts all agents configured with run: true
 	StartAgents(ctx context.Context) error
 
+	// WaitForAgentsReady blocks until every run:true agent started by
+	// StartAgents has settled (ready or failed), or ctx is done
+	WaitForAgentsReady(ctx context.Context)
+
 	// StopAgents stops all running agent containers
 	StopAgents(ctx context.Context) error
 

--- a/internal/services/agent_manager.go
+++ b/internal/services/agent_manager.go
@@ -45,6 +45,7 @@ type AgentManager struct {
 	probeStop            chan struct{}
 	probeStopOnce        sync.Once
 	probeWg              sync.WaitGroup
+	startWg              sync.WaitGroup
 	agentStates          map[string]domain.AgentState
 }
 
@@ -117,7 +118,11 @@ func (am *AgentManager) StartAgents(ctx context.Context) error {
 	}
 
 	for _, agent := range agentsToStart {
-		go am.startAgentAsync(ctx, agent)
+		am.startWg.Add(1)
+		go func(agent config.AgentEntry) {
+			defer am.startWg.Done()
+			am.startAgentAsync(ctx, agent)
+		}(agent)
 	}
 
 	if len(agentsToStart) > 0 {
@@ -128,6 +133,33 @@ func (am *AgentManager) StartAgents(ctx context.Context) error {
 
 	am.isRunning = true
 	return nil
+}
+
+// WaitForAgentsReady blocks until every run:true agent started by StartAgents
+// has settled (ready or failed), or ctx is done. Headless mode calls this
+// before the first LLM turn so the model never races an agent whose 3GB image
+// is still pulling; failed agents settle too, so a broken agent can't block
+// forever. Chat mode never calls it (the TUI streams status instead).
+func (am *AgentManager) WaitForAgentsReady(ctx context.Context) {
+	settled := make(chan struct{})
+	go func() {
+		am.startWg.Wait()
+		close(settled)
+	}()
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-settled:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			logger.Info("waiting for local A2A agents to become ready (image pull can take a while)")
+		}
+	}
 }
 
 // initializeExternalAgents loads external agents and monitors their readiness

--- a/internal/services/agent_manager_test.go
+++ b/internal/services/agent_manager_test.go
@@ -1,9 +1,11 @@
 package services
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
@@ -170,4 +172,27 @@ func TestSetURLPort(t *testing.T) {
 			t.Errorf("setURLPort(%q, %d) = %q, want %q", c.in, c.port, got, c.want)
 		}
 	}
+}
+
+func TestAgentManager_WaitForAgentsReady(t *testing.T) {
+	am := NewAgentManager("session", &config.Config{}, &config.AgentsConfig{}, nil, nil)
+
+	done := make(chan struct{})
+	go func() {
+		am.WaitForAgentsReady(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("WaitForAgentsReady should return immediately with no agents starting")
+	}
+
+	am.startWg.Add(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	am.WaitForAgentsReady(ctx)
+	require.Less(t, time.Since(start), time.Second, "WaitForAgentsReady should respect ctx cancellation")
+	am.startWg.Done()
 }


### PR DESCRIPTION
## Summary

Two fixes surfaced by the infer-action screenshot retest (run 30719983818): the headless notification delivery from #983 works, but the screenshot still never reached the result comment, and the orchestrator burned turns querying an agent whose 3GB image was still pulling.

### 1. Auto-download completed task artifacts (opt-in, default off)

The completion notification listed "Artifacts Available" but no Download URL: `formatArtifact` only read `artifact.Metadata["url"]` and never looked at `artifact.Parts` (`FilePart.FileWithURI`), and even with a URL, downloading depended on the model deciding to WebFetch it - which it didn't.

- `formatArtifact` now resolves the URL from metadata **or** file parts (`artifactDownloadURL`) - unconditional bug fix.
- New `a2a.task.artifacts_auto_download` (default `false`, env `INFER_A2A_TASK_ARTIFACTS_AUTO_DOWNLOAD`): on task completion the polling goroutine downloads each artifact from its trusted agent host into `<configDir>/tmp` (same dir WebFetch saves to) and the notification renders `Saved to: <path>` plus an "already downloaded" hint instead of the WebFetch instruction. Downloads are restricted to configured agent hosts (same trust rule as WebFetch's agent-host exemption); failures fall back to the URL line.

### 2. Headless waits for local agents before the first turn

`StartAgents` fires container startup goroutines and returns; `infer agent` began the LLM loop immediately, so the model got "connection refused" from `A2A_QueryAgent`/`A2A_SubmitTask` while the image was still pulling and wasted turns probing for alternatives.

- New `AgentManager.WaitForAgentsReady(ctx)`: blocks until every `run: true` agent settles (ready or failed), logging every 10s.
- `cmd/agent.go` calls it once before the loop, capped by new config `a2a.agents_ready_timeout_sec` (default 600, env `INFER_A2A_AGENTS_READY_TIMEOUT_SEC`) so a wedged image pull cannot hang a CI job. Chat mode is untouched - the TUI already streams agent status.

## Verification

- `task test` (56 packages) and `task lint` green; new unit tests for the URL fallback, `Saved to` rendering, download + host-trust + default-off, and the ready-wait.
- Headless e2e (`INFER_A2A_TASK_ARTIFACTS_AUTO_DOWNLOAD=true`, deepseek-v4-flash + browser-agent): no connection-refused turns, single submit, completion injected with `Saved to: ~/.infer/tmp/fullpage_….png` (1920×4290 PNG on disk), model reported the local path without any WebFetch - 6 LLM requests total, exit 0.

## Cross-repo impact

- **infer-action**: after release, set `INFER_A2A_TASK_ARTIFACTS_AUTO_DOWNLOAD=true` on the run-agent step (with the CLI version-pin bump) - the existing collect step then picks the file up from `$HOME/.infer/tmp` and embeds it in the result comment. No other repos affected.
