### PR TITLE
fix(cmd): strip ANSI from status icons when output colors disabled

### DIFF
--- a/cmd/table.go
+++ b/cmd/table.go
@@ -45,6 +45,8 @@ func disableOutputColors() {
 	tableBodyCell = lipgloss.NewStyle().Padding(0, 1)
 	tableBorderInk = lipgloss.NewStyle()
 	traceTreeStyle = telemetry.TreeStyle{}
+	icons.CheckMarkStyle = lipgloss.NewStyle()
+	icons.CrossMarkStyle = lipgloss.NewStyle()
 }
 
 // newListTable returns a lipgloss table pre-styled for command-line list

--- a/cmd/table_test.go
+++ b/cmd/table_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	telemetry "github.com/inference-gateway/cli/internal/telemetry"
+	icons "github.com/inference-gateway/cli/internal/ui/styles/icons"
 )
 
 // disableOutputColors must leave no ANSI escape sequences in any shared
-// command-output rendering path (tables, titles, hints, fields, trace trees).
+// command-output rendering path (tables, titles, hints, fields, trace trees)
+// or in the status icons that shortcut Output strings embed and the extension
+// bridge mirrors verbatim.
 func TestDisableOutputColorsStripsEscapes(t *testing.T) {
 	disableOutputColors()
 
@@ -19,6 +22,8 @@ func TestDisableOutputColorsStripsEscapes(t *testing.T) {
 		"field": listField("Session", "abc"),
 		"hint":  listHint("legend"),
 		"tree":  telemetry.RenderTraceTree([]*telemetry.TraceSpan{span}, traceTreeStyle),
+		"check": icons.StyledCheckMark(),
+		"cross": icons.StyledCrossMark(),
 	}
 	for name, out := range outputs {
 		if strings.Contains(out, "\x1b") {


### PR DESCRIPTION
## Summary

`disableOutputColors()` now also resets `icons.CheckMarkStyle` and `icons.CrossMarkStyle`, so `StyledCheckMark()` / `StyledCrossMark()` emit no escape sequences.

## Why

The extension bridge mirrors tool approval output verbatim (see #1062). The status icons embed styled check/cross marks, so color codes leaked into headless/no-color output even after `disableOutputColors()` was called — breaking the no-ANSI invariant for everything downstream of command output rendering.

## Changes

- `cmd/table.go`: reset the two icon styles in `disableOutputColors()`
- `cmd/table_test.go`: extend `TestDisableOutputColorsStripsEscapes` to cover `check` and `cross` outputs

## Verification

- `go test ./cmd -run TestDisableOutputColorsStripsEscapes` passes
- `task precommit:run` passes (fmt, lint, mod-tidy, markdownlint)