### PR TITLE
feat(daemon): decouple scheduler from channels and persist run records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,7 +1048,7 @@ export INFER_CHANNELS_TELEGRAM_ALLOWED_USERS="123456789"
 **4. Start the channel listener:**
 
 ```bash
-infer channels-manager
+infer daemon
 ```
 
 **5. Send a message** to your bot in Telegram - the agent will respond.
@@ -1094,9 +1094,10 @@ For detailed documentation including custom channel development, see [Channels D
 
 ### Scheduled Tasks
 
-When the channels-manager daemon is running, you can ask the bot to schedule
-prompts on a cron schedule. The agent's response is delivered back through
-the originating channel (e.g. the Telegram chat where you set it up).
+When the daemon is running, the agent can schedule prompts on a cron
+schedule. Every fire runs an agent and records the run to storage; jobs
+created from a channel chat (e.g. Telegram) additionally deliver the
+response back through that channel.
 
 > *"Send me an inspiring quote every day at 8 AM"* - recurring
 > *"Remind me at 6pm today to call mum"* - one-off (deletes itself after firing)
@@ -1128,7 +1129,7 @@ walkthroughs, see [Scheduling Documentation](docs/scheduling.md).
 Heartbeat wakes the agent on a fixed interval - without any user input -
 so it can check for pending todos, background tasks, or anything else
 your system prompt tells it to monitor. It runs alongside the scheduler
-inside the `infer channels-manager` daemon and is **disabled by default**.
+inside the `infer daemon` process and is **disabled by default**.
 
 Unlike the [Schedule](docs/scheduling.md) tool (which the LLM uses to
 create user-driven cron jobs that deliver to a channel), heartbeat is a
@@ -1154,7 +1155,7 @@ wake-up behaviour separately from chat-mode behaviour.
 Then start the daemon:
 
 ```bash
-infer channels-manager
+infer daemon
 ```
 
 Heartbeat alone is a valid run mode - you don't need any channel

--- a/cmd/conversation_title.go
+++ b/cmd/conversation_title.go
@@ -99,7 +99,7 @@ var statusTitlesCmd = &cobra.Command{
 	},
 }
 
