### PR TITLE
fix(config): parse INFER_TOOLS_WEB_FETCH_ALLOWED_DOMAINS as a delimited list

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,8 +74,9 @@ func init() {
 }
 
 // parseDelimitedList splits a comma/newline-separated env value into trimmed,
-// non-empty entries. Used for INFER_A2A_AGENTS and the bash allow-list append
-// override (tools.bash.mode.all.allow), neither of which viper can parse
+// non-empty entries. Used for INFER_A2A_AGENTS,
+// INFER_TOOLS_WEB_FETCH_ALLOWED_DOMAINS, and the bash allow-list append
+// override (tools.bash.mode.all.allow), none of which viper can parse
 // generically into a slice from a single env var.
 func parseDelimitedList(value string) []string {
 	var out []string
@@ -212,6 +213,10 @@ func initConfig() {
 
 	if a2aAgents := os.Getenv("INFER_A2A_AGENTS"); a2aAgents != "" {
 		v.Set("a2a.agents", parseDelimitedList(a2aAgents))
+	}
+
+	if domains := os.Getenv("INFER_TOOLS_WEB_FETCH_ALLOWED_DOMAINS"); domains != "" {
+		v.Set("tools.web_fetch.allowed_domains", parseDelimitedList(domains))
 	}
 
 	if err := v.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose")); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -82,6 +82,22 @@ func TestA2AAgentsEnvironmentVariable(t *testing.T) {
 	}
 }
 
+// A single comma-joined env value must become a real slice: viper would
+// otherwise hand the WebFetch domain matcher one bogus element that matches
+// nothing, silently blocking every fetch (including the defaults).
+func TestWebFetchAllowedDomainsEnvironmentVariable(t *testing.T) {
+	t.Setenv("INFER_TOOLS_WEB_FETCH_ALLOWED_DOMAINS", "github.com, raw.githubusercontent.com,user-images.githubusercontent.com")
+
+	initConfig()
+
+	domains := V.GetStringSlice("tools.web_fetch.allowed_domains")
+	assert.Equal(t, []string{"github.com", "raw.githubusercontent.com", "user-images.githubusercontent.com"}, domains)
+
+	cfg, err := loadConfigFromViper()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"github.com", "raw.githubusercontent.com", "user-images.githubusercontent.com"}, cfg.Tools.WebFetch.AllowedDomains)
+}
+
 // bashAllowAppendEnv / bashAllowAppendFlag are the override knobs reintroduced so
 // CI (and infer-action) can add a few commands to the allow-list baseline without
 // rewriting tools.bash.mode.all.allow or shipping ".*".

--- a/config/reminders.go
+++ b/config/reminders.go
@@ -51,7 +51,7 @@ const defaultReminderInterval = 4
 const defaultMemoryReminderInterval = 10
 
 const defaultTodoReminderText = `<system-reminder>
-This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware. If you are working on tasks that would benefit from a todo list please use the TodoWrite tool to create one. If not, please feel free to ignore. Again do not mention this message to the user.
+This is a reminder to keep your todo list current. If you are working on tasks that would benefit from a todo list, use the TodoWrite tool to create one or update it as you make progress. If not, please feel free to ignore. DO NOT mention this message to the user.
 </system-reminder>`
 
 const defaultMemoryHygieneReminderText = `<system-reminder>

--- a/internal/agent/tools/web_fetch.go
+++ b/internal/agent/tools/web_fetch.go
@@ -288,7 +288,8 @@ func (t *WebFetchTool) validateURLDomain(url string) error {
 		}
 	}
 
-	return fmt.Errorf("domain not allowed")
+	return fmt.Errorf("domain not allowed (tools.web_fetch.allowed_domains: %s)",
+		strings.Join(t.config.Tools.WebFetch.AllowedDomains, ", "))
 }
 
 // isTrustedAgentHost reports whether url points at the host of a configured


### PR DESCRIPTION
## Problem

Investigating why the `@infer` agent "got stuck" on #992 (run 30807789026): the issue's only content is a screenshot, and the agent's very first `WebFetch` of it failed with `domain not allowed` — so it worked blind and looped in read-only analysis for 24 minutes until cancelled.

Root cause: the org workflow sets `INFER_TOOLS_WEB_FETCH_ALLOWED_DOMAINS` as a comma-separated list, but the CLI only list-parses `INFER_A2A_AGENTS` and `INFER_TOOLS_BASH_ALLOW_APPEND`. Viper turns the comma string into a **single bogus slice element**, and `validateURLDomain` matches with `strings.Contains(url, domain)` — so nothing ever matches. The env override silently bricks WebFetch for every domain in CI, even `github.com`, which is in the built-in defaults.

## Changes

- `cmd/root.go`: parse `INFER_TOOLS_WEB_FETCH_ALLOWED_DOMAINS` with `parseDelimitedList`, same pattern as `INFER_A2A_AGENTS`; test added.
- `internal/agent/tools/web_fetch.go`: the rejection message now includes the effective allow-list, so a misconfigured list is visible instead of a silent mystery.
- `config/reminders.go`: the interval-fired todo-hygiene reminder no longer falsely asserts the todo list is empty.

## Verification

- New `TestWebFetchAllowedDomainsEnvironmentVariable` asserts the env value resolves to a real slice both in viper and in the unmarshalled config.
- `task test` and `task lint` pass.