### PR TITLE
feat(agent): stream ag-ui reasoning and content deltas

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -715,12 +715,62 @@ func (s *AgentSession) executeTurn() error {
 		Messages:  messages,
 	}
 
+	if agui != nil {
+		return s.executeStreamingTurn(ctx, req, requestID)
+	}
+
 	response, err := s.agentService.Run(ctx, req)
 	if err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 
 	return s.processSyncResponse(response, requestID)
+}
+
+// executeStreamingTurn runs one model turn with token-level streaming and emits
+// AG-UI reasoning/text deltas as they arrive, then processes the assembled
+// response (persistence + tool execution) without re-emitting the streamed
+// text. Only used in AG-UI output mode.
+func (s *AgentSession) executeStreamingTurn(ctx context.Context, req *domain.AgentRequest, requestID string) error {
+	msgID := requestID
+	reasoningOpen := false
+	textOpen := false
+
+	onDelta := func(content, reasoning string, _ []sdk.ChatCompletionMessageToolCallChunk) {
+		if reasoning != "" {
+			if !reasoningOpen {
+				agui.emitReasoningStart(msgID)
+				reasoningOpen = true
+			}
+			agui.emitReasoningDelta(msgID, reasoning)
+		}
+		if content != "" {
+			if reasoningOpen {
+				agui.emitReasoningEnd(msgID)
+				reasoningOpen = false
+			}
+			if !textOpen {
+				agui.emitTextStart(msgID)
+				textOpen = true
+			}
+			agui.emitTextDelta(msgID, content)
+		}
+	}
+
+	response, err := s.agentService.RunStreaming(ctx, req, onDelta)
+
+	if reasoningOpen {
+		agui.emitReasoningEnd(msgID)
+	}
+	if textOpen {
+		agui.emitTextEnd(msgID)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to send message: %w", err)
+	}
+
+	return s.processStreamedResponse(response, requestID)
 }
 
 func (s *AgentSession) buildSDKMessages() []sdk.Message {
@@ -802,6 +852,29 @@ func (s *AgentSession) toolImagesFollowUpMessage(images []domain.ImageAttachment
 }
 
 func (s *AgentSession) processSyncResponse(response *domain.ChatSyncResponse, requestID string) error {
+	return s.applyResponse(response, requestID, s.outputMessage)
+}
+
+// processStreamedResponse handles a response whose text and reasoning were
+// already streamed as AG-UI deltas: it persists and executes the same way as
+// the sync path but only emits the assistant message's tool calls (the text was
+// already sent).
+func (s *AgentSession) processStreamedResponse(response *domain.ChatSyncResponse, requestID string) error {
+	return s.applyResponse(response, requestID, func(msg ConversationMessage) {
+		if agui != nil {
+			agui.emitToolCalls(msg)
+		}
+	})
+}
+
+// applyResponse records the assistant message, emits it via emitAssistant, and
+// executes any tool calls. The sync and streamed paths differ only in how the
+// assistant message reaches the output (whole message vs. tool calls only).
+func (s *AgentSession) applyResponse(
+	response *domain.ChatSyncResponse,
+	requestID string,
+	emitAssistant func(ConversationMessage),
+) error {
 	s.lastFinishReason = response.FinishReason
 
 	if response.Content == "" && len(response.ToolCalls) == 0 {
@@ -822,7 +895,7 @@ func (s *AgentSession) processSyncResponse(response *domain.ChatSyncResponse, re
 	}
 
 	s.addMessage(assistantMsg)
-	s.outputMessage(assistantMsg)
+	emitAssistant(assistantMsg)
 
 	if len(response.ToolCalls) == 0 {
 		return nil

--- a/cmd/agent_agui.go
+++ b/cmd/agent_agui.go
@@ -152,3 +152,54 @@ func (e *aguiEncoder) emitRunError(message string) {
 	}
 	e.emit(aguievents.NewRunErrorEvent(message, opts...))
 }
+
+// --- Streaming emit points ---
+//
+// When `infer agent --output-format ag-ui` streams a model turn (see
+// executeStreamingTurn in agent.go), text and reasoning arrive token by token.
+// These helpers emit the AG-UI START/CONTENT/END triads incrementally so a
+// client renders the answer and the thinking as they are generated, instead of
+// one full message per turn via emitMessage.
+
+func (e *aguiEncoder) emitTextStart(messageID string) {
+	e.emit(aguievents.NewTextMessageStartEvent(messageID, aguievents.WithRole("assistant")))
+}
+
+func (e *aguiEncoder) emitTextDelta(messageID, delta string) {
+	e.emit(aguievents.NewTextMessageContentEvent(messageID, delta))
+}
+
+func (e *aguiEncoder) emitTextEnd(messageID string) {
+	e.emit(aguievents.NewTextMessageEndEvent(messageID))
+}
+
+func (e *aguiEncoder) emitReasoningStart(messageID string) {
+	e.emit(aguievents.NewReasoningMessageStartEvent(messageID, "assistant"))
+}
+
+func (e *aguiEncoder) emitReasoningDelta(messageID, delta string) {
+	e.emit(aguievents.NewReasoningMessageContentEvent(messageID, delta))
+}
+
+func (e *aguiEncoder) emitReasoningEnd(messageID string) {
+	e.emit(aguievents.NewReasoningMessageEndEvent(messageID))
+}
+
+// emitToolCalls emits only the tool-call triads of an assistant message. The
+// streaming path uses it after the turn: text and reasoning were already
+// streamed as deltas, but the turn's tool calls still need to reach the client.
+// ponytail: tool-call arguments are emitted whole, not token-streamed - args
+// are JSON with no rendering benefit from streaming. Stream them per-delta if a
+// client ever needs live arg preview.
+func (e *aguiEncoder) emitToolCalls(msg ConversationMessage) {
+	if msg.ToolCalls == nil {
+		return
+	}
+	for _, tc := range *msg.ToolCalls {
+		e.emit(aguievents.NewToolCallStartEvent(tc.ID, tc.Function.Name))
+		if tc.Function.Arguments != "" {
+			e.emit(aguievents.NewToolCallArgsEvent(tc.ID, tc.Function.Arguments))
+		}
+		e.emit(aguievents.NewToolCallEndEvent(tc.ID))
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -463,7 +463,25 @@ func (s *AgentServiceImpl) SetMemoryBackend(backend domain.MemoryBackend) {
 }
 
 // Run executes an agent task synchronously (for background/batch processing)
-func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*domain.ChatSyncResponse, error) {
+// turnOutput is the assembled result of a single model turn, produced by the
+// sync or streaming executor passed to runTurn.
+type turnOutput struct {
+	content      string
+	reasoning    string
+	toolCalls    []sdk.ChatCompletionMessageToolCall
+	finishReason string
+	usage        *sdk.CompletionUsage
+}
+
+// turnExec issues the actual model call (sync or streaming) against a prepared
+// client and returns the assembled output.
+type turnExec func(ctx context.Context, client sdk.Client, provider sdk.Provider, model string, messages []sdk.Message) (turnOutput, error)
+
+// runTurn wraps a single model turn with the shared preamble/postamble - message
+// prep, timeout + span, client + tool construction, metrics, response assembly -
+// and delegates the model call itself to exec. Run and RunStreaming differ only
+// in exec (and whether streaming usage is requested).
+func (s *AgentServiceImpl) runTurn(ctx context.Context, req *domain.AgentRequest, stream bool, exec turnExec) (*domain.ChatSyncResponse, error) {
 	if err := s.validateRequest(req); err != nil {
 		return nil, err
 	}
@@ -486,68 +504,182 @@ func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*
 
 	startTime := time.Now()
 
-	var availableTools []sdk.ChatCompletionTool
-
-	response, err := func(timeoutCtx context.Context, model string, messages []sdk.Message) (*sdk.CreateChatCompletionResponse, error) {
-		provider, modelName, err := s.parseProvider(model)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse provider from model '%s': %w", model, err)
-		}
-
-		providerType := sdk.Provider(provider)
-
-		client := s.client.WithOptions(&sdk.CreateChatCompletionRequest{
-			MaxTokens:       &s.maxTokens,
-			ReasoningEffort: s.reasoningEffortOptionFor(model),
-		}).
-			WithMiddlewareOptions(&sdk.MiddlewareOptions{
-				SkipMCP: true,
-			})
-		if s.toolService != nil {
-			mode := domain.AgentModeStandard
-			if s.stateManager != nil {
-				mode = s.stateManager.GetAgentMode()
-			}
-			availableTools = s.toolService.ListToolsForMode(mode)
-			if len(availableTools) > 0 {
-				client = client.WithTools(&availableTools)
-			}
-		}
-
-		response, err := client.GenerateContent(timeoutCtx, providerType, modelName, messages)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate content: %w", err)
-		}
-
-		return response, nil
-	}(timeoutCtx, req.Model, messages)
+	provider, modelName, err := s.parseProvider(req.Model)
 	if err != nil {
-		telemetry.SetSpanError(timeoutCtx, err)
-		return nil, fmt.Errorf("failed to generate content: %w", err)
+		return nil, fmt.Errorf("failed to parse provider from model '%s': %w", req.Model, err)
 	}
 
-	duration := time.Since(startTime)
+	opts := &sdk.CreateChatCompletionRequest{
+		MaxTokens:       &s.maxTokens,
+		ReasoningEffort: s.reasoningEffortOptionFor(req.Model),
+	}
+	if stream {
+		opts.StreamOptions = &sdk.ChatCompletionStreamOptions{IncludeUsage: true}
+	}
+	client := s.client.WithOptions(opts).WithMiddlewareOptions(&sdk.MiddlewareOptions{SkipMCP: true})
 
-	content, reasoningContent, toolCalls, finishReason := extractFirstChoice(response)
+	var availableTools []sdk.ChatCompletionTool
+	if s.toolService != nil {
+		mode := domain.AgentModeStandard
+		if s.stateManager != nil {
+			mode = s.stateManager.GetAgentMode()
+		}
+		availableTools = s.toolService.ListToolsForMode(mode)
+		if len(availableTools) > 0 {
+			client = client.WithTools(&availableTools)
+		}
+	}
 
-	effectiveUsage := s.storeIterationMetrics(timeoutCtx, req.RequestID, req.Model, startTime, response.Usage, &storeIterationMetricsInput{
+	out, err := exec(timeoutCtx, client, sdk.Provider(provider), modelName, messages)
+	if err != nil {
+		telemetry.SetSpanError(timeoutCtx, err)
+		return nil, err
+	}
+
+	effectiveUsage := s.storeIterationMetrics(timeoutCtx, req.RequestID, req.Model, startTime, out.usage, &storeIterationMetricsInput{
 		inputMessages:   messages,
-		outputContent:   content,
-		outputToolCalls: toolCalls,
+		outputContent:   out.content,
+		outputToolCalls: out.toolCalls,
 		availableTools:  availableTools,
 	})
 
-	syncResponse := &domain.ChatSyncResponse{
+	return &domain.ChatSyncResponse{
 		RequestID:        req.RequestID,
-		Content:          content,
-		ReasoningContent: reasoningContent,
-		ToolCalls:        toolCalls,
+		Content:          out.content,
+		ReasoningContent: out.reasoning,
+		ToolCalls:        out.toolCalls,
 		Usage:            effectiveUsage,
-		Duration:         duration,
-		FinishReason:     finishReason,
-	}
+		Duration:         time.Since(startTime),
+		FinishReason:     out.finishReason,
+	}, nil
+}
 
-	return syncResponse, nil
+func (s *AgentServiceImpl) Run(ctx context.Context, req *domain.AgentRequest) (*domain.ChatSyncResponse, error) {
+	return s.runTurn(ctx, req, false, func(ctx context.Context, client sdk.Client, provider sdk.Provider, model string, messages []sdk.Message) (turnOutput, error) {
+		response, err := client.GenerateContent(ctx, provider, model, messages)
+		if err != nil {
+			return turnOutput{}, fmt.Errorf("failed to generate content: %w", err)
+		}
+		content, reasoning, toolCalls, finishReason := extractFirstChoice(response)
+		return turnOutput{
+			content:      content,
+			reasoning:    reasoning,
+			toolCalls:    toolCalls,
+			finishReason: finishReason,
+			usage:        response.Usage,
+		}, nil
+	})
+}
+
+// RunStreaming executes a single model turn with streaming, invoking onDelta for
+// each content/reasoning/tool-call delta as it arrives, and returns the same
+// assembled ChatSyncResponse as Run. It is the streaming counterpart of Run for
+// callers that own their own agentic loop (the headless AG-UI agent) and want
+// token-level output without adopting the full EventDrivenAgent. onDelta may be
+// nil.
+func (s *AgentServiceImpl) RunStreaming(
+	ctx context.Context,
+	req *domain.AgentRequest,
+	onDelta func(content, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk),
+) (*domain.ChatSyncResponse, error) {
+	return s.runTurn(ctx, req, true, func(ctx context.Context, client sdk.Client, provider sdk.Provider, model string, messages []sdk.Message) (turnOutput, error) {
+		events, err := client.GenerateContentStream(ctx, provider, model, messages)
+		if err != nil {
+			return turnOutput{}, fmt.Errorf("failed to generate content stream: %w", err)
+		}
+
+		s.clearToolCallsMap()
+
+		var acc streamAccumulator
+		for streaming := true; streaming; {
+			select {
+			case <-ctx.Done():
+				return turnOutput{}, fmt.Errorf("failed to generate content stream: %w", ctx.Err())
+			case event, ok := <-events:
+				if ok {
+					acc.ingest(event, onDelta)
+				} else {
+					streaming = false
+				}
+			}
+		}
+
+		s.accumulateToolCalls(acc.toolDeltas)
+		accumulated := s.getAccumulatedToolCalls()
+		toolCalls := make([]sdk.ChatCompletionMessageToolCall, 0, len(accumulated))
+		for _, tc := range accumulated {
+			toolCalls = append(toolCalls, *tc)
+		}
+
+		return turnOutput{
+			content:      acc.content.String(),
+			reasoning:    acc.reasoning.String(),
+			toolCalls:    toolCalls,
+			finishReason: acc.finishReason,
+			usage:        acc.usage,
+		}, nil
+	})
+}
+
+// streamAccumulator folds streaming SSE events into the assembled content,
+// reasoning, tool-call deltas, usage, and finish reason for one model turn.
+type streamAccumulator struct {
+	content      strings.Builder
+	reasoning    strings.Builder
+	toolDeltas   []sdk.ChatCompletionMessageToolCallChunk
+	usage        *sdk.CompletionUsage
+	finishReason string
+}
+
+// ingest folds one SSE event in, invoking onDelta (may be nil) for each
+// non-empty content/reasoning/tool-call delta.
+func (a *streamAccumulator) ingest(
+	event sdk.SSEvent,
+	onDelta func(content, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk),
+) {
+	if event.Event == nil || event.Data == nil {
+		return
+	}
+	switch string(*event.Event) {
+	case "message_stop", "system_init", "hook_event", "tool_failure", "result_metadata":
+		return
+	}
+	var streamResponse sdk.CreateChatCompletionStreamResponse
+	if err := json.Unmarshal(*event.Data, &streamResponse); err != nil {
+		logger.Error("failed to unmarshal chat completion stream response", "error", err)
+		return
+	}
+	if streamResponse.Usage != nil {
+		a.usage = streamResponse.Usage
+	}
+	for _, choice := range streamResponse.Choices {
+		a.ingestChoice(choice, onDelta)
+	}
+}
+
+func (a *streamAccumulator) ingestChoice(
+	choice sdk.ChatCompletionStreamChoice,
+	onDelta func(content, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk),
+) {
+	deltaContent := choice.Delta.Content
+	if deltaContent != "" {
+		a.content.WriteString(deltaContent)
+	}
+	reasoning := extractReasoningForEvent(choice.Delta)
+	if reasoning != "" {
+		a.reasoning.WriteString(reasoning)
+	}
+	var toolCalls []sdk.ChatCompletionMessageToolCallChunk
+	if choice.Delta.ToolCalls != nil {
+		toolCalls = *choice.Delta.ToolCalls
+		a.toolDeltas = append(a.toolDeltas, toolCalls...)
+	}
+	if choice.FinishReason != "" {
+		a.finishReason = string(choice.FinishReason)
+	}
+	if onDelta != nil && (deltaContent != "" || reasoning != "" || len(toolCalls) > 0) {
+		onDelta(deltaContent, reasoning, toolCalls)
+	}
 }
 
 // extractFirstChoice pulls content, reasoning, tool calls, and finish reason

--- a/internal/domain/agent.go
+++ b/internal/domain/agent.go
@@ -97,6 +97,12 @@ type AgentService interface {
 	// RunWithStream executes an agent task with streaming (for interactive chat)
 	RunWithStream(ctx context.Context, req *AgentRequest) (<-chan ChatEvent, error)
 
+	// RunStreaming executes a single model turn with streaming, invoking onDelta
+	// for each content/reasoning/tool-call delta, and returns the assembled
+	// response like Run. For callers that own their own agentic loop (the
+	// headless AG-UI agent) but want token-level output. onDelta may be nil.
+	RunStreaming(ctx context.Context, req *AgentRequest, onDelta func(content, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk)) (*ChatSyncResponse, error)
+
 	// CancelRequest cancels an active request
 	CancelRequest(requestID string) error
 

--- a/tests/mocks/domain/fake_agent_service.go
+++ b/tests/mocks/domain/fake_agent_service.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/inference-gateway/cli/internal/domain"
+	"github.com/inference-gateway/sdk"
 )
 
 type FakeAgentService struct {
@@ -62,6 +63,21 @@ type FakeAgentService struct {
 		result2 error
 	}
 	runReturnsOnCall map[int]struct {
+		result1 *domain.ChatSyncResponse
+		result2 error
+	}
+	RunStreamingStub        func(context.Context, *domain.AgentRequest, func(content string, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk)) (*domain.ChatSyncResponse, error)
+	runStreamingMutex       sync.RWMutex
+	runStreamingArgsForCall []struct {
+		arg1 context.Context
+		arg2 *domain.AgentRequest
+		arg3 func(content string, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk)
+	}
+	runStreamingReturns struct {
+		result1 *domain.ChatSyncResponse
+		result2 error
+	}
+	runStreamingReturnsOnCall map[int]struct {
 		result1 *domain.ChatSyncResponse
 		result2 error
 	}
@@ -382,6 +398,72 @@ func (fake *FakeAgentService) RunReturnsOnCall(i int, result1 *domain.ChatSyncRe
 		})
 	}
 	fake.runReturnsOnCall[i] = struct {
+		result1 *domain.ChatSyncResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAgentService) RunStreaming(arg1 context.Context, arg2 *domain.AgentRequest, arg3 func(content string, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk)) (*domain.ChatSyncResponse, error) {
+	fake.runStreamingMutex.Lock()
+	ret, specificReturn := fake.runStreamingReturnsOnCall[len(fake.runStreamingArgsForCall)]
+	fake.runStreamingArgsForCall = append(fake.runStreamingArgsForCall, struct {
+		arg1 context.Context
+		arg2 *domain.AgentRequest
+		arg3 func(content string, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk)
+	}{arg1, arg2, arg3})
+	stub := fake.RunStreamingStub
+	fakeReturns := fake.runStreamingReturns
+	fake.recordInvocation("RunStreaming", []interface{}{arg1, arg2, arg3})
+	fake.runStreamingMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAgentService) RunStreamingCallCount() int {
+	fake.runStreamingMutex.RLock()
+	defer fake.runStreamingMutex.RUnlock()
+	return len(fake.runStreamingArgsForCall)
+}
+
+func (fake *FakeAgentService) RunStreamingCalls(stub func(context.Context, *domain.AgentRequest, func(content string, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk)) (*domain.ChatSyncResponse, error)) {
+	fake.runStreamingMutex.Lock()
+	defer fake.runStreamingMutex.Unlock()
+	fake.RunStreamingStub = stub
+}
+
+func (fake *FakeAgentService) RunStreamingArgsForCall(i int) (context.Context, *domain.AgentRequest, func(content string, reasoning string, toolCalls []sdk.ChatCompletionMessageToolCallChunk)) {
+	fake.runStreamingMutex.RLock()
+	defer fake.runStreamingMutex.RUnlock()
+	argsForCall := fake.runStreamingArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeAgentService) RunStreamingReturns(result1 *domain.ChatSyncResponse, result2 error) {
+	fake.runStreamingMutex.Lock()
+	defer fake.runStreamingMutex.Unlock()
+	fake.RunStreamingStub = nil
+	fake.runStreamingReturns = struct {
+		result1 *domain.ChatSyncResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAgentService) RunStreamingReturnsOnCall(i int, result1 *domain.ChatSyncResponse, result2 error) {
+	fake.runStreamingMutex.Lock()
+	defer fake.runStreamingMutex.Unlock()
+	fake.RunStreamingStub = nil
+	if fake.runStreamingReturnsOnCall == nil {
+		fake.runStreamingReturnsOnCall = make(map[int]struct {
+			result1 *domain.ChatSyncResponse
+			result2 error
+		})
+	}
+	fake.runStreamingReturnsOnCall[i] = struct {
 		result1 *domain.ChatSyncResponse
 		result2 error
 	}{result1, result2}


### PR DESCRIPTION
## Summary

Headless `infer agent --output-format ag-ui` now streams a model turn token by token instead of emitting one full message per turn, and it surfaces model reasoning that was previously dropped.

Builds on #1034 (ag-ui output format). Consumers (e.g. the desktop app) can now render live content and a live thinking/reasoning stream.

## Changes

- **`RunStreaming` (single streaming turn):** new `AgentService.RunStreaming` built on the SDK's `GenerateContentStream`. Returns the same `ChatSyncResponse` as `Run` while invoking an `onDelta` callback per content/reasoning/tool-call delta - so the headless `AgentSession` keeps ownership of tool execution, approvals, and looping (no `EventDrivenAgent` adoption).
- **Streamed AG-UI events:** the encoder emits `REASONING_MESSAGE_*` for reasoning and per-delta `TEXT_MESSAGE_*` for content; tool calls are emitted at turn end via `emitToolCalls`.
- **`executeTurn`** streams in ag-ui mode via `executeStreamingTurn`; the plain-JSON sync path is unchanged. `processSyncResponse` / `processStreamedResponse` share a single `applyResponse` helper.
- Regenerated the `AgentService` counterfeiter fake for the new interface method.

## Verification

- `go build ./...`, `task lint` (0 issues), and `go test ./internal/agent/... ./cmd/...` pass.
- Raw AG-UI stream check (mock, reasoning scenario): stdout now carries `REASONING_MESSAGE_START/CONTENT/END` plus multiple `TEXT_MESSAGE_CONTENT` deltas, in reasoning-then-text order.