### PR TITLE
fix(agent): finish_reason-aware continuation and todo-aware completion in headless loop

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -107,6 +107,8 @@ type AgentSession struct {
 	memoryBackend    domain.MemoryBackend
 	firedReminders   map[string]bool
 	lastToolFailed   bool
+	lastFinishReason string
+	latestTodos      []domain.TodoItem
 	saveEnabled      bool
 	bgWaiter         *services.BackgroundTasksWaiter
 	requireApproval  bool
@@ -548,11 +550,27 @@ func (s *AgentSession) execute(taskDescription string, files []string) error {
 
 		consecutiveNoToolCalls++
 
-		if consecutiveNoToolCalls >= 1 {
-			logger.Info("task appears complete (no more tool calls)", "turns", s.completedTurns)
-			completedNormally = true
-			break
+		if s.lastFinishReason == string(sdk.Length) {
+			logger.Warn("response truncated by token limit; continuing", "strike", consecutiveNoToolCalls)
+			s.addMessage(truncationContinuationMessage())
+			continue
 		}
+
+		incomplete := incompleteTodoItems(s.latestTodos)
+		if len(incomplete) > 0 && consecutiveNoToolCalls < 3 {
+			logger.Info("no tool calls but todos incomplete; nudging model to continue",
+				"incomplete", len(incomplete), "strike", consecutiveNoToolCalls, "finish_reason", s.lastFinishReason)
+			s.addMessage(todoContinuationMessage(incomplete))
+			continue
+		}
+
+		if len(incomplete) > 0 {
+			logger.Info("task stopped with incomplete todos", "turns", s.completedTurns, "incomplete", len(incomplete))
+		} else {
+			logger.Info("task appears complete (no more tool calls)", "turns", s.completedTurns, "finish_reason", s.lastFinishReason)
+		}
+		completedNormally = true
+		break
 	}
 
 	var sessionErr error
@@ -623,6 +641,50 @@ func (s *AgentSession) injectDrained(drained []services.DrainedMessage) int {
 
 	logger.Info("injected background task results into conversation", "count", len(drained))
 	return len(drained)
+}
+
+// incompleteTodoItems returns the todos not yet marked completed.
+func incompleteTodoItems(todos []domain.TodoItem) []domain.TodoItem {
+	var incomplete []domain.TodoItem
+	for _, t := range todos {
+		if t.Status != "completed" {
+			incomplete = append(incomplete, t)
+		}
+	}
+	return incomplete
+}
+
+// todoContinuationMessage is the headless loop's termination guard (#946): a
+// no-tool-call reply normally ends the session, but while the model's own todo
+// list still has open items the reply is treated as a stall, not completion.
+func todoContinuationMessage(incomplete []domain.TodoItem) ConversationMessage {
+	var items strings.Builder
+	for _, t := range incomplete {
+		fmt.Fprintf(&items, "- [%s] %s\n", t.Status, t.Content)
+	}
+	return ConversationMessage{
+		Role: "user",
+		Content: fmt.Sprintf(`<system-reminder>
+This is an automated check, not a message from the user. Your todo list still has incomplete items:
+%sYour last reply had no tool calls, which ends the session. Continue working on the next incomplete item now, using tool calls. If an item is already done or obsolete, update the list via TodoWrite (mark it completed or remove it) before stopping. Do not reply with prose only.
+</system-reminder>`, items.String()),
+		Timestamp: time.Now(),
+		Internal:  true,
+	}
+}
+
+// truncationContinuationMessage is injected when finish_reason is "length": the
+// reply was cut off by the token limit and may have swallowed a pending tool
+// call, so it is never treated as completion.
+func truncationContinuationMessage() ConversationMessage {
+	return ConversationMessage{
+		Role: "user",
+		Content: `<system-reminder>
+This is an automated check, not a message from the user. Your previous response was truncated by the token limit before any tool call was emitted. Continue where you left off: keep the reply short and re-issue the intended tool call.
+</system-reminder>`,
+		Timestamp: time.Now(),
+		Internal:  true,
+	}
 }
 
 // completionNotice distills a drained background-task result into a one-line
@@ -795,6 +857,8 @@ func (s *AgentSession) buildContentParts(msg ConversationMessage) []sdk.ContentP
 }
 
 func (s *AgentSession) processSyncResponse(response *domain.ChatSyncResponse, requestID string) error {
+	s.lastFinishReason = response.FinishReason
+
 	if response.Content == "" && len(response.ToolCalls) == 0 {
 		return nil
 	}
@@ -1282,6 +1346,12 @@ func (s *AgentSession) injectDueReminders(hook domain.HookPoint, turn int) {
 
 func (s *AgentSession) addMessage(msg ConversationMessage) {
 	s.conversation = append(s.conversation, msg)
+
+	if msg.ToolExecution != nil && msg.ToolExecution.Success {
+		if todoResult, ok := msg.ToolExecution.Data.(*domain.TodoWriteToolResult); ok {
+			s.latestTodos = todoResult.Todos
+		}
+	}
 
 	if s.saveEnabled && s.conversationRepo != nil {
 		entry := s.convertToConversationEntry(msg)

--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -1578,3 +1578,127 @@ func TestCompletionNotice(t *testing.T) {
 		})
 	}
 }
+
+func TestAddMessageCapturesTodoSnapshot(t *testing.T) {
+	todos := []domain.TodoItem{
+		{ID: "1", Content: "bump the sdk", Status: "completed"},
+		{ID: "2", Content: "wire modalities", Status: "in_progress"},
+	}
+
+	tests := []struct {
+		name      string
+		execution *domain.ToolExecutionResult
+		want      int
+	}{
+		{
+			name: "successful TodoWrite result captured",
+			execution: &domain.ToolExecutionResult{
+				ToolName: "TodoWrite",
+				Success:  true,
+				Data:     &domain.TodoWriteToolResult{Todos: todos},
+			},
+			want: 2,
+		},
+		{
+			name: "failed TodoWrite result ignored",
+			execution: &domain.ToolExecutionResult{
+				ToolName: "TodoWrite",
+				Success:  false,
+				Data:     &domain.TodoWriteToolResult{Todos: todos},
+			},
+			want: 0,
+		},
+		{
+			name: "non-todo tool result ignored",
+			execution: &domain.ToolExecutionResult{
+				ToolName: "Read",
+				Success:  true,
+				Data:     "file content",
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := &AgentSession{}
+			session.addMessage(ConversationMessage{
+				Role:          "tool",
+				Content:       "result",
+				ToolExecution: tt.execution,
+				Timestamp:     mockTime(),
+			})
+			if len(session.latestTodos) != tt.want {
+				t.Errorf("latestTodos = %d items, want %d", len(session.latestTodos), tt.want)
+			}
+		})
+	}
+}
+
+func TestIncompleteTodoItems(t *testing.T) {
+	tests := []struct {
+		name  string
+		todos []domain.TodoItem
+		want  int
+	}{
+		{"no todos", nil, 0},
+		{"all completed", []domain.TodoItem{
+			{ID: "1", Content: "a", Status: "completed"},
+			{ID: "2", Content: "b", Status: "completed"},
+		}, 0},
+		{"mixed statuses", []domain.TodoItem{
+			{ID: "1", Content: "a", Status: "completed"},
+			{ID: "2", Content: "b", Status: "in_progress"},
+			{ID: "3", Content: "c", Status: "pending"},
+		}, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := incompleteTodoItems(tt.todos); len(got) != tt.want {
+				t.Errorf("incompleteTodoItems = %d items, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestTodoContinuationMessage(t *testing.T) {
+	msg := todoContinuationMessage([]domain.TodoItem{
+		{ID: "1", Content: "wire modalities", Status: "in_progress"},
+		{ID: "2", Content: "open draft PR", Status: "pending"},
+	})
+
+	if msg.Role != "user" || !msg.Internal {
+		t.Errorf("nudge must be an internal user message, got role=%q internal=%v", msg.Role, msg.Internal)
+	}
+	for _, want := range []string{"<system-reminder>", "[in_progress] wire modalities", "[pending] open draft PR"} {
+		if !strings.Contains(msg.Content, want) {
+			t.Errorf("nudge content missing %q:\n%s", want, msg.Content)
+		}
+	}
+}
+
+func TestTruncationContinuationMessage(t *testing.T) {
+	msg := truncationContinuationMessage()
+	if msg.Role != "user" || !msg.Internal {
+		t.Errorf("truncation note must be an internal user message, got role=%q internal=%v", msg.Role, msg.Internal)
+	}
+	if !strings.Contains(msg.Content, "truncated by the token limit") {
+		t.Errorf("truncation note content unexpected:\n%s", msg.Content)
+	}
+}
+
+func TestProcessSyncResponseRecordsFinishReason(t *testing.T) {
+	session := &AgentSession{}
+
+	err := session.processSyncResponse(&domain.ChatSyncResponse{
+		RequestID:    "req_1",
+		FinishReason: "length",
+	}, "req_1")
+	if err != nil {
+		t.Fatalf("processSyncResponse: %v", err)
+	}
+	if session.lastFinishReason != "length" {
+		t.Errorf("lastFinishReason = %q, want %q (must be recorded even for empty responses)", session.lastFinishReason, "length")
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -520,7 +520,7 @@ func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*
 
 	duration := time.Since(startTime)
 
-	content, reasoningContent, toolCalls := extractFirstChoice(response)
+	content, reasoningContent, toolCalls, finishReason := extractFirstChoice(response)
 
 	effectiveUsage := s.storeIterationMetrics(timeoutCtx, req.RequestID, req.Model, startTime, response.Usage, &storeIterationMetricsInput{
 		inputMessages:   messages,
@@ -536,17 +536,18 @@ func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*
 		ToolCalls:        toolCalls,
 		Usage:            effectiveUsage,
 		Duration:         duration,
+		FinishReason:     finishReason,
 	}
 
 	return syncResponse, nil
 }
 
-// extractFirstChoice pulls content, reasoning, and tool calls from the first
-// choice of a non-streaming response. Reasoning preference matches the
-// streaming path in agent_streaming.go.
-func extractFirstChoice(response *sdk.CreateChatCompletionResponse) (string, string, []sdk.ChatCompletionMessageToolCall) {
+// extractFirstChoice pulls content, reasoning, tool calls, and finish reason
+// from the first choice of a non-streaming response. Reasoning preference
+// matches the streaming path in agent_streaming.go.
+func extractFirstChoice(response *sdk.CreateChatCompletionResponse) (string, string, []sdk.ChatCompletionMessageToolCall, string) {
 	if len(response.Choices) == 0 {
-		return "", "", nil
+		return "", "", nil, ""
 	}
 
 	choice := response.Choices[0]
@@ -569,7 +570,7 @@ func extractFirstChoice(response *sdk.CreateChatCompletionResponse) (string, str
 		toolCalls = *choice.Message.ToolCalls
 	}
 
-	return content, reasoning, toolCalls
+	return content, reasoning, toolCalls, string(choice.FinishReason)
 }
 
 // ensureConversationIntegrity enforces the OpenAI tool_call/response

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -306,6 +306,7 @@ type ChatSyncResponse struct {
 	ToolCalls        []sdk.ChatCompletionMessageToolCall `json:"tool_calls,omitempty"`
 	Usage            *sdk.CompletionUsage                `json:"usage,omitempty"`
 	Duration         time.Duration                       `json:"duration"`
+	FinishReason     string                              `json:"finish_reason,omitempty"`
 }
 
 // ChatService handles chat completion operations

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,6 +117,54 @@ func TestAgentTextOnlyTerminatesAfterOneTurn(t *testing.T) {
 	require.Len(t, reqs, 1)
 	require.Equal(t, "text-only", reqs[0].Scenario, "scenario must be text-only")
 	require.False(t, reqs[0].Stream, "headless agent uses the non-streaming path")
+}
+
+// TestAgentNudgesOnIncompleteTodos guards the todo-aware completion gate
+// (#946; regression via #994): a text-only reply while the model's own todo
+// list still has open items is a stall, not completion — the loop injects up
+// to two continuation nudges listing the open items before giving up. A run
+// with no todos (TestAgentTextOnlyTerminatesAfterOneTurn) still ends on the
+// first no-tool-call turn.
+func TestAgentNudgesOnIncompleteTodos(t *testing.T) {
+	defs, err := mockgateway.Load([]byte(`
+fallback:
+  content: "Done."
+scenarios:
+  - name: todo-stall
+    match: '(?i)^implement the vision feature'
+    turns:
+      - tool_calls:
+          - name: TodoWrite
+            args:
+              todos:
+                - { id: "1", content: "bump the sdk", status: "in_progress" }
+                - { id: "2", content: "wire modalities", status: "pending" }
+      - content: "Let me check the callers next."
+      - content: "Still reading the code."
+      - content: "Wrapping up."
+`))
+	require.NoError(t, err)
+	gw, url := harness.StartMock(t, defs)
+
+	stdout, code := runAgent(t, url, t.TempDir(), "implement the vision feature")
+	require.Zero(t, code)
+
+	reqs := gw.Requests()
+	require.Len(t, reqs, 4, "TodoWrite turn, text-only strike + nudge, nudged retry + nudge, final retry then break")
+
+	nudges := 0
+	for _, m := range reqs[3].Body.Messages {
+		text := m.Content.Text()
+		if strings.Contains(text, "todo list still has incomplete items") {
+			nudges++
+			require.Contains(t, text, "[pending] wire modalities", "nudge must list the open items verbatim")
+		}
+	}
+	require.Equal(t, 2, nudges, "exactly two continuation nudges before giving up")
+
+	stats := statusOfType(jsonLines(t, stdout), "session_stats")
+	require.NotNil(t, stats)
+	require.EqualValues(t, 4, stats["requests"])
 }
 
 func TestAgentMockModeNeedsOnlyOneEnvVar(t *testing.T) {


### PR DESCRIPTION
## Problem

The `@infer` run on #997 ([run 30964470394](https://github.com/inference-gateway/cli/actions/runs/30964470394)) ended "Stopped early" with exit 0 and 5 of 6 todos untouched: deepseek-v4-flash replied *"Let me check the callers of BuildSystemPrompt..."* — text only, no tool calls — and the headless loop terminated on the spot.

Root cause chain:

- `cmd/agent.go` breaks the session loop on the **first** no-tool-call turn (`consecutiveNoToolCalls >= 1`) — a regression from #994 (which removed the unconditional verify nudge to fix the #993 double-reply, but took the second chance with it).
- #946 reported this todo-blind completion heuristic earlier and was closed without code landing.
- The CLI ignored `finish_reason` entirely, so a reply truncated by the token limit (`length`) — which can swallow the tool call the model was about to emit — was indistinguishable from a deliberate stop.

## Fix

`finish_reason` is the primary signal, the model's own todo list is the backstop:

| No-tool-call turn with… | Action |
|---|---|
| `finish_reason: length` | Never completion — inject a truncation note and continue |
| deliberate stop + incomplete todos | Inject a nudge listing the open items verbatim, max 2 per stall, then break with a `task stopped with incomplete todos` log |
| deliberate stop + no todos / all complete | Break on the first turn — unchanged ReAct stop, #993 stays fixed |

- `FinishReason` threaded through `domain.ChatSyncResponse` from the first choice (sync path; headless is sync-only).
- Latest `TodoWrite` snapshot tracked on `AgentSession` via the `addMessage` funnel (headless previously had no todo state at all — the `publishTodoUpdate` consumers are all chat-UI).
- The nudge is *conditional termination logic* gated on loop + todo state, not a revival of the unconditional reminder #993/#994 removed; the reminders framework stays the home for unconditional injection.
- `--max-turns` remains the hard ceiling on every path; exit code stays 0 at the nudge cap, so infer-action's `incompleteTodos` detection remains the reporting safety net.

## Tests

- Unit: todo snapshot capture, `incompleteTodoItems`, both continuation messages, finish_reason recording (incl. empty responses).
- E2E: new `TestAgentNudgesOnIncompleteTodos` (custom multi-step mock scenario: TodoWrite with open items, then three text-only turns → asserts 4 requests, exactly 2 nudges listing the items, exit 0). Existing `TestAgentTextOnlyTerminatesAfterOneTurn` (#993 guard) stays green.
- The mock can't fake `finish_reason: length` (tokenless v0.1.2 hardcodes stop/tool_calls), so the truncation path is unit-tested; scenario-configurable finish_reason in tokenless is a possible follow-up.

## Cross-repo impact

CLI only. infer-action unchanged. Optional follow-up: `inference-gateway/tokenless` scenario-configurable `finish_reason`.

no docs ticket: internal-only behavior fix

Fixes #946
Related: #997 (repro), #994 / #993 (regression source)