### PR TITLE
feat(agent): inject system reminder after 3 identical failing tool calls

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -390,7 +390,6 @@ func NewAgent(
 		reminderProvider: cfg.Reminders,
 		hookProvider:     hookProvider,
 		firedReminders:   make(map[string]bool),
-		failedCalls:      make(map[string]int),
 		activeSessions:   make(map[string]*sessionCancel),
 		metrics:          make(map[string]*domain.ChatMetrics),
 		toolCallsMap:     make(map[string]*sdk.ChatCompletionMessageToolCall),

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1476,7 +1476,7 @@ func (s *AgentServiceImpl) trackRepeatedFailure(tc sdk.ChatCompletionMessageTool
 		return ""
 	}
 	return fmt.Sprintf(
-		"\n\n<system-reminder>\nYou have called %s with these exact arguments %d times and it failed every time. STOP retrying this call - the result will not change. Do not guess arguments: verify your assumptions first (e.g. for file paths, list the directory or search with Grep/Glob to see what actually exists), then take a different approach.\n</system-reminder>",
+		"\n\n<system-reminder>\n%s failed %d times with identical arguments. Stop retrying - verify your assumptions (list or search first) and take a different approach.\n</system-reminder>",
 		tc.Function.Name, n,
 	)
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -54,6 +54,11 @@ type AgentServiceImpl struct {
 	firedReminders map[string]bool
 	reminderMux    sync.Mutex
 
+	// ponytail: session-lifetime map of identical failing tool calls
+	// (name+args), reset per key on success; backs the retry-loop breaker
+	failedCalls    map[string]int
+	failedCallsMux sync.Mutex
+
 	// Session tracking: covers the full lifetime of a RunWithStream call.
 	// Cancelling a session aborts streaming, tool execution, approval waits,
 	// and the main event loop in one shot. Idempotent via sync.Once so
@@ -386,6 +391,7 @@ func NewAgent(
 		reminderProvider: cfg.Reminders,
 		hookProvider:     hookProvider,
 		firedReminders:   make(map[string]bool),
+		failedCalls:      make(map[string]int),
 		activeSessions:   make(map[string]*sessionCancel),
 		metrics:          make(map[string]*domain.ChatMetrics),
 		toolCallsMap:     make(map[string]*sdk.ChatCompletionMessageToolCall),
@@ -1052,6 +1058,14 @@ func (s *AgentServiceImpl) executeToolInternal(
 	eventPublisher.publishToolStatusChange(tc.ID, tc.Function.Name, "running", "Executing...", nil)
 
 	defer func() {
+		if note := s.trackRepeatedFailure(tc, finalEntry); note != "" {
+			if txt, err := finalEntry.Message.Content.AsMessageContent0(); err == nil {
+				finalEntry.Message.Content = sdk.NewMessageContent(txt + note)
+			}
+		}
+	}()
+
+	defer func() {
 		status, message := "completed", "Completed successfully"
 		var images []domain.ImageAttachment
 		if finalEntry.ToolExecution != nil {
@@ -1439,6 +1453,32 @@ func (s *AgentServiceImpl) requestToolApproval(
 	}
 
 	return approved, err
+}
+
+// trackRepeatedFailure counts identical failing tool calls (same name and
+// arguments) and, from the third failure on, returns a <system-reminder> to
+// append to the tool result so the model stops retrying a call that will
+// never succeed (e.g. reading a guessed, non-existent file path). A success
+// with the same arguments resets the counter.
+func (s *AgentServiceImpl) trackRepeatedFailure(tc sdk.ChatCompletionMessageToolCall, entry domain.ConversationEntry) string {
+	key := tc.Function.Name + "\x00" + tc.Function.Arguments
+	s.failedCallsMux.Lock()
+	defer s.failedCallsMux.Unlock()
+
+	if entry.ToolExecution == nil || entry.ToolExecution.Success {
+		delete(s.failedCalls, key)
+		return ""
+	}
+
+	s.failedCalls[key]++
+	n := s.failedCalls[key]
+	if n < 3 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"\n\n<system-reminder>\nYou have called %s with these exact arguments %d times and it failed every time. STOP retrying this call - the result will not change. Do not guess arguments: verify your assumptions first (e.g. for file paths, list the directory or search with Grep/Glob to see what actually exists), then take a different approach.\n</system-reminder>",
+		tc.Function.Name, n,
+	)
 }
 
 func (s *AgentServiceImpl) createErrorEntry(tc sdk.ChatCompletionMessageToolCall, err error, startTime time.Time) domain.ConversationEntry {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -698,8 +698,6 @@ func (s *AgentServiceImpl) RunWithStream(ctx context.Context, req *domain.AgentR
 		return nil, fmt.Errorf("execution is paused")
 	}
 
-	// Retry loops the repeated-failure breaker targets happen within a single
-	// run; resetting per run also keeps the map from growing across a session.
 	s.failedCallsMux.Lock()
 	clear(s.failedCalls)
 	s.failedCallsMux.Unlock()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1470,6 +1470,10 @@ func (s *AgentServiceImpl) trackRepeatedFailure(tc sdk.ChatCompletionMessageTool
 	s.failedCallsMux.Lock()
 	defer s.failedCallsMux.Unlock()
 
+	if s.failedCalls == nil {
+		s.failedCalls = make(map[string]int)
+	}
+
 	if entry.ToolExecution == nil || entry.ToolExecution.Success {
 		delete(s.failedCalls, key)
 		return ""

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -54,7 +54,6 @@ type AgentServiceImpl struct {
 	firedReminders map[string]bool
 	reminderMux    sync.Mutex
 
-	// ponytail: session-lifetime map of identical failing tool calls
 	// (name+args), reset per key on success; backs the retry-loop breaker
 	failedCalls    map[string]int
 	failedCallsMux sync.Mutex
@@ -698,6 +697,12 @@ func (s *AgentServiceImpl) RunWithStream(ctx context.Context, req *domain.AgentR
 		logger.Info("execution is paused, waiting for resume")
 		return nil, fmt.Errorf("execution is paused")
 	}
+
+	// Retry loops the repeated-failure breaker targets happen within a single
+	// run; resetting per run also keeps the map from growing across a session.
+	s.failedCallsMux.Lock()
+	clear(s.failedCalls)
+	s.failedCallsMux.Unlock()
 
 	chatEvents := make(chan domain.ChatEvent, 1000)
 	eventPublisher := newEventPublisher(req.RequestID, chatEvents)

--- a/internal/agent/agent_repeated_failure_test.go
+++ b/internal/agent/agent_repeated_failure_test.go
@@ -4,12 +4,13 @@ import (
 	"strings"
 	"testing"
 
-	domain "github.com/inference-gateway/cli/internal/domain"
 	sdk "github.com/inference-gateway/sdk"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
 )
 
 func TestTrackRepeatedFailure(t *testing.T) {
-	s := &AgentServiceImpl{failedCalls: make(map[string]int)}
+	s := &AgentServiceImpl{}
 	tc := sdk.ChatCompletionMessageToolCall{
 		Function: sdk.ChatCompletionMessageToolCallFunction{
 			Name:      "Read",

--- a/internal/agent/agent_repeated_failure_test.go
+++ b/internal/agent/agent_repeated_failure_test.go
@@ -31,14 +31,12 @@ func TestTrackRepeatedFailure(t *testing.T) {
 		t.Fatalf("3rd failure should warn, got: %q", note)
 	}
 
-	// different args = different key
 	tc2 := tc
 	tc2.Function.Arguments = `{"file_path":"/other.go"}`
 	if s.trackRepeatedFailure(tc2, failed) != "" {
 		t.Fatal("different args should start a fresh count")
 	}
 
-	// success resets
 	s.trackRepeatedFailure(tc, ok)
 	if s.trackRepeatedFailure(tc, failed) != "" {
 		t.Fatal("count should reset after success")

--- a/internal/agent/agent_repeated_failure_test.go
+++ b/internal/agent/agent_repeated_failure_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	sdk "github.com/inference-gateway/sdk"
+)
+
+func TestTrackRepeatedFailure(t *testing.T) {
+	s := &AgentServiceImpl{failedCalls: make(map[string]int)}
+	tc := sdk.ChatCompletionMessageToolCall{
+		Function: sdk.ChatCompletionMessageToolCallFunction{
+			Name:      "Read",
+			Arguments: `{"file_path":"/nope/reminders.go"}`,
+		},
+	}
+	failed := domain.ConversationEntry{ToolExecution: &domain.ToolExecutionResult{Success: false}}
+	ok := domain.ConversationEntry{ToolExecution: &domain.ToolExecutionResult{Success: true}}
+
+	if s.trackRepeatedFailure(tc, failed) != "" {
+		t.Fatal("1st failure should not warn")
+	}
+	if s.trackRepeatedFailure(tc, failed) != "" {
+		t.Fatal("2nd failure should not warn")
+	}
+	note := s.trackRepeatedFailure(tc, failed)
+	if !strings.Contains(note, "<system-reminder>") || !strings.Contains(note, "3 times") {
+		t.Fatalf("3rd failure should warn, got: %q", note)
+	}
+
+	// different args = different key
+	tc2 := tc
+	tc2.Function.Arguments = `{"file_path":"/other.go"}`
+	if s.trackRepeatedFailure(tc2, failed) != "" {
+		t.Fatal("different args should start a fresh count")
+	}
+
+	// success resets
+	s.trackRepeatedFailure(tc, ok)
+	if s.trackRepeatedFailure(tc, failed) != "" {
+		t.Fatal("count should reset after success")
+	}
+}


### PR DESCRIPTION
## Summary

Weak models can hallucinate a tool call (e.g. a guessed file path) and retry it verbatim forever. In [run 30960749987](https://github.com/inference-gateway/cli/actions/runs/30960749987) `deepseek-v4-flash` retried `Read internal/domain/reminders.go` (a non-existent file) 100+ times — 263 Read calls, 44% failure rate, 42.9M uncached prompt tokens — until the provider returned 400 on context overflow.

## Change

- Track identical failing tool calls (same tool name + exact arguments) in `AgentServiceImpl`, reset per key on success.
- From the 3rd identical failure on, append a `<system-reminder>` to the tool result telling the model to stop retrying and verify its assumptions (list/Grep/Glob for file paths) instead of guessing.
- Applied via a `defer` in `executeToolInternal` — the single choke point for both the standard and event-driven execution paths, so error entries and failed results are all covered, for every tool.

## Testing

- `TestTrackRepeatedFailure` covers the threshold, per-arguments keying, and reset-on-success.
- `task precommit:run` green.