-var daemonCmd = &cobra.Command{
+var titleDaemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Run conversation title generation daemon",
 	Long:  `Run the background job manager as a daemon to continuously generate titles for conversations.`,
@@ -141,6 +141,6 @@ var daemonCmd = &cobra.Command{
 func init() {
 	conversationTitleCmd.AddCommand(generateTitlesCmd)
 	conversationTitleCmd.AddCommand(statusTitlesCmd)
-	conversationTitleCmd.AddCommand(daemonCmd)
+	conversationTitleCmd.AddCommand(titleDaemonCmd)
 	rootCmd.AddCommand(conversationTitleCmd)
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -52,6 +52,10 @@ Examples:
   INFER_CHANNELS_TELEGRAM_ALLOWED_USERS="123456789" \
   infer daemon`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Dedicated log file: the scheduler's headless subprocesses share this
+		// cwd and write app-<date>.log, so the daemon gets its own.
+		loggerCfg.FilePrefix = "daemon"
+		logger.Init(loggerCfg)
 		return RunDaemonCommand(Cfg)
 	},
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -52,9 +52,8 @@ Examples:
   INFER_CHANNELS_TELEGRAM_ALLOWED_USERS="123456789" \
   infer daemon`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Dedicated log file: the scheduler's headless subprocesses share this
-		// cwd and write app-<date>.log, so the daemon gets its own.
 		loggerCfg.FilePrefix = "daemon"
+		loggerCfg.Stdout = true
 		logger.Init(loggerCfg)
 		return RunDaemonCommand(Cfg)
 	},

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -52,6 +55,11 @@ Examples:
   INFER_CHANNELS_TELEGRAM_ALLOWED_USERS="123456789" \
   infer daemon`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if V.GetString("logging.dir") == "" {
+			if home, err := os.UserHomeDir(); err == nil {
+				loggerCfg.LogDir = filepath.Join(home, config.ConfigDirName, config.LogsDirName)
+			}
+		}
 		loggerCfg.FilePrefix = "daemon"
 		loggerCfg.Stdout = true
 		logger.Init(loggerCfg)
@@ -67,6 +75,12 @@ func RunDaemonCommand(cfg *config.Config) error {
 	if !cfg.Channels.Enabled && !cfg.Tools.Schedule.Enabled && !cfg.Heartbeat.Enabled {
 		return fmt.Errorf("nothing to run: enable at least one of channels, scheduler, or heartbeat in .infer/")
 	}
+
+	release, err := acquireDaemonLock()
+	if err != nil {
+		return err
+	}
+	defer release()
 
 	telemetry.ExecutionMode = telemetry.ExecDaemon
 	sessionID := domain.GenerateSessionID()
@@ -164,6 +178,30 @@ func RunDaemonCommand(cfg *config.Config) error {
 
 // startScheduler initialises the schedule scheduler service when the schedule
 // tool is enabled. Returns nil scheduler when disabled.
+// acquireDaemonLock enforces one daemon per machine via a PID file in
+// ~/.infer/run/daemon.pid (next to gateway.pid). Stale files (dead PID) are
+// overwritten. The returned release func removes the file.
+// ponytail: check-then-write race; flock if two daemons ever start in the same instant.
+func acquireDaemonLock() (func(), error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return func() {}, nil
+	}
+	pidPath := filepath.Join(home, config.ConfigDirName, "run", "daemon.pid")
+	if data, err := os.ReadFile(pidPath); err == nil {
+		if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid != os.Getpid() && services.ProcessAlive(pid) {
+			return nil, fmt.Errorf("daemon already running (pid %d); stop it or remove %s", pid, pidPath)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
+		return nil, err
+	}
+	return func() { _ = os.Remove(pidPath) }, nil
+}
+
 func startScheduler(ctx context.Context, cm *services.ChannelManagerService, cfg *config.Config) (*scheduler.Service, error) {
 	if !cfg.Tools.Schedule.Enabled {
 		return nil, nil

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -22,40 +22,45 @@ import (
 	cobra "github.com/spf13/cobra"
 )
 
-var channelsCmd = &cobra.Command{
-	Use:   "channels-manager",
-	Short: "Start the channel listener for remote messaging platforms",
-	Long: `Start a long-running daemon that listens for messages from external platforms
-(e.g., Telegram) and triggers the agent for each incoming message.
+var daemonCmd = &cobra.Command{
+	Use:   "daemon",
+	Short: "Start the background daemon: scheduler, channels, and heartbeat",
+	Long: `Start a long-running daemon hosting up to three subsystems, whichever are
+enabled in config:
 
-Each message spawns a new agent invocation with a deterministic session ID per sender,
-so conversations persist across messages. The agent runs autonomously, and the response
-is sent back through the originating channel.
+  - scheduler:  fires scheduled jobs (tools.schedule.enabled); each fire runs an
+    agent and records the run to storage, so job output is consumable even
+    without a delivery channel
+  - channels:   listens for messages from external platforms (e.g., Telegram)
+    and triggers the agent for each incoming message; also delivers scheduled
+    job output to the job's channel
+  - heartbeat:  periodic agent wake-ups (heartbeat.enabled)
 
-Configuration is done via .infer/channels.yaml (seeded by 'infer init') or
-INFER_CHANNELS_* environment variables. The legacy 'channels:' block in
-config.yaml is no longer read - re-run 'infer init' to migrate it.
+Each channel message spawns a new agent invocation with a deterministic session
+ID per sender, so conversations persist across messages. Channel configuration
+lives in .infer/channels.yaml (seeded by 'infer init') or INFER_CHANNELS_*
+environment variables.
 
 Examples:
-  # Start listening for Telegram messages
-  infer channels-manager
+  # Start the daemon (scheduler and/or channels, per config)
+  infer daemon
 
   # With environment variables
   INFER_CHANNELS_ENABLED=true \
   INFER_CHANNELS_TELEGRAM_ENABLED=true \
   INFER_CHANNELS_TELEGRAM_BOT_TOKEN="your-token" \
   INFER_CHANNELS_TELEGRAM_ALLOWED_USERS="123456789" \
-  infer channels-manager`,
+  infer daemon`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return RunChannelsCommand(Cfg)
+		return RunDaemonCommand(Cfg)
 	},
 }
 
-// RunChannelsCommand starts the channel listener daemon. The daemon
-// hosts up to three subsystems - channels, scheduler, and heartbeat -
-// and starts whichever are enabled. At least one must be enabled or
-// the daemon refuses to boot (otherwise it would just sleep forever).
-func RunChannelsCommand(cfg *config.Config) error {
+// RunDaemonCommand starts the daemon. It hosts up to three subsystems -
+// channels, scheduler, and heartbeat - and starts whichever are enabled. At
+// least one must be enabled or the daemon refuses to boot (otherwise it would
+// just sleep forever).
+func RunDaemonCommand(cfg *config.Config) error {
 	if !cfg.Channels.Enabled && !cfg.Tools.Schedule.Enabled && !cfg.Heartbeat.Enabled {
 		return fmt.Errorf("nothing to run: enable at least one of channels, scheduler, or heartbeat in .infer/")
 	}
@@ -86,7 +91,7 @@ func RunChannelsCommand(cfg *config.Config) error {
 		}
 	}
 
-	logger.Info("starting channels-manager", "version", version)
+	logger.Info("starting daemon", "version", version)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -170,9 +175,11 @@ func startScheduler(ctx context.Context, cm *services.ChannelManagerService, cfg
 		return nil, fmt.Errorf("failed to initialize storage: %w", err)
 	}
 
+	notifier := services.NewScheduleNotifier(cm.GetChannel)
 	svc, err := scheduler.NewService(scheduler.Options{
-		Store:         stores.ScheduledJobs,
-		ChannelLookup: cm.GetChannel,
+		Store:      stores.ScheduledJobs,
+		Runs:       stores.ScheduledRuns,
+		OnRunEvent: notifier.Notify,
 	})
 	if err != nil {
 		return nil, err
@@ -345,5 +352,5 @@ func registerChannels(cm *services.ChannelManagerService, cfg *config.Config, co
 }
 
 func init() {
-	rootCmd.AddCommand(channelsCmd)
+	rootCmd.AddCommand(daemonCmd)
 }

--- a/cmd/daemon_overlay_test.go
+++ b/cmd/daemon_overlay_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestLoadConfigFromViper_ChannelsDefaultsWhenFileAbsent confirms that
 // runtime falls back to DefaultChannelsConfig when no channels.yaml exists,
-// so a fresh checkout doesn't crash the channels-manager daemon when it
+// so a fresh checkout doesn't crash the daemon when it
 // tries to read cfg.Channels.
 func TestLoadConfigFromViper_ChannelsDefaultsWhenFileAbsent(t *testing.T) {
 	withHermeticEnv(t)

--- a/config/config.go
+++ b/config/config.go
@@ -297,7 +297,7 @@ type AskUserQuestionToolConfig struct {
 // When enabled, the tool lets the LLM create recurring jobs that fire on a
 // cron schedule and deliver their output through a configured channel
 // (e.g. Telegram). Jobs are persisted through the configured storage backend
-// and hot-reloaded by the channels-manager daemon.
+// and hot-reloaded by the daemon.
 type ScheduleToolConfig struct {
 	Enabled         bool  `yaml:"enabled" mapstructure:"enabled"`
 	RequireApproval *bool `yaml:"require_approval,omitempty" mapstructure:"require_approval,omitempty"`

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -612,7 +612,7 @@ Notes:
 			Description: `Search the web using Google or DuckDuckGo search engines`,
 		},
 		Schedule: PromptsToolDescription{
-			Description: `Schedule a task that fires on a cron schedule and delivers its output through the same messaging channel that triggered the current session (e.g. Telegram).
+			Description: `Schedule a task that fires on a cron schedule. Each fire runs an agent and records the run to storage; when the current session was triggered by a messaging channel (e.g. Telegram), the output is also delivered back through that channel.
 
 IMPORTANT - clarify intent before creating: ALWAYS confirm with the user whether they want the task to run **once** (e.g. "remind me at 6pm today to call mum") or **recurring** (e.g. "send me a quote every morning"). If their request is ambiguous, ASK them - do not guess. Set run_once=true for one-off tasks; the scheduler will delete the job automatically after it fires once. Set run_once=false (or omit) for recurring tasks.
 
@@ -625,7 +625,7 @@ Operations:
 - update: Modify an existing job. Required: job_id. Any of cron_expression, prompt, run_once, name, description, model can be updated.
 - delete: Remove a job. Required: job_id.
 
-Routing (channel + recipient) is derived automatically from the current session - you never pass it. The tool can therefore only be used from a channel-driven session (e.g. when responding to a Telegram message); it will fail with a clear error if invoked from any other context.
+Delivery routing (channel + recipient) is derived automatically from the current session - you never pass it. From a channel-driven session (e.g. responding to a Telegram message) the job delivers its output back to that channel; from any other session the job is record-only and its results are read from storage.
 
 Cron expression format: standard 5-field crontab syntax (minute hour day-of-month month day-of-week). The "@every <duration>" descriptor is also supported. Examples:
 - "0 8 * * *"       - every day at 08:00 (recurring)
@@ -636,7 +636,7 @@ Cron expression format: standard 5-field crontab syntax (minute hour day-of-mont
 
 For one-off jobs, build a cron expression that pinpoints the exact moment (use the current date's day/month) and set run_once=true. The job will fire once at that time and then be deleted automatically.
 
-The scheduler runs inside the 'infer channels-manager' daemon. Jobs only fire while that daemon is running.`,
+The scheduler runs inside the 'infer daemon' process. Jobs only fire while that daemon is running.`,
 		},
 		Agent: PromptsToolDescription{
 			Description: `Spawn local subagents - each an autonomous "infer headless" subprocess with its own isolated session - to run work in parallel and fold their results back into this conversation. Use this to fan out independent tasks (research, edits across separate areas, parallel investigations) without standing up an A2A agent server.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -19,7 +19,7 @@ remote-control the agent from external platforms like Telegram or WhatsApp.
 ## Overview
 
 Channels provide a bridge between external messaging platforms and the CLI
-agent. The `infer channels-manager` command runs as a standalone long-running daemon
+agent. The `infer daemon` command runs as a standalone long-running daemon
 that listens for messages from platforms like Telegram. When a message arrives,
 it triggers `infer headless --session-id <id>` as a subprocess. The agent
 processes the message and the response is sent back through the channel.
@@ -40,7 +40,7 @@ Key features:
 
 ```text
 ┌──────────┐       ┌────────────────────────────────────────────────────┐
-│ Telegram │◀─────▶│     infer channels-manager (long-running daemon)   │
+│ Telegram │◀─────▶│     infer daemon (long-running)   │
 │ Bot API  │       │                                                    │
 └──────────┘       │     Channel ──▶ inbox ──▶ routeInbound             │
                    │                            │                       │
@@ -125,7 +125,7 @@ export INFER_AGENT_MODEL="openai/gpt-4"
 ### 4. Start the Channel Listener
 
 ```bash
-infer channels-manager
+infer daemon
 ```
 
 This starts a long-running daemon that listens for Telegram messages. Each
@@ -348,7 +348,7 @@ conversations, which means:
 
 ## Remote-Control Prompt and System Reminders
 
-Messages routed through the channels-manager invoke `infer headless --remote`,
+Messages routed through the daemon invoke `infer headless --remote`,
 which swaps the default agent system prompt for
 `prompts.agent.system_prompt_remote`. That prompt is tuned for short,
 chat-style replies so that a casual "Hi" does not trigger a paragraph-long
@@ -497,7 +497,7 @@ case "mychannel":
 
 ### Bot not responding
 
-1. Verify the channel listener is running (`infer channels-manager`)
+1. Verify the channel listener is running (`infer daemon`)
 2. Check that `infer headless` works independently:
    `infer headless "Hello" --session-id test`
 3. Look for `[channels] agent failed` in logs

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -377,7 +377,7 @@ for SCM tickets like GitHub issues, CI/CD pipelines, and automated workflows.
 - `--no-save`: Disable saving conversation to database
 - `--require-approval`: Enable IPC-based tool approval via stdin/stdout (used by channel manager)
 - `--heartbeat`: Use heartbeat system prompt (used by the heartbeat service)
-- `--remote`: Use remote-control system prompt (used by the channels-manager daemon)
+- `--remote`: Use remote-control system prompt (used by the daemon)
 - `--result-file`: Write the final assistant message and outcome as JSON to this path on exit
 - `--format json|ag-ui|text`: Output format (default json)
 

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -137,7 +137,7 @@ create them, and the seeded `.gitignore` already excludes them.
   `RequestPlanApproval` tool when the agent runs in [Plan Mode](plan-mode.md).
   Both accepted and rejected plans are kept as an audit trail.
 - **`schedules/<id>.yaml`** *(userspace)* - one YAML per scheduled job.
-  Written by the `Schedule` tool, hot-reloaded by the channels-manager
+  Written by the `Schedule` tool, hot-reloaded by the daemon
   daemon. See [Scheduling](scheduling.md).
 
 ---

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -16,7 +16,7 @@ each tick using a tailored system prompt.
 
 ```text
 ┌───────────────────────────────────────────────────────────────┐
-│  infer channels-manager (long-running daemon)                 │
+│  infer daemon (long-running)                 │
 │                                                               │
 │   ├─ ChannelManagerService    (channels - optional)           │
 │   ├─ SchedulerService         (cron jobs - optional)          │
@@ -42,8 +42,7 @@ Key properties:
 - **Single global instance.** One interval, one prompt - for
   multi-job use cases use the [Schedule tool](./scheduling.md)
   instead.
-- **Daemon-bound.** Heartbeat only fires while `infer
-  channels-manager` is running. If the daemon is down, ticks are
+- **Daemon-bound.** Heartbeat only fires while `infer daemon` is running. If the daemon is down, ticks are
   skipped (no replay).
 - **Fresh session per tick.** Each tick gets a new UUID session ID;
   no context carries between fires. The agent inspects persistent
@@ -99,7 +98,7 @@ concrete step per tick, and exit. Override it to fit your workflow.
 ### 3. Run the daemon
 
 ```bash
-infer channels-manager
+infer daemon
 ```
 
 The daemon hosts up to three subsystems - channels, scheduler, and
@@ -107,7 +106,7 @@ heartbeat - and starts whichever are enabled. You can run with
 heartbeat alone (no channels, no scheduler) if that is all you need.
 
 ```text
-INFO Starting channels-manager
+INFO Starting daemon
 INFO Heartbeat service started  interval=1h0m0s  initial_delay=1m0s
 INFO Daemon ready. Press Ctrl+C to stop.
 ```
@@ -173,7 +172,7 @@ against opening issues or pushing changes automatically.
 ## Troubleshooting
 
 **Heartbeat never fires** - confirm `enabled: true` and that
-`infer channels-manager` is running. The daemon logs `Heartbeat
+`infer daemon` is running. The daemon logs `Heartbeat
 service started` on boot when it picks up the config.
 
 **Heartbeat fires too often / not enough** - check `interval`

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -2,25 +2,29 @@
 
 [← Back to README](../README.md)
 
-The `Schedule` tool lets the LLM create recurring tasks that run on a cron schedule
-and deliver their output back to the user through a configured messaging channel
-(e.g. Telegram). It is designed for use cases like *"every morning at 8 AM, send me
-an inspiring quote"* - initiated from a chat with the bot rather than from the CLI.
+The `Schedule` tool lets the LLM create tasks that run on a cron schedule. Every
+fire runs a real agent and records the run to storage; when the job was created
+from a messaging channel (e.g. Telegram), the output is additionally delivered
+back through that channel. Typical use cases: *"every morning at 8 AM, send me an
+inspiring quote"* from a chat with the bot, or record-only background jobs
+created from any session whose results are read from storage.
 
 ## How it works
 
 ```text
-┌─────────────────────────────────────────────────────────────┐
-│  infer channels-manager (long-running daemon)               │
+┌──────────────────────────────────────────────────────────────┐
+│  infer daemon (long-running)                                 │
 │                                                              │
+│   SchedulerService                                           │
+│    ├─ robfig/cron/v3 scheduler                               │
+│    ├─ 2s poll + diff against storage backend                 │
+│    └─ on fire: persist RunRecord, spawn                      │
+│       `infer headless --session-id <uuid>`,                  │
+│       emit run events ──► ScheduleNotifier                   │
+│                            └─ job has a channel? Send(...)   │
 │   ChannelManagerService                                      │
-│    ├─ inbound msgs   → spawn `infer headless`                   │
-│    └─ SchedulerService                                       │
-│         ├─ robfig/cron/v3 scheduler                          │
-│         ├─ 2s poll + diff against storage backend            │
-│         └─ on fire: spawn `infer headless --session-id <uuid>`  │
-│                     capture stdout → channel.Send(...)       │
-└─────────────────────────────────────────────────────────────┘
+│    └─ inbound msgs → spawn `infer headless`                  │
+└──────────────────────────────────────────────────────────────┘
            ▲                                       ▲
            │ writes via storage backend            │ reads via storage backend
 ┌──────────┴───────────┐                 ┌─────────┴──────────────┐
@@ -42,7 +46,15 @@ Key properties:
   since a per-process store can never be seen by the daemon.
 - **Fresh session per fire.** Each scheduled run gets a brand-new agent session ID.
   Nothing carries between fires; design prompts to be self-contained.
-- **Daemon-bound execution.** Jobs only fire while `infer channels-manager` is running.
+- **Run records.** Every fire persists a `RunRecord` (`session_id`, `job_id`,
+  `status`, `error`, timestamps) through the storage backend. The `session_id` is
+  the conversation ID of that run, so the full transcript is readable from
+  conversation storage - this is how non-channel consumers (e.g. the desktop app)
+  pick up job output. The newest 200 records are retained.
+- **Optional delivery.** `channel`/`recipient_id` on a job are a delivery target,
+  not a requirement. Jobs created from a channel session deliver their output back
+  to that channel; jobs created anywhere else are record-only.
+- **Daemon-bound execution.** Jobs only fire while `infer daemon` is running.
 
 ## Setup
 
@@ -65,15 +77,18 @@ You can also use environment variables:
 export INFER_TOOLS_SCHEDULE_ENABLED=true
 ```
 
-### 2. Configure at least one channel
+### 2. (Optional) Configure a channel
 
-The Schedule tool refuses to create a job for a channel that isn't enabled. Set up
-Telegram (or any other supported channel) following [Channels Guide](channels.md).
+Channel delivery is optional - without one, jobs are record-only. To have job
+output delivered to a messaging platform, set up Telegram (or any other supported
+channel) following [Channels Guide](channels.md) and create the job from a chat on
+that channel. The tool errors when a channel-driven session references a channel
+that isn't enabled - a misconfiguration, not a record-only job.
 
 ### 3. Run the daemon
 
 ```bash
-infer channels-manager
+infer daemon
 ```
 
 You should see a log line like `Scheduler started jobs=0`.
@@ -106,8 +121,9 @@ Required: `cron_expression`, `prompt`. Optional: `run_once`, `name`, `descriptio
 `model`.
 
 Channel and recipient are **derived automatically** from the current session
-(format: `channel-<name>-<sender_id>`). The LLM never passes them. The tool
-errors out when invoked outside a channel-driven session.
+(format: `channel-<name>-<sender_id>`). The LLM never passes them. Outside a
+channel-driven session (chat, headless, desktop) the job is created without a
+delivery target and its output is read from storage via the run records.
 
 ```json
 {
@@ -207,7 +223,7 @@ Provide `job_id` and any of: `cron_expression`, `prompt`, `run_once`, `name`,
 
 **Jobs aren't firing.**
 
-- Make sure `infer channels-manager` is running and `Scheduler started` appears
+- Make sure `infer daemon` is running and `Scheduler started` appears
   in the logs.
 - Check that the channel referenced in the job is enabled in config.
 - Inspect the job's `last_error` field after the expected fire time.

--- a/docs/shortcuts-guide.md
+++ b/docs/shortcuts-guide.md
@@ -125,7 +125,7 @@ input field - ready to review and send. It is **disabled by default** and gated 
 `whisper-cli`/`whisper-cpp` binary to transcribe it. The GGML model (default `tiny`) is downloaded
 on first use. If a required tool is missing, `/voice` reports an actionable error with install
 hints. The same speech-to-text engine also transcribes inbound Telegram voice messages when running
-`infer channels-manager`.
+`infer daemon`.
 
 ### Image Generation
 

--- a/docs/speech-to-text.md
+++ b/docs/speech-to-text.md
@@ -82,7 +82,7 @@ Append `.en` (e.g. `base.en`) for English-only variants. You can also pass a ful
 
 ## Telegram voice messages
 
-When `speech_to_text.enabled` is set and you run `infer channels-manager`, voice notes sent to your
+When `speech_to_text.enabled` is set and you run `infer daemon`, voice notes sent to your
 Telegram bot are downloaded, decoded with `ffmpeg`, transcribed, and forwarded to the agent as text.
 When speech-to-text is disabled, voice messages are ignored (as before). See
 [Channels](channels.md) for channel setup.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -694,11 +694,13 @@ today to call mum" - initiated from a chat with the bot.
 **How it works:**
 
 - Each scheduled job is persisted as a YAML file under `~/.infer/schedules/`.
-- The `infer channels-manager` daemon hosts the scheduler and watches that directory via fsnotify, so newly created jobs fire without a restart.
-- Each fire spawns a brand-new `infer headless` session - no context carries between runs. Make prompts specific and self-contained.
+- The `infer daemon` process hosts the scheduler and polls storage every 2s, so newly created jobs fire without a restart.
+- Each fire spawns a brand-new `infer headless` session - no context carries between runs. Make prompts specific and
+  self-contained. A run record (`session_id`, `status`, `error`, timestamps) is persisted per fire, so job output is
+  readable from storage.
 - Channel + recipient are derived automatically from the current session ID -
-  the LLM never passes them. The tool can therefore only be used from a
-  channel-driven session.
+  the LLM never passes them. From a channel-driven session the job delivers its
+  output back to that channel; from any other session the job is record-only.
 - One-off jobs (`run_once: true`) are deleted automatically after their first fire.
 
 **Disabled by default.** Enable in config under `tools.schedule.enabled: true`.
@@ -765,9 +767,9 @@ tools:
 **Security:**
 
 - **Approval required by default** - the LLM cannot create/modify schedules without user confirmation.
-- **Channel must be configured** - the tool refuses to schedule for channels that aren't enabled in `channels.<name>.enabled`.
-- **Channel-session only** - the tool errors out if invoked from chat mode or any non-channel session, since it has no recipient to route to.
-- **Daemon-bound execution** - jobs only fire while `infer channels-manager` is running.
+- **Channel must be configured for delivery** - a channel-driven session that references a channel not enabled in
+  `channels.<name>.enabled` errors out instead of silently skipping delivery.
+- **Daemon-bound execution** - jobs only fire while `infer daemon` is running.
 
 ---
 

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -2,7 +2,7 @@
 
 End-to-end deployment on a local [k3d](https://k3d.io/) cluster using the
 [Inference Gateway Operator](https://github.com/inference-gateway/operator):
-a Gateway, an Orchestrator (the `infer` CLI in channels-manager mode), an A2A
+a Gateway, an Orchestrator (the `infer` CLI in daemon mode), an A2A
 mock agent, and an OpenTelemetry collector - all declared as operator CRDs
 (`core.inference-gateway.com/v1alpha1`).
 
@@ -55,7 +55,7 @@ k3d cluster
 │   └── Inference Gateway Operator (reconciles the CRs below)
 └── infer namespace
     ├── Gateway "inference-gateway"      (CRD → Deployment + Service :8080)
-    ├── Orchestrator "orchestrator"      (CRD → infer CLI, channels-manager mode)
+    ├── Orchestrator "orchestrator"      (CRD → infer CLI, daemon mode)
     ├── Agent "mock-agent"               (CRD → A2A mock agent)
     ├── otel-collector                   (plain Deployment, OTLP :4317/:4318)
     ├── jaeger                           (plain Deployment, UI :16686)
@@ -150,7 +150,7 @@ task jaeger:ui   # http://localhost:16686, service "orchestrator"
 The Orchestrator runs the released `ghcr.io/inference-gateway/cli:latest`. Two
 things need a CLI new enough: the `[inference-gateway]` spans (the gateway SDK
 client must send W3C `traceparent`), and a readable TUI (the operator sets
-`INFER_LOGGING_STDOUT=true` for the channels-manager daemon, and `infer chat`
+`INFER_LOGGING_STDOUT=true` for the daemon, and `infer chat`
 must ignore it - on an older image, prefix the exec with
 `env INFER_LOGGING_STDOUT=false`). Only one process per pod can hold the
 receiver port, so an `infer headless` subprocess spawned by a channel while you
@@ -191,7 +191,7 @@ The mock gateway itself emits no spans; the last hop
 - The `infer` namespace carries the `inference-gateway.com/managed: "true"`
   label - the operator only reconciles CRs in namespaces labeled this way.
 - The `telegram-bot-credentials` Secret in `orchestrator.yaml` holds a dummy
-  token: the channels-manager needs at least one enabled channel to boot, so
+  token: the daemon with channels enabled needs at least one enabled channel to boot, so
   Telegram is enabled but its poller just logs an error and stops while the
   daemon (scheduler) keeps running. Put a real bot token in the Secret to use
   Telegram for real.

--- a/examples/postgres-storage/README.md
+++ b/examples/postgres-storage/README.md
@@ -1,7 +1,7 @@
 # PostgreSQL conversation storage
 
 Persist conversations to PostgreSQL instead of the default local JSONL files.
-Useful when several `infer` processes — chat, the `channels-manager` daemon, the
+Useful when several `infer` processes — chat, the `infer daemon` process, the
 web terminal — should share one conversation store.
 
 `docker-compose.yml` runs the Inference Gateway plus a PostgreSQL container;

--- a/examples/telegram-channel/README.md
+++ b/examples/telegram-channel/README.md
@@ -9,7 +9,7 @@ your phone. A VNC viewer is included so you can watch the browser navigate live.
 ## What's Included
 
 - **inference-gateway** - routes LLM requests to your configured providers
-- **infer-channels-manager** - long-polls Telegram, spawns `infer headless` per message
+- **infer-daemon** - long-polls Telegram, spawns `infer headless` per message
 - **browser-agent** - A2A service running Playwright in headed mode under Xvfb
 - **browser-vnc** *(optional, `--profile vnc`)* - `x11vnc` bridge so you can watch the browser at `vnc://localhost:5900`
 
@@ -73,7 +73,7 @@ Send any of these to your bot:
 - *"Browse to <https://news.ycombinator.com> and list the top 5 story titles."*
 - *"Find the current weather in Berlin from a public website."*
 
-The channels-manager has `INFER_A2A_ENABLED=true` and the browser agent
+The daemon has `INFER_A2A_ENABLED=true` and the browser agent
 registered, so the spawned `infer headless` process will pick `A2A_SubmitTask`
 and delegate the browsing task to the `browser-agent` container.
 
@@ -102,7 +102,7 @@ image - the bot itself works without it.
 ## How It Works
 
 ```text
-You (Telegram) --> Telegram Bot API --> infer channels-manager (listener)
+You (Telegram) --> Telegram Bot API --> infer daemon (listener)
                                             |
                                             v
                                      infer headless --session-id <id>
@@ -117,7 +117,7 @@ You (Telegram) --> Telegram Bot API --> infer channels-manager (listener)
                                      JSON stdout (parsed)
                                             |
                                             v
-                                     infer channels-manager --> Telegram Bot API --> You (Telegram)
+                                     infer daemon --> Telegram Bot API --> You (Telegram)
 ```
 
 1. You send a message in Telegram
@@ -252,7 +252,7 @@ export INFER_CHANNELS_TELEGRAM_ALLOWED_USERS="your-chat-id"
 export INFER_AGENT_MODEL="openai/gpt-4"
 
 # Start the channel listener
-infer channels-manager
+infer daemon
 ```
 
 ## Security
@@ -291,7 +291,7 @@ telegram:
 
 ```bash
 # Check channel listener logs
-docker compose logs infer-channels-manager
+docker compose logs infer-daemon
 
 # Verify bot token is valid
 curl https://api.telegram.org/bot<TOKEN>/getMe

--- a/examples/telegram-channel/docker-compose.override.yml
+++ b/examples/telegram-channel/docker-compose.override.yml
@@ -1,7 +1,7 @@
 ---
-# Local testing override — points the channels-manager at the locally built
+# Local testing override — points the daemon at the locally built
 # image instead of the published one. Not for commit.
 services:
-  infer-channels-manager:
+  infer-daemon:
     image: ghcr.io/inference-gateway/cli:local
     pull_policy: never

--- a/examples/telegram-channel/docker-compose.yml
+++ b/examples/telegram-channel/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - browser-agent
     restart: unless-stopped
 
-  infer-channels-manager:
+  infer-daemon:
     image: ghcr.io/inference-gateway/cli:latest
     pull_policy: always
     depends_on:
@@ -95,5 +95,5 @@ services:
     volumes:
       - ./tmp:/home/infer
     command:
-      - channels-manager
+      - daemon
     restart: unless-stopped

--- a/internal/agent/tools/schedule.go
+++ b/internal/agent/tools/schedule.go
@@ -32,7 +32,7 @@ type ScheduleToolResult struct {
 }
 
 // ScheduleTool lets the LLM create, inspect, and remove recurring jobs that
-// are executed by the channels-manager daemon's scheduler. Jobs are persisted
+// are executed by the daemon's scheduler. Jobs are persisted
 // through the injected storage backend; the daemon hot-reloads by polling it.
 type ScheduleTool struct {
 	config    *config.Config
@@ -261,26 +261,27 @@ func (t *ScheduleTool) execCreate(ctx context.Context, args map[string]any, stor
 	if job.RunOnce {
 		mode = "one-off"
 	}
+	delivery := "output is recorded to storage (no delivery channel)"
+	if channel != "" {
+		delivery = fmt.Sprintf("output will be delivered via %s", channel)
+	}
 	return t.success(args, start, &ScheduleToolResult{
 		Operation: scheduleOpCreate,
 		Job:       job,
-		Message:   fmt.Sprintf("Scheduled %s job %s created. Will fire via %s while 'infer channels-manager' is running.", mode, job.ID, channel),
+		Message:   fmt.Sprintf("Scheduled %s job %s created; %s. Fires while 'infer daemon' is running.", mode, job.ID, delivery),
 	})
 }
 
-// resolveRouting derives channel + recipient_id from the current session ID
-// (set by cmd/agent.go via domain.WithSessionID). Channel-driven sessions are
-// formatted "channel-<name>-<sender_id>" by the channels-manager. Returns an
-// error when the tool is invoked outside a channel-driven session, or when
-// the channel is not enabled in config.
+// resolveRouting derives an optional delivery target from the current session
+// ID. Channel-driven sessions ("channel-<name>-<sender_id>", set by the
+// daemon's channel manager) stamp that channel/recipient as the job's delivery
+// target; any other session creates a record-only job whose output lives in
+// storage. It only errors when the session names a channel that is not enabled
+// in config - a silent no-delivery there would hide a misconfiguration.
 func (t *ScheduleTool) resolveRouting(ctx context.Context) (channel, recipient string, err error) {
-	sessionID := domain.GetSessionID(ctx)
-	if sessionID == "" {
-		return "", "", errors.New("schedule can only be used from a channel-driven session (no session id in context)")
-	}
-	channel, recipient, ok := domain.ParseChannelSessionID(sessionID)
+	channel, recipient, ok := domain.ParseChannelSessionID(domain.GetSessionID(ctx))
 	if !ok {
-		return "", "", fmt.Errorf("schedule can only be used from a channel-driven session; current session %q is not channel-formatted", sessionID)
+		return "", "", nil
 	}
 	if !t.channelConfigured(channel) {
 		return "", "", fmt.Errorf("channel %q is not enabled in config (enable it under channels.<name>.enabled)", channel)
@@ -484,18 +485,7 @@ func (t *ScheduleTool) formatScheduleData(data any) string {
 		fmt.Fprintf(&out, "Message: %s\n", d.Message)
 	}
 	if d.Job != nil {
-		fmt.Fprintf(&out, "Job: %s\n", d.Job.ID)
-		fmt.Fprintf(&out, "Cron: %s\n", d.Job.CronExpression)
-		fmt.Fprintf(&out, "Channel: %s -> %s\n", d.Job.Channel, d.Job.RecipientID)
-		if d.Job.Name != "" {
-			fmt.Fprintf(&out, "Name: %s\n", d.Job.Name)
-		}
-		if d.Job.LastRun != nil {
-			fmt.Fprintf(&out, "Last run: %s\n", d.Job.LastRun.Format(time.RFC3339))
-		}
-		if d.Job.LastError != "" {
-			fmt.Fprintf(&out, "Last error: %s\n", d.Job.LastError)
-		}
+		formatJobDetail(&out, d.Job)
 	}
 	if len(d.Jobs) > 0 {
 		fmt.Fprintf(&out, "Jobs (%d):\n", len(d.Jobs))
@@ -505,6 +495,24 @@ func (t *ScheduleTool) formatScheduleData(data any) string {
 		}
 	}
 	return out.String()
+}
+
+// formatJobDetail renders one job's fields, omitting empty optionals.
+func formatJobDetail(out *strings.Builder, job *domain.ScheduledJob) {
+	fmt.Fprintf(out, "Job: %s\n", job.ID)
+	fmt.Fprintf(out, "Cron: %s\n", job.CronExpression)
+	if job.Channel != "" {
+		fmt.Fprintf(out, "Channel: %s -> %s\n", job.Channel, job.RecipientID)
+	}
+	if job.Name != "" {
+		fmt.Fprintf(out, "Name: %s\n", job.Name)
+	}
+	if job.LastRun != nil {
+		fmt.Fprintf(out, "Last run: %s\n", job.LastRun.Format(time.RFC3339))
+	}
+	if job.LastError != "" {
+		fmt.Fprintf(out, "Last error: %s\n", job.LastError)
+	}
 }
 
 // ShouldCollapseArg controls per-arg collapsing in the chat UI.

--- a/internal/agent/tools/schedule_test.go
+++ b/internal/agent/tools/schedule_test.go
@@ -242,8 +242,7 @@ func TestScheduleTool_Execute_Create_RunOnce(t *testing.T) {
 func TestScheduleTool_Execute_NonChannelSessionCreatesRecordOnlyJob(t *testing.T) {
 	tool := NewScheduleTool(newScheduleCfg(t, true), storage.NewMemoryStorage())
 	for _, ctx := range []context.Context{
-		context.Background(), // no session ID at all
-		// Non-channel session ID (e.g. chat mode generates "1234567890-abcdef").
+		context.Background(),
 		domain.WithSessionID(context.Background(), "1733678400-a3f2bc8d"),
 	} {
 		r, err := tool.Execute(ctx, map[string]any{

--- a/internal/agent/tools/schedule_test.go
+++ b/internal/agent/tools/schedule_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // channelCtx returns a context tagged with a channel-formatted session ID,
-// matching the format the channels-manager uses when spawning agents.
+// matching the format the daemon's channel manager uses when spawning agents.
 func channelCtx(channel, recipient string) context.Context {
 	return domain.WithSessionID(context.Background(), "channel-"+channel+"-"+recipient)
 }
@@ -239,29 +239,25 @@ func TestScheduleTool_Execute_Create_RunOnce(t *testing.T) {
 	}
 }
 
-func TestScheduleTool_Execute_RejectsNonChannelSession(t *testing.T) {
+func TestScheduleTool_Execute_NonChannelSessionCreatesRecordOnlyJob(t *testing.T) {
 	tool := NewScheduleTool(newScheduleCfg(t, true), storage.NewMemoryStorage())
-	// Plain context - no session ID at all.
-	r, err := tool.Execute(context.Background(), map[string]any{
-		"operation":       "create",
-		"cron_expression": "0 8 * * *",
-		"prompt":          "x",
-	})
-	if err != nil {
-		t.Fatalf("expected nil error: %v", err)
-	}
-	if r.Success {
-		t.Fatal("expected failure when no session ID is in context")
-	}
-
-	// Non-channel session ID (e.g. chat mode generates "1234567890-abcdef").
-	r, _ = tool.Execute(domain.WithSessionID(context.Background(), "1733678400-a3f2bc8d"), map[string]any{
-		"operation":       "create",
-		"cron_expression": "0 8 * * *",
-		"prompt":          "x",
-	})
-	if r.Success {
-		t.Fatal("expected failure when session is not channel-formatted")
+	for _, ctx := range []context.Context{
+		context.Background(), // no session ID at all
+		// Non-channel session ID (e.g. chat mode generates "1234567890-abcdef").
+		domain.WithSessionID(context.Background(), "1733678400-a3f2bc8d"),
+	} {
+		r, err := tool.Execute(ctx, map[string]any{
+			"operation":       "create",
+			"cron_expression": "0 8 * * *",
+			"prompt":          "x",
+		})
+		if err != nil || !r.Success {
+			t.Fatalf("expected record-only create to succeed: err=%v result=%+v", err, r)
+		}
+		job := r.Data.(*ScheduleToolResult).Job
+		if job.Channel != "" || job.RecipientID != "" {
+			t.Fatalf("expected no delivery target, got channel=%q recipient=%q", job.Channel, job.RecipientID)
+		}
 	}
 }
 

--- a/internal/constants/timing.go
+++ b/internal/constants/timing.go
@@ -45,5 +45,5 @@ const GitCommandTimeout = 10 * time.Second
 
 // ApprovalTimeout is how long the agent waits for a tool-approval decision
 // before auto-rejecting, in every delivery path (chat TUI prompt, headless
-// IPC under the channels-manager, and channel auto-reject).
+// IPC under the daemon, and channel auto-reject).
 const ApprovalTimeout = 5 * time.Minute

--- a/internal/domain/scheduler.go
+++ b/internal/domain/scheduler.go
@@ -5,20 +5,23 @@ import (
 	"time"
 )
 
-// ScheduledJob describes a recurring task that the LLM has asked the system
-// to run on a cron schedule. Jobs are persisted as YAML files and loaded by
-// the SchedulerService running inside the channels-manager daemon.
+// ScheduledJob describes a task that the LLM has asked the system to run on a
+// cron schedule. Jobs are persisted through the configured storage backend and
+// executed by the scheduler running inside the `infer daemon` process.
 //
-// Each fire spawns a fresh `infer headless` subprocess with a brand-new session
-// ID - no context is carried between fires, matching the issue's requirement.
+// Each fire spawns a fresh `infer headless` subprocess with its own session
+// ID - no context is carried between fires. Channel/RecipientID are an
+// optional delivery target: when set, run output is forwarded to that channel;
+// when empty, the run is record-only and its output lives in storage (run
+// record + conversation).
 type ScheduledJob struct {
 	ID             string     `yaml:"id" json:"id"`
 	Name           string     `yaml:"name,omitempty" json:"name,omitempty"`
 	Description    string     `yaml:"description,omitempty" json:"description,omitempty"`
 	CronExpression string     `yaml:"cron_expression" json:"cron_expression"`
 	Prompt         string     `yaml:"prompt" json:"prompt"`
-	Channel        string     `yaml:"channel" json:"channel"`
-	RecipientID    string     `yaml:"recipient_id" json:"recipient_id"`
+	Channel        string     `yaml:"channel,omitempty" json:"channel,omitempty"`
+	RecipientID    string     `yaml:"recipient_id,omitempty" json:"recipient_id,omitempty"`
 	Model          string     `yaml:"model,omitempty" json:"model,omitempty"`
 	RunOnce        bool       `yaml:"run_once,omitempty" json:"run_once,omitempty"`
 	CreatedAt      time.Time  `yaml:"created_at" json:"created_at"`
@@ -27,10 +30,40 @@ type ScheduledJob struct {
 	LastError      string     `yaml:"last_error,omitempty" json:"last_error,omitempty"`
 }
 
+// RunStatus is the lifecycle state of a single scheduled-job run.
+type RunStatus string
+
+const (
+	RunStatusRunning   RunStatus = "running"
+	RunStatusCompleted RunStatus = "completed"
+	RunStatusFailed    RunStatus = "failed"
+)
+
+// RunRecord is the persisted record of one scheduled-job fire. SessionID is
+// both the record key and the conversation ID of the `infer headless` run, so
+// consumers (e.g. the desktop app) can load the full transcript from
+// conversation storage.
+type RunRecord struct {
+	SessionID  string     `yaml:"session_id" json:"session_id"`
+	JobID      string     `yaml:"job_id" json:"job_id"`
+	Status     RunStatus  `yaml:"status" json:"status"`
+	Error      string     `yaml:"error,omitempty" json:"error,omitempty"`
+	StartedAt  time.Time  `yaml:"started_at" json:"started_at"`
+	FinishedAt *time.Time `yaml:"finished_at,omitempty" json:"finished_at,omitempty"`
+}
+
+// RunEvent is emitted by the scheduler as a job run progresses. Line events
+// carry one raw agent stdout line (valid only for the duration of the
+// callback); the terminal event has Done set, with Err populated on failure.
+type RunEvent struct {
+	Line []byte
+	Err  error
+	Done bool
+}
+
 // SchedulerService manages the lifecycle of scheduled jobs. It is started by
-// the channels-manager daemon and watches the schedule storage directory for
-// changes so that jobs created by an agent process are picked up without a
-// daemon restart.
+// the `infer daemon` process and watches the schedule storage for changes so
+// that jobs created by an agent process are picked up without a restart.
 type SchedulerService interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -63,7 +63,7 @@ func (s SessionID) Age() time.Duration {
 	return time.Since(time.Unix(timestamp, 0))
 }
 
-// FormatChannelSessionID builds the session ID the channels-manager uses for
+// FormatChannelSessionID builds the session ID the daemon's channel manager uses for
 // a channel/sender pair, the inverse of ParseChannelSessionID.
 // ponytail: channel names must not contain '-' (they're a fixed enum today;
 // sender IDs may contain dashes and are parsed back as the tail).
@@ -72,7 +72,7 @@ func FormatChannelSessionID(channel, senderID string) string {
 }
 
 // ParseChannelSessionID extracts the channel name and recipient ID from a
-// session ID created by the channels-manager. The channel manager builds
+// session ID created by the daemon's channel manager. The channel manager builds
 // session IDs as "channel-<name>-<sender_id>" (see channel_manager.go).
 //
 // Returns ok=false when the session ID does not match this format (e.g. for

--- a/internal/infra/storage/d1.go
+++ b/internal/infra/storage/d1.go
@@ -796,6 +796,72 @@ func (s *D1Storage) DeleteJob(ctx context.Context, id string) error {
 }
 
 // ---------------------------------------------------------------------------
+// ScheduledRunStorage (D1Storage)
+// ---------------------------------------------------------------------------
+
+// SaveRun creates or updates a run record via UPSERT.
+func (s *D1Storage) SaveRun(ctx context.Context, run *domain.RunRecord) error {
+	_, err := s.exec(ctx, `
+	INSERT INTO scheduled_job_runs(session_id, job_id, status, error, started_at, finished_at)
+	VALUES (?, ?, ?, ?, ?, ?)
+	ON CONFLICT(session_id) DO UPDATE SET
+		status = excluded.status,
+		error = excluded.error,
+		finished_at = excluded.finished_at
+`, run.SessionID, run.JobID, string(run.Status), run.Error, run.StartedAt, run.FinishedAt)
+	if err != nil {
+		return fmt.Errorf("save run %s: %w", run.SessionID, err)
+	}
+	return nil
+}
+
+// ListRuns returns run records sorted by StartedAt descending.
+func (s *D1Storage) ListRuns(ctx context.Context, jobID string) ([]*domain.RunRecord, error) {
+	query := `
+	SELECT session_id, job_id, status, error, started_at, finished_at
+	FROM scheduled_job_runs`
+	args := []any{}
+	if jobID != "" {
+		query += " WHERE job_id = ?"
+		args = append(args, jobID)
+	}
+	query += " ORDER BY started_at DESC"
+
+	rows, err := s.queryRows(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list runs: %w", err)
+	}
+	var runs []*domain.RunRecord
+	for _, r := range rows {
+		run := &domain.RunRecord{
+			SessionID: asString(r["session_id"]),
+			JobID:     asString(r["job_id"]),
+			Status:    domain.RunStatus(asString(r["status"])),
+			Error:     asString(r["error"]),
+			StartedAt: asTime(r["started_at"]),
+		}
+		if ft := asTimePtr(r["finished_at"]); ft != nil {
+			run.FinishedAt = ft
+		}
+		runs = append(runs, run)
+	}
+	return runs, nil
+}
+
+// PruneRuns deletes all but the newest keep run records.
+func (s *D1Storage) PruneRuns(ctx context.Context, keep int) error {
+	_, err := s.exec(ctx, `
+	DELETE FROM scheduled_job_runs WHERE session_id NOT IN (
+		SELECT session_id FROM scheduled_job_runs ORDER BY started_at DESC LIMIT ?
+	)
+`, keep)
+	if err != nil {
+		return fmt.Errorf("prune runs: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
 // PlanStorage (D1Storage)
 // ---------------------------------------------------------------------------
 

--- a/internal/infra/storage/factory.go
+++ b/internal/infra/storage/factory.go
@@ -96,6 +96,7 @@ type fullBackend interface {
 	ConversationStorage
 	SessionGroupStorage
 	ScheduledJobStorage
+	ScheduledRunStorage
 	PlanStorage
 	ShellHistoryStorage
 }
@@ -110,6 +111,7 @@ func NewStorage(config StorageConfig) (*Stores, error) {
 		Conversations: backend,
 		SessionGroups: backend,
 		ScheduledJobs: backend,
+		ScheduledRuns: backend,
 		Plans:         backend,
 		ShellHistory:  backend,
 	}, nil

--- a/internal/infra/storage/interfaces.go
+++ b/internal/infra/storage/interfaces.go
@@ -89,6 +89,20 @@ type ScheduledJobStorage interface {
 // ErrJobNotFound is returned by ScheduledJobStorage when a job ID is not found.
 var ErrJobNotFound = errors.New("scheduled job not found")
 
+// ScheduledRunStorage persists per-fire run records for scheduled jobs, keyed
+// by SessionID (which doubles as the conversation ID of the agent run).
+type ScheduledRunStorage interface {
+	// SaveRun creates or updates a run record (upsert by SessionID).
+	SaveRun(ctx context.Context, run *domain.RunRecord) error
+
+	// ListRuns returns run records sorted by StartedAt descending. An empty
+	// jobID returns runs for all jobs.
+	ListRuns(ctx context.Context, jobID string) ([]*domain.RunRecord, error)
+
+	// PruneRuns deletes all but the newest keep run records (across all jobs).
+	PruneRuns(ctx context.Context, keep int) error
+}
+
 // PlanRecord is a stored plan-mode plan. The ID is the filename stem
 // "<UTC stamp>-<slug>" (e.g. "2026-07-17-153000-add-auth"), identical across
 // backends, and Body is the raw plan markdown without the title H1.
@@ -128,6 +142,7 @@ type Stores struct {
 	Conversations ConversationStorage
 	SessionGroups SessionGroupStorage
 	ScheduledJobs ScheduledJobStorage
+	ScheduledRuns ScheduledRunStorage
 	Plans         PlanStorage
 	ShellHistory  ShellHistoryStorage
 }

--- a/internal/infra/storage/jsonl.go
+++ b/internal/infra/storage/jsonl.go
@@ -1003,6 +1003,90 @@ func (s *JsonlStorage) DeleteJob(_ context.Context, id string) error {
 }
 
 // ---------------------------------------------------------------------------
+// ScheduledRunStorage (JsonlStorage) - one YAML file per run
+// ---------------------------------------------------------------------------
+
+// runsDir returns the path to the schedule run-records directory.
+func (s *JsonlStorage) runsDir() string {
+	return filepath.Join(s.schedulesDir(), "runs")
+}
+
+// runFilePath returns the YAML path for a given run session ID.
+func (s *JsonlStorage) runFilePath(sessionID string) string {
+	return filepath.Join(s.runsDir(), sessionID+".yaml")
+}
+
+// SaveRun writes the run record to disk atomically as YAML.
+func (s *JsonlStorage) SaveRun(_ context.Context, run *domain.RunRecord) error {
+	if run == nil || run.SessionID == "" {
+		return errors.New("run session ID is required")
+	}
+	dir := s.runsDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create runs dir %s: %w", dir, err)
+	}
+	data, err := yaml.Marshal(run)
+	if err != nil {
+		return fmt.Errorf("failed to marshal run %s: %w", run.SessionID, err)
+	}
+	final := s.runFilePath(run.SessionID)
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write temp file %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("failed to rename %s -> %s: %w", tmp, final, err)
+	}
+	return nil
+}
+
+// ListRuns returns run records sorted by StartedAt descending.
+func (s *JsonlStorage) ListRuns(_ context.Context, jobID string) ([]*domain.RunRecord, error) {
+	entries, err := os.ReadDir(s.runsDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read runs dir: %w", err)
+	}
+	var runs []*domain.RunRecord
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.runsDir(), e.Name()))
+		if err != nil {
+			continue
+		}
+		run := &domain.RunRecord{}
+		if err := yaml.Unmarshal(data, run); err != nil {
+			continue
+		}
+		if jobID != "" && run.JobID != jobID {
+			continue
+		}
+		runs = append(runs, run)
+	}
+	slices.SortFunc(runs, func(a, b *domain.RunRecord) int {
+		return b.StartedAt.Compare(a.StartedAt)
+	})
+	return runs, nil
+}
+
+// PruneRuns deletes all but the newest keep run records.
+func (s *JsonlStorage) PruneRuns(ctx context.Context, keep int) error {
+	runs, err := s.ListRuns(ctx, "")
+	if err != nil {
+		return err
+	}
+	for i := keep; i < len(runs); i++ {
+		_ = os.Remove(s.runFilePath(runs[i].SessionID))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
 // PlanStorage (JsonlStorage) - file-based, keeps historical paths
 // ---------------------------------------------------------------------------
 

--- a/internal/infra/storage/memory.go
+++ b/internal/infra/storage/memory.go
@@ -16,6 +16,7 @@ type MemoryStorage struct {
 	conversations map[string]conversationData
 	sessionGroups map[string]SessionGroupEntry
 	scheduledJobs map[string]*domain.ScheduledJob
+	scheduledRuns map[string]*domain.RunRecord
 	plans         map[string]*PlanRecord
 	shellHistory  []string
 	mutex         sync.RWMutex
@@ -261,6 +262,54 @@ func (m *MemoryStorage) DeleteJob(ctx context.Context, id string) error {
 		return ErrJobNotFound
 	}
 	delete(m.scheduledJobs, id)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// ScheduledRunStorage (MemoryStorage)
+// ---------------------------------------------------------------------------
+
+// SaveRun creates or updates a run record.
+func (m *MemoryStorage) SaveRun(ctx context.Context, run *domain.RunRecord) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.scheduledRuns == nil {
+		m.scheduledRuns = make(map[string]*domain.RunRecord)
+	}
+	cp := *run
+	m.scheduledRuns[run.SessionID] = &cp
+	return nil
+}
+
+// ListRuns returns copies of run records sorted by StartedAt descending.
+func (m *MemoryStorage) ListRuns(ctx context.Context, jobID string) ([]*domain.RunRecord, error) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	var runs []*domain.RunRecord
+	for _, run := range m.scheduledRuns {
+		if jobID != "" && run.JobID != jobID {
+			continue
+		}
+		cp := *run
+		runs = append(runs, &cp)
+	}
+	slices.SortFunc(runs, func(a, b *domain.RunRecord) int {
+		return b.StartedAt.Compare(a.StartedAt)
+	})
+	return runs, nil
+}
+
+// PruneRuns deletes all but the newest keep run records.
+func (m *MemoryStorage) PruneRuns(ctx context.Context, keep int) error {
+	runs, err := m.ListRuns(ctx, "")
+	if err != nil {
+		return err
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	for i := keep; i < len(runs); i++ {
+		delete(m.scheduledRuns, runs[i].SessionID)
+	}
 	return nil
 }
 

--- a/internal/infra/storage/migrations/postgres_migrations.go
+++ b/internal/infra/storage/migrations/postgres_migrations.go
@@ -108,5 +108,22 @@ func GetPostgresMigrations() []Migration {
 				DROP TABLE IF EXISTS shell_history;
 			`,
 		},
+		{
+			Version:     "006",
+			Description: "Scheduled job run records table",
+			UpSQL: `
+				CREATE TABLE IF NOT EXISTS scheduled_job_runs (
+					session_id  TEXT PRIMARY KEY,
+					job_id      TEXT NOT NULL,
+					status      TEXT NOT NULL,
+					error       TEXT NOT NULL DEFAULT '',
+					started_at  TIMESTAMP WITH TIME ZONE NOT NULL,
+					finished_at TIMESTAMP WITH TIME ZONE
+				);
+			`,
+			DownSQL: `
+				DROP TABLE IF EXISTS scheduled_job_runs;
+			`,
+		},
 	}
 }

--- a/internal/infra/storage/migrations/sqlite_migrations.go
+++ b/internal/infra/storage/migrations/sqlite_migrations.go
@@ -101,5 +101,22 @@ func GetSQLiteMigrations() []Migration {
 				DROP TABLE IF EXISTS shell_history;
 			`,
 		},
+		{
+			Version:     "006",
+			Description: "Scheduled job run records table",
+			UpSQL: `
+				CREATE TABLE IF NOT EXISTS scheduled_job_runs (
+					session_id  TEXT PRIMARY KEY,
+					job_id      TEXT NOT NULL,
+					status      TEXT NOT NULL,
+					error       TEXT NOT NULL DEFAULT '',
+					started_at  DATETIME NOT NULL,
+					finished_at DATETIME
+				);
+			`,
+			DownSQL: `
+				DROP TABLE IF EXISTS scheduled_job_runs;
+			`,
+		},
 	}
 }

--- a/internal/infra/storage/redis.go
+++ b/internal/infra/storage/redis.go
@@ -579,6 +579,77 @@ func (s *RedisStorage) DeleteJob(ctx context.Context, id string) error {
 }
 
 // ---------------------------------------------------------------------------
+// ScheduledRunStorage (RedisStorage)
+// ---------------------------------------------------------------------------
+
+const redisScheduledRunsKey = "scheduled_job_runs"
+
+// scheduledRunKey returns the Redis key for a run record.
+func (s *RedisStorage) scheduledRunKey(sessionID string) string {
+	return fmt.Sprintf("%s:%s", redisScheduledRunsKey, sessionID)
+}
+
+// SaveRun creates or updates a run record. No TTL - retention is handled by
+// PruneRuns so records don't silently expire mid-run.
+func (s *RedisStorage) SaveRun(ctx context.Context, run *domain.RunRecord) error {
+	data, err := json.Marshal(run)
+	if err != nil {
+		return fmt.Errorf("marshal run %s: %w", run.SessionID, err)
+	}
+	return s.client.Set(ctx, s.scheduledRunKey(run.SessionID), data, 0).Err()
+}
+
+// ListRuns returns run records sorted by StartedAt descending.
+func (s *RedisStorage) ListRuns(ctx context.Context, jobID string) ([]*domain.RunRecord, error) {
+	keys, err := s.scanKeys(ctx, redisScheduledRunsKey+":*")
+	if err != nil {
+		return nil, fmt.Errorf("list run keys: %w", err)
+	}
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	pipe := s.client.Pipeline()
+	var cmds []*redis.StringCmd
+	for _, k := range keys {
+		cmds = append(cmds, pipe.Get(ctx, k))
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return nil, fmt.Errorf("load runs: %w", err)
+	}
+	var runs []*domain.RunRecord
+	for _, cmd := range cmds {
+		data, err := cmd.Bytes()
+		if err != nil {
+			continue
+		}
+		var run domain.RunRecord
+		if err := json.Unmarshal(data, &run); err != nil {
+			continue
+		}
+		if jobID != "" && run.JobID != jobID {
+			continue
+		}
+		runs = append(runs, &run)
+	}
+	slices.SortFunc(runs, func(a, b *domain.RunRecord) int {
+		return b.StartedAt.Compare(a.StartedAt)
+	})
+	return runs, nil
+}
+
+// PruneRuns deletes all but the newest keep run records.
+func (s *RedisStorage) PruneRuns(ctx context.Context, keep int) error {
+	runs, err := s.ListRuns(ctx, "")
+	if err != nil {
+		return err
+	}
+	for i := keep; i < len(runs); i++ {
+		_ = s.client.Del(ctx, s.scheduledRunKey(runs[i].SessionID)).Err()
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
 // PlanStorage (RedisStorage)
 // ---------------------------------------------------------------------------
 

--- a/internal/infra/storage/sql_store.go
+++ b/internal/infra/storage/sql_store.go
@@ -613,6 +613,74 @@ func (s *sqlStore) DeleteJob(ctx context.Context, id string) error {
 }
 
 // ---------------------------------------------------------------------------
+// ScheduledRunStorage (sqlStore)
+// ---------------------------------------------------------------------------
+
+// SaveRun creates or updates a run record via UPSERT.
+func (s *sqlStore) SaveRun(ctx context.Context, run *domain.RunRecord) error {
+	_, err := s.db.ExecContext(ctx, s.rebind(`
+		INSERT INTO scheduled_job_runs(session_id, job_id, status, error, started_at, finished_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(session_id) DO UPDATE SET
+			status = excluded.status,
+			error = excluded.error,
+			finished_at = excluded.finished_at
+	`), run.SessionID, run.JobID, string(run.Status), run.Error, run.StartedAt, run.FinishedAt)
+	if err != nil {
+		return fmt.Errorf("save run %s: %w", run.SessionID, err)
+	}
+	return nil
+}
+
+// ListRuns returns run records sorted by StartedAt descending.
+func (s *sqlStore) ListRuns(ctx context.Context, jobID string) ([]*domain.RunRecord, error) {
+	query := `
+		SELECT session_id, job_id, status, error, started_at, finished_at
+		FROM scheduled_job_runs`
+	args := []any{}
+	if jobID != "" {
+		query += " WHERE job_id = ?"
+		args = append(args, jobID)
+	}
+	query += " ORDER BY started_at DESC"
+
+	rows, err := s.db.QueryContext(ctx, s.rebind(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list runs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var runs []*domain.RunRecord
+	for rows.Next() {
+		var run domain.RunRecord
+		var status string
+		var finished sql.NullTime
+		if err := rows.Scan(&run.SessionID, &run.JobID, &status, &run.Error, &run.StartedAt, &finished); err != nil {
+			return nil, fmt.Errorf("scan run: %w", err)
+		}
+		run.Status = domain.RunStatus(status)
+		if finished.Valid {
+			run.FinishedAt = &finished.Time
+		}
+		runs = append(runs, &run)
+	}
+	return runs, rows.Err()
+}
+
+// PruneRuns deletes all but the newest keep run records.
+func (s *sqlStore) PruneRuns(ctx context.Context, keep int) error {
+	_, err := s.db.ExecContext(ctx, s.rebind(`
+		DELETE FROM scheduled_job_runs WHERE session_id NOT IN (
+			SELECT session_id FROM scheduled_job_runs ORDER BY started_at DESC LIMIT ?
+		)
+	`), keep)
+	if err != nil {
+		return fmt.Errorf("prune runs: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
 // PlanStorage (sqlStore)
 // ---------------------------------------------------------------------------
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -26,6 +26,8 @@ type Config struct {
 	Stdout           bool
 	ArchiveEnabled   bool
 	ArchiveMaxSizeMB int
+	// FilePrefix names the log file (<prefix>-<date>.log); defaults to "app".
+	FilePrefix string
 }
 
 // Init initializes the global logger (for migration period)
@@ -50,7 +52,11 @@ func NewLogger(cfg Config) (*zap.Logger, error) {
 		return zap.NewNop(), err
 	}
 
-	logFile := fmt.Sprintf("%s/app-%s.log", logDir, time.Now().Format("2006-01-02"))
+	prefix := cfg.FilePrefix
+	if prefix == "" {
+		prefix = "app"
+	}
+	logFile := fmt.Sprintf("%s/%s-%s.log", logDir, prefix, time.Now().Format("2006-01-02"))
 
 	if cfg.ArchiveEnabled {
 		if err := archiveLogFile(logFile, cfg.ArchiveMaxSizeMB); err != nil {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -4,7 +4,10 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"path/filepath"
+	"sync"
 	"time"
 
 	zap "go.uber.org/zap"
@@ -64,9 +67,19 @@ func NewLogger(cfg Config) (*zap.Logger, error) {
 		}
 	}
 
+	absLogFile, err := filepath.Abs(logFile)
+	if err != nil {
+		absLogFile = logFile
+	}
+	registerReopenSinkOnce.Do(func() {
+		_ = zap.RegisterSink("reopen", func(u *url.URL) (zap.Sink, error) {
+			return &reopenFileSink{path: u.Path}, nil
+		})
+	})
+
 	zapCfg := zap.NewProductionConfig()
-	zapCfg.OutputPaths = []string{logFile}
-	zapCfg.ErrorOutputPaths = []string{logFile}
+	zapCfg.OutputPaths = []string{"reopen://" + absLogFile}
+	zapCfg.ErrorOutputPaths = []string{"reopen://" + absLogFile}
 
 	if cfg.Stdout {
 		zapCfg.OutputPaths = append(zapCfg.OutputPaths, "stdout")
@@ -78,6 +91,68 @@ func NewLogger(cfg Config) (*zap.Logger, error) {
 	}
 
 	return zapCfg.Build(zap.AddCallerSkip(1))
+}
+
+// registerReopenSinkOnce guards zap's global sink registry: RegisterSink errors
+// on a duplicate scheme and Init runs more than once (e.g. disableStdoutLogging).
+var registerReopenSinkOnce sync.Once
+
+// reopenFileSink is a zap sink that reopens its file (recreating the parent
+// directory) whenever the path no longer exists, so deleting the logs directory
+// mid-session resumes logging instead of writing to a dead fd forever.
+// ponytail: one os.Stat per log write; buffer behind zapcore.BufferedWriteSyncer if it ever shows up in a profile.
+type reopenFileSink struct {
+	mu   sync.Mutex
+	path string
+	file *os.File
+}
+
+func (s *reopenFileSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.ensureOpen(); err != nil {
+		return 0, err
+	}
+	return s.file.Write(p)
+}
+
+func (s *reopenFileSink) ensureOpen() error {
+	if s.file != nil {
+		if _, err := os.Stat(s.path); err == nil {
+			return nil
+		}
+		_ = s.file.Close()
+		s.file = nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	s.file = f
+	return nil
+}
+
+func (s *reopenFileSink) Sync() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
+		return nil
+	}
+	return s.file.Sync()
+}
+
+func (s *reopenFileSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
+		return nil
+	}
+	err := s.file.Close()
+	s.file = nil
+	return err
 }
 
 // GetGlobalLogger returns the global logger instance

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -29,8 +29,7 @@ type Config struct {
 	Stdout           bool
 	ArchiveEnabled   bool
 	ArchiveMaxSizeMB int
-	// FilePrefix names the log file (<prefix>-<date>.log); defaults to "app".
-	FilePrefix string
+	FilePrefix       string
 }
 
 // Init initializes the global logger (for migration period)

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -123,3 +123,28 @@ func TestArchiveLogFile(t *testing.T) {
 		}
 	})
 }
+
+func TestReopenFileSinkRecreatesDeletedLogFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "logs", "app.log")
+	sink := &reopenFileSink{path: path}
+	defer func() { _ = sink.Close() }()
+
+	if _, err := sink.Write([]byte("first\n")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Dir(path)); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sink.Write([]byte("second\n")); err != nil {
+		t.Fatalf("write after delete: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("log file not recreated: %v", err)
+	}
+	if string(data) != "second\n" {
+		t.Fatalf("expected recreated file to contain only the second line, got %q", string(data))
+	}
+}

--- a/internal/services/heartbeat/heartbeat.go
+++ b/internal/services/heartbeat/heartbeat.go
@@ -1,6 +1,6 @@
 // Package heartbeat implements a periodic "wake-up" service that
 // spawns the agent on a fixed interval to check for pending work. It
-// is hosted by the channels-manager daemon (peer to the scheduler)
+// is hosted by the daemon (peer to the scheduler)
 // and is disabled by default.
 //
 // Unlike the scheduler, heartbeat does not route output to a channel.

--- a/internal/services/process_alive.go
+++ b/internal/services/process_alive.go
@@ -1,0 +1,6 @@
+package services
+
+// ProcessAlive reports whether a process with the given PID exists.
+func ProcessAlive(pid int) bool {
+	return processAlive(pid)
+}

--- a/internal/services/schedule_notifier.go
+++ b/internal/services/schedule_notifier.go
@@ -1,0 +1,63 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	logger "github.com/inference-gateway/cli/internal/logger"
+)
+
+// ScheduleNotifier delivers scheduled-job run output to the job's delivery
+// channel. It subscribes to the scheduler's run events (Options.OnRunEvent);
+// jobs without a delivery target are record-only, so their events are ignored
+// here and their output lives in storage.
+type ScheduleNotifier struct {
+	lookup func(name string) domain.Channel
+}
+
+// NewScheduleNotifier constructs a notifier resolving channels through lookup
+// (typically ChannelManagerService.GetChannel).
+func NewScheduleNotifier(lookup func(name string) domain.Channel) *ScheduleNotifier {
+	return &ScheduleNotifier{lookup: lookup}
+}
+
+// Notify implements the scheduler's OnRunEvent hook.
+func (n *ScheduleNotifier) Notify(job domain.ScheduledJob, e domain.RunEvent) {
+	if job.Channel == "" {
+		return
+	}
+	ch := n.lookup(job.Channel)
+	if ch == nil {
+		logger.Warn("scheduled job delivery skipped: channel not registered", "id", job.ID, "channel", job.Channel)
+		return
+	}
+
+	var content string
+	switch {
+	case e.Line != nil:
+		content = formatAgentMessage(e.Line)
+	case e.Done && e.Err != nil:
+		name := job.Name
+		if name == "" {
+			name = job.ID
+		}
+		content = fmt.Sprintf("⚠️ Scheduled task %q failed: %v", name, e.Err)
+	}
+	if content == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out := domain.OutboundMessage{
+		ChannelName: job.Channel,
+		RecipientID: job.RecipientID,
+		Content:     content,
+		Timestamp:   time.Now(),
+	}
+	if err := ch.Send(ctx, out); err != nil {
+		logger.Error("failed to send scheduled-job output", "id", job.ID, "channel", job.Channel, "error", err)
+	}
+}

--- a/internal/services/schedule_notifier_test.go
+++ b/internal/services/schedule_notifier_test.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+type notifierFakeChannel struct {
+	mu       sync.Mutex
+	name     string
+	received []domain.OutboundMessage
+}
+
+func (f *notifierFakeChannel) Name() string { return f.name }
+func (f *notifierFakeChannel) Start(_ context.Context, _ chan<- domain.InboundMessage) error {
+	return nil
+}
+func (f *notifierFakeChannel) Stop() error { return nil }
+func (f *notifierFakeChannel) Send(_ context.Context, m domain.OutboundMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.received = append(f.received, m)
+	return nil
+}
+
+func (f *notifierFakeChannel) Snapshot() []domain.OutboundMessage {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]domain.OutboundMessage, len(f.received))
+	copy(out, f.received)
+	return out
+}
+
+func newNotifierWithChannel(ch *notifierFakeChannel) *ScheduleNotifier {
+	return NewScheduleNotifier(func(name string) domain.Channel {
+		if ch != nil && name == ch.name {
+			return ch
+		}
+		return nil
+	})
+}
+
+func TestScheduleNotifier_DeliversAssistantLines(t *testing.T) {
+	ch := &notifierFakeChannel{name: "telegram"}
+	n := newNotifierWithChannel(ch)
+	job := domain.ScheduledJob{ID: "j1", Channel: "telegram", RecipientID: "user1"}
+
+	n.Notify(job, domain.RunEvent{Line: []byte(`{"role":"assistant","content":"hello"}`)})
+
+	got := ch.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(got))
+	}
+	if got[0].ChannelName != "telegram" || got[0].RecipientID != "user1" || got[0].Content != "hello" {
+		t.Fatalf("wrong message: %+v", got[0])
+	}
+}
+
+func TestScheduleNotifier_RecordOnlyJobIsIgnored(t *testing.T) {
+	ch := &notifierFakeChannel{name: "telegram"}
+	n := newNotifierWithChannel(ch)
+	job := domain.ScheduledJob{ID: "j1"} // no delivery target
+
+	n.Notify(job, domain.RunEvent{Line: []byte(`{"role":"assistant","content":"hello"}`)})
+	n.Notify(job, domain.RunEvent{Done: true, Err: errors.New("boom")})
+
+	if got := ch.Snapshot(); len(got) != 0 {
+		t.Fatalf("expected no delivery for record-only job, got %d messages", len(got))
+	}
+}
+
+func TestScheduleNotifier_FailureEvent(t *testing.T) {
+	ch := &notifierFakeChannel{name: "telegram"}
+	n := newNotifierWithChannel(ch)
+	job := domain.ScheduledJob{ID: "j1", Name: "morning report", Channel: "telegram", RecipientID: "user1"}
+
+	n.Notify(job, domain.RunEvent{Done: true, Err: errors.New("agent exploded")})
+
+	got := ch.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 failure message, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Content, "morning report") || !strings.Contains(got[0].Content, "agent exploded") {
+		t.Fatalf("failure message missing details: %q", got[0].Content)
+	}
+}
+
+func TestScheduleNotifier_UnregisteredChannelIsSkipped(t *testing.T) {
+	n := newNotifierWithChannel(nil)
+	job := domain.ScheduledJob{ID: "j1", Channel: "telegram", RecipientID: "user1"}
+	// Must not panic on nil channel lookup.
+	n.Notify(job, domain.RunEvent{Line: []byte(`{"role":"assistant","content":"hello"}`)})
+}

--- a/internal/services/schedule_notifier_test.go
+++ b/internal/services/schedule_notifier_test.go
@@ -64,7 +64,7 @@ func TestScheduleNotifier_DeliversAssistantLines(t *testing.T) {
 func TestScheduleNotifier_RecordOnlyJobIsIgnored(t *testing.T) {
 	ch := &notifierFakeChannel{name: "telegram"}
 	n := newNotifierWithChannel(ch)
-	job := domain.ScheduledJob{ID: "j1"} // no delivery target
+	job := domain.ScheduledJob{ID: "j1"}
 
 	n.Notify(job, domain.RunEvent{Line: []byte(`{"role":"assistant","content":"hello"}`)})
 	n.Notify(job, domain.RunEvent{Done: true, Err: errors.New("boom")})

--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -2,7 +2,6 @@ package scheduler
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -19,24 +18,24 @@ import (
 	agentrunner "github.com/inference-gateway/cli/internal/services/agentrunner"
 )
 
-// ChannelLookupFn returns the registered Channel for a name, or nil if unknown.
-type ChannelLookupFn func(name string) domain.Channel
-
-// Service runs scheduled jobs inside the channels-manager daemon. Jobs are
+// Service runs scheduled jobs inside the `infer daemon` process. Jobs are
 // loaded from the configured ScheduledJobStorage, registered with a robfig/cron
 // scheduler, and hot-reloaded by polling the storage and diffing (reconcile).
 //
 // On fire, a fresh `infer headless --session-id <uuid>` subprocess is spawned -
 // every fire gets a brand-new session, so no context carries between runs.
-// Each assistant line emitted by the agent is forwarded to the configured
-// channel/recipient via the in-process channel lookup.
+// A RunRecord is persisted per fire (keyed by that session ID, so the run's
+// conversation is discoverable from storage), and progress is emitted through
+// the optional OnRunEvent hook. The scheduler knows nothing about channels -
+// delivery is a subscriber concern (see services.ScheduleNotifier).
 type Service struct {
-	store         storage.ScheduledJobStorage
-	cron          *cron.Cron
-	parser        cron.Parser
-	channelLookup ChannelLookupFn
-	execCmd       agentrunner.ExecFunc
-	binaryPath    string
+	store      storage.ScheduledJobStorage
+	runs       storage.ScheduledRunStorage
+	onRunEvent func(domain.ScheduledJob, domain.RunEvent)
+	cron       *cron.Cron
+	parser     cron.Parser
+	execCmd    agentrunner.ExecFunc
+	binaryPath string
 
 	mu       sync.Mutex
 	entryIDs map[string]cron.EntryID
@@ -51,10 +50,18 @@ type Service struct {
 // the jobs in storage.
 const pollInterval = 2 * time.Second
 
+// maxRunRecords caps how many run records are retained across all jobs.
+// ponytail: global cap; per-job retention if one chatty job ever starves the rest.
+const maxRunRecords = 200
+
 // Options bundles dependencies and configuration for NewService.
 type Options struct {
-	Store         storage.ScheduledJobStorage
-	ChannelLookup ChannelLookupFn
+	Store storage.ScheduledJobStorage
+	Runs  storage.ScheduledRunStorage
+	// OnRunEvent, when non-nil, receives every run event: one event per raw
+	// agent stdout line (Line valid only for the duration of the call), and a
+	// terminal event with Done set (Err non-nil on failure).
+	OnRunEvent func(domain.ScheduledJob, domain.RunEvent)
 	// ExecCommand defaults to exec.CommandContext when nil.
 	ExecCommand agentrunner.ExecFunc
 	// BinaryPath defaults to os.Args[0] (current binary) when empty.
@@ -66,19 +73,20 @@ func NewService(opts Options) (*Service, error) {
 	if opts.Store == nil {
 		return nil, errors.New("scheduler: Store is required")
 	}
-	if opts.ChannelLookup == nil {
-		return nil, errors.New("scheduler: ChannelLookup is required")
+	if opts.Runs == nil {
+		return nil, errors.New("scheduler: Runs is required")
 	}
 	parser := cron.NewParser(
 		cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
 	)
 	return &Service{
-		store:         opts.Store,
-		parser:        parser,
-		channelLookup: opts.ChannelLookup,
-		execCmd:       opts.ExecCommand,
-		binaryPath:    opts.BinaryPath,
-		entryIDs:      make(map[string]cron.EntryID),
+		store:      opts.Store,
+		runs:       opts.Runs,
+		onRunEvent: opts.OnRunEvent,
+		parser:     parser,
+		execCmd:    opts.ExecCommand,
+		binaryPath: opts.BinaryPath,
+		entryIDs:   make(map[string]cron.EntryID),
 	}, nil
 }
 
@@ -174,7 +182,7 @@ func (s *Service) registerJob(job *domain.ScheduledJob) error {
 	}
 	s.entryIDs[id] = eid
 	s.mu.Unlock()
-	logger.Info("scheduled job registered", "id", id, "cron", job.CronExpression, "channel", job.Channel)
+	logger.Info("scheduled job registered", "id", id, "cron", job.CronExpression)
 	return nil
 }
 
@@ -189,56 +197,53 @@ func (s *Service) removeJob(id string) {
 	}
 }
 
-// fire runs a single execution of the job: spawns `infer headless`, streams
-// stdout into channel messages, and persists run metadata back to the store.
+// emit forwards a run event to the subscriber, if any.
+func (s *Service) emit(job domain.ScheduledJob, e domain.RunEvent) {
+	if s.onRunEvent != nil {
+		s.onRunEvent(job, e)
+	}
+}
+
+// fire runs a single execution of the job: persists a RunRecord, spawns
+// `infer headless`, streams stdout lines through the OnRunEvent hook, and
+// persists the run outcome plus the job's LastRun/LastError metadata.
 func (s *Service) fire(job domain.ScheduledJob) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
-	logger.Info("firing scheduled job", "id", job.ID, "channel", job.Channel)
-
 	now := time.Now().UTC()
 	job.LastRun = &now
-
-	ch := s.channelLookup(job.Channel)
-	if ch == nil {
-		job.LastError = fmt.Sprintf("channel %q is not registered", job.Channel)
-		logger.Error("scheduled job: channel not found", "id", job.ID, "channel", job.Channel)
-		s.persistRun(&job)
-		return
+	run := &domain.RunRecord{
+		SessionID: uuid.New().String(),
+		JobID:     job.ID,
+		Status:    domain.RunStatusRunning,
+		StartedAt: now,
 	}
+	logger.Info("firing scheduled job", "id", job.ID, "session_id", run.SessionID)
+	s.saveRun(run)
 
-	var firstSendErr error
-	sendFn := func(content string) {
-		if content == "" {
-			return
-		}
-		out := domain.OutboundMessage{
-			ChannelName: job.Channel,
-			RecipientID: job.RecipientID,
-			Content:     content,
-			Timestamp:   time.Now(),
-		}
-		if err := ch.Send(ctx, out); err != nil {
-			logger.Error("failed to send scheduled-job output", "id", job.ID, "channel", job.Channel, "error", err)
-			if firstSendErr == nil {
-				firstSendErr = err
-			}
-		}
-	}
-
-	switch err := s.runAgent(ctx, job, sendFn); {
-	case err != nil:
+	err := s.runAgent(ctx, job, run.SessionID)
+	finished := time.Now().UTC()
+	run.FinishedAt = &finished
+	if err != nil {
+		run.Status = domain.RunStatusFailed
+		run.Error = err.Error()
 		job.LastError = err.Error()
 		logger.Error("scheduled job execution failed", "id", job.ID, "error", err)
-		sendFn(fmt.Sprintf("⚠️ Scheduled task %q failed: %v", displayName(&job), err))
-	case firstSendErr != nil:
-		job.LastError = fmt.Sprintf("delivery to %s/%s failed: %v", job.Channel, job.RecipientID, firstSendErr)
-	default:
+	} else {
+		run.Status = domain.RunStatusCompleted
 		job.LastError = ""
 	}
+	s.saveRun(run)
+	if pruneErr := s.runs.PruneRuns(context.Background(), maxRunRecords); pruneErr != nil {
+		logger.Warn("failed to prune run records", "error", pruneErr)
+	}
+	s.emit(job, domain.RunEvent{Done: true, Err: err})
 
 	if job.RunOnce {
+		// Unregister immediately - waiting for the next poll tick would let
+		// short intervals (e.g. @every 2s) fire again before the delete lands.
+		s.removeJob(job.ID)
 		if err := s.store.DeleteJob(context.Background(), job.ID); err != nil {
 			logger.Warn("failed to delete one-off scheduled job after fire", "id", job.ID, "error", err)
 		} else {
@@ -247,6 +252,14 @@ func (s *Service) fire(job domain.ScheduledJob) {
 		return
 	}
 	s.persistRun(&job)
+}
+
+// saveRun persists a run record. Errors are only logged - a failed record
+// write must not abort the run itself.
+func (s *Service) saveRun(run *domain.RunRecord) {
+	if err := s.runs.SaveRun(context.Background(), run); err != nil {
+		logger.Warn("failed to persist run record", "job_id", run.JobID, "session_id", run.SessionID, "error", err)
+	}
 }
 
 // persistRun writes the updated LastRun/LastError back to disk. Errors are
@@ -264,19 +277,17 @@ func (s *Service) persistRun(job *domain.ScheduledJob) {
 	}
 }
 
-// runAgent spawns `infer headless --session-id <new-uuid> <prompt>` (via the shared
-// agentrunner) and forwards each formatted assistant line through sendFn.
-func (s *Service) runAgent(ctx context.Context, job domain.ScheduledJob, sendFn func(string)) error {
+// runAgent spawns `infer headless --session-id <sessionID> <prompt>` (via the
+// shared agentrunner) and forwards each stdout line through the run-event hook.
+func (s *Service) runAgent(ctx context.Context, job domain.ScheduledJob, sessionID string) error {
 	res, err := agentrunner.Run(ctx, agentrunner.Options{
 		BinaryPath: s.binaryPath,
 		Exec:       s.execCmd,
-		SessionID:  uuid.New().String(),
+		SessionID:  sessionID,
 		Prompt:     job.Prompt,
 		Model:      job.Model,
 		OnLine: func(line []byte) {
-			if msg := formatAgentLine(line); msg != "" {
-				sendFn(msg)
-			}
+			s.emit(job, domain.RunEvent{Line: line})
 		},
 	})
 	if err != nil {
@@ -286,50 +297,6 @@ func (s *Service) runAgent(ctx context.Context, job domain.ScheduledJob, sendFn 
 		return err
 	}
 	return nil
-}
-
-// formatAgentLine is a near-duplicate of services.formatAgentMessage. It's
-// kept here to avoid an import cycle (services -> services/scheduler ->
-// services). Behaviour must stay in sync with the original.
-func formatAgentLine(line []byte) string {
-	var msg map[string]any
-	if err := json.Unmarshal(line, &msg); err != nil {
-		return ""
-	}
-	if _, isStatus := msg["type"]; isStatus {
-		return ""
-	}
-	role, _ := msg["role"].(string)
-	switch role {
-	case "assistant":
-		content, _ := msg["content"].(string)
-		if tools, ok := msg["tools"].([]any); ok && len(tools) > 0 {
-			toolNames := make([]string, 0, len(tools))
-			for _, t := range tools {
-				if name, ok := t.(string); ok {
-					toolNames = append(toolNames, name)
-				}
-			}
-			toolMsg := fmt.Sprintf("🔧 Using tool: %s", strings.Join(toolNames, ", "))
-			if content != "" {
-				return content + "\n\n" + toolMsg
-			}
-			return toolMsg
-		}
-		if content != "" {
-			return content
-		}
-	case "tool":
-		return ""
-	}
-	return ""
-}
-
-func displayName(job *domain.ScheduledJob) string {
-	if job.Name != "" {
-		return job.Name
-	}
-	return job.ID
 }
 
 // startPoller reconciles cron entries against storage once synchronously (so

--- a/internal/services/scheduler/scheduler.go
+++ b/internal/services/scheduler/scheduler.go
@@ -56,16 +56,11 @@ const maxRunRecords = 200
 
 // Options bundles dependencies and configuration for NewService.
 type Options struct {
-	Store storage.ScheduledJobStorage
-	Runs  storage.ScheduledRunStorage
-	// OnRunEvent, when non-nil, receives every run event: one event per raw
-	// agent stdout line (Line valid only for the duration of the call), and a
-	// terminal event with Done set (Err non-nil on failure).
-	OnRunEvent func(domain.ScheduledJob, domain.RunEvent)
-	// ExecCommand defaults to exec.CommandContext when nil.
+	Store       storage.ScheduledJobStorage
+	Runs        storage.ScheduledRunStorage
+	OnRunEvent  func(domain.ScheduledJob, domain.RunEvent)
 	ExecCommand agentrunner.ExecFunc
-	// BinaryPath defaults to os.Args[0] (current binary) when empty.
-	BinaryPath string
+	BinaryPath  string
 }
 
 // NewService constructs a Service. Returns an error if required deps are missing.

--- a/internal/services/scheduler/scheduler_test.go
+++ b/internal/services/scheduler/scheduler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os/exec"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,27 +13,39 @@ import (
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
 )
 
-type fakeChannel struct {
-	mu       sync.Mutex
-	name     string
-	received []domain.OutboundMessage
+// eventSink records run events emitted by the scheduler.
+type eventSink struct {
+	mu     sync.Mutex
+	events []domain.RunEvent
+	lines  []string
 }
 
-func (f *fakeChannel) Name() string                                                    { return f.name }
-func (f *fakeChannel) Start(ctx context.Context, _ chan<- domain.InboundMessage) error { return nil }
-func (f *fakeChannel) Stop() error                                                     { return nil }
-func (f *fakeChannel) Send(_ context.Context, m domain.OutboundMessage) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.received = append(f.received, m)
-	return nil
+func (e *eventSink) Notify(_ domain.ScheduledJob, ev domain.RunEvent) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if ev.Line != nil {
+		e.lines = append(e.lines, string(ev.Line))
+	}
+	e.events = append(e.events, domain.RunEvent{Err: ev.Err, Done: ev.Done})
 }
-func (f *fakeChannel) Snapshot() []domain.OutboundMessage {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	out := make([]domain.OutboundMessage, len(f.received))
-	copy(out, f.received)
+
+func (e *eventSink) Lines() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.lines))
+	copy(out, e.lines)
 	return out
+}
+
+func (e *eventSink) TerminalErr() (bool, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, ev := range e.events {
+		if ev.Done {
+			return true, ev.Err
+		}
+	}
+	return false, nil
 }
 
 func TestParseCron(t *testing.T) {
@@ -55,21 +66,17 @@ func TestNewService_ValidatesDeps(t *testing.T) {
 	}
 	memStore := storage.NewMemoryStorage()
 	if _, err := NewService(Options{Store: memStore}); err == nil {
-		t.Fatal("expected error when ChannelLookup is nil")
+		t.Fatal("expected error when Runs is nil")
 	}
 }
 
-func newTestService(t *testing.T, ch *fakeChannel, fired *atomic.Int32) (*Service, storage.ScheduledJobStorage) {
+func newTestService(t *testing.T, sink *eventSink, fired *atomic.Int32) (*Service, *storage.MemoryStorage) {
 	t.Helper()
 	memStore := storage.NewMemoryStorage()
 	svc, err := NewService(Options{
-		Store: memStore,
-		ChannelLookup: func(name string) domain.Channel {
-			if name == ch.name {
-				return ch
-			}
-			return nil
-		},
+		Store:      memStore,
+		Runs:       memStore,
+		OnRunEvent: sink.Notify,
 		ExecCommand: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 			fired.Add(1)
 			return exec.CommandContext(ctx, "echo",
@@ -84,16 +91,14 @@ func newTestService(t *testing.T, ch *fakeChannel, fired *atomic.Int32) (*Servic
 }
 
 func TestService_Start_LoadsExistingJobs(t *testing.T) {
-	ch := &fakeChannel{name: "telegram"}
+	sink := &eventSink{}
 	fired := &atomic.Int32{}
-	svc, store := newTestService(t, ch, fired)
+	svc, store := newTestService(t, sink, fired)
 
 	job := &domain.ScheduledJob{
 		ID:             "preexisting",
 		CronExpression: "@every 1s",
 		Prompt:         "test",
-		Channel:        "telegram",
-		RecipientID:    "user1",
 		CreatedAt:      time.Now().UTC(),
 	}
 	if err := store.SaveJob(context.Background(), job); err != nil {
@@ -112,17 +117,15 @@ func TestService_Start_LoadsExistingJobs(t *testing.T) {
 	}
 }
 
-func TestService_Fire_SendsToChannel(t *testing.T) {
-	ch := &fakeChannel{name: "telegram"}
+func TestService_Fire_EmitsEventsAndRecordsRun(t *testing.T) {
+	sink := &eventSink{}
 	fired := &atomic.Int32{}
-	svc, store := newTestService(t, ch, fired)
+	svc, store := newTestService(t, sink, fired)
 
 	job := &domain.ScheduledJob{
 		ID:             "fast",
 		CronExpression: "@every 1s",
 		Prompt:         "test",
-		Channel:        "telegram",
-		RecipientID:    "user1",
 		CreatedAt:      time.Now().UTC(),
 	}
 	if err := store.SaveJob(context.Background(), job); err != nil {
@@ -137,28 +140,103 @@ func TestService_Fire_SendsToChannel(t *testing.T) {
 
 	deadline := time.Now().Add(4 * time.Second)
 	for time.Now().Before(deadline) {
-		if fired.Load() >= 1 && len(ch.Snapshot()) >= 1 {
+		if done, _ := sink.TerminalErr(); done {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	got := ch.Snapshot()
-	if len(got) == 0 {
-		t.Fatalf("expected at least 1 outbound message, got 0 (fired=%d)", fired.Load())
+	lines := sink.Lines()
+	if len(lines) == 0 {
+		t.Fatalf("expected at least 1 line event, got 0 (fired=%d)", fired.Load())
 	}
-	if got[0].ChannelName != "telegram" || got[0].RecipientID != "user1" {
-		t.Fatalf("wrong routing: %+v", got[0])
+	if lines[0] != `{"role":"assistant","content":"hello from scheduler"}` {
+		t.Fatalf("wrong line content: %q", lines[0])
 	}
-	if got[0].Content != "hello from scheduler" {
-		t.Fatalf("wrong content: %q", got[0].Content)
+	done, termErr := sink.TerminalErr()
+	if !done || termErr != nil {
+		t.Fatalf("expected clean terminal event, done=%v err=%v", done, termErr)
+	}
+
+	runs, err := store.ListRuns(context.Background(), "fast")
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Fatal("expected a run record to be persisted")
+	}
+	if runs[0].Status != domain.RunStatusCompleted {
+		t.Fatalf("expected completed run, got %q (error=%q)", runs[0].Status, runs[0].Error)
+	}
+	if runs[0].SessionID == "" || runs[0].FinishedAt == nil {
+		t.Fatalf("run record incomplete: %+v", runs[0])
+	}
+}
+
+func TestService_Fire_AgentFailure_RecordsFailedRun(t *testing.T) {
+	sink := &eventSink{}
+	memStore := storage.NewMemoryStorage()
+	svc, err := NewService(Options{
+		Store:      memStore,
+		Runs:       memStore,
+		OnRunEvent: sink.Notify,
+		ExecCommand: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "false")
+		},
+		BinaryPath: "/usr/bin/false",
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	job := &domain.ScheduledJob{
+		ID:             "agent-fails",
+		CronExpression: "@every 1s",
+		Prompt:         "x",
+		CreatedAt:      time.Now().UTC(),
+	}
+	if err := memStore.SaveJob(context.Background(), job); err != nil {
+		t.Fatalf("SaveJob: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = svc.Stop(ctx) }()
+
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		if done, _ := sink.TerminalErr(); done {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	done, termErr := sink.TerminalErr()
+	if !done || termErr == nil {
+		t.Fatalf("expected failing terminal event, done=%v err=%v", done, termErr)
+	}
+	runs, err := memStore.ListRuns(context.Background(), "agent-fails")
+	if err != nil || len(runs) == 0 {
+		t.Fatalf("expected run record, err=%v", err)
+	}
+	if runs[0].Status != domain.RunStatusFailed || runs[0].Error == "" {
+		t.Fatalf("expected failed run with error, got %+v", runs[0])
+	}
+	loaded, err := memStore.LoadJob(context.Background(), "agent-fails")
+	if err != nil {
+		t.Fatalf("LoadJob: %v", err)
+	}
+	if loaded.LastError == "" {
+		t.Fatal("expected LastError to be set when the agent run fails")
 	}
 }
 
 func TestService_PollReload_AddsNewJob(t *testing.T) {
-	ch := &fakeChannel{name: "telegram"}
+	sink := &eventSink{}
 	fired := &atomic.Int32{}
-	svc, store := newTestService(t, ch, fired)
+	svc, store := newTestService(t, sink, fired)
 
 	ctx := context.Background()
 	if err := svc.Start(ctx); err != nil {
@@ -174,8 +252,6 @@ func TestService_PollReload_AddsNewJob(t *testing.T) {
 		ID:             "added-later",
 		CronExpression: "0 8 * * *",
 		Prompt:         "morning",
-		Channel:        "telegram",
-		RecipientID:    "user1",
 		CreatedAt:      time.Now().UTC(),
 	}
 	if err := store.SaveJob(context.Background(), job); err != nil {
@@ -196,16 +272,14 @@ func TestService_PollReload_AddsNewJob(t *testing.T) {
 }
 
 func TestService_PollReload_UpdatesChangedJob(t *testing.T) {
-	ch := &fakeChannel{name: "telegram"}
+	sink := &eventSink{}
 	fired := &atomic.Int32{}
-	svc, store := newTestService(t, ch, fired)
+	svc, store := newTestService(t, sink, fired)
 
 	job := &domain.ScheduledJob{
 		ID:             "editable",
 		CronExpression: "0 8 * * *",
 		Prompt:         "before",
-		Channel:        "telegram",
-		RecipientID:    "user1",
 		CreatedAt:      time.Now().UTC(),
 	}
 	if err := store.SaveJob(context.Background(), job); err != nil {
@@ -232,16 +306,14 @@ func TestService_PollReload_UpdatesChangedJob(t *testing.T) {
 }
 
 func TestService_PollReload_RemovesJob(t *testing.T) {
-	ch := &fakeChannel{name: "telegram"}
+	sink := &eventSink{}
 	fired := &atomic.Int32{}
-	svc, store := newTestService(t, ch, fired)
+	svc, store := newTestService(t, sink, fired)
 
 	job := &domain.ScheduledJob{
 		ID:             "doomed",
 		CronExpression: "0 8 * * *",
 		Prompt:         "x",
-		Channel:        "telegram",
-		RecipientID:    "user1",
 		CreatedAt:      time.Now().UTC(),
 	}
 	if err := store.SaveJob(context.Background(), job); err != nil {
@@ -273,91 +345,15 @@ func TestService_PollReload_RemovesJob(t *testing.T) {
 	}
 }
 
-type sendErrChannel struct {
-	name    string
-	sendErr error
-	calls   atomic.Int32
-}
-
-func (s *sendErrChannel) Name() string                                                    { return s.name }
-func (s *sendErrChannel) Start(ctx context.Context, _ chan<- domain.InboundMessage) error { return nil }
-func (s *sendErrChannel) Stop() error                                                     { return nil }
-func (s *sendErrChannel) Send(_ context.Context, _ domain.OutboundMessage) error {
-	s.calls.Add(1)
-	return s.sendErr
-}
-
-func TestService_Fire_SendError_RecordedInLastError(t *testing.T) {
-	ch := &sendErrChannel{name: "telegram", sendErr: errors.New("invalid chat ID \"test\"")}
-	memStore := storage.NewMemoryStorage()
-	svc, err := NewService(Options{
-		Store: memStore,
-		ChannelLookup: func(name string) domain.Channel {
-			if name == ch.name {
-				return ch
-			}
-			return nil
-		},
-		ExecCommand: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			return exec.CommandContext(ctx, "echo",
-				`{"role":"assistant","content":"will fail to deliver"}`)
-		},
-		BinaryPath: "/usr/bin/true",
-	})
-	if err != nil {
-		t.Fatalf("NewService: %v", err)
-	}
-
-	job := &domain.ScheduledJob{
-		ID:             "send-fails",
-		CronExpression: "@every 1s",
-		Prompt:         "x",
-		Channel:        "telegram",
-		RecipientID:    "test",
-		CreatedAt:      time.Now().UTC(),
-	}
-	if err := memStore.SaveJob(context.Background(), job); err != nil {
-		t.Fatalf("SaveJob: %v", err)
-	}
-
-	ctx := context.Background()
-	if err := svc.Start(ctx); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	defer func() { _ = svc.Stop(ctx) }()
-
-	deadline := time.Now().Add(4 * time.Second)
-	for time.Now().Before(deadline) {
-		loaded, err := memStore.LoadJob(context.Background(), "send-fails")
-		if err == nil && loaded.LastError != "" {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	loaded, err := memStore.LoadJob(context.Background(), "send-fails")
-	if err != nil {
-		t.Fatalf("LoadJob: %v", err)
-	}
-	if loaded.LastError == "" {
-		t.Fatal("expected LastError to be set when channel.Send fails")
-	}
-	if !strings.Contains(loaded.LastError, "invalid chat ID") {
-		t.Fatalf("expected LastError to mention underlying send error, got %q", loaded.LastError)
-	}
-}
-
 func TestService_Fire_RunOnce_DeletesAfterFire(t *testing.T) {
-	ch := &fakeChannel{name: "telegram"}
+	sink := &eventSink{}
 	fired := &atomic.Int32{}
-	svc, store := newTestService(t, ch, fired)
+	svc, store := newTestService(t, sink, fired)
 
 	job := &domain.ScheduledJob{
 		ID:             "one-shot",
 		CronExpression: "@every 1s",
 		Prompt:         "x",
-		Channel:        "telegram",
-		RecipientID:    "user1",
 		RunOnce:        true,
 		CreatedAt:      time.Now().UTC(),
 	}
@@ -385,45 +381,12 @@ func TestService_Fire_RunOnce_DeletesAfterFire(t *testing.T) {
 	if fired.Load() < 1 {
 		t.Fatal("expected job to fire at least once")
 	}
-}
-
-func TestService_Fire_ChannelMissing_RecordsError(t *testing.T) {
-	ch := &fakeChannel{name: "telegram"}
-	fired := &atomic.Int32{}
-	svc, store := newTestService(t, ch, fired)
-
-	job := &domain.ScheduledJob{
-		ID:             "wrong-channel",
-		CronExpression: "@every 1s",
-		Prompt:         "x",
-		Channel:        "nonexistent",
-		RecipientID:    "user1",
-		CreatedAt:      time.Now().UTC(),
-	}
-	if err := store.SaveJob(context.Background(), job); err != nil {
-		t.Fatalf("SaveJob: %v", err)
-	}
-
-	ctx := context.Background()
-	if err := svc.Start(ctx); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	defer func() { _ = svc.Stop(ctx) }()
-
-	deadline := time.Now().Add(4 * time.Second)
-	for time.Now().Before(deadline) {
-		loaded, err := store.LoadJob(context.Background(), "wrong-channel")
-		if err == nil && loaded.LastError != "" {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	loaded, err := store.LoadJob(context.Background(), "wrong-channel")
+	// The run record must survive the job deletion.
+	runs, err := store.ListRuns(context.Background(), "one-shot")
 	if err != nil {
-		t.Fatalf("LoadJob: %v", err)
+		t.Fatalf("ListRuns: %v", err)
 	}
-	if loaded.LastError == "" {
-		t.Fatal("expected LastError to be set when channel not found")
+	if len(runs) == 0 {
+		t.Fatal("expected run record to survive one-off job deletion")
 	}
 }

--- a/internal/telemetry/recorder.go
+++ b/internal/telemetry/recorder.go
@@ -428,7 +428,7 @@ func (r *Recorder) RecordSession(mode, outcome string, dur time.Duration) {
 }
 
 // Meter returns the meter from the provider, or nil when the recorder is nil
-// or the provider is nil. Used by subsystems (e.g. channels-manager) to
+// or the provider is nil. Used by subsystems (e.g. the daemon) to
 // register their own instruments on the shared meter provider.
 func (r *Recorder) Meter() metric.Meter {
 	if r == nil || r.provider == nil {


### PR DESCRIPTION
## Summary

Closes #1049.

Separates the scheduling subsystem into three concerns - agent runs, scheduling, and notification delivery - and renames the daemon accordingly.

- **`infer channels-manager` -> `infer daemon`** (hard rename, no alias). Same three subsystems: scheduler, channel listener, heartbeat.
- **Scheduler only runs agents.** `ChannelLookupFn` and the duplicated `formatAgentLine` are removed from `internal/services/scheduler`. Every fire persists a `RunRecord` (`session_id` = the run's conversation ID, `job_id`, `status`, `error`, timestamps) and streams progress through an `OnRunEvent` hook. Newest 200 records retained; `RunOnce` records survive job deletion.
- **Delivery is a subscriber.** New `ScheduleNotifier` (`internal/services/schedule_notifier.go`) receives run events, and only when the job has a delivery target formats with the existing `formatAgentMessage` and calls `Channel.Send`.
- **Schedule tool works from any session.** Non-channel sessions (chat, headless, desktop UUIDs) create record-only jobs; channel sessions keep today's behavior (delivery target derived from the session ID). A channel session naming a disabled channel still errors.
- **Storage**: new `ScheduledRunStorage` interface implemented by all six backends (jsonl, sqlite, postgres, redis, d1, memory); migration 006 (`scheduled_job_runs`).
- **Bug fix**: `RunOnce` jobs now unregister their cron entry immediately on fire - previously a short interval (e.g. `@every 2s`) could fire again before the poller noticed the delete.

This supersedes the LocalChannel/JSONL direction from #1050: consumers read run records and conversations straight from the shared storage backend.

## Cross-repo impact

- **desktop**: inference-gateway/desktop#109 (consume run records, spawn `infer daemon`) - unblocks inference-gateway/desktop#83.
- **docs**: inference-gateway/docs#545 (command rename + run-record semantics).
- **Breaking**: the `channels-manager` command no longer exists; deployments (docker-compose examples updated in this PR, k8s Orchestrator CRD args) must switch to `infer daemon`.

## Testing

- `task precommit:run` green (fmt, lint, tidy, full `go test ./...`).
- New unit tests: scheduler fire -> run events + persisted run records (success and failure), `RunOnce` record survival, `ScheduleNotifier` delivery/record-only/failure/unregistered-channel paths, Schedule tool record-only creation from non-channel sessions.
- Manual smoke test: `infer daemon` with a jsonl backend fired a hand-dropped record-only job, persisted failed run records with the real subprocess error, and deleted the one-off job while keeping its records.
