### PR TITLE
feat(scheduler): add github scheduling backend

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -17,6 +17,8 @@ import (
 	logger "github.com/inference-gateway/cli/internal/logger"
 	services "github.com/inference-gateway/cli/internal/services"
 	channels "github.com/inference-gateway/cli/internal/services/channels"
+	githubscheduler "github.com/inference-gateway/cli/internal/services/githubscheduler"
+	githubsetup "github.com/inference-gateway/cli/internal/services/githubsetup"
 	heartbeat "github.com/inference-gateway/cli/internal/services/heartbeat"
 	scheduler "github.com/inference-gateway/cli/internal/services/scheduler"
 	shortcuts "github.com/inference-gateway/cli/internal/shortcuts"
@@ -140,11 +142,26 @@ func RunDaemonCommand(cfg *config.Config) error {
 		return fmt.Errorf("failed to start heartbeat: %w", err)
 	}
 
+	poller, err := startArtifactPoller(ctx, cfg)
+	if err != nil {
+		// Artifact polling is a convenience; the daemon still serves its other
+		// subsystems if it cannot start (e.g. gh not authenticated).
+		logger.Error("failed to start github artifact poller", "error", err)
+	}
+
 	logger.Info("daemon ready. Press Ctrl+C to stop.")
 
 	<-sigChan
 	logger.Info("shutting down...")
 	cancel()
+
+	if poller != nil {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := poller.Stop(stopCtx); err != nil {
+			logger.Error("failed to stop github artifact poller", "error", err)
+		}
+		stopCancel()
+	}
 
 	if hb != nil {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -206,6 +223,10 @@ func startScheduler(ctx context.Context, cm *services.ChannelManagerService, cfg
 	if !cfg.Tools.Schedule.Enabled {
 		return nil, nil
 	}
+	if cfg.Scheduler.Backend == config.SchedulerBackendGitHub {
+		logger.Info("scheduler backend is github; jobs run on GitHub Actions, local cron disabled")
+		return nil, nil
+	}
 
 	storageConfig := storage.NewStorageFromConfig(cfg)
 	if storageConfig.Type == config.StorageTypeMemory {
@@ -221,6 +242,73 @@ func startScheduler(ctx context.Context, cm *services.ChannelManagerService, cfg
 		Store:      stores.ScheduledJobs,
 		Runs:       stores.ScheduledRuns,
 		OnRunEvent: notifier.Notify,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := svc.Start(ctx); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+// startArtifactPoller starts the GitHub artifact poller when the github
+// scheduler backend is active with artifacts enabled. It pulls conversation
+// jsonl files uploaded by GitHub-backed job runs into local storage, so it
+// only runs on the jsonl storage backend. Returns nil when not applicable.
+func startArtifactPoller(ctx context.Context, cfg *config.Config) (*githubscheduler.ArtifactPoller, error) {
+	art := cfg.Scheduler.GitHub.Artifacts
+	if cfg.Scheduler.Backend != config.SchedulerBackendGitHub || !art.Enabled {
+		return nil, nil
+	}
+	if cfg.Storage.Type != config.StorageTypeJsonl {
+		logger.Warn("github artifact polling requires storage.type jsonl; skipping", "type", cfg.Storage.Type)
+		return nil, nil
+	}
+
+	interval, err := time.ParseDuration(art.PollInterval)
+	if err != nil {
+		return nil, fmt.Errorf("parse scheduler.github.artifacts.poll_interval %q: %w", art.PollInterval, err)
+	}
+	var initialDelay time.Duration
+	if art.InitialDelay != "" {
+		if initialDelay, err = time.ParseDuration(art.InitialDelay); err != nil {
+			return nil, fmt.Errorf("parse scheduler.github.artifacts.initial_delay %q: %w", art.InitialDelay, err)
+		}
+	}
+	backoff := time.Hour
+	if art.RateLimitBackoff != "" {
+		if backoff, err = time.ParseDuration(art.RateLimitBackoff); err != nil {
+			return nil, fmt.Errorf("parse scheduler.github.artifacts.rate_limit_backoff %q: %w", art.RateLimitBackoff, err)
+		}
+	}
+
+	runner := &githubsetup.RealRunner{}
+	repo, err := githubscheduler.ResolveRepo(ctx, runner, cfg.Scheduler.GitHub.Repository)
+	if err != nil {
+		return nil, err
+	}
+
+	conversationsDir := cfg.Storage.Jsonl.Path
+	if strings.HasPrefix(conversationsDir, "~") {
+		if home, err := os.UserHomeDir(); err == nil {
+			conversationsDir = filepath.Join(home, strings.TrimPrefix(conversationsDir, "~"))
+		}
+	}
+	statePath := ""
+	if home, err := os.UserHomeDir(); err == nil {
+		statePath = filepath.Join(home, config.ConfigDirName, "schedules", "github-artifacts-state.json")
+	}
+
+	svc, err := githubscheduler.NewArtifactPoller(githubscheduler.ArtifactPollerOptions{
+		Runner:           runner,
+		Repo:             repo,
+		ConversationsDir: conversationsDir,
+		StatePath:        statePath,
+		Interval:         interval,
+		InitialDelay:     initialDelay,
+		MaxAttempts:      art.MaxAttempts,
+		RateLimitBackoff: backoff,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -144,8 +144,6 @@ func RunDaemonCommand(cfg *config.Config) error {
 
 	poller, err := startArtifactPoller(ctx, cfg)
 	if err != nil {
-		// Artifact polling is a convenience; the daemon still serves its other
-		// subsystems if it cannot start (e.g. gh not authenticated).
 		logger.Error("failed to start github artifact poller", "error", err)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Agent            AgentConfig            `yaml:"agent" mapstructure:"agent"`
 	Git              GitConfig              `yaml:"git" mapstructure:"git"`
 	Storage          StorageConfig          `yaml:"storage" mapstructure:"storage"`
+	Scheduler        SchedulerConfig        `yaml:"scheduler" mapstructure:"scheduler"`
 	Telemetry        TelemetryConfig        `yaml:"telemetry" mapstructure:"telemetry"`
 	Conversation     ConversationConfig     `yaml:"conversation" mapstructure:"conversation"`
 	Chat             ChatConfig             `yaml:"chat" mapstructure:"chat"`
@@ -695,6 +696,42 @@ const (
 	StorageTypeD1       StorageType = "d1"
 )
 
+// SchedulerBackend selects who executes scheduled jobs.
+const (
+	SchedulerBackendLocal  = "local"  // `infer daemon` cron on this machine (default)
+	SchedulerBackendGitHub = "github" // GitHub Actions scheduled workflows in a repo
+)
+
+// SchedulerConfig selects the scheduling backend. With the default "local"
+// backend jobs fire inside `infer daemon`. With "github" every job is
+// materialized as a GitHub Actions scheduled workflow in the configured repo;
+// each save opens a PR and merging deploys the schedule.
+type SchedulerConfig struct {
+	Backend string                `yaml:"backend" mapstructure:"backend"`
+	GitHub  SchedulerGitHubConfig `yaml:"github" mapstructure:"github"`
+}
+
+// SchedulerGitHubConfig configures the github scheduling backend.
+type SchedulerGitHubConfig struct {
+	// Repository is "<owner>/<name>". Empty means "<authenticated user>/.routines".
+	Repository string `yaml:"repository" mapstructure:"repository"`
+	// PullRequests, when true, routes every save through a pull request instead
+	// of pushing workflow changes directly to the default branch.
+	PullRequests bool                     `yaml:"pull_requests" mapstructure:"pull_requests"`
+	Artifacts    SchedulerArtifactsConfig `yaml:"artifacts" mapstructure:"artifacts"`
+}
+
+// SchedulerArtifactsConfig controls the daemon-hosted poller that downloads
+// conversation artifacts uploaded by GitHub-backed job runs into local
+// conversation storage.
+type SchedulerArtifactsConfig struct {
+	Enabled          bool   `yaml:"enabled" mapstructure:"enabled"`
+	PollInterval     string `yaml:"poll_interval" mapstructure:"poll_interval"`
+	InitialDelay     string `yaml:"initial_delay" mapstructure:"initial_delay"`
+	MaxAttempts      int    `yaml:"max_attempts" mapstructure:"max_attempts"`             // per artifact, then skipped permanently
+	RateLimitBackoff string `yaml:"rate_limit_backoff" mapstructure:"rate_limit_backoff"` // pause after a rate-limited API call
+}
+
 // TelemetryConfig controls the OpenTelemetry metrics the CLI records - tool
 // outcomes, token usage, sessions. The recorded data is written as OTLP/semconv
 // JSON under <config-dir>/telemetry (always, private - no prompt/response
@@ -1120,6 +1157,20 @@ func DefaultConfig() *Config { //nolint:funlen
 				DatabaseID: "",
 				APIToken:   "",
 				BaseURL:    "https://api.cloudflare.com/client/v4",
+			},
+		},
+		Scheduler: SchedulerConfig{
+			Backend: SchedulerBackendLocal,
+			GitHub: SchedulerGitHubConfig{
+				Repository:   "",
+				PullRequests: false,
+				Artifacts: SchedulerArtifactsConfig{
+					Enabled:          true,
+					PollInterval:     "10m",
+					InitialDelay:     "1m",
+					MaxAttempts:      3,
+					RateLimitBackoff: "1h",
+				},
 			},
 		},
 		Telemetry: TelemetryConfig{

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -837,6 +837,17 @@ tools:
 - `INFER_STORAGE_REDIS_PASSWORD`: Redis password
 - `INFER_STORAGE_REDIS_DB`: Redis database number (default: `0`)
 
+### Scheduler Configuration
+
+- `INFER_SCHEDULER_BACKEND`: Scheduling backend, `local` or `github` (default: `local`). See the [Scheduling Guide](scheduling.md#github-backend)
+- `INFER_SCHEDULER_GITHUB_REPOSITORY`: Repository for GitHub-backed schedules (default: `<login>/.routines`)
+- `INFER_SCHEDULER_GITHUB_PULL_REQUESTS`: Deploy schedule changes via pull request instead of pushing to the default branch (default: `false`)
+- `INFER_SCHEDULER_GITHUB_ARTIFACTS_ENABLED`: Pull conversation artifacts from GitHub-backed runs into local storage (default: `true`)
+- `INFER_SCHEDULER_GITHUB_ARTIFACTS_POLL_INTERVAL`: Artifact poll interval (default: `10m`)
+- `INFER_SCHEDULER_GITHUB_ARTIFACTS_INITIAL_DELAY`: Delay before the first poll (default: `1m`)
+- `INFER_SCHEDULER_GITHUB_ARTIFACTS_MAX_ATTEMPTS`: Download attempts per artifact before it is skipped (default: `3`)
+- `INFER_SCHEDULER_GITHUB_ARTIFACTS_RATE_LIMIT_BACKOFF`: Polling pause after a rate-limited GitHub API call (default: `1h`)
+
 ### Conversation Configuration
 
 - `INFER_CONVERSATION_TITLE_GENERATION_ENABLED`: Enable AI-powered title generation (default: `true`)

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -110,6 +110,76 @@ Standard 5-field crontab format: `minute hour day-of-month month day-of-week`.
 The full grammar (including `@every`, `@daily`, `@hourly` descriptors) is documented
 at [robfig/cron](https://pkg.go.dev/github.com/robfig/cron/v3#hdr-CRON_Expression_Format).
 
+## GitHub backend
+
+Set `scheduler.backend: github` to run schedules on GitHub Actions instead of a
+local daemon - cloud scheduling with zero user-owned infrastructure. Each job is
+materialized as one scheduled workflow (`.github/workflows/<job-id>.yml`) in a
+repository you configure; the workflow runs the job's prompt via
+[`inference-gateway/infer-action`](https://github.com/inference-gateway/infer-action)
+under your infer GitHub App's bot identity.
+
+```yaml
+# .infer/config.yaml
+scheduler:
+  backend: github
+  github:
+    repository: "" # "" => <your login>/.routines, created private on first save
+    pull_requests: false # true => deploy via PR instead of pushing to main
+    artifacts:
+      enabled: true
+      poll_interval: 10m
+      initial_delay: 1m
+      max_attempts: 3 # download attempts per artifact, then skipped
+      rate_limit_backoff: 1h # pause after a rate-limited GitHub API call
+```
+
+How it behaves:
+
+- **Save → deploy.** Creating, updating, or deleting a job clones the repo,
+  writes (or removes) that job's workflow file, and pushes the commit to the
+  default branch. With `pull_requests: true` the change lands on a branch and a
+  PR is opened instead - merging deploys, and the PR is the review step and
+  audit trail.
+- **Repo auto-creation.** If the configured repository does not exist it is
+  created private (default name `.routines` under the authenticated user). All
+  GitHub access goes through the `gh` CLI, so `gh auth login` must be done once.
+- **Cron is translated.** GitHub Actions cron is UTC-only, 5-field, minimum
+  5-minute interval. Descriptors are translated (`@daily` → `0 0 * * *`,
+  `@every 10m` → `*/10 * * * *`, ...); expressions that cannot be expressed
+  (e.g. `@every 7m`, `* * * * *`) are rejected at save time with a clear error.
+- **One-off jobs.** `run_once` jobs render a final step that disables the
+  workflow after its first fire (the file stays in the repo, disabled).
+- **Conversation pull-back.** The workflow uploads the run's conversation
+  `*.jsonl` files as an Actions artifact (`infer-conversations-<run_id>`). While
+  `infer daemon` is running, an artifact poller downloads new artifacts into
+  local conversation storage on the configured interval (jsonl storage backend
+  only). Each artifact gets up to `max_attempts` download attempts; a
+  rate-limited API call pauses polling for `rate_limit_backoff`.
+- **Local list stays authoritative for the CLI.** Jobs are still recorded
+  locally, so `list`/`get`/`update`/`delete` work as usual. A failed GitHub sync
+  aborts the save entirely - no phantom jobs.
+
+### Required repository secrets
+
+The CLI never writes secrets. Set these as Actions secrets on the routines
+repository (Settings → Secrets and variables → Actions):
+
+- `APP_CLIENT_ID` / `APP_PRIVATE_KEY` - your infer GitHub App's client ID and
+  private key; the workflow mints an installation token with
+  `actions/create-github-app-token` and runs infer-action as the App bot. For
+  `run_once` self-disabling, the App needs the **Actions (read & write)**
+  repository permission.
+- The API key secret(s) for your provider(s): `ANTHROPIC_API_KEY`,
+  `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `DEEPSEEK_API_KEY`, `GROQ_API_KEY`,
+  `MISTRAL_API_KEY`, `CLOUDFLARE_API_KEY`, `COHERE_API_KEY`,
+  `OLLAMA_CLOUD_API_KEY`, `MOONSHOT_API_KEY`, `MINIMAX_API_KEY`,
+  `NVIDIA_API_KEY`, `ZAI_API_KEY`. Only the ones for the models your jobs use
+  are needed.
+
+Out of scope for this backend (first cut): channel delivery of job output,
+syncing runs into local `RunRecord`s.
+
 ## Tool operations
 
 The `Schedule` tool is a single tool with an `operation` parameter. The LLM picks

--- a/internal/agent/tools/schedule.go
+++ b/internal/agent/tools/schedule.go
@@ -211,6 +211,16 @@ func optionalBool(args map[string]any, key string) bool {
 	return v
 }
 
+// prSuffix surfaces the pull-request URL when the store deployed the change
+// via a PR (github backend with pull_requests enabled). Direct-push deploys
+// and the local backend return "".
+func prSuffix(store storage.ScheduledJobStorage) string {
+	if pr, ok := store.(interface{ LastPRURL() string }); ok && pr.LastPRURL() != "" {
+		return " Review and merge the PR to deploy: " + pr.LastPRURL()
+	}
+	return ""
+}
+
 // channelConfigured reports whether the named channel is enabled in config.
 // We only check the channel's *enabled* flag - runtime registration is the
 // daemon's job.
@@ -265,10 +275,15 @@ func (t *ScheduleTool) execCreate(ctx context.Context, args map[string]any, stor
 	if channel != "" {
 		delivery = fmt.Sprintf("output will be delivered via %s", channel)
 	}
+	execution := "Fires while 'infer daemon' is running."
+	if t.config.Scheduler.Backend == config.SchedulerBackendGitHub {
+		execution = "Runs on GitHub Actions (schedules fire in UTC)."
+	}
+	msg := fmt.Sprintf("Scheduled %s job %s created; %s. %s", mode, job.ID, delivery, execution)
 	return t.success(args, start, &ScheduleToolResult{
 		Operation: scheduleOpCreate,
 		Job:       job,
-		Message:   fmt.Sprintf("Scheduled %s job %s created; %s. Fires while 'infer daemon' is running.", mode, job.ID, delivery),
+		Message:   msg + prSuffix(store),
 	})
 }
 
@@ -363,7 +378,7 @@ func (t *ScheduleTool) execUpdate(args map[string]any, store storage.ScheduledJo
 	return t.success(args, start, &ScheduleToolResult{
 		Operation: scheduleOpUpdate,
 		Job:       job,
-		Message:   fmt.Sprintf("Updated job %s.", id),
+		Message:   fmt.Sprintf("Updated job %s.", id) + prSuffix(store),
 	})
 }
 
@@ -377,7 +392,7 @@ func (t *ScheduleTool) execDelete(args map[string]any, store storage.ScheduledJo
 	}
 	return t.success(args, start, &ScheduleToolResult{
 		Operation: scheduleOpDelete,
-		Message:   fmt.Sprintf("Deleted job %s.", id),
+		Message:   fmt.Sprintf("Deleted job %s.", id) + prSuffix(store),
 	})
 }
 

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -33,6 +33,7 @@ import (
 	directexec "github.com/inference-gateway/cli/internal/services/directexec"
 	eventlistener "github.com/inference-gateway/cli/internal/services/eventlistener"
 	githubissues "github.com/inference-gateway/cli/internal/services/githubissues"
+	githubscheduler "github.com/inference-gateway/cli/internal/services/githubscheduler"
 	githubsetup "github.com/inference-gateway/cli/internal/services/githubsetup"
 	jobs "github.com/inference-gateway/cli/internal/services/jobs"
 	skills "github.com/inference-gateway/cli/internal/services/skills"
@@ -339,6 +340,9 @@ func (c *ServiceContainer) initializeDomainServices() {
 
 	storageConfig := storage.NewStorageFromConfig(c.config)
 	stores, err := storage.NewStorage(storageConfig)
+	if stores != nil && c.config.Scheduler.Backend == config.SchedulerBackendGitHub {
+		stores.ScheduledJobs = githubscheduler.NewStore(stores.ScheduledJobs, &githubsetup.RealRunner{}, c.config.Scheduler.GitHub, c.config.Agent.Model)
+	}
 	c.stores = stores
 
 	c.imageAnnotator = c.createImageAnnotator()

--- a/internal/services/githubscheduler/artifacts.go
+++ b/internal/services/githubscheduler/artifacts.go
@@ -220,7 +220,7 @@ func (p *ArtifactPoller) tick(ctx context.Context) error {
 			p.pausedUntil = time.Now().Add(p.opts.RateLimitBackoff)
 			logger.Warn("github artifact download rate-limited, backing off",
 				"until", p.pausedUntil.Format(time.RFC3339))
-			break // rate-limited attempts do not count against MaxAttempts
+			break
 		}
 		changed = true
 		if err != nil {
@@ -262,13 +262,11 @@ func (p *ArtifactPoller) extract(zipData []byte) error {
 		return err
 	}
 	for _, f := range r.File {
-		name := filepath.Base(f.Name) // flatten; also blocks path traversal
+		name := filepath.Base(f.Name)
 		if !strings.HasSuffix(name, ".jsonl") {
 			continue
 		}
 		dest := filepath.Join(p.opts.ConversationsDir, name)
-		// Zip-slip guard: the flattened name can never escape, but keep the
-		// containment check explicit (and CodeQL-recognizable).
 		if !strings.HasPrefix(dest, filepath.Clean(p.opts.ConversationsDir)+string(os.PathSeparator)) {
 			continue
 		}

--- a/internal/services/githubscheduler/artifacts.go
+++ b/internal/services/githubscheduler/artifacts.go
@@ -267,6 +267,11 @@ func (p *ArtifactPoller) extract(zipData []byte) error {
 			continue
 		}
 		dest := filepath.Join(p.opts.ConversationsDir, name)
+		// Zip-slip guard: the flattened name can never escape, but keep the
+		// containment check explicit (and CodeQL-recognizable).
+		if !strings.HasPrefix(dest, filepath.Clean(p.opts.ConversationsDir)+string(os.PathSeparator)) {
+			continue
+		}
 		if _, err := os.Stat(dest); err == nil {
 			continue
 		}

--- a/internal/services/githubscheduler/artifacts.go
+++ b/internal/services/githubscheduler/artifacts.go
@@ -1,0 +1,352 @@
+package githubscheduler
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	logger "github.com/inference-gateway/cli/internal/logger"
+)
+
+// ArtifactPollerOptions bundles dependencies for NewArtifactPoller.
+type ArtifactPollerOptions struct {
+	Runner           CommandRunner
+	Repo             string // "<owner>/<name>", already resolved
+	ConversationsDir string // local dir jsonl files are extracted into
+	StatePath        string // cursor/attempts persistence file
+	Interval         time.Duration
+	InitialDelay     time.Duration
+	MaxAttempts      int           // per artifact; then skipped permanently
+	RateLimitBackoff time.Duration // pause after a rate-limited API call
+}
+
+// CommandRunner matches githubsetup.CommandRunner; redeclared locally so the
+// poller can be constructed without importing githubsetup.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// ArtifactPoller periodically downloads conversation artifacts uploaded by
+// GitHub-backed job runs and drops their jsonl files into local conversation
+// storage. Lifecycle mirrors the heartbeat service.
+// ponytail: raw jsonl drop only works for storage.type jsonl; parse-and-save via ConversationStorage if sqlite/postgres users ask.
+type ArtifactPoller struct {
+	opts ArtifactPollerOptions
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	running     atomic.Int32
+	pausedUntil time.Time // rate-limit backoff deadline
+	state       pollerState
+
+	started bool
+	mu      sync.Mutex
+}
+
+// pollerState is persisted across daemon restarts. Cursor is the highest
+// artifact ID ever listed; Pending tracks download attempts for artifacts that
+// have not been fully extracted yet.
+type pollerState struct {
+	Cursor  int64         `json:"cursor"`
+	Pending map[int64]int `json:"pending,omitempty"`
+}
+
+type artifactList struct {
+	Artifacts []artifactInfo `json:"artifacts"`
+}
+
+type artifactInfo struct {
+	ID      int64  `json:"id"`
+	Name    string `json:"name"`
+	Expired bool   `json:"expired"`
+}
+
+// NewArtifactPoller validates options and constructs a poller.
+func NewArtifactPoller(opts ArtifactPollerOptions) (*ArtifactPoller, error) {
+	if opts.Interval <= 0 {
+		return nil, errors.New("artifact poller: interval must be > 0")
+	}
+	if opts.Repo == "" {
+		return nil, errors.New("artifact poller: repo is required")
+	}
+	if opts.MaxAttempts <= 0 {
+		opts.MaxAttempts = 3
+	}
+	return &ArtifactPoller{opts: opts, state: pollerState{Pending: map[int64]int{}}}, nil
+}
+
+// Start launches the ticker goroutine. Calling Start more than once is a no-op.
+func (p *ArtifactPoller) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return nil
+	}
+	p.ctx, p.cancel = context.WithCancel(ctx)
+	p.started = true
+	p.loadState()
+
+	logger.Info("github artifact poller started",
+		"repo", p.opts.Repo,
+		"interval", p.opts.Interval.String(),
+		"conversations_dir", p.opts.ConversationsDir,
+	)
+
+	p.wg.Add(1)
+	go p.run()
+	return nil
+}
+
+// Stop cancels the ticker and waits for an in-flight tick to finish.
+func (p *ArtifactPoller) Stop(ctx context.Context) error {
+	p.mu.Lock()
+	if !p.started {
+		p.mu.Unlock()
+		return nil
+	}
+	p.cancel()
+	p.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		logger.Info("github artifact poller stopped")
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("artifact poller stop: %w", ctx.Err())
+	}
+}
+
+func (p *ArtifactPoller) run() {
+	defer p.wg.Done()
+
+	if p.opts.InitialDelay > 0 {
+		select {
+		case <-time.After(p.opts.InitialDelay):
+		case <-p.ctx.Done():
+			return
+		}
+	}
+
+	p.tickGuarded()
+
+	ticker := time.NewTicker(p.opts.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.tickGuarded()
+		case <-p.ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *ArtifactPoller) tickGuarded() {
+	if !p.running.CompareAndSwap(0, 1) {
+		return
+	}
+	defer p.running.Store(0)
+
+	if time.Now().Before(p.pausedUntil) {
+		return
+	}
+	if err := p.tick(p.ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		logger.Error("github artifact poll failed", "error", err)
+	}
+}
+
+// tick lists artifacts, downloads new conversation artifacts (up to
+// MaxAttempts each), and persists the advanced cursor.
+func (p *ArtifactPoller) tick(ctx context.Context) error {
+	out, err := p.runGH(ctx, ghCommandTimeout,
+		"api", fmt.Sprintf("repos/%s/actions/artifacts?per_page=100", p.opts.Repo))
+	if err != nil {
+		if isRateLimited(out) {
+			p.pausedUntil = time.Now().Add(p.opts.RateLimitBackoff)
+			logger.Warn("github artifact poll rate-limited, backing off",
+				"until", p.pausedUntil.Format(time.RFC3339))
+			return nil
+		}
+		return fmt.Errorf("list artifacts: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	var list artifactList
+	if err := json.Unmarshal(out, &list); err != nil {
+		return fmt.Errorf("parse artifact list: %w", err)
+	}
+
+	changed := false
+	for _, a := range list.Artifacts {
+		if !strings.HasPrefix(a.Name, ArtifactNamePrefix) || a.Expired {
+			continue
+		}
+		if a.ID > p.state.Cursor {
+			p.state.Cursor = a.ID
+			p.state.Pending[a.ID] = 0
+			changed = true
+		}
+	}
+
+	for id, attempts := range p.state.Pending {
+		if attempts >= p.opts.MaxAttempts {
+			logger.Warn("giving up on artifact after max attempts", "artifact_id", id, "attempts", attempts)
+			delete(p.state.Pending, id)
+			changed = true
+			continue
+		}
+		rateLimited, err := p.download(ctx, id)
+		if rateLimited {
+			p.pausedUntil = time.Now().Add(p.opts.RateLimitBackoff)
+			logger.Warn("github artifact download rate-limited, backing off",
+				"until", p.pausedUntil.Format(time.RFC3339))
+			break // rate-limited attempts do not count against MaxAttempts
+		}
+		changed = true
+		if err != nil {
+			p.state.Pending[id]++
+			logger.Warn("artifact download failed", "artifact_id", id, "attempt", p.state.Pending[id], "error", err)
+			continue
+		}
+		delete(p.state.Pending, id)
+	}
+
+	if changed {
+		p.saveState()
+	}
+	return nil
+}
+
+// download fetches one artifact zip and extracts its jsonl files. The bool
+// reports a rate-limited failure (which must not consume an attempt).
+func (p *ArtifactPoller) download(ctx context.Context, id int64) (bool, error) {
+	out, err := p.runGH(ctx, ghNetworkTimeout,
+		"api", fmt.Sprintf("repos/%s/actions/artifacts/%d/zip", p.opts.Repo, id))
+	if err != nil {
+		if isRateLimited(out) {
+			return true, err
+		}
+		return false, fmt.Errorf("download: %s: %w", firstLine(out), err)
+	}
+	return false, p.extract(out)
+}
+
+// extract writes every *.jsonl entry of the zip into the conversations dir,
+// skipping files that already exist so re-polls stay idempotent.
+func (p *ArtifactPoller) extract(zipData []byte) error {
+	r, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
+	if err != nil {
+		return fmt.Errorf("open artifact zip: %w", err)
+	}
+	if err := os.MkdirAll(p.opts.ConversationsDir, 0755); err != nil {
+		return err
+	}
+	for _, f := range r.File {
+		name := filepath.Base(f.Name) // flatten; also blocks path traversal
+		if !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		dest := filepath.Join(p.opts.ConversationsDir, name)
+		if _, err := os.Stat(dest); err == nil {
+			continue
+		}
+		if err := extractFile(f, dest); err != nil {
+			return err
+		}
+		logger.Info("pulled conversation from github artifact", "file", name)
+	}
+	return nil
+}
+
+func extractFile(f *zip.File, dest string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("open %s in artifact zip: %w", f.Name, err)
+	}
+	defer func() { _ = rc.Close() }()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return fmt.Errorf("read %s from artifact zip: %w", f.Name, err)
+	}
+	return os.WriteFile(dest, data, 0644)
+}
+
+func (p *ArtifactPoller) runGH(ctx context.Context, timeout time.Duration, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return p.opts.Runner.Run(ctx, "gh", args...)
+}
+
+// loadState restores the cursor file; a missing or corrupt file starts fresh.
+func (p *ArtifactPoller) loadState() {
+	if p.opts.StatePath == "" {
+		return
+	}
+	data, err := os.ReadFile(p.opts.StatePath)
+	if err != nil {
+		return
+	}
+	var st pollerState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return
+	}
+	if st.Pending == nil {
+		st.Pending = map[int64]int{}
+	}
+	p.state = st
+}
+
+// saveState persists the cursor atomically (tmp+rename); failures are logged,
+// not fatal - the worst case is re-downloading already-extracted artifacts.
+func (p *ArtifactPoller) saveState() {
+	if p.opts.StatePath == "" {
+		return
+	}
+	data, err := json.Marshal(p.state)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(p.opts.StatePath), 0755); err != nil {
+		logger.Warn("persist artifact poller state failed", "error", err)
+		return
+	}
+	tmp := p.opts.StatePath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		logger.Warn("persist artifact poller state failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmp, p.opts.StatePath); err != nil {
+		logger.Warn("persist artifact poller state failed", "error", err)
+	}
+}
+
+// isRateLimited sniffs a gh api failure for GitHub rate-limit responses.
+func isRateLimited(out []byte) bool {
+	s := strings.ToLower(string(out))
+	return strings.Contains(s, "rate limit") || strings.Contains(s, "http 429")
+}
+
+func firstLine(out []byte) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(string(out)), "\n")
+	return line
+}

--- a/internal/services/githubscheduler/artifacts_test.go
+++ b/internal/services/githubscheduler/artifacts_test.go
@@ -1,0 +1,201 @@
+package githubscheduler
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func makeZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for name, content := range files {
+		f, err := w.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func newTestPoller(t *testing.T, runner CommandRunner) *ArtifactPoller {
+	t.Helper()
+	dir := t.TempDir()
+	p, err := NewArtifactPoller(ArtifactPollerOptions{
+		Runner:           runner,
+		Repo:             "me/.routines",
+		ConversationsDir: filepath.Join(dir, "conversations"),
+		StatePath:        filepath.Join(dir, "state.json"),
+		Interval:         time.Minute,
+		MaxAttempts:      3,
+		RateLimitBackoff: time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.ctx = context.Background()
+	return p
+}
+
+const listJSON = `{"artifacts":[
+	{"id":11,"name":"infer-conversations-100","expired":false},
+	{"id":12,"name":"other-artifact","expired":false},
+	{"id":13,"name":"infer-conversations-101","expired":true}
+]}`
+
+func TestPollerDownloadsAndIsIdempotent(t *testing.T) {
+	zipData := makeZip(t, map[string]string{
+		"abc.jsonl":      `{"role":"user"}`,
+		"nested/x.jsonl": `{"role":"assistant"}`,
+		"notes.txt":      "ignore me",
+	})
+	downloads := 0
+	runner := &scriptRunner{respond: func(name string, args []string) ([]byte, error) {
+		switch {
+		case strings.Contains(args[1], "/zip"):
+			downloads++
+			return zipData, nil
+		default:
+			return []byte(listJSON), nil
+		}
+	}}
+	p := newTestPoller(t, runner)
+
+	if err := p.tick(context.Background()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	// Only the non-expired infer-conversations artifact is downloaded.
+	if downloads != 1 {
+		t.Fatalf("downloads = %d, want 1", downloads)
+	}
+	for _, f := range []string{"abc.jsonl", "x.jsonl"} {
+		if _, err := os.Stat(filepath.Join(p.opts.ConversationsDir, f)); err != nil {
+			t.Errorf("missing extracted file %s: %v", f, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(p.opts.ConversationsDir, "notes.txt")); err == nil {
+		t.Errorf("non-jsonl file must not be extracted")
+	}
+
+	// Second tick: cursor advanced, nothing re-downloaded.
+	if err := p.tick(context.Background()); err != nil {
+		t.Fatalf("second tick: %v", err)
+	}
+	if downloads != 1 {
+		t.Fatalf("second tick re-downloaded: downloads = %d", downloads)
+	}
+
+	// State survives a restart (fresh poller, same state path).
+	p2 := newTestPoller(t, runner)
+	p2.opts.StatePath = p.opts.StatePath
+	p2.loadState()
+	if p2.state.Cursor != 11 {
+		t.Fatalf("cursor = %d, want 11", p2.state.Cursor)
+	}
+}
+
+func TestPollerRetriesThenGivesUp(t *testing.T) {
+	runner := &scriptRunner{respond: func(name string, args []string) ([]byte, error) {
+		if strings.Contains(args[1], "/zip") {
+			return []byte("boom"), fmt.Errorf("exit 1")
+		}
+		return []byte(listJSON), nil
+	}}
+	p := newTestPoller(t, runner)
+
+	for range 3 {
+		if err := p.tick(context.Background()); err != nil {
+			t.Fatalf("tick: %v", err)
+		}
+	}
+	if p.state.Pending[11] != 3 {
+		t.Fatalf("attempts = %d, want 3", p.state.Pending[11])
+	}
+
+	// Fourth tick gives up permanently; no further download attempts.
+	if err := p.tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, pending := p.state.Pending[11]; pending {
+		t.Fatalf("artifact should be dropped after max attempts")
+	}
+	before := len(runner.commands)
+	if err := p.tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range runner.commands[before:] {
+		if strings.Contains(cmd, "/zip") {
+			t.Fatalf("no download expected after giving up: %v", cmd)
+		}
+	}
+}
+
+func TestPollerRateLimitBackoff(t *testing.T) {
+	calls := 0
+	runner := &scriptRunner{respond: func(name string, args []string) ([]byte, error) {
+		calls++
+		return []byte("API rate limit exceeded for user"), errors.New("exit 1")
+	}}
+	p := newTestPoller(t, runner)
+
+	if err := p.tick(context.Background()); err != nil {
+		t.Fatalf("rate-limited tick must not error: %v", err)
+	}
+	if p.pausedUntil.IsZero() || time.Until(p.pausedUntil) < 30*time.Minute {
+		t.Fatalf("expected ~1h pause, got %v", p.pausedUntil)
+	}
+
+	// While paused, guarded ticks are no-ops.
+	p.tickGuarded()
+	if calls != 1 {
+		t.Fatalf("paused poller must not call gh: calls = %d", calls)
+	}
+}
+
+func TestPollerRateLimitDoesNotConsumeAttempts(t *testing.T) {
+	rateLimit := false
+	runner := &scriptRunner{respond: func(name string, args []string) ([]byte, error) {
+		if strings.Contains(args[1], "/zip") {
+			if rateLimit {
+				return []byte("API rate limit exceeded"), errors.New("exit 1")
+			}
+			return []byte("boom"), errors.New("exit 1")
+		}
+		return []byte(listJSON), nil
+	}}
+	p := newTestPoller(t, runner)
+
+	if err := p.tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if p.state.Pending[11] != 1 {
+		t.Fatalf("attempts = %d, want 1", p.state.Pending[11])
+	}
+
+	rateLimit = true
+	p.pausedUntil = time.Time{}
+	if err := p.tick(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if p.state.Pending[11] != 1 {
+		t.Fatalf("rate-limited attempt must not count: attempts = %d", p.state.Pending[11])
+	}
+	if p.pausedUntil.IsZero() {
+		t.Fatalf("expected backoff after rate-limited download")
+	}
+}

--- a/internal/services/githubscheduler/artifacts_test.go
+++ b/internal/services/githubscheduler/artifacts_test.go
@@ -79,7 +79,6 @@ func TestPollerDownloadsAndIsIdempotent(t *testing.T) {
 		t.Fatalf("tick: %v", err)
 	}
 
-	// Only the non-expired infer-conversations artifact is downloaded.
 	if downloads != 1 {
 		t.Fatalf("downloads = %d, want 1", downloads)
 	}
@@ -92,7 +91,6 @@ func TestPollerDownloadsAndIsIdempotent(t *testing.T) {
 		t.Errorf("non-jsonl file must not be extracted")
 	}
 
-	// Second tick: cursor advanced, nothing re-downloaded.
 	if err := p.tick(context.Background()); err != nil {
 		t.Fatalf("second tick: %v", err)
 	}
@@ -127,7 +125,6 @@ func TestPollerRetriesThenGivesUp(t *testing.T) {
 		t.Fatalf("attempts = %d, want 3", p.state.Pending[11])
 	}
 
-	// Fourth tick gives up permanently; no further download attempts.
 	if err := p.tick(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +157,6 @@ func TestPollerRateLimitBackoff(t *testing.T) {
 		t.Fatalf("expected ~1h pause, got %v", p.pausedUntil)
 	}
 
-	// While paused, guarded ticks are no-ops.
 	p.tickGuarded()
 	if calls != 1 {
 		t.Fatalf("paused poller must not call gh: calls = %d", calls)

--- a/internal/services/githubscheduler/cron.go
+++ b/internal/services/githubscheduler/cron.go
@@ -1,0 +1,104 @@
+// Package githubscheduler implements the "github" scheduling backend: each
+// scheduled job is materialized as a GitHub Actions scheduled workflow in a
+// user-configured repository, deployed via pull requests. GitHub runs the
+// jobs; nothing executes locally except the optional artifact poller.
+package githubscheduler
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	scheduler "github.com/inference-gateway/cli/internal/services/scheduler"
+)
+
+// ghCronConstraints names the GitHub Actions scheduling limits for error text.
+const ghCronConstraints = "GitHub Actions cron is UTC-only, 5-field, minimum 5-minute interval"
+
+var descriptorTable = map[string]string{
+	"@hourly":   "0 * * * *",
+	"@daily":    "0 0 * * *",
+	"@midnight": "0 0 * * *",
+	"@weekly":   "0 0 * * 0",
+	"@monthly":  "0 0 1 * *",
+	"@yearly":   "0 0 1 1 *",
+	"@annually": "0 0 1 1 *",
+}
+
+// TranslateCron converts a robfig/cron expression (including @descriptors and
+// @every durations) into a GitHub Actions compatible 5-field UTC cron, or
+// returns an error explaining why the expression cannot be scheduled on GitHub.
+func TranslateCron(expr string) (string, error) {
+	expr = strings.TrimSpace(expr)
+	if translated, ok := descriptorTable[strings.ToLower(expr)]; ok {
+		return translated, nil
+	}
+	if rest, ok := strings.CutPrefix(strings.ToLower(expr), "@every "); ok {
+		return translateEvery(strings.TrimSpace(rest))
+	}
+	if strings.HasPrefix(expr, "@") {
+		return "", fmt.Errorf("cron descriptor %q is not supported by the github backend (%s)", expr, ghCronConstraints)
+	}
+	if err := scheduler.ParseCron(expr); err != nil {
+		return "", fmt.Errorf("invalid cron expression %q: %w", expr, err)
+	}
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return "", fmt.Errorf("cron expression %q must have exactly 5 fields for the github backend (%s)", expr, ghCronConstraints)
+	}
+	if err := checkMinuteField(fields[0]); err != nil {
+		return "", fmt.Errorf("cron expression %q: %w (%s)", expr, err, ghCronConstraints)
+	}
+	return strings.Join(fields, " "), nil
+}
+
+// checkMinuteField rejects the obvious sub-5-minute minute fields.
+// ponytail: only catches * and */N; exotic lists (1,2,3 * * * *) pass through - GitHub throttles them.
+func checkMinuteField(minute string) error {
+	if minute == "*" {
+		return fmt.Errorf("fires every minute")
+	}
+	if step, ok := strings.CutPrefix(minute, "*/"); ok {
+		n, err := strconv.Atoi(step)
+		if err == nil && n < 5 {
+			return fmt.Errorf("fires every %d minute(s)", n)
+		}
+	}
+	return nil
+}
+
+// translateEvery maps `@every <duration>` onto a */N cron when the duration
+// divides an hour (or a day) evenly; anything else is rejected.
+func translateEvery(durStr string) (string, error) {
+	d, err := time.ParseDuration(durStr)
+	if err != nil {
+		return "", fmt.Errorf("invalid @every duration %q: %w", durStr, err)
+	}
+	reject := func() (string, error) {
+		return "", fmt.Errorf("@every %s cannot be expressed as a GitHub Actions cron (%s; use a whole number of minutes dividing 60, or hours dividing 24)", durStr, ghCronConstraints)
+	}
+	if d%time.Minute != 0 || d < 5*time.Minute {
+		return reject()
+	}
+	if d%time.Hour == 0 {
+		h := int(d / time.Hour)
+		switch {
+		case h == 1:
+			return "0 * * * *", nil
+		case h == 24:
+			return "0 0 * * *", nil
+		case h < 24 && 24%h == 0:
+			return fmt.Sprintf("0 */%d * * *", h), nil
+		default:
+			return reject()
+		}
+	}
+	if d < time.Hour {
+		m := int(d / time.Minute)
+		if 60%m == 0 {
+			return fmt.Sprintf("*/%d * * * *", m), nil
+		}
+	}
+	return reject()
+}

--- a/internal/services/githubscheduler/cron_test.go
+++ b/internal/services/githubscheduler/cron_test.go
@@ -10,7 +10,7 @@ func TestTranslateCron(t *testing.T) {
 		name    string
 		in      string
 		want    string
-		wantErr string // substring of the expected error; empty means success
+		wantErr string
 	}{
 		{"hourly", "@hourly", "0 * * * *", ""},
 		{"daily", "@daily", "0 0 * * *", ""},

--- a/internal/services/githubscheduler/cron_test.go
+++ b/internal/services/githubscheduler/cron_test.go
@@ -1,0 +1,67 @@
+package githubscheduler
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTranslateCron(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr string // substring of the expected error; empty means success
+	}{
+		{"hourly", "@hourly", "0 * * * *", ""},
+		{"daily", "@daily", "0 0 * * *", ""},
+		{"midnight", "@midnight", "0 0 * * *", ""},
+		{"weekly", "@weekly", "0 0 * * 0", ""},
+		{"monthly", "@monthly", "0 0 1 * *", ""},
+		{"yearly", "@yearly", "0 0 1 1 *", ""},
+		{"annually", "@annually", "0 0 1 1 *", ""},
+		{"descriptor case-insensitive", "@Daily", "0 0 * * *", ""},
+		{"every 10m", "@every 10m", "*/10 * * * *", ""},
+		{"every 5m", "@every 5m", "*/5 * * * *", ""},
+		{"every 30m", "@every 30m", "*/30 * * * *", ""},
+		{"every 1h", "@every 1h", "0 * * * *", ""},
+		{"every 60m", "@every 60m", "0 * * * *", ""},
+		{"every 2h", "@every 2h", "0 */2 * * *", ""},
+		{"every 6h", "@every 6h", "0 */6 * * *", ""},
+		{"every 24h", "@every 24h", "0 0 * * *", ""},
+		{"every 1m too small", "@every 1m", "", "GitHub Actions cron"},
+		{"every 90s not whole minutes", "@every 90s", "", "GitHub Actions cron"},
+		{"every 7m does not divide 60", "@every 7m", "", "GitHub Actions cron"},
+		{"every 5h does not divide 24", "@every 5h", "", "GitHub Actions cron"},
+		{"every 90m mixed", "@every 90m", "", "GitHub Actions cron"},
+		{"every 48h too big", "@every 48h", "", "GitHub Actions cron"},
+		{"every garbage", "@every soon", "", "invalid @every duration"},
+		{"unknown descriptor", "@reboot", "", "not supported"},
+		{"plain 5-field", "0 8 * * *", "0 8 * * *", ""},
+		{"5-field trimmed", "  30 6 * * 1  ", "30 6 * * 1", ""},
+		{"5-field every minute", "* * * * *", "", "fires every minute"},
+		{"5-field sub-5min step", "*/2 * * * *", "", "fires every 2 minute"},
+		{"5-field 5min step ok", "*/5 * * * *", "*/5 * * * *", ""},
+		{"invalid expression", "not a cron", "", "invalid cron expression"},
+		{"six fields", "0 0 8 * * *", "", "invalid cron expression"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TranslateCron(tt.in)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("TranslateCron(%q) = %q, want error containing %q", tt.in, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("TranslateCron(%q) error = %v, want substring %q", tt.in, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("TranslateCron(%q) unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("TranslateCron(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/services/githubscheduler/store.go
+++ b/internal/services/githubscheduler/store.go
@@ -21,7 +21,7 @@ const (
 	DefaultRepoName = ".routines"
 
 	ghCommandTimeout = 30 * time.Second
-	ghNetworkTimeout = 2 * time.Minute // clone/push are network-heavy
+	ghNetworkTimeout = 2 * time.Minute
 )
 
 // Store decorates a local ScheduledJobStorage: reads delegate to the local

--- a/internal/services/githubscheduler/store.go
+++ b/internal/services/githubscheduler/store.go
@@ -1,0 +1,256 @@
+package githubscheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+	storage "github.com/inference-gateway/cli/internal/infra/storage"
+)
+
+const (
+	// DefaultRepoName is the repository created under the authenticated user
+	// when scheduler.github.repository is not configured.
+	DefaultRepoName = ".routines"
+
+	ghCommandTimeout = 30 * time.Second
+	ghNetworkTimeout = 2 * time.Minute // clone/push are network-heavy
+)
+
+// Store decorates a local ScheduledJobStorage: reads delegate to the local
+// store (source of truth for the CLI), writes additionally render the job's
+// Actions workflow and deploy it to the configured GitHub repository - pushed
+// straight to the default branch, or via a PR when pull_requests is enabled.
+// A failed GitHub sync aborts the local write, so no phantom jobs.
+type Store struct {
+	inner        storage.ScheduledJobStorage
+	runner       CommandRunner
+	cfg          config.SchedulerGitHubConfig
+	defaultModel string
+
+	mu        sync.Mutex // one clone/branch/PR sequence at a time
+	lastPRURL string
+}
+
+// NewStore wraps inner with GitHub workflow sync. runner is typically
+// &githubsetup.RealRunner{}.
+func NewStore(inner storage.ScheduledJobStorage, runner CommandRunner, cfg config.SchedulerGitHubConfig, defaultModel string) *Store {
+	return &Store{inner: inner, runner: runner, cfg: cfg, defaultModel: defaultModel}
+}
+
+// LastPRURL returns the URL of the PR opened by the most recent successful
+// SaveJob/DeleteJob, or "" when the last write needed no PR. The schedule tool
+// type-asserts for this to surface the link to the user.
+func (s *Store) LastPRURL() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastPRURL
+}
+
+// LoadJob delegates to the local store.
+func (s *Store) LoadJob(ctx context.Context, id string) (*domain.ScheduledJob, error) {
+	return s.inner.LoadJob(ctx, id)
+}
+
+// ListJobs delegates to the local store.
+func (s *Store) ListJobs(ctx context.Context) ([]*domain.ScheduledJob, error) {
+	return s.inner.ListJobs(ctx)
+}
+
+// SaveJob renders the job's workflow, deploys it to the repo, then persists
+// the job locally. Validation failures and gh errors abort before the local save.
+func (s *Store) SaveJob(ctx context.Context, job *domain.ScheduledJob) error {
+	ghCron, err := TranslateCron(job.CronExpression)
+	if err != nil {
+		return err
+	}
+	content, err := RenderWorkflow(job, ghCron, s.defaultModel)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prURL, err := s.syncRepo(ctx, job, func(dir string) (bool, error) {
+		path := filepath.Join(dir, WorkflowPath(job.ID))
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return false, err
+		}
+		return true, os.WriteFile(path, content, 0644)
+	}, "upsert")
+	if err != nil {
+		return err
+	}
+	s.lastPRURL = prURL
+	return s.inner.SaveJob(ctx, job)
+}
+
+// DeleteJob removes the job's workflow from the repo (skipped when the file
+// is absent), then deletes the job locally.
+func (s *Store) DeleteJob(ctx context.Context, id string) error {
+	job, err := s.inner.LoadJob(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prURL, err := s.syncRepo(ctx, job, func(dir string) (bool, error) {
+		path := filepath.Join(dir, WorkflowPath(id))
+		if _, err := os.Stat(path); err != nil {
+			return false, nil // never deployed; nothing to remove
+		}
+		return true, os.Remove(path)
+	}, "remove")
+	if err != nil {
+		return err
+	}
+	s.lastPRURL = prURL
+	return s.inner.DeleteJob(ctx, id)
+}
+
+// syncRepo ensures the repo exists, clones it, applies mutate in the checkout,
+// commits, and deploys the change: pushed straight to the default branch, or -
+// when pull_requests is configured - via a branch and PR (URL returned). mutate
+// returns false to signal a no-op (nothing is pushed and "" is returned).
+func (s *Store) syncRepo(ctx context.Context, job *domain.ScheduledJob, mutate func(dir string) (bool, error), verb string) (string, error) {
+	repo, err := ResolveRepo(ctx, s.runner, s.cfg.Repository)
+	if err != nil {
+		return "", err
+	}
+	if err := s.ensureRepo(ctx, repo); err != nil {
+		return "", err
+	}
+
+	dir, err := os.MkdirTemp("", "infer-routines-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	if out, err := s.run(ctx, ghNetworkTimeout, "gh", "repo", "clone", repo, dir, "--", "--depth", "1"); err != nil {
+		return "", fmt.Errorf("clone %s: %s: %w", repo, strings.TrimSpace(string(out)), err)
+	}
+
+	changed, err := mutate(dir)
+	if err != nil {
+		return "", fmt.Errorf("update workflow checkout: %w", err)
+	}
+	if !changed {
+		return "", nil
+	}
+
+	jobLabel := job.Name
+	if jobLabel == "" {
+		jobLabel = job.ID
+	}
+	title := fmt.Sprintf("chore(schedule): %s %s", verb, jobLabel)
+
+	git := func(timeout time.Duration, args ...string) error {
+		out, err := s.run(ctx, timeout, "git", append([]string{"-C", dir}, args...)...)
+		if err != nil {
+			return fmt.Errorf("git %s: %s: %w", args[0], strings.TrimSpace(string(out)), err)
+		}
+		return nil
+	}
+
+	branch := ""
+	if s.cfg.PullRequests {
+		branch = fmt.Sprintf("infer/schedule-%s-%d", shortID(job.ID), time.Now().Unix())
+		if err := git(ghCommandTimeout, "checkout", "-b", branch); err != nil {
+			return "", err
+		}
+	}
+	if err := git(ghCommandTimeout, "add", "-A"); err != nil {
+		return "", err
+	}
+	if err := git(ghCommandTimeout,
+		"-c", "user.name=infer", "-c", "user.email=infer@users.noreply.github.com",
+		"commit", "-m", title); err != nil {
+		return "", err
+	}
+
+	if !s.cfg.PullRequests {
+		if err := git(ghNetworkTimeout, "push", "origin", "HEAD"); err != nil {
+			return "", err
+		}
+		return "", nil
+	}
+
+	if err := git(ghNetworkTimeout, "push", "-u", "origin", branch); err != nil {
+		return "", err
+	}
+	out, err := s.run(ctx, ghCommandTimeout, "gh", "pr", "create",
+		"--repo", repo,
+		"--head", branch,
+		"--title", title,
+		"--body", prBody(job, verb))
+	if err != nil {
+		return "", fmt.Errorf("create PR: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ResolveRepo returns the configured repository, defaulting to
+// "<authenticated user>/.routines".
+func ResolveRepo(ctx context.Context, runner CommandRunner, configured string) (string, error) {
+	if repo := strings.TrimSpace(configured); repo != "" {
+		return repo, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, ghCommandTimeout)
+	defer cancel()
+	out, err := runner.Run(ctx, "gh", "api", "user", "-q", ".login")
+	if err != nil {
+		return "", fmt.Errorf("resolve GitHub user (is gh authenticated?): %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	login := strings.TrimSpace(string(out))
+	if login == "" {
+		return "", errors.New("resolve GitHub user: gh returned an empty login")
+	}
+	return login + "/" + DefaultRepoName, nil
+}
+
+// ensureRepo creates the repository (private, with an initial commit so a
+// default branch exists) when it does not exist yet.
+func (s *Store) ensureRepo(ctx context.Context, repo string) error {
+	if _, err := s.run(ctx, ghCommandTimeout, "gh", "repo", "view", repo, "--json", "name"); err == nil {
+		return nil
+	}
+	out, err := s.run(ctx, ghCommandTimeout, "gh", "repo", "create", repo, "--private", "--add-readme")
+	if err != nil {
+		return fmt.Errorf("create repo %s: %s: %w", repo, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// run executes one subprocess under its own timeout, honoring the caller ctx.
+func (s *Store) run(ctx context.Context, timeout time.Duration, name string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return s.runner.Run(ctx, name, args...)
+}
+
+func prBody(job *domain.ScheduledJob, verb string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Scheduled job %s: %s\n\n", verb, job.ID)
+	if job.Name != "" {
+		fmt.Fprintf(&b, "**Name:** %s\n\n", job.Name)
+	}
+	fmt.Fprintf(&b, "**Cron:** `%s` (GitHub Actions schedules run in **UTC**)\n\n", job.CronExpression)
+	b.WriteString("Merging this PR deploys the schedule. Nothing is pushed to the default branch directly.\n\n")
+	b.WriteString("### Required repository Actions secrets\n\n")
+	b.WriteString("The workflow passes these through to infer-action; set the one(s) for your provider (Settings → Secrets and variables → Actions). The CLI never writes secrets.\n\n")
+	for _, s := range requiredSecrets {
+		fmt.Fprintf(&b, "- `%s`\n", s)
+	}
+	return b.String()
+}

--- a/internal/services/githubscheduler/store_test.go
+++ b/internal/services/githubscheduler/store_test.go
@@ -185,8 +185,6 @@ func TestDeleteJobRemovesWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The workflow file does not exist in the (fake) clone, so no push happens
-	// but the local job is still deleted.
 	if err := store.DeleteJob(context.Background(), job.ID); err != nil {
 		t.Fatalf("DeleteJob: %v", err)
 	}

--- a/internal/services/githubscheduler/store_test.go
+++ b/internal/services/githubscheduler/store_test.go
@@ -1,0 +1,209 @@
+package githubscheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+	storage "github.com/inference-gateway/cli/internal/infra/storage"
+)
+
+// scriptRunner records every command and answers via respond; nil respond
+// means every command succeeds with empty output.
+type scriptRunner struct {
+	commands []string
+	respond  func(name string, args []string) ([]byte, error)
+}
+
+func (r *scriptRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.commands = append(r.commands, name+" "+strings.Join(args, " "))
+	if r.respond != nil {
+		return r.respond(name, args)
+	}
+	return nil, nil
+}
+
+// has reports whether any recorded command contains all the given substrings.
+func (r *scriptRunner) has(subs ...string) bool {
+	for _, cmd := range r.commands {
+		ok := true
+		for _, s := range subs {
+			if !strings.Contains(cmd, s) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func newTestStore(runner *scriptRunner, cfg config.SchedulerGitHubConfig) (*Store, storage.ScheduledJobStorage) {
+	inner := storage.NewMemoryStorage()
+	return NewStore(inner, runner, cfg, "anthropic/claude"), inner
+}
+
+func TestSaveJobDirectPush(t *testing.T) {
+	runner := &scriptRunner{}
+	store, inner := newTestStore(runner, config.SchedulerGitHubConfig{Repository: "me/.routines"})
+
+	job := testJob()
+	if err := store.SaveJob(context.Background(), job); err != nil {
+		t.Fatalf("SaveJob: %v", err)
+	}
+
+	for _, want := range [][]string{
+		{"gh repo view me/.routines"},
+		{"gh repo clone me/.routines"},
+		{"git", "add -A"},
+		{"git", "commit -m chore(schedule): upsert morning briefing"},
+		{"git", "push origin HEAD"},
+	} {
+		if !runner.has(want...) {
+			t.Errorf("missing command %v in %v", want, runner.commands)
+		}
+	}
+	if runner.has("gh pr create") {
+		t.Errorf("direct-push mode must not open a PR: %v", runner.commands)
+	}
+	if runner.has("git checkout -b") {
+		t.Errorf("direct-push mode must not branch: %v", runner.commands)
+	}
+	if store.LastPRURL() != "" {
+		t.Errorf("LastPRURL = %q, want empty", store.LastPRURL())
+	}
+	if _, err := inner.LoadJob(context.Background(), job.ID); err != nil {
+		t.Errorf("job not persisted locally: %v", err)
+	}
+}
+
+func TestSaveJobPullRequestMode(t *testing.T) {
+	runner := &scriptRunner{respond: func(name string, args []string) ([]byte, error) {
+		if name == "gh" && args[0] == "pr" {
+			return []byte("https://github.com/me/.routines/pull/7\n"), nil
+		}
+		return nil, nil
+	}}
+	store, _ := newTestStore(runner, config.SchedulerGitHubConfig{Repository: "me/.routines", PullRequests: true})
+
+	if err := store.SaveJob(context.Background(), testJob()); err != nil {
+		t.Fatalf("SaveJob: %v", err)
+	}
+	if !runner.has("git", "checkout -b infer/schedule-0b7f4a2c") {
+		t.Errorf("missing branch creation: %v", runner.commands)
+	}
+	if !runner.has("gh pr create --repo me/.routines") {
+		t.Errorf("missing pr create: %v", runner.commands)
+	}
+	if got := store.LastPRURL(); got != "https://github.com/me/.routines/pull/7" {
+		t.Errorf("LastPRURL = %q", got)
+	}
+}
+
+func TestSaveJobCreatesMissingRepo(t *testing.T) {
+	runner := &scriptRunner{respond: func(name string, args []string) ([]byte, error) {
+		if name == "gh" && args[0] == "repo" && args[1] == "view" {
+			return []byte("Could not resolve to a Repository"), errors.New("exit 1")
+		}
+		return nil, nil
+	}}
+	store, _ := newTestStore(runner, config.SchedulerGitHubConfig{Repository: "me/.routines"})
+
+	if err := store.SaveJob(context.Background(), testJob()); err != nil {
+		t.Fatalf("SaveJob: %v", err)
+	}
+	if !runner.has("gh repo create me/.routines --private --add-readme") {
+		t.Errorf("missing repo create: %v", runner.commands)
+	}
+}
+
+func TestSaveJobResolvesDefaultRepo(t *testing.T) {
+	runner := &scriptRunner{respond: func(name string, args []string) ([]byte, error) {
+		if name == "gh" && args[0] == "api" && args[1] == "user" {
+			return []byte("someone\n"), nil
+		}
+		return nil, nil
+	}}
+	store, _ := newTestStore(runner, config.SchedulerGitHubConfig{})
+
+	if err := store.SaveJob(context.Background(), testJob()); err != nil {
+		t.Fatalf("SaveJob: %v", err)
+	}
+	if !runner.has("gh repo view someone/.routines") {
+		t.Errorf("default repo not resolved: %v", runner.commands)
+	}
+}
+
+func TestSaveJobBadCronRejectedBeforeAnyCommand(t *testing.T) {
+	runner := &scriptRunner{}
+	store, inner := newTestStore(runner, config.SchedulerGitHubConfig{Repository: "me/.routines"})
+
+	job := testJob()
+	job.CronExpression = "@every 7m"
+	err := store.SaveJob(context.Background(), job)
+	if err == nil || !strings.Contains(err.Error(), "GitHub Actions cron") {
+		t.Fatalf("want cron rejection, got %v", err)
+	}
+	if len(runner.commands) != 0 {
+		t.Errorf("no gh/git command should run on invalid cron: %v", runner.commands)
+	}
+	if _, err := inner.LoadJob(context.Background(), job.ID); !errors.Is(err, storage.ErrJobNotFound) {
+		t.Errorf("job must not be persisted locally: %v", err)
+	}
+}
+
+func TestSaveJobGhFailureLeavesLocalUnchanged(t *testing.T) {
+	runner := &scriptRunner{respond: func(name string, args []string) ([]byte, error) {
+		if name == "git" && slices.Contains(args, "push") {
+			return []byte("permission denied"), fmt.Errorf("exit 1")
+		}
+		return nil, nil
+	}}
+	store, inner := newTestStore(runner, config.SchedulerGitHubConfig{Repository: "me/.routines"})
+
+	job := testJob()
+	err := store.SaveJob(context.Background(), job)
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("want push failure, got %v", err)
+	}
+	if _, err := inner.LoadJob(context.Background(), job.ID); !errors.Is(err, storage.ErrJobNotFound) {
+		t.Errorf("failed sync must not persist the job locally: %v", err)
+	}
+}
+
+func TestDeleteJobRemovesWorkflow(t *testing.T) {
+	runner := &scriptRunner{}
+	store, inner := newTestStore(runner, config.SchedulerGitHubConfig{Repository: "me/.routines"})
+	job := testJob()
+	if err := inner.SaveJob(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+
+	// The workflow file does not exist in the (fake) clone, so no push happens
+	// but the local job is still deleted.
+	if err := store.DeleteJob(context.Background(), job.ID); err != nil {
+		t.Fatalf("DeleteJob: %v", err)
+	}
+	if runner.has("git", "push") {
+		t.Errorf("nothing to remove -> no push expected: %v", runner.commands)
+	}
+	if _, err := inner.LoadJob(context.Background(), job.ID); !errors.Is(err, storage.ErrJobNotFound) {
+		t.Errorf("job should be deleted locally: %v", err)
+	}
+}
+
+func TestSaveJobRunOnceAllowed(t *testing.T) {
+	runner := &scriptRunner{}
+	store, _ := newTestStore(runner, config.SchedulerGitHubConfig{Repository: "me/.routines"})
+	job := testJob()
+	job.RunOnce = true
+	if err := store.SaveJob(context.Background(), job); err != nil {
+		t.Fatalf("SaveJob run_once: %v", err)
+	}
+}

--- a/internal/services/githubscheduler/workflow.go
+++ b/internal/services/githubscheduler/workflow.go
@@ -156,7 +156,6 @@ func RenderWorkflow(job *domain.ScheduledJob, ghCron, defaultModel string) ([]by
 			},
 		},
 		{
-			// actions/upload-artifact does not expand ~, so a shell step stages the files first.
 			Name: "Collect conversation output",
 			If:   "always()",
 			Run:  `cp -r ~/.infer/conversations "$GITHUB_WORKSPACE/.infer-conversations" 2>/dev/null || true`,
@@ -173,8 +172,6 @@ func RenderWorkflow(job *domain.ScheduledJob, ghCron, defaultModel string) ([]by
 		},
 	}
 	if job.RunOnce {
-		// The app token carries the disable permission; the App needs the
-		// "Actions" (read & write) repository permission.
 		steps = append(steps, step{
 			Name: "Disable after first fire",
 			If:   "always()",

--- a/internal/services/githubscheduler/workflow.go
+++ b/internal/services/githubscheduler/workflow.go
@@ -1,0 +1,223 @@
+package githubscheduler
+
+import (
+	"fmt"
+	"strings"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	githubsetup "github.com/inference-gateway/cli/internal/services/githubsetup"
+	yaml "gopkg.in/yaml.v3"
+)
+
+const (
+	// ArtifactNamePrefix is shared by the rendered upload step and the poller.
+	ArtifactNamePrefix     = "infer-conversations-"
+	uploadArtifactAction   = "actions/upload-artifact@v4"
+	workflowTimeoutMinutes = 30
+)
+
+// WorkflowPath returns the repo-relative path of a job's workflow file.
+func WorkflowPath(jobID string) string {
+	return ".github/workflows/" + jobID + ".yml"
+}
+
+// Workflow YAML is built from structs and marshalled with yaml.v3 so user
+// prompts (multiline, colons, quotes) are always escaped correctly.
+type workflowDoc struct {
+	Name        string              `yaml:"name"`
+	On          workflowOn          `yaml:"on"`
+	Permissions workflowPermissions `yaml:"permissions"`
+	Jobs        map[string]jobSpec  `yaml:"jobs"`
+}
+
+type workflowOn struct {
+	Schedule         []cronSpec `yaml:"schedule"`
+	WorkflowDispatch struct{}   `yaml:"workflow_dispatch"`
+}
+
+type cronSpec struct {
+	Cron string `yaml:"cron"`
+}
+
+type workflowPermissions struct {
+	Contents string `yaml:"contents"`
+}
+
+type jobSpec struct {
+	RunsOn         string `yaml:"runs-on"`
+	TimeoutMinutes int    `yaml:"timeout-minutes"`
+	Steps          []step `yaml:"steps"`
+}
+
+type step struct {
+	Name string            `yaml:"name,omitempty"`
+	ID   string            `yaml:"id,omitempty"`
+	If   string            `yaml:"if,omitempty"`
+	Uses string            `yaml:"uses,omitempty"`
+	With any               `yaml:"with,omitempty"`
+	Env  map[string]string `yaml:"env,omitempty"`
+	Run  string            `yaml:"run,omitempty"`
+}
+
+// inferActionInputs mirrors the provider pass-through list of
+// githubsetup.workflowAgentInputs; a struct keeps the rendered key order stable.
+type inferActionInputs struct {
+	DirectPrompt      string `yaml:"direct-prompt"`
+	Model             string `yaml:"model"`
+	GithubToken       string `yaml:"github-token"`
+	GithubAppSlug     string `yaml:"github-app-slug"`
+	AnthropicAPIKey   string `yaml:"anthropic-api-key"`
+	OpenAIAPIKey      string `yaml:"openai-api-key"`
+	GoogleAPIKey      string `yaml:"google-api-key"`
+	DeepseekAPIKey    string `yaml:"deepseek-api-key"`
+	GroqAPIKey        string `yaml:"groq-api-key"`
+	MistralAPIKey     string `yaml:"mistral-api-key"`
+	CloudflareAPIKey  string `yaml:"cloudflare-api-key"`
+	CohereAPIKey      string `yaml:"cohere-api-key"`
+	OllamaCloudAPIKey string `yaml:"ollama-cloud-api-key"`
+	MoonshotAPIKey    string `yaml:"moonshot-api-key"`
+	MinimaxAPIKey     string `yaml:"minimax-api-key"`
+	NvidiaAPIKey      string `yaml:"nvidia-api-key"`
+	ZaiAPIKey         string `yaml:"zai-api-key"`
+}
+
+type uploadArtifactInputs struct {
+	Name           string `yaml:"name"`
+	Path           string `yaml:"path"`
+	IfNoFilesFound string `yaml:"if-no-files-found"`
+}
+
+// appTokenInputs configures actions/create-github-app-token: the workflow runs
+// infer-action under the infer GitHub App bot identity. `repositories` is
+// omitted on purpose - schedule events carry no event payload, and the default
+// scopes the token to the installation's repos on the owner.
+type appTokenInputs struct {
+	ClientID   string `yaml:"client-id"`
+	PrivateKey string `yaml:"private-key"`
+	Owner      string `yaml:"owner"`
+}
+
+type checkoutInputs struct {
+	Token string `yaml:"token"`
+}
+
+// RenderWorkflow renders one job's Actions workflow. ghCron must already be
+// translated via TranslateCron; defaultModel is used when the job has none.
+func RenderWorkflow(job *domain.ScheduledJob, ghCron, defaultModel string) ([]byte, error) {
+	model := job.Model
+	if model == "" {
+		model = defaultModel
+	}
+	if model == "" {
+		model = githubsetup.DefaultWorkflowModel
+	}
+	name := job.Name
+	if name == "" {
+		name = "infer job " + shortID(job.ID)
+	}
+
+	permissions := workflowPermissions{Contents: "read"}
+	steps := []step{
+		{
+			Name: "Generate GitHub App token",
+			ID:   "app-token",
+			Uses: "actions/create-github-app-token@" + githubsetup.AppTokenActionVersion,
+			With: appTokenInputs{
+				ClientID:   "${{ secrets.APP_CLIENT_ID }}",
+				PrivateKey: "${{ secrets.APP_PRIVATE_KEY }}",
+				Owner:      "${{ github.repository_owner }}",
+			},
+		},
+		{
+			Uses: "actions/checkout@" + githubsetup.CheckoutActionVersion,
+			With: checkoutInputs{Token: "${{ steps.app-token.outputs.token }}"},
+		},
+		{
+			Name: "Run Infer Agent",
+			Uses: "inference-gateway/infer-action@" + githubsetup.InferActionVersion,
+			With: inferActionInputs{
+				DirectPrompt:      job.Prompt,
+				Model:             model,
+				GithubToken:       "${{ steps.app-token.outputs.token }}",
+				GithubAppSlug:     "${{ steps.app-token.outputs.app-slug }}",
+				AnthropicAPIKey:   "${{ secrets.ANTHROPIC_API_KEY }}",
+				OpenAIAPIKey:      "${{ secrets.OPENAI_API_KEY }}",
+				GoogleAPIKey:      "${{ secrets.GOOGLE_API_KEY }}",
+				DeepseekAPIKey:    "${{ secrets.DEEPSEEK_API_KEY }}",
+				GroqAPIKey:        "${{ secrets.GROQ_API_KEY }}",
+				MistralAPIKey:     "${{ secrets.MISTRAL_API_KEY }}",
+				CloudflareAPIKey:  "${{ secrets.CLOUDFLARE_API_KEY }}",
+				CohereAPIKey:      "${{ secrets.COHERE_API_KEY }}",
+				OllamaCloudAPIKey: "${{ secrets.OLLAMA_CLOUD_API_KEY }}",
+				MoonshotAPIKey:    "${{ secrets.MOONSHOT_API_KEY }}",
+				MinimaxAPIKey:     "${{ secrets.MINIMAX_API_KEY }}",
+				NvidiaAPIKey:      "${{ secrets.NVIDIA_API_KEY }}",
+				ZaiAPIKey:         "${{ secrets.ZAI_API_KEY }}",
+			},
+		},
+		{
+			// actions/upload-artifact does not expand ~, so a shell step stages the files first.
+			Name: "Collect conversation output",
+			If:   "always()",
+			Run:  `cp -r ~/.infer/conversations "$GITHUB_WORKSPACE/.infer-conversations" 2>/dev/null || true`,
+		},
+		{
+			Name: "Upload conversation artifact",
+			If:   "always()",
+			Uses: uploadArtifactAction,
+			With: uploadArtifactInputs{
+				Name:           ArtifactNamePrefix + "${{ github.run_id }}",
+				Path:           ".infer-conversations/*.jsonl",
+				IfNoFilesFound: "ignore",
+			},
+		},
+	}
+	if job.RunOnce {
+		// The app token carries the disable permission; the App needs the
+		// "Actions" (read & write) repository permission.
+		steps = append(steps, step{
+			Name: "Disable after first fire",
+			If:   "always()",
+			Env:  map[string]string{"GH_TOKEN": "${{ steps.app-token.outputs.token }}"},
+			Run:  `gh workflow disable "${{ github.workflow }}" --repo "${{ github.repository }}"`,
+		})
+	}
+
+	doc := workflowDoc{
+		Name:        name,
+		On:          workflowOn{Schedule: []cronSpec{{Cron: ghCron}}},
+		Permissions: permissions,
+		Jobs: map[string]jobSpec{
+			"run": {
+				RunsOn:         "ubuntu-24.04",
+				TimeoutMinutes: workflowTimeoutMinutes,
+				Steps:          steps,
+			},
+		},
+	}
+
+	body, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal workflow for job %s: %w", job.ID, err)
+	}
+	header := fmt.Sprintf(`# Generated by infer - scheduled job %s
+# name: %s
+# original cron: %s
+# NOTE: GitHub Actions schedules run in UTC.
+`, job.ID, name, job.CronExpression)
+	return append([]byte(header), body...), nil
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+// requiredSecrets lists the Actions secrets the rendered workflow references,
+// for the PR body. The CLI never writes secret values.
+var requiredSecrets = strings.Fields(`APP_CLIENT_ID APP_PRIVATE_KEY
+ANTHROPIC_API_KEY OPENAI_API_KEY GOOGLE_API_KEY DEEPSEEK_API_KEY
+GROQ_API_KEY MISTRAL_API_KEY CLOUDFLARE_API_KEY COHERE_API_KEY OLLAMA_CLOUD_API_KEY
+MOONSHOT_API_KEY MINIMAX_API_KEY NVIDIA_API_KEY ZAI_API_KEY`)

--- a/internal/services/githubscheduler/workflow_test.go
+++ b/internal/services/githubscheduler/workflow_test.go
@@ -30,7 +30,6 @@ func TestRenderWorkflow(t *testing.T) {
 	}
 	content := string(out)
 
-	// Well-formed YAML round-trip (multiline prompt with a colon must survive).
 	var doc map[string]any
 	if err := yaml.Unmarshal(out, &doc); err != nil {
 		t.Fatalf("rendered workflow is not valid YAML: %v\n%s", err, content)
@@ -57,7 +56,6 @@ func TestRenderWorkflow(t *testing.T) {
 		}
 	}
 
-	// Prompt survives the YAML round-trip byte-for-byte.
 	jobs := doc["jobs"].(map[string]any)
 	steps := jobs["run"].(map[string]any)["steps"].([]any)
 	var gotPrompt string

--- a/internal/services/githubscheduler/workflow_test.go
+++ b/internal/services/githubscheduler/workflow_test.go
@@ -1,0 +1,106 @@
+package githubscheduler
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+	githubsetup "github.com/inference-gateway/cli/internal/services/githubsetup"
+	yaml "gopkg.in/yaml.v3"
+)
+
+func testJob() *domain.ScheduledJob {
+	return &domain.ScheduledJob{
+		ID:             "0b7f4a2c-1234-5678-9abc-def012345678",
+		Name:           "morning briefing",
+		CronExpression: "@daily",
+		Prompt:         "Summarize my day.\nInclude: weather, calendar, and a quote.",
+		Model:          "openai/gpt-4o",
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+}
+
+func TestRenderWorkflow(t *testing.T) {
+	job := testJob()
+	out, err := RenderWorkflow(job, "0 0 * * *", "anthropic/claude")
+	if err != nil {
+		t.Fatalf("RenderWorkflow: %v", err)
+	}
+	content := string(out)
+
+	// Well-formed YAML round-trip (multiline prompt with a colon must survive).
+	var doc map[string]any
+	if err := yaml.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("rendered workflow is not valid YAML: %v\n%s", err, content)
+	}
+
+	for _, want := range []string{
+		"cron: 0 0 * * *",
+		"name: morning briefing",
+		"model: openai/gpt-4o",
+		"inference-gateway/infer-action@" + githubsetup.InferActionVersion,
+		"actions/checkout@" + githubsetup.CheckoutActionVersion,
+		"actions/create-github-app-token@" + githubsetup.AppTokenActionVersion,
+		"${{ secrets.APP_CLIENT_ID }}",
+		"${{ secrets.APP_PRIVATE_KEY }}",
+		"github-token: ${{ steps.app-token.outputs.token }}",
+		"github-app-slug: ${{ steps.app-token.outputs.app-slug }}",
+		uploadArtifactAction,
+		ArtifactNamePrefix + "${{ github.run_id }}",
+		"workflow_dispatch",
+		"# original cron: @daily",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("rendered workflow missing %q\n%s", want, content)
+		}
+	}
+
+	// Prompt survives the YAML round-trip byte-for-byte.
+	jobs := doc["jobs"].(map[string]any)
+	steps := jobs["run"].(map[string]any)["steps"].([]any)
+	var gotPrompt string
+	for _, s := range steps {
+		if with, ok := s.(map[string]any)["with"].(map[string]any); ok {
+			if p, ok := with["direct-prompt"].(string); ok {
+				gotPrompt = p
+			}
+		}
+	}
+	if gotPrompt != job.Prompt {
+		t.Errorf("prompt did not round-trip: got %q want %q", gotPrompt, job.Prompt)
+	}
+
+	if strings.Contains(content, "Disable after first fire") {
+		t.Errorf("recurring job must not render the self-disable step")
+	}
+}
+
+func TestRenderWorkflowRunOnceAndDefaults(t *testing.T) {
+	job := testJob()
+	job.Name = ""
+	job.Model = ""
+	job.RunOnce = true
+	out, err := RenderWorkflow(job, "*/10 * * * *", "")
+	if err != nil {
+		t.Fatalf("RenderWorkflow: %v", err)
+	}
+	content := string(out)
+
+	if !strings.Contains(content, "gh workflow disable") {
+		t.Errorf("run_once job missing self-disable step\n%s", content)
+	}
+	if !strings.Contains(content, "name: infer job 0b7f4a2c") {
+		t.Errorf("missing fallback name\n%s", content)
+	}
+	if !strings.Contains(content, "model: "+githubsetup.DefaultWorkflowModel) {
+		t.Errorf("missing fallback model\n%s", content)
+	}
+}
+
+func TestWorkflowPath(t *testing.T) {
+	if got := WorkflowPath("abc"); got != ".github/workflows/abc.yml" {
+		t.Fatalf("WorkflowPath = %q", got)
+	}
+}

--- a/internal/services/githubsetup/service.go
+++ b/internal/services/githubsetup/service.go
@@ -48,10 +48,10 @@ func NewService(runner CommandRunner) *Service {
 // Version pins and defaults for the generated .github/workflows/infer.yml.
 // Bumping any of these is a one-line change picked up by both templates.
 const (
-	inferActionVersion     = "v0.29.0"
-	checkoutActionVersion  = "v7.0.0"
-	appTokenActionVersion  = "v3.2.0"
-	workflowDefaultModel   = "ollama_cloud/deepseek-v4-flash"
+	InferActionVersion     = "v0.29.0"
+	CheckoutActionVersion  = "v7.0.0"
+	AppTokenActionVersion  = "v3.2.0"
+	DefaultWorkflowModel   = "ollama_cloud/deepseek-v4-flash"
 	workflowTimeoutMinutes = 15
 )
 
@@ -136,7 +136,7 @@ jobs:
 // workflowAgentInputs is the shared tail of the "Run Infer Agent" step: the
 // agent defaults and the provider API key pass-throughs.
 const workflowAgentInputs = `          trigger-phrase: '@infer'
-          model: ` + workflowDefaultModel + `
+          model: ` + DefaultWorkflowModel + `
           direct-prompt: ${{ inputs.prompt }}
           agents: ${{ inputs.browser-agent && 'browser-agent' || '' }}
           debug: ${{ inputs.debug }}
@@ -246,7 +246,7 @@ func (s *Service) GenerateStandardWorkflowContent() string {
         uses: inference-gateway/infer-action@%s
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-`, checkoutActionVersion, inferActionVersion) + workflowAgentInputs
+`, CheckoutActionVersion, InferActionVersion) + workflowAgentInputs
 }
 
 // GenerateGithubActionWorkflowContent generates the GitHub App-based workflow
@@ -288,7 +288,7 @@ func (s *Service) GenerateGithubActionWorkflowContent() string {
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           github-app-slug: ${{ steps.app-token.outputs.app-slug }}
-`, appTokenActionVersion, checkoutActionVersion, inferActionVersion) + workflowAgentInputs
+`, AppTokenActionVersion, CheckoutActionVersion, InferActionVersion) + workflowAgentInputs
 }
 
 // PreparePRCreation creates a branch, commits the workflow file, pushes it,

--- a/internal/services/githubsetup/service.go
+++ b/internal/services/githubsetup/service.go
@@ -48,8 +48,8 @@ func NewService(runner CommandRunner) *Service {
 // Version pins and defaults for the generated .github/workflows/infer.yml.
 // Bumping any of these is a one-line change picked up by both templates.
 const (
-	InferActionVersion     = "v0.29.0"
-	CheckoutActionVersion  = "v7.0.0"
+	InferActionVersion     = "v0.46.4"
+	CheckoutActionVersion  = "v7.0.1"
 	AppTokenActionVersion  = "v3.2.0"
 	DefaultWorkflowModel   = "ollama_cloud/deepseek-v4-flash"
 	workflowTimeoutMinutes = 15

--- a/internal/services/githubsetup/service_test.go
+++ b/internal/services/githubsetup/service_test.go
@@ -231,7 +231,7 @@ func TestGenerateGithubActionWorkflowContent(t *testing.T) {
 	assertWorkflowCommon(t, content)
 
 	for _, want := range []string{
-		"actions/create-github-app-token@" + appTokenActionVersion,
+		"actions/create-github-app-token@" + AppTokenActionVersion,
 		"client-id: ${{ secrets.INFER_APP_ID }}",
 		"private-key: ${{ secrets.INFER_APP_PRIVATE_KEY }}",
 		"github-token: ${{ steps.app-token.outputs.token }}",
@@ -255,10 +255,10 @@ func assertWorkflowCommon(t *testing.T, content string) {
 	}
 
 	for _, want := range []string{
-		"inference-gateway/infer-action@" + inferActionVersion,
-		"actions/checkout@" + checkoutActionVersion,
+		"inference-gateway/infer-action@" + InferActionVersion,
+		"actions/checkout@" + CheckoutActionVersion,
 		"timeout-minutes: 15",
-		"model: " + workflowDefaultModel,
+		"model: " + DefaultWorkflowModel,
 		"workflow_dispatch:",
 		"browser-agent:",
 		"debug:",


### PR DESCRIPTION
## Summary

Adds a `github` scheduling backend (closes #1055): schedules materialize as GitHub Actions scheduled workflows in a repository the user configures — cloud scheduling with zero user-owned infrastructure.

```yaml
scheduler:
  backend: github
  github:
    repository: ""        # "" => <login>/.routines, created private on first save
    pull_requests: false  # true => deploy via PR instead of pushing to main
    artifacts:
      enabled: true
      poll_interval: 10m
      initial_delay: 1m
      max_attempts: 3
      rate_limit_backoff: 1h
```

## How it works

- **Decorator store** (`internal/services/githubscheduler.Store`): wraps the local `ScheduledJobStorage`; reads stay local, writes render the job's workflow (`.github/workflows/<job-id>.yml`) and deploy it — pushed straight to the default branch by default, or via a branch + PR when `pull_requests: true`. A failed GitHub sync aborts the local save (no phantom jobs).
- **Repo auto-creation**: `gh repo create <owner>/.routines --private --add-readme` on first save when missing. All GitHub access goes through the `gh` CLI (reusing the `githubsetup` runner seam).
- **Bot identity**: the rendered workflow mints an installation token with `actions/create-github-app-token` (`APP_CLIENT_ID` / `APP_PRIVATE_KEY` secrets, same convention as opentask) and runs `inference-gateway/infer-action` with `github-token` + `github-app-slug` from the step outputs, using the job's prompt as `direct-prompt`.
- **Cron translation**: descriptors are translated to GitHub's 5-field UTC syntax (`@daily` → `0 0 * * *`, `@every 10m` → `*/10 * * * *`, …); inexpressible ones (`@every 7m`, `* * * * *`, sub-5-minute steps) are rejected at save time with a clear error.
- **run_once**: renders a final step that disables the workflow after its first fire (App needs Actions read & write).
- **Conversation pull-back**: the workflow uploads `~/.infer/conversations/*.jsonl` as an `infer-conversations-<run_id>` artifact; a daemon-hosted poller (mirrors the heartbeat service) downloads new artifacts into local conversation storage — configurable interval (10m), max 3 attempts per artifact, 1h backoff after a rate-limited API call (rate-limited attempts don't consume attempts). Jsonl storage backend only.
- **Daemon**: with `backend: github` the local cron scheduler is skipped; the artifact poller starts instead.
- The schedule tool surfaces the PR URL (`pull_requests: true`) and notes that GitHub schedules fire in UTC.

## Out of scope (per issue)

Channel delivery of GitHub-backed job output, syncing runs into `RunRecord`s, other cloud backends.

## Testing

- `cron_test.go`: full translation matrix (descriptors, `@every`, rejections).
- `workflow_test.go`: YAML round-trip with multiline/colon prompts, pins, app-token/upload/self-disable steps.
- `store_test.go`: scripted fake runner — exact gh/git sequences for direct-push vs PR mode, repo auto-create, default-repo resolution, cron rejected before any subprocess, gh failure leaves local store unchanged.
- `artifacts_test.go`: zip extraction + idempotence, state persistence across restarts, retry-then-give-up, rate-limit backoff semantics.
- `task precommit:run` green; full `go test ./...` green.

## Docs

- `docs/scheduling.md`: new **GitHub backend** section (setup, secrets, save-to-deploy flow, artifact pull-back).
- `docs/configuration-reference.md`: `INFER_SCHEDULER_*` env vars.