### PR TITLE
fix(bash): allow quoted newlines in allow-list matching

### DIFF
--- a/config/bash_allowedlist.go
+++ b/config/bash_allowedlist.go
@@ -183,15 +183,17 @@ func hasAllowAll(allow []string) bool {
 }
 
 // matchesAnyAllow reports whether seg matches any allow entry as a WHOLE command.
-// Each entry is wrapped as \A(?:entry)\z so it must match the entire command - a
+// Each entry is wrapped as \A(?s:entry)\z so it must match the entire command - a
 // prefix match is never enough, and any anchors the entry already carries are
-// harmless. Invalid regexes are skipped rather than failing the whole check.
+// harmless. The s flag lets . span quoted newlines (e.g. a multi-line
+// git commit -m "..."); unquoted newlines never reach here - they are segment
+// split points. Invalid regexes are skipped rather than failing the whole check.
 func matchesAnyAllow(seg string, allow []string) bool {
 	for _, entry := range allow {
 		if entry == "" {
 			continue
 		}
-		matched, err := regexp.MatchString(`\A(?:`+entry+`)\z`, seg)
+		matched, err := regexp.MatchString(`\A(?s:`+entry+`)\z`, seg)
 		if err == nil && matched {
 			return true
 		}

--- a/config/bash_allowedlist_test.go
+++ b/config/bash_allowedlist_test.go
@@ -145,6 +145,31 @@ func TestIsBashCommandAllowed_QuotedOperators(t *testing.T) {
 	}
 }
 
+// TestIsBashCommandAllowed_QuotedNewlines verifies that .* in an allow entry
+// spans newlines inside quoted arguments (the (?s) wrap in matchesAnyAllow) - a
+// multi-line git commit -m "..." must match `git commit( .*)?` - while unquoted
+// newlines still split into segments and hit the single-command policy.
+func TestIsBashCommandAllowed_QuotedNewlines(t *testing.T) {
+	cfg := &Config{
+		Tools: ToolsConfig{
+			Enabled: true,
+			Bash: BashToolConfig{
+				Enabled: true,
+				Mode: BashModesConfig{
+					All: BashModeAllowConfig{Allow: []string{"git commit( .*)?"}},
+				},
+			},
+		},
+	}
+
+	if !cfg.IsBashCommandAllowed("git commit -m \"subject\n\nmulti-line body\"", "standard") {
+		t.Error("expected multi-line quoted commit message to be allowed")
+	}
+	if cfg.IsBashCommandAllowed("git commit -m subject\nrm -rf /", "standard") {
+		t.Error("expected unquoted newline to stay denied (single-command policy)")
+	}
+}
+
 func TestIsBashCommandAllowed_MalformedAndEmpty(t *testing.T) {
 	cfg := DefaultConfig()
 


### PR DESCRIPTION
## Problem

In CI run [30945714459](https://github.com/inference-gateway/cli/actions/runs/30945714459/job/92115058136) the agent's `git commit -m "<multi-line message>"` was blocked even though `git commit( .*)?` was in the bash allow-list.

Root cause: `matchesAnyAllow` wraps entries as `\A(?:entry)\z`, and in Go regexp `.` does not match `\n`. A quoted newline is correctly kept inside a single segment by `splitBashSegments`, but `( .*)?` then can't span it, so the full-match fails against every entry and the command falls through to approval → blocked headless (with the misleading generic "not auto-approved" message).

## Fix

Wrap entries as `\A(?s:entry)\z` so `.` spans newlines. This only legalises newlines inside quoted arguments — unquoted newlines are segment split points and multi-segment commands are still rejected by the single-command policy before matching runs.

## Tests

- `TestIsBashCommandAllowed_QuotedNewlines`: multi-line quoted `git commit -m` matches `git commit( .*)?`; an unquoted-newline chain stays denied.
- `go test ./config/` and `task lint` pass.
