### PR TITLE
feat(bridge): mirror tool approvals to the browser extension

### DIFF
--- a/docs/browser-extension-protocol.md
+++ b/docs/browser-extension-protocol.md
@@ -43,7 +43,7 @@ Extension → CLI, first frame, within 5 seconds of connecting:
 CLI → extension on success (on failure the socket is closed):
 
 ```json
-{"type": "browser_hello_ack", "protocol_version": 1}
+{"type": "browser_hello_ack", "protocol_version": 2}
 ```
 
 Immediately after the ack the CLI sends a conversation snapshot (see below).
@@ -107,8 +107,41 @@ agent is busy, exactly like typing in the TUI):
 {"type": "user_message", "content": "please also check the docs page"}
 ```
 
-Tool approval prompts are **not** mirrored in protocol v1 — approvals stay in
-the terminal. An `approval` flow is reserved for a future protocol version.
+## Tool approvals (protocol v2)
+
+When a tool call needs the user's approval, the CLI sends an approval request
+instead of mirroring it as a chat line. The extension shows Approve/Deny and
+sends the decision back. The same decision can still be made in the terminal —
+whichever answers first wins; the loser is a harmless no-op.
+
+CLI → extension, one per pending tool call:
+
+```json
+{"type": "approval_request", "request_id": "<uuid>", "tool_name": "Bash", "tool_args": "{\"command\":\"rm -rf ...\"}"}
+```
+
+- `tool_args` is the raw tool-call arguments JSON string (may be empty).
+
+Extension → CLI, the user's decision:
+
+```json
+{"type": "approval_response", "request_id": "<uuid>", "action": "approve"}
+```
+
+- `action` is `"approve"` or `"reject"`. Any other value (including unknown
+  future actions) is treated as `reject`, failing safe.
+
+CLI → extension, when the request is no longer pending (answered in the panel
+**or** in the terminal) so the extension can clear its prompt:
+
+```json
+{"type": "approval_resolved", "request_id": "<uuid>"}
+```
+
+- A `request_id` the extension does not recognize (already cleared, or never
+  seen) MUST be ignored. Duplicate `approval_resolved` for the same id is fine.
+- An `approval_response` for an unknown/already-answered `request_id` is ignored
+  by the CLI.
 
 ## Extension-side checklist
 

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -24,8 +24,9 @@ import (
 )
 
 // extensionProtocolVersion is the wire protocol version sent in the hello ack.
-// Documented in docs/browser-extension-protocol.md.
-const extensionProtocolVersion = 1
+// Documented in docs/browser-extension-protocol.md. v2 adds the approval flow
+// (approval_request / approval_response / approval_resolved).
+const extensionProtocolVersion = 2
 
 // Bridge wire messages. One flat envelope per frame, discriminated by Type;
 // unknown types are ignored for forward compatibility.
@@ -34,12 +35,26 @@ type extInbound struct {
 	Token            string `json:"token,omitempty"`
 	ExtensionVersion string `json:"extension_version,omitempty"`
 	// browser_result fields (Content doubles as the user_message text)
-	ID      string   `json:"id,omitempty"`
-	URL     string   `json:"url,omitempty"`
-	Title   string   `json:"title,omitempty"`
-	Content string   `json:"content,omitempty"`
-	Events  []string `json:"events,omitempty"`
-	Error   string   `json:"error,omitempty"`
+	ID        string   `json:"id,omitempty"`
+	URL       string   `json:"url,omitempty"`
+	Title     string   `json:"title,omitempty"`
+	Content   string   `json:"content,omitempty"`
+	Events    []string `json:"events,omitempty"`
+	Error     string   `json:"error,omitempty"`
+	RequestID string   `json:"request_id,omitempty"`
+	Action    string   `json:"action,omitempty"`
+}
+
+type extApprovalRequest struct {
+	Type      string `json:"type"`
+	RequestID string `json:"request_id"`
+	ToolName  string `json:"tool_name"`
+	ToolArgs  string `json:"tool_args"`
+}
+
+type extApprovalResolved struct {
+	Type      string `json:"type"`
+	RequestID string `json:"request_id"`
 }
 
 type extHelloAck struct {
@@ -86,10 +101,14 @@ type ExtensionBridge struct {
 	addr     string
 	startErr error
 
-	mu       sync.Mutex // guards conn, connStop, pending
+	mu       sync.Mutex // guards conn, connStop, pending, pendingApprovals
 	conn     *websocket.Conn
 	connStop chan struct{}
 	pending  map[string]chan extInbound
+	// pendingApprovals maps an approval RequestID to the tool call awaiting a
+	// decision, so an approval_response frame can answer the right one. Normally
+	// holds at most one entry (the agent turn is paused while it waits).
+	pendingApprovals map[string]sdk.ChatCompletionMessageToolCall
 
 	writeMu sync.Mutex // serializes writes to conn
 }
@@ -98,12 +117,13 @@ type ExtensionBridge struct {
 // (conversation sync is then skipped); cfg must not be nil.
 func NewExtensionBridge(cfg *config.BrowserUseConfig, notifier domain.UINotifier, repo domain.ConversationRepository, events domain.EventBridge, sessionID string) *ExtensionBridge {
 	return &ExtensionBridge{
-		cfg:       cfg,
-		notifier:  notifier,
-		repo:      repo,
-		events:    events,
-		sessionID: sessionID,
-		pending:   make(map[string]chan extInbound),
+		cfg:              cfg,
+		notifier:         notifier,
+		repo:             repo,
+		events:           events,
+		sessionID:        sessionID,
+		pending:          make(map[string]chan extInbound),
+		pendingApprovals: make(map[string]sdk.ChatCompletionMessageToolCall),
 	}
 }
 
@@ -190,6 +210,8 @@ func (b *ExtensionBridge) adopt(conn *websocket.Conn) {
 	b.conn = conn
 	stop := make(chan struct{})
 	b.connStop = stop
+
+	b.pendingApprovals = make(map[string]sdk.ChatCompletionMessageToolCall)
 	b.mu.Unlock()
 
 	b.sendSnapshot(conn)
@@ -234,6 +256,8 @@ func (b *ExtensionBridge) readLoop(conn *websocket.Conn, stop chan struct{}) {
 			if b.notifier != nil && msg.Content != "" {
 				b.notifier.Notify(domain.UserInputEvent{Content: msg.Content})
 			}
+		case "approval_response":
+			b.answerApproval(conn, msg.RequestID, msg.Action)
 		default:
 			// Unknown frame types are ignored for forward compatibility.
 		}
@@ -243,9 +267,12 @@ func (b *ExtensionBridge) readLoop(conn *websocket.Conn, stop chan struct{}) {
 // chatPump mirrors chat events to the extension as AG-UI lines wrapped in
 // chat_event frames.
 //
-// ponytail: ToolApprovalRequestedEvent is filtered out - approvals stay in
-// the terminal. Mirroring them would double-answer the approval channel;
-// extension-side approvals come with a protocol bump.
+// ToolApprovalRequestedEvent is not rendered as a chat line; instead it is
+// forwarded as an approval_request frame so the panel can answer it (protocol
+// v2). Because the agent turn blocks on the approval's ResponseChan, no other
+// event streams until the approval is answered - so the first event that
+// arrives after a request reliably means it was resolved (here or in the
+// terminal), which is when we send approval_resolved to clear the panel card.
 func (b *ExtensionBridge) chatPump(conn *websocket.Conn, stop chan struct{}) {
 	if b.events == nil {
 		return
@@ -264,9 +291,11 @@ func (b *ExtensionBridge) chatPump(conn *websocket.Conn, stop chan struct{}) {
 				if !ok {
 					return
 				}
-				if _, isApproval := ev.(domain.ToolApprovalRequestedEvent); isApproval {
+				if req, isApproval := ev.(domain.ToolApprovalRequestedEvent); isApproval {
+					b.requestApproval(conn, req)
 					continue
 				}
+				b.resolvePendingApprovals(conn)
 				select {
 				case filtered <- ev:
 				case <-stop:
@@ -309,6 +338,67 @@ func (w *chatEventWriter) Write(p []byte) (int, error) {
 			w.bridge.write(w.conn, extChatEvent{Type: "chat_event", Event: line})
 		}
 	}
+}
+
+// requestApproval stashes the pending tool call and asks the panel to decide.
+func (b *ExtensionBridge) requestApproval(conn *websocket.Conn, req domain.ToolApprovalRequestedEvent) {
+	b.mu.Lock()
+	b.pendingApprovals[req.RequestID] = req.ToolCall
+	b.mu.Unlock()
+	b.write(conn, extApprovalRequest{
+		Type:      "approval_request",
+		RequestID: req.RequestID,
+		ToolName:  req.ToolCall.Function.Name,
+		ToolArgs:  req.ToolCall.Function.Arguments,
+	})
+}
+
+// resolvePendingApprovals clears any outstanding approval cards. Called when the
+// next event streams (the approval was answered here or in the terminal). A
+// duplicate approval_resolved is harmless - the panel ignores unknown ids.
+func (b *ExtensionBridge) resolvePendingApprovals(conn *websocket.Conn) {
+	b.mu.Lock()
+	if len(b.pendingApprovals) == 0 {
+		b.mu.Unlock()
+		return
+	}
+	ids := make([]string, 0, len(b.pendingApprovals))
+	for id := range b.pendingApprovals {
+		ids = append(ids, id)
+	}
+	b.pendingApprovals = make(map[string]sdk.ChatCompletionMessageToolCall)
+	b.mu.Unlock()
+	for _, id := range ids {
+		b.write(conn, extApprovalResolved{Type: "approval_resolved", RequestID: id})
+	}
+}
+
+// answerApproval turns a panel approval_response into the same
+// ToolApprovalResponseEvent the terminal emits, then confirms the card cleared.
+func (b *ExtensionBridge) answerApproval(conn *websocket.Conn, requestID, action string) {
+	b.mu.Lock()
+	toolCall, ok := b.pendingApprovals[requestID]
+	delete(b.pendingApprovals, requestID)
+	b.mu.Unlock()
+	if !ok {
+		return
+	}
+	if b.notifier != nil {
+		b.notifier.Notify(domain.ToolApprovalResponseEvent{
+			Action:   approvalAction(action),
+			ToolCall: toolCall,
+		})
+	}
+	b.write(conn, extApprovalResolved{Type: "approval_resolved", RequestID: requestID})
+}
+
+// approvalAction maps the wire action to a decision; anything but "approve"
+// (including unknown values) is treated as a reject, failing safe.
+func approvalAction(action string) domain.ApprovalAction {
+	if action == "approve" {
+		return domain.ApprovalApprove
+	}
+	return domain.ApprovalReject
 }
 
 func (b *ExtensionBridge) pingLoop(conn *websocket.Conn, stop chan struct{}) {

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -105,9 +105,6 @@ type ExtensionBridge struct {
 	conn     *websocket.Conn
 	connStop chan struct{}
 	pending  map[string]chan extInbound
-	// pendingApprovals maps an approval RequestID to the tool call awaiting a
-	// decision, so an approval_response frame can answer the right one. Normally
-	// holds at most one entry (the agent turn is paused while it waits).
 	pendingApprovals map[string]sdk.ChatCompletionMessageToolCall
 
 	writeMu sync.Mutex // serializes writes to conn

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -31,17 +31,17 @@ const extensionProtocolVersion = 2
 // Bridge wire messages. One flat envelope per frame, discriminated by Type;
 // unknown types are ignored for forward compatibility.
 type extInbound struct {
-	Type             string `json:"type"`
-	Token            string `json:"token,omitempty"`
-	ExtensionVersion string `json:"extension_version,omitempty"`
-	ID        string   `json:"id,omitempty"`
-	URL       string   `json:"url,omitempty"`
-	Title     string   `json:"title,omitempty"`
-	Content   string   `json:"content,omitempty"`
-	Events    []string `json:"events,omitempty"`
-	Error     string   `json:"error,omitempty"`
-	RequestID string   `json:"request_id,omitempty"`
-	Action    string   `json:"action,omitempty"`
+	Type             string   `json:"type"`
+	Token            string   `json:"token,omitempty"`
+	ExtensionVersion string   `json:"extension_version,omitempty"`
+	ID               string   `json:"id,omitempty"`
+	URL              string   `json:"url,omitempty"`
+	Title            string   `json:"title,omitempty"`
+	Content          string   `json:"content,omitempty"`
+	Events           []string `json:"events,omitempty"`
+	Error            string   `json:"error,omitempty"`
+	RequestID        string   `json:"request_id,omitempty"`
+	Action           string   `json:"action,omitempty"`
 }
 
 type extApprovalRequest struct {
@@ -100,10 +100,10 @@ type ExtensionBridge struct {
 	addr     string
 	startErr error
 
-	mu       sync.Mutex // guards conn, connStop, pending, pendingApprovals
-	conn     *websocket.Conn
-	connStop chan struct{}
-	pending  map[string]chan extInbound
+	mu               sync.Mutex // guards conn, connStop, pending, pendingApprovals
+	conn             *websocket.Conn
+	connStop         chan struct{}
+	pending          map[string]chan extInbound
 	pendingApprovals map[string]sdk.ChatCompletionMessageToolCall
 
 	writeMu sync.Mutex // serializes writes to conn

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -34,7 +34,6 @@ type extInbound struct {
 	Type             string `json:"type"`
 	Token            string `json:"token,omitempty"`
 	ExtensionVersion string `json:"extension_version,omitempty"`
-	// browser_result fields (Content doubles as the user_message text)
 	ID        string   `json:"id,omitempty"`
 	URL       string   `json:"url,omitempty"`
 	Title     string   `json:"title,omitempty"`

--- a/internal/services/extension_bridge_test.go
+++ b/internal/services/extension_bridge_test.go
@@ -7,11 +7,141 @@ import (
 	"time"
 
 	websocket "github.com/gorilla/websocket"
+	sdk "github.com/inference-gateway/sdk"
 
 	config "github.com/inference-gateway/cli/config"
 	macos "github.com/inference-gateway/cli/internal/display/macos"
 	domain "github.com/inference-gateway/cli/internal/domain"
 )
+
+// readFrameOfType reads frames until one with the given type arrives, failing
+// on timeout. Returns the decoded frame.
+func readFrameOfType(t *testing.T, conn *websocket.Conn, typ string) map[string]any {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for {
+		var frame map[string]any
+		if err := conn.ReadJSON(&frame); err != nil {
+			t.Fatalf("read %q: %v", typ, err)
+		}
+		if frame["type"] == typ {
+			return frame
+		}
+	}
+}
+
+func toolApprovalEvent(id, name, args string) domain.ToolApprovalRequestedEvent {
+	return domain.ToolApprovalRequestedEvent{
+		RequestID:    id,
+		ResponseChan: make(chan domain.ApprovalAction, 1),
+		ToolCall: sdk.ChatCompletionMessageToolCall{
+			ID:       "call-" + id,
+			Function: sdk.ChatCompletionMessageToolCallFunction{Name: name, Arguments: args},
+		},
+	}
+}
+
+func TestExtensionBridgeApprovalRoundTrip(t *testing.T) {
+	notifier := &recordingNotifier{}
+	events := macos.NewEventBridge()
+	bridge := startBridge(t, bridgeConfig(), notifier, events)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	time.Sleep(50 * time.Millisecond) // let the chat pump subscribe
+	events.Publish(toolApprovalEvent("req-1", "Bash", `{"command":"ls"}`))
+
+	req := readFrameOfType(t, conn, "approval_request")
+	if req["request_id"] != "req-1" || req["tool_name"] != "Bash" || req["tool_args"] != `{"command":"ls"}` {
+		t.Fatalf("unexpected approval_request: %v", req)
+	}
+
+	if err := conn.WriteJSON(map[string]string{"type": "approval_response", "request_id": "req-1", "action": "approve"}); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		found := false
+		for _, ev := range notifier.all() {
+			resp, ok := ev.(domain.ToolApprovalResponseEvent)
+			if !ok {
+				continue
+			}
+			if resp.Action != domain.ApprovalApprove {
+				t.Fatalf("expected approve, got %v", resp.Action)
+			}
+			if resp.ToolCall.Function.Name != "Bash" {
+				t.Fatalf("wrong tool call echoed back: %+v", resp.ToolCall)
+			}
+			found = true
+		}
+		if found {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("notifier never received the approval response")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if resolved := readFrameOfType(t, conn, "approval_resolved"); resolved["request_id"] != "req-1" {
+		t.Fatalf("unexpected approval_resolved: %v", resolved)
+	}
+}
+
+func TestExtensionBridgeApprovalUnknownActionRejects(t *testing.T) {
+	notifier := &recordingNotifier{}
+	events := macos.NewEventBridge()
+	bridge := startBridge(t, bridgeConfig(), notifier, events)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	time.Sleep(50 * time.Millisecond)
+	events.Publish(toolApprovalEvent("req-2", "Bash", "{}"))
+	readFrameOfType(t, conn, "approval_request")
+
+	if err := conn.WriteJSON(map[string]string{"type": "approval_response", "request_id": "req-2", "action": "wat"}); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		for _, ev := range notifier.all() {
+			if resp, ok := ev.(domain.ToolApprovalResponseEvent); ok {
+				if resp.Action != domain.ApprovalReject {
+					t.Fatalf("unknown action should reject, got %v", resp.Action)
+				}
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("notifier never received the approval response")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A stale approval_response for an already-answered id must be a no-op, not a
+// second decision.
+func TestExtensionBridgeApprovalIgnoresUnknownID(t *testing.T) {
+	notifier := &recordingNotifier{}
+	events := macos.NewEventBridge()
+	bridge := startBridge(t, bridgeConfig(), notifier, events)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	if err := conn.WriteJSON(map[string]string{"type": "approval_response", "request_id": "ghost", "action": "approve"}); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	for _, ev := range notifier.all() {
+		if _, ok := ev.(domain.ToolApprovalResponseEvent); ok {
+			t.Fatal("unknown request id must not produce an approval response")
+		}
+	}
+}
 
 // recordingNotifier lives in mcp_manager_test.go; all returns a snapshot of
 // its collected events.

--- a/internal/services/extension_bridge_test.go
+++ b/internal/services/extension_bridge_test.go
@@ -48,7 +48,7 @@ func TestExtensionBridgeApprovalRoundTrip(t *testing.T) {
 	conn := dial(t, bridge)
 	hello(t, conn, "test-token")
 
-	time.Sleep(50 * time.Millisecond) // let the chat pump subscribe
+	time.Sleep(50 * time.Millisecond)
 	events.Publish(toolApprovalEvent("req-1", "Bash", `{"command":"ls"}`))
 
 	req := readFrameOfType(t, conn, "approval_request")


### PR DESCRIPTION
## What

Bumps the browser-extension bridge protocol to **v2**, adding a tool-approval flow so approvals can be answered from the opentask side panel instead of only the terminal.

Three new frames (documented in `docs/browser-extension-protocol.md`):
- `approval_request` (CLI → extension) — emitted when a tool call needs a decision, carrying `request_id`, `tool_name`, `tool_args`.
- `approval_response` (extension → CLI) — `"approve"` / `"reject"` (unknown actions fail safe to reject).
- `approval_resolved` (CLI → extension) — sent when the request is answered here **or** in the terminal, so the panel clears its card.

## How

`ToolApprovalRequestedEvent` was previously filtered out of the extension chat pump. Now the bridge stashes the pending tool call and forwards it as `approval_request`. An incoming `approval_response` is turned back into the **same** `ToolApprovalResponseEvent` the terminal emits (via `notifier.Notify`), so the existing non-blocking resolve + state-clear naturally wins any terminal/panel race — no new locking, no touching the approval `ResponseChan` directly. Because the agent turn blocks on the approval, the next streamed event reliably signals resolution and triggers `approval_resolved`.

## Companion change

Extension side: inference-gateway/opentask (branch `feat/cli-bridge-sidepanel`).

## Tests

- `TestExtensionBridgeApprovalRoundTrip` — request emitted, response reaches the notifier with the right action + tool call, `approval_resolved` sent.
- `TestExtensionBridgeApprovalUnknownActionRejects` — unknown action fails safe.
- `TestExtensionBridgeApprovalIgnoresUnknownID` — stale/unknown id is a no-op.

`go build ./...`, `go vet`, and the services suite pass.