### PR TITLE
fix(storage): resolve schedules dir against the user home, not the conversations path

### DIFF
--- a/internal/infra/storage/jsonl.go
+++ b/internal/infra/storage/jsonl.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -900,12 +901,19 @@ func (s *JsonlStorage) ListSessionGroups(_ context.Context) (map[string]SessionG
 }
 
 // ---------------------------------------------------------------------------
-// ScheduledJobStorage (JsonlStorage) - file-based, keeps historical paths
+// ScheduledJobStorage (JsonlStorage) - file-based, machine-global
 // ---------------------------------------------------------------------------
 
-// schedulesDir returns the path to the schedules directory.
+// schedulesDir returns the machine-global schedules directory. Jobs are
+// executed by the single per-machine daemon, so they live under the user's
+// home config dir regardless of where conversation storage points -
+// project-local storage used to orphan jobs the daemon never saw (#1053).
 func (s *JsonlStorage) schedulesDir() string {
-	return filepath.Join(filepath.Dir(s.basePath), "schedules")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(filepath.Dir(s.basePath), "schedules")
+	}
+	return filepath.Join(home, config.ConfigDirName, "schedules")
 }
 
 // jobFilePath returns the YAML path for a given job ID.

--- a/internal/infra/storage/jsonl_test.go
+++ b/internal/infra/storage/jsonl_test.go
@@ -857,12 +857,39 @@ func TestJsonlStorage_SessionGroups_AtomicWrite(t *testing.T) {
 }
 
 // newConformanceJsonlStorage returns a jsonl backend rooted in an isolated
-// temp dir (schedules/plans/history live next to the conversations dir).
+// temp dir. HOME is overridden because schedules are machine-global and
+// resolve against the user's home config dir.
 func newConformanceJsonlStorage(t *testing.T) *JsonlStorage {
 	t.Helper()
-	storage, err := NewJsonlStorage(JsonlStorageConfig{Path: filepath.Join(t.TempDir(), "conversations")})
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	storage, err := NewJsonlStorage(JsonlStorageConfig{Path: filepath.Join(tmp, "conversations")})
 	require.NoError(t, err)
 	return storage
+}
+
+// TestJsonlStorage_SchedulesAreMachineGlobal saves a job through a storage
+// rooted in one project and reads it back through a storage rooted in
+// another - both must resolve the same ~/.infer/schedules dir (#1053).
+func TestJsonlStorage_SchedulesAreMachineGlobal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	a, err := NewJsonlStorage(JsonlStorageConfig{Path: filepath.Join(t.TempDir(), ".infer", "conversations")})
+	require.NoError(t, err)
+	b, err := NewJsonlStorage(JsonlStorageConfig{Path: filepath.Join(t.TempDir(), ".infer", "conversations")})
+	require.NoError(t, err)
+
+	job := &domain.ScheduledJob{ID: "global-job", CronExpression: "@every 1h", Prompt: "hi", CreatedAt: time.Now()}
+	require.NoError(t, a.SaveJob(context.Background(), job))
+
+	jobs, err := b.ListJobs(context.Background())
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, "global-job", jobs[0].ID)
+
+	if _, err := os.Stat(filepath.Join(home, ".infer", "schedules", "global-job.yaml")); err != nil {
+		t.Fatalf("job not written under HOME: %v", err)
+	}
 }
 
 // TestJsonlStorage_Conformance runs the shared behavioural suites for the


### PR DESCRIPTION
Resolves #1053

## Summary

Scheduled jobs are a machine-global concern - they are executed by the single per-machine `infer daemon` - but the jsonl backend stored them next to the session's conversations directory. A session running in a project directory wrote jobs to `<project>/.infer/schedules`, which the daemon (resolving storage from its own cwd/config) never saw: the job was created successfully and silently never fired.

## Changes

- `internal/infra/storage/jsonl.go`: `schedulesDir()` resolves to `~/.infer/schedules` unconditionally (run records under `~/.infer/schedules/runs` follow via `runsDir()`), falling back to the old conversations-relative path only when the home directory cannot be determined.
- `internal/infra/storage/jsonl_test.go`: conformance helper now isolates `HOME` into the test temp dir; new regression test `TestJsonlStorage_SchedulesAreMachineGlobal` saves a job through one project-rooted storage and reads it back through another.

## Notes

- DB backends (postgres/redis/d1) are consistent by nature (shared server); a project-local sqlite file still scopes jobs to that DB - acceptable, since pointing sessions and daemon at the same DB is the user's explicit choice there.
- Cross-repo: unblocks inference-gateway/desktop#105 (scheduled-jobs list reads `~/.infer/schedules`) and desktop#109. No docs ticket: behavior matches what docs#545 already describes (global scheduling); no page changes needed.

## Acceptance

- Job created from a project-cwd chat session is visible to `infer daemon` started anywhere, and fires.
- Full test suite green, golangci-lint clean.