### PR TITLE
fix(bridge): clear extension approval card on the answer, not the next event

### DIFF
--- a/internal/display/macos/event_bridge.go
+++ b/internal/display/macos/event_bridge.go
@@ -35,8 +35,8 @@ func NewEventBridge() *EventBridge {
 	}
 }
 
-// Publish broadcasts an event to all subscribers
-// Non-blocking: if a subscriber's channel is full, the event is dropped for that subscriber
+// Publish broadcasts an event to every subscriber. Delivery is non-blocking so
+// one slow subscriber can never stall the bus for the others.
 func (eb *EventBridge) Publish(event domain.ChatEvent) {
 	eb.subMutex.Lock()
 	eb.eventBuffer.Value = event
@@ -45,16 +45,35 @@ func (eb *EventBridge) Publish(event domain.ChatEvent) {
 	copy(subscribers, eb.subscribers)
 	eb.subMutex.Unlock()
 
+	_, droppable := event.(domain.ChatChunkEvent)
 	for _, sub := range subscribers {
-		sub.mu.Lock()
-		if !sub.closed {
-			select {
-			case sub.ch <- event:
-			default:
-			}
-		}
-		sub.mu.Unlock()
+		sub.enqueue(event, droppable)
 	}
+}
+
+// enqueue delivers one event without blocking: a full buffer drops a chunk, but
+// a control event evicts the oldest buffered event to guarantee room.
+func (s *subscriber) enqueue(event domain.ChatEvent, droppable bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	select {
+	case s.ch <- event:
+		return
+	default:
+	}
+	if droppable {
+		return
+	}
+	// Buffer full. We hold s.mu, so no other producer adds and the consumer only
+	// drains - freeing a slot that stays free - so this send cannot block.
+	select {
+	case <-s.ch: // discard the oldest buffered event to make room
+	default:
+	}
+	s.ch <- event
 }
 
 // Subscribe creates a new event channel and returns it

--- a/internal/display/macos/event_bridge.go
+++ b/internal/display/macos/event_bridge.go
@@ -67,10 +67,8 @@ func (s *subscriber) enqueue(event domain.ChatEvent, droppable bool) {
 	if droppable {
 		return
 	}
-	// Buffer full. We hold s.mu, so no other producer adds and the consumer only
-	// drains - freeing a slot that stays free - so this send cannot block.
 	select {
-	case <-s.ch: // discard the oldest buffered event to make room
+	case <-s.ch:
 	default:
 	}
 	s.ch <- event

--- a/internal/display/macos/event_bridge_test.go
+++ b/internal/display/macos/event_bridge_test.go
@@ -1,0 +1,56 @@
+package macos
+
+import (
+	"testing"
+	"time"
+
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// A control event (e.g. a tool approval) must reach the subscriber even when the
+// buffer is saturated with streaming chunks; otherwise the panel never shows the
+// approval card. Publish is non-blocking, so this is fully synchronous.
+func TestPublish_DeliversControlEventWhenBufferFull(t *testing.T) {
+	eb := NewEventBridge()
+	ch := eb.Subscribe()
+
+	for i := 0; i < cap(ch)*2; i++ {
+		eb.Publish(domain.ChatChunkEvent{Content: "x"})
+	}
+
+	eb.Publish(domain.ToolApprovalRequestedEvent{RequestID: "r1"})
+
+	found := false
+	for len(ch) > 0 {
+		if a, ok := (<-ch).(domain.ToolApprovalRequestedEvent); ok && a.RequestID == "r1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("approval event was dropped: control events must not be lost on a full buffer")
+	}
+}
+
+// Streaming chunks stay lossy so a slow subscriber can't apply backpressure to
+// the whole bus over cosmetic deltas.
+func TestPublish_DropsChunksWhenBufferFull(t *testing.T) {
+	eb := NewEventBridge()
+	ch := eb.Subscribe()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < cap(ch)*2; i++ {
+			eb.Publish(domain.ChatChunkEvent{Content: "x"})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("chunk publish blocked: streaming deltas must be droppable")
+	}
+	if got := len(ch); got > cap(ch) {
+		t.Fatalf("buffered %d chunks, want <= cap %d", got, cap(ch))
+	}
+}

--- a/internal/domain/events.go
+++ b/internal/domain/events.go
@@ -263,6 +263,17 @@ type ToolApprovalRequestedEvent struct {
 func (e ToolApprovalRequestedEvent) GetRequestID() string    { return e.RequestID }
 func (e ToolApprovalRequestedEvent) GetTimestamp() time.Time { return e.Timestamp }
 
+// ToolApprovalResolvedEvent signals that a tool approval was answered (terminal
+// or panel), so bus subscribers like the extension bridge clear their card. It is
+// the reliable "answered" signal, replacing the racy next-event heuristic.
+type ToolApprovalResolvedEvent struct {
+	RequestID string
+	Timestamp time.Time
+}
+
+func (e ToolApprovalResolvedEvent) GetRequestID() string    { return e.RequestID }
+func (e ToolApprovalResolvedEvent) GetTimestamp() time.Time { return e.Timestamp }
+
 // ToolCancelledEvent is published when the conversation validator
 // synthesizes a Tool-role response for an assistant tool_call whose
 // real execution never completed (typically because the user pressed

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -260,15 +260,9 @@ func (b *ExtensionBridge) readLoop(conn *websocket.Conn, stop chan struct{}) {
 	}
 }
 
-// chatPump mirrors chat events to the extension as AG-UI lines wrapped in
-// chat_event frames.
-//
-// ToolApprovalRequestedEvent is not rendered as a chat line; instead it is
-// forwarded as an approval_request frame so the panel can answer it (protocol
-// v2). Because the agent turn blocks on the approval's ResponseChan, no other
-// event streams until the approval is answered - so the first event that
-// arrives after a request reliably means it was resolved (here or in the
-// terminal), which is when we send approval_resolved to clear the panel card.
+// chatPump mirrors chat events to the extension as chat_event frames, and turns
+// ToolApprovalRequestedEvent / ToolApprovalResolvedEvent into approval_request /
+// approval_resolved frames so the panel can drive the approval handshake.
 func (b *ExtensionBridge) chatPump(conn *websocket.Conn, stop chan struct{}) {
 	if b.events == nil {
 		return
@@ -291,7 +285,10 @@ func (b *ExtensionBridge) chatPump(conn *websocket.Conn, stop chan struct{}) {
 					b.requestApproval(conn, req)
 					continue
 				}
-				b.resolvePendingApprovals(conn)
+				if _, isResolved := ev.(domain.ToolApprovalResolvedEvent); isResolved {
+					b.resolvePendingApprovals(conn)
+					continue
+				}
 				select {
 				case filtered <- ev:
 				case <-stop:
@@ -349,9 +346,9 @@ func (b *ExtensionBridge) requestApproval(conn *websocket.Conn, req domain.ToolA
 	})
 }
 
-// resolvePendingApprovals clears any outstanding approval cards. Called when the
-// next event streams (the approval was answered here or in the terminal). A
-// duplicate approval_resolved is harmless - the panel ignores unknown ids.
+// resolvePendingApprovals clears any outstanding approval cards on a
+// ToolApprovalResolvedEvent. A duplicate approval_resolved is harmless - the
+// panel ignores unknown ids (the panel path already cleared it in answerApproval).
 func (b *ExtensionBridge) resolvePendingApprovals(conn *websocket.Conn) {
 	b.mu.Lock()
 	if len(b.pendingApprovals) == 0 {

--- a/internal/services/extension_bridge_test.go
+++ b/internal/services/extension_bridge_test.go
@@ -90,6 +90,35 @@ func TestExtensionBridgeApprovalRoundTrip(t *testing.T) {
 	}
 }
 
+// A tool-call chat event streaming after the approval_request must NOT clear the
+// card - only an explicit ToolApprovalResolvedEvent does. Regression test for the
+// card vanishing before the user could answer.
+func TestExtensionBridgeApprovalSurvivesTrailingEvents(t *testing.T) {
+	events := macos.NewEventBridge()
+	bridge := startBridge(t, bridgeConfig(), nil, events)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	time.Sleep(50 * time.Millisecond)
+	events.Publish(toolApprovalEvent("req-9", "Write", `{"file_path":"x"}`))
+	readFrameOfType(t, conn, "approval_request")
+
+	events.Publish(domain.ChatChunkEvent{Content: "streamed"})
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var frame map[string]any
+	if err := conn.ReadJSON(&frame); err != nil {
+		t.Fatalf("read after trailing chunk: %v", err)
+	}
+	if frame["type"] == "approval_resolved" {
+		t.Fatal("a trailing chat event resolved the approval before the user answered")
+	}
+
+	events.Publish(domain.ToolApprovalResolvedEvent{})
+	if resolved := readFrameOfType(t, conn, "approval_resolved"); resolved["request_id"] != "req-9" {
+		t.Fatalf("unexpected approval_resolved: %v", resolved)
+	}
+}
+
 func TestExtensionBridgeApprovalUnknownActionRejects(t *testing.T) {
 	notifier := &recordingNotifier{}
 	events := macos.NewEventBridge()

--- a/internal/services/toolcoordinator/coordinator.go
+++ b/internal/services/toolcoordinator/coordinator.go
@@ -169,6 +169,8 @@ func (c *Coordinator) HandleToolApprovalResponse(msg domain.ToolApprovalResponse
 
 	c.updateToolApprovalStatus(msg.Action)
 
+	c.stateManager.BroadcastEvent(domain.ToolApprovalResolvedEvent{})
+
 	if msg.Action == domain.ApprovalAutoAccept {
 		return c.applyAutoAccept(msg)
 	}


### PR DESCRIPTION
## Problem

Tool-approval cards mirrored to the opentask extension panel appeared and then vanished milliseconds later, forcing the user to answer in the terminal.

The bridge's `chatPump` sent `approval_resolved` on **the first chat event after an `approval_request`**, assuming the agent turn blocks on the approval so nothing streams until the user answers. That assumption is false: `approval_request` takes a fast intercept path to the socket, while the tool-call chat events for the same turn are buffered through `RenderAGUI` and flush *after* it — each one tripping the "next event = answered" heuristic.

Confirmed via the extension's service-worker log:

```
approval_request         ← card shows
chat_event REASONING_END
chat_event TOOL_CALL_START/ARGS/END
approval_resolved        ← card cleared
```

## Fix

- Resolve on an explicit **`ToolApprovalResolvedEvent`** (new `domain` event, a `ChatEvent`), broadcast from `Coordinator.HandleToolApprovalResponse` — the single point where **both** terminal and panel answers converge. `chatPump` now emits `approval_resolved` only on that event; the speculative next-event heuristic is gone.
- Make `EventBridge.Publish` deliver control events reliably: streaming `ChatChunkEvent`s stay droppable (a lost delta is cosmetic), but a full buffer now **evicts the oldest chunk** to make room for a control frame instead of silently dropping it — so the approval (and the new resolved event) survive a long-response flood. Fully non-blocking, no cross-subscriber coupling.

## Tests

- `TestExtensionBridgeApprovalSurvivesTrailingEvents` — a trailing chat event must not resolve the card; only `ToolApprovalResolvedEvent` does.
- `TestPublish_DeliversControlEventWhenBufferFull` / `TestPublish_DropsChunksWhenBufferFull` — control events survive a saturated buffer; chunks stay droppable.

All pass with `-race`; `task precommit:run` clean.

Pairs with opentask#142 (the extension side).