### PR TITLE
feat(tools): add BrowserScreenshot, BrowserTabs, and coordinate click

### DIFF
--- a/config/browser_use.go
+++ b/config/browser_use.go
@@ -62,10 +62,12 @@ type BrowserConfig struct {
 
 // BrowserUseToolsConfig contains individual browser use tool settings.
 type BrowserUseToolsConfig struct {
-	Navigate BrowserToolConfig `yaml:"navigate" mapstructure:"navigate"`
-	Click    BrowserToolConfig `yaml:"click" mapstructure:"click"`
-	Type     BrowserToolConfig `yaml:"type" mapstructure:"type"`
-	Read     BrowserToolConfig `yaml:"read" mapstructure:"read"`
+	Navigate   BrowserToolConfig `yaml:"navigate" mapstructure:"navigate"`
+	Click      BrowserToolConfig `yaml:"click" mapstructure:"click"`
+	Type       BrowserToolConfig `yaml:"type" mapstructure:"type"`
+	Read       BrowserToolConfig `yaml:"read" mapstructure:"read"`
+	Screenshot BrowserToolConfig `yaml:"screenshot" mapstructure:"screenshot"`
+	Tabs       BrowserToolConfig `yaml:"tabs" mapstructure:"tabs"`
 }
 
 // BrowserToolConfig contains per-tool settings.
@@ -97,10 +99,12 @@ func DefaultBrowserUseConfig() *BrowserUseConfig {
 			WindowSeconds:       60,
 		},
 		Tools: BrowserUseToolsConfig{
-			Navigate: BrowserToolConfig{Enabled: true},
-			Click:    BrowserToolConfig{Enabled: true},
-			Type:     BrowserToolConfig{Enabled: true},
-			Read:     BrowserToolConfig{Enabled: true},
+			Navigate:   BrowserToolConfig{Enabled: true},
+			Click:      BrowserToolConfig{Enabled: true},
+			Type:       BrowserToolConfig{Enabled: true},
+			Read:       BrowserToolConfig{Enabled: true},
+			Screenshot: BrowserToolConfig{Enabled: true},
+			Tabs:       BrowserToolConfig{Enabled: true},
 		},
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1293,7 +1293,7 @@ func DefaultConfig() *Config { //nolint:funlen
 
 // IsApprovalRequired checks if approval is required for a specific tool
 // It returns true if tool-specific approval is set to true, or if global approval is true and tool-specific is not set to false
-func (c *Config) IsApprovalRequired(toolName string) bool { // nolint:gocyclo,cyclop
+func (c *Config) IsApprovalRequired(toolName string) bool { // nolint:gocyclo,cyclop,funlen
 	globalApproval := c.Tools.Safety.RequireApproval
 
 	switch toolName {
@@ -1392,6 +1392,8 @@ func (c *Config) IsApprovalRequired(toolName string) bool { // nolint:gocyclo,cy
 	case "Memory":
 		return false
 	case "MouseMove", "MouseClick", "MouseScroll", "KeyboardType", "GetFocusedApp", "ActivateApp", "GetLatestFrame":
+		return false
+	case "BrowserRead", "BrowserScreenshot", "BrowserTabs":
 		return false
 	}
 

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -101,6 +101,8 @@ func mergeToolDefaults(loaded, defaults *PromptsToolsConfig) {
 	mergeToolDescription(&loaded.BrowserClick, &defaults.BrowserClick)
 	mergeToolDescription(&loaded.BrowserType, &defaults.BrowserType)
 	mergeToolDescription(&loaded.BrowserRead, &defaults.BrowserRead)
+	mergeToolDescription(&loaded.BrowserScreenshot, &defaults.BrowserScreenshot)
+	mergeToolDescription(&loaded.BrowserTabs, &defaults.BrowserTabs)
 	mergeToolDescription(&loaded.GetFocusedApp, &defaults.GetFocusedApp)
 	mergeToolDescription(&loaded.ActivateApp, &defaults.ActivateApp)
 	mergeToolDescription(&loaded.GetLatestFrame, &defaults.GetLatestFrame)
@@ -230,6 +232,8 @@ type PromptsToolsConfig struct {
 	BrowserClick        PromptsToolDescription `yaml:"BrowserClick" mapstructure:"BrowserClick"`
 	BrowserType         PromptsToolDescription `yaml:"BrowserType" mapstructure:"BrowserType"`
 	BrowserRead         PromptsToolDescription `yaml:"BrowserRead" mapstructure:"BrowserRead"`
+	BrowserScreenshot   PromptsToolDescription `yaml:"BrowserScreenshot" mapstructure:"BrowserScreenshot"`
+	BrowserTabs         PromptsToolDescription `yaml:"BrowserTabs" mapstructure:"BrowserTabs"`
 	GetFocusedApp       PromptsToolDescription `yaml:"GetFocusedApp" mapstructure:"GetFocusedApp"`
 	ActivateApp         PromptsToolDescription `yaml:"ActivateApp" mapstructure:"ActivateApp"`
 	GetLatestFrame      PromptsToolDescription `yaml:"GetLatestFrame" mapstructure:"GetLatestFrame"`
@@ -704,13 +708,19 @@ Each subagent is independent and cannot itself spawn further subagents. Prefer n
 			Description: `Opens a URL in the automated browser session. Launches the browser on first use (or attaches to a running one when a CDP endpoint is configured) and keeps the session open across browser tool calls. Returns the final URL and page title after navigation.`,
 		},
 		BrowserClick: PromptsToolDescription{
-			Description: `Clicks an element in the current browser page identified by a CSS selector or text= / role-based Playwright selector. Use BrowserRead first to inspect the page and find selectors. Requires an active page (call BrowserNavigate first).`,
+			Description: `Clicks in the current browser page, either at an element (CSS selector or text= / role-based Playwright selector) or at viewport x/y coordinates (CSS pixels) taken from a BrowserScreenshot. Provide 'selector' OR both 'x' and 'y'. Use BrowserRead or BrowserScreenshot first to locate the target. Coordinate clicks are not available on the extension backend. Requires an active page (call BrowserNavigate first).`,
 		},
 		BrowserType: PromptsToolDescription{
 			Description: `Types text into an input element in the current browser page identified by a selector, replacing its existing value. Set press_enter to true to submit afterwards (e.g. search boxes, forms). Requires an active page (call BrowserNavigate first).`,
 		},
 		BrowserRead: PromptsToolDescription{
-			Description: `Reads the current browser page: URL, title, and visible text (of the whole page or of the element matched by an optional selector). Also returns recent browser-initiated events (console messages, dialogs, and window.inferNotify(...) calls from page scripts) so pages can signal back to you. Read-only.`,
+			Description: `Reads the current browser page: URL, title, and visible text (of the whole page or of the element matched by an optional selector). Sensitive input values (passwords, tokens, one-time codes) are redacted. Also returns recent browser-initiated events (console messages, dialogs, and window.inferNotify(...) calls from page scripts) so pages can signal back to you. Read-only.`,
+		},
+		BrowserScreenshot: PromptsToolDescription{
+			Description: `Captures a screenshot of the current browser page/active tab and attaches it as an image (models with vision see it inline). Use it to see what the user is looking at, then act with BrowserClick (by selector or x/y coordinates). Password fields render masked by the browser. Read-only.`,
+		},
+		BrowserTabs: PromptsToolDescription{
+			Description: `Lists the browser's open tabs (index, URL, title) and marks the active one, so you know which page the user is currently on. Read-only.`,
 		},
 		GetFocusedApp: PromptsToolDescription{
 			Description: `Gets the currently focused (frontmost) application. Returns the application name and bundle identifier. Use this before performing computer use actions to verify the correct application is in focus.`,

--- a/docs/browser-extension-protocol.md
+++ b/docs/browser-extension-protocol.md
@@ -43,21 +43,23 @@ Extension → CLI, first frame, within 5 seconds of connecting:
 CLI → extension on success (on failure the socket is closed):
 
 ```json
-{"type": "browser_hello_ack", "protocol_version": 2}
+{"type": "browser_hello_ack", "protocol_version": 3}
 ```
 
 Immediately after the ack the CLI sends a conversation snapshot (see below).
 
 ## Browser commands (CLI → extension)
 
-One shape, four actions; only the fields relevant to the action are set.
+One shape, six actions; only the fields relevant to the action are set.
 `timeout_ms` is the per-action budget the extension must enforce.
 
 ```json
-{"type": "browser_command", "id": "<uuid>", "action": "navigate", "url": "https://example.com", "timeout_ms": 30000}
-{"type": "browser_command", "id": "<uuid>", "action": "click",    "selector": "button.submit", "timeout_ms": 30000}
-{"type": "browser_command", "id": "<uuid>", "action": "type",     "selector": "input[name=q]", "text": "hello", "press_enter": true, "timeout_ms": 30000}
-{"type": "browser_command", "id": "<uuid>", "action": "read",     "selector": "", "timeout_ms": 30000}
+{"type": "browser_command", "id": "<uuid>", "action": "navigate",   "url": "https://example.com", "timeout_ms": 30000}
+{"type": "browser_command", "id": "<uuid>", "action": "click",      "selector": "button.submit", "timeout_ms": 30000}
+{"type": "browser_command", "id": "<uuid>", "action": "type",       "selector": "input[name=q]", "text": "hello", "press_enter": true, "timeout_ms": 30000}
+{"type": "browser_command", "id": "<uuid>", "action": "read",       "selector": "", "timeout_ms": 30000}
+{"type": "browser_command", "id": "<uuid>", "action": "screenshot", "timeout_ms": 30000}
+{"type": "browser_command", "id": "<uuid>", "action": "tabs",       "timeout_ms": 30000}
 ```
 
 - `navigate`: open the URL in the controlled tab (`chrome.tabs.update`, or
@@ -66,17 +68,31 @@ One shape, four actions; only the fields relevant to the action are set.
 - `click`: `document.querySelector(selector).click()` semantics.
 - `type`: replace the element's value with `text`, dispatch `input`/`change`,
   then a keyboard Enter when `press_enter` is true.
-- `read`: `innerText` of the selector (empty selector means `body`).
+- `read`: `innerText` of the selector (empty selector means `body`). **Must
+  redact secrets:** never return the `value` of `<input type="password">`,
+  inputs whose `autocomplete` is `current-password`/`new-password`/
+  `one-time-code`, or inputs whose name/id/aria-label matches
+  `/pass|secret|token|otp|cvc|card/i` — substitute `"[redacted]"`. `innerText`
+  already excludes input values; this rule binds any richer extraction.
+- `screenshot` (v3): capture the visible controlled tab
+  (`chrome.tabs.captureVisibleTab`) and return it as base64 in the result's
+  `image` field. Passwords render masked by the browser, so no extra redaction
+  is required.
+- `tabs` (v3): enumerate the open tabs (`chrome.tabs.query`) and return them in
+  the result's `tabs` array, flagging the controlled/active one.
 
 Extension → CLI, exactly one result per command id:
 
 ```json
 {"type": "browser_result", "id": "<uuid>", "url": "https://example.com/", "title": "Example", "content": "...", "events": [], "error": ""}
+{"type": "browser_result", "id": "<uuid>", "image": "<base64>", "image_mime_type": "image/png", "url": "...", "title": "..."}
+{"type": "browser_result", "id": "<uuid>", "tabs": [{"index": 0, "url": "...", "title": "...", "active": true}]}
 ```
 
 - `error != ""` means the command failed; other fields may be empty.
-- `content` is only meaningful for `read`. `events` carries optional
-  browser-initiated notices (console lines etc.) and may always be empty.
+- `content` is only meaningful for `read`; `image`/`image_mime_type` for
+  `screenshot`; `tabs` for `tabs`. `events` carries optional browser-initiated
+  notices (console lines etc.) and may always be empty.
 - `url`/`title` reflect the controlled tab after the action.
 
 ## Conversation sync
@@ -148,7 +164,11 @@ CLI → extension, when the request is no longer pending (answered in the panel
 - WS client in the background service worker; port + token from the options
   page storage; reconnect with backoff.
 - `tabs` + `scripting` permissions and matching host permissions for the
-  controlled tab.
+  controlled tab. `screenshot` additionally needs `activeTab`/host permission
+  for `chrome.tabs.captureVisibleTab`.
+- `read` must redact secret input values before returning (see the `read`
+  action above); `screenshot` must not click-to-reveal masked fields.
 - Known ceiling: `chrome.scripting`-synthesized clicks/keys are untrusted
-  events some sites ignore; the upgrade path is `chrome.debugger` (CDP
-  `Input.dispatch*`), which changes extension permissions, not this protocol.
+  events some sites ignore, and there is no coordinate-click action for the same
+  reason; the upgrade path is `chrome.debugger` (CDP `Input.dispatch*`), which
+  changes extension permissions, not this protocol.

--- a/internal/agent/tools/browser.go
+++ b/internal/agent/tools/browser.go
@@ -2,7 +2,10 @@ package tools
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -249,7 +252,68 @@ func (s *browserSession) Type(_ context.Context, selector, text string, pressEnt
 	return domain.BrowserToolResult{Action: "type", Selector: selector, Text: text, URL: page.URL(), Title: title}, nil
 }
 
-// Read implements domain.BrowserDriver.
+// browserReadJS extracts text from the matched element. For form fields it
+// returns the field's metadata + value (so BrowserRead can report input
+// contents); for everything else it returns rendered innerText, which never
+// includes input values. Go decides redaction from the metadata (see
+// extractReadContent) so the security rule lives in testable Go, not JS.
+const browserReadJS = `(el) => {
+  const tag = el.tagName ? el.tagName.toLowerCase() : "";
+  if (tag === "input" || tag === "textarea" || tag === "select") {
+    return JSON.stringify({
+      field: true,
+      type: el.getAttribute("type") || "",
+      autocomplete: el.getAttribute("autocomplete") || "",
+      name: el.getAttribute("name") || "",
+      id: el.id || "",
+      aria: el.getAttribute("aria-label") || "",
+      value: el.value || ""
+    });
+  }
+  return JSON.stringify({ field: false, text: el.innerText || el.textContent || "" });
+}`
+
+// sensitiveNameRE flags inputs whose name/id/aria-label suggests a secret.
+var sensitiveNameRE = regexp.MustCompile(`(?i)pass|secret|token|otp|cvc|card`)
+
+// isSensitiveField decides whether an input's value must be withheld from the
+// LLM. Pure so it can be unit-tested without a browser.
+func isSensitiveField(fieldType, autocomplete, name, id, aria string) bool {
+	if strings.EqualFold(fieldType, "password") {
+		return true
+	}
+	switch strings.ToLower(autocomplete) {
+	case "current-password", "new-password", "one-time-code":
+		return true
+	}
+	return sensitiveNameRE.MatchString(name + " " + id + " " + aria)
+}
+
+// extractReadContent turns the browserReadJS payload into the text BrowserRead
+// returns, redacting sensitive field values to "[redacted]".
+func extractReadContent(raw any) string {
+	s, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	var r struct {
+		Field                                           bool
+		Type, Autocomplete, Name, ID, Aria, Value, Text string
+	}
+	if err := json.Unmarshal([]byte(s), &r); err != nil {
+		return ""
+	}
+	if r.Field {
+		if isSensitiveField(r.Type, r.Autocomplete, r.Name, r.ID, r.Aria) {
+			return "[redacted]"
+		}
+		return r.Value
+	}
+	return r.Text
+}
+
+// Read implements domain.BrowserDriver. It returns rendered text (never raw
+// input values), with sensitive field values redacted.
 func (s *browserSession) Read(_ context.Context, selector string) (domain.BrowserToolResult, error) {
 	page, err := s.Page()
 	if err != nil {
@@ -259,12 +323,11 @@ func (s *browserSession) Read(_ context.Context, selector string) (domain.Browse
 	if target == "" {
 		target = "body"
 	}
-	content, err := page.Locator(target).First().InnerText(playwright.LocatorInnerTextOptions{
-		Timeout: playwright.Float(s.timeoutMs()),
-	})
+	raw, err := page.Locator(target).First().Evaluate(browserReadJS, nil)
 	if err != nil {
 		return domain.BrowserToolResult{}, fmt.Errorf("failed to read %q: %w", target, err)
 	}
+	content := extractReadContent(raw)
 	if len(content) > maxBrowserReadChars {
 		content = content[:maxBrowserReadChars] + "\n... (truncated)"
 	}
@@ -277,6 +340,72 @@ func (s *browserSession) Read(_ context.Context, selector string) (domain.Browse
 		Content:  content,
 		Events:   s.DrainEvents(),
 	}, nil
+}
+
+// ClickAt implements domain.BrowserDriver: clicks viewport coordinates (CSS
+// pixels), for use with a BrowserScreenshot. ponytail: coords are CSS pixels;
+// if the screenshot's devicePixelRatio != 1 the model must scale - the DPR
+// knob lives in the browser context, not here.
+func (s *browserSession) ClickAt(_ context.Context, x, y float64) (domain.BrowserToolResult, error) {
+	page, err := s.Page()
+	if err != nil {
+		return domain.BrowserToolResult{}, err
+	}
+	if err := page.Mouse().Click(x, y); err != nil {
+		return domain.BrowserToolResult{}, fmt.Errorf("failed to click at (%.0f, %.0f): %w", x, y, err)
+	}
+	title, _ := page.Title()
+	return domain.BrowserToolResult{Action: "click", URL: page.URL(), Title: title}, nil
+}
+
+// Screenshot implements domain.BrowserDriver: captures the active page as PNG.
+func (s *browserSession) Screenshot(_ context.Context) (domain.BrowserScreenshotResult, error) {
+	page, err := s.Page()
+	if err != nil {
+		return domain.BrowserScreenshotResult{}, err
+	}
+	buf, err := page.Screenshot(playwright.PageScreenshotOptions{
+		Timeout: playwright.Float(s.timeoutMs()),
+	})
+	if err != nil {
+		return domain.BrowserScreenshotResult{}, fmt.Errorf("failed to screenshot page: %w", err)
+	}
+	title, _ := page.Title()
+	res := domain.BrowserScreenshotResult{
+		Data:     base64.StdEncoding.EncodeToString(buf),
+		MimeType: "image/png",
+		URL:      page.URL(),
+		Title:    title,
+	}
+	if vp := page.ViewportSize(); vp != nil {
+		res.Width = vp.Width
+		res.Height = vp.Height
+	}
+	return res, nil
+}
+
+// Tabs implements domain.BrowserDriver: lists open pages across all contexts,
+// marking the one the verbs currently act on.
+func (s *browserSession) Tabs(_ context.Context) ([]domain.BrowserTab, error) {
+	if _, err := s.Page(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	browser, active := s.browser, s.page
+	s.mu.Unlock()
+	if browser == nil {
+		return nil, fmt.Errorf("browser not started")
+	}
+	var tabs []domain.BrowserTab
+	idx := 0
+	for _, bctx := range browser.Contexts() {
+		for _, p := range bctx.Pages() {
+			title, _ := p.Title()
+			tabs = append(tabs, domain.BrowserTab{Index: idx, URL: p.URL(), Title: title, Active: p == active})
+			idx++
+		}
+	}
+	return tabs, nil
 }
 
 // Close shuts the browser and the Playwright driver down. Safe to call when

--- a/internal/agent/tools/browser_click.go
+++ b/internal/agent/tools/browser_click.go
@@ -2,11 +2,13 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	sdk "github.com/inference-gateway/sdk"
 
 	config "github.com/inference-gateway/cli/config"
 	domain "github.com/inference-gateway/cli/internal/domain"
-	sdk "github.com/inference-gateway/sdk"
 )
 
 // BrowserClickTool clicks an element in the shared browser session
@@ -41,10 +43,18 @@ func (t *BrowserClickTool) Definition() sdk.ChatCompletionTool {
 				"properties": map[string]any{
 					"selector": map[string]any{
 						"type":        "string",
-						"description": "CSS or Playwright selector of the element to click (e.g. 'button.submit', 'text=Sign in')",
+						"description": "CSS or Playwright selector of the element to click (e.g. 'button.submit', 'text=Sign in'). Provide this OR x/y coordinates.",
+					},
+					"x": map[string]any{
+						"type":        "number",
+						"description": "Viewport x coordinate (CSS pixels) to click, from a BrowserScreenshot. Must be paired with y.",
+					},
+					"y": map[string]any{
+						"type":        "number",
+						"description": "Viewport y coordinate (CSS pixels) to click, from a BrowserScreenshot. Must be paired with x.",
 					},
 				},
-				"required": []string{"selector"},
+				"required": []string{},
 			},
 		},
 	}
@@ -56,6 +66,14 @@ func (t *BrowserClickTool) Execute(ctx context.Context, args map[string]any) (*d
 
 	if err := t.checkRateLimit(); err != nil {
 		return t.errorResult(args, start, err.Error()), nil
+	}
+
+	if x, y, ok := clickCoords(args); ok {
+		result, err := t.driver.ClickAt(ctx, x, y)
+		if err != nil {
+			return t.errorResult(args, start, err.Error()), nil
+		}
+		return t.successResult(args, start, result), nil
 	}
 
 	selector, err := requireString(args, "selector")
@@ -70,8 +88,40 @@ func (t *BrowserClickTool) Execute(ctx context.Context, args map[string]any) (*d
 	return t.successResult(args, start, result), nil
 }
 
-// Validate checks if the tool arguments are valid
+// Validate checks if the tool arguments are valid: a selector, or an x/y pair.
 func (t *BrowserClickTool) Validate(args map[string]any) error {
+	_, hasX := numberArg(args, "x")
+	_, hasY := numberArg(args, "y")
+	if hasX || hasY {
+		if !hasX || !hasY {
+			return fmt.Errorf("x and y must be provided together")
+		}
+		return nil
+	}
 	_, err := requireString(args, "selector")
 	return err
+}
+
+// clickCoords returns the x/y click target when both are present.
+func clickCoords(args map[string]any) (float64, float64, bool) {
+	x, hasX := numberArg(args, "x")
+	y, hasY := numberArg(args, "y")
+	return x, y, hasX && hasY
+}
+
+// numberArg reads a numeric argument, tolerating the int/float forms JSON and
+// callers may produce.
+func numberArg(args map[string]any, key string) (float64, bool) {
+	switch v := args[key].(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
 }

--- a/internal/agent/tools/browser_live_test.go
+++ b/internal/agent/tools/browser_live_test.go
@@ -1,0 +1,89 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+// TestBrowserSessionLive exercises the real Playwright driver end-to-end against
+// headless bundled Chromium. Skipped by default (it launches / may download a
+// browser); run it with INFER_BROWSER_LIVE=1 to verify the screenshot, tabs,
+// coordinate-click, and password-redacting read paths for real.
+func TestBrowserSessionLive(t *testing.T) {
+	if os.Getenv("INFER_BROWSER_LIVE") != "1" {
+		t.Skip("set INFER_BROWSER_LIVE=1 to run the live browser test")
+	}
+
+	cfg := config.DefaultBrowserUseConfig()
+	cfg.Browser.Headless = true
+	cfg.Browser.Channel = ""
+	session := newBrowserSession(cfg)
+	defer session.Close()
+
+	ctx := context.Background()
+	const page = `data:text/html,<html><head><title>login</title></head>` +
+		`<body onclick="document.title='clicked'">` +
+		`<p>Welcome to the site</p>` +
+		`<input id="pw" type="password" name="password" value="hunter2">` +
+		`<input id="q" type="text" name="q" value="searchterm">` +
+		`</body></html>`
+
+	if _, err := session.Navigate(ctx, page); err != nil {
+		t.Fatalf("Navigate: %v", err)
+	}
+
+	body, err := session.Read(ctx, "")
+	if err != nil {
+		t.Fatalf("Read body: %v", err)
+	}
+	if !strings.Contains(body.Content, "Welcome to the site") {
+		t.Errorf("body read missing page text: %q", body.Content)
+	}
+	if strings.Contains(body.Content, "hunter2") || strings.Contains(body.Content, "searchterm") {
+		t.Errorf("body read leaked an input value: %q", body.Content)
+	}
+
+	pw, err := session.Read(ctx, "#pw")
+	if err != nil {
+		t.Fatalf("Read #pw: %v", err)
+	}
+	if pw.Content != "[redacted]" {
+		t.Errorf("password read = %q, want [redacted]", pw.Content)
+	}
+
+	q, err := session.Read(ctx, "#q")
+	if err != nil {
+		t.Fatalf("Read #q: %v", err)
+	}
+	if q.Content != "searchterm" {
+		t.Errorf("text read = %q, want searchterm", q.Content)
+	}
+
+	shot, err := session.Screenshot(ctx)
+	if err != nil {
+		t.Fatalf("Screenshot: %v", err)
+	}
+	if shot.Data == "" || shot.MimeType != "image/png" || shot.Width == 0 || shot.Height == 0 {
+		t.Errorf("bad screenshot: mime=%q w=%d h=%d datalen=%d", shot.MimeType, shot.Width, shot.Height, len(shot.Data))
+	}
+
+	tabs, err := session.Tabs(ctx)
+	if err != nil {
+		t.Fatalf("Tabs: %v", err)
+	}
+	if len(tabs) == 0 || !tabs[0].Active {
+		t.Errorf("tabs = %+v, want at least one active tab", tabs)
+	}
+
+	clicked, err := session.ClickAt(ctx, 30, 30)
+	if err != nil {
+		t.Fatalf("ClickAt: %v", err)
+	}
+	if clicked.Title != "clicked" {
+		t.Errorf("coordinate click did not fire: title = %q", clicked.Title)
+	}
+}

--- a/internal/agent/tools/browser_screenshot.go
+++ b/internal/agent/tools/browser_screenshot.go
@@ -1,0 +1,114 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"time"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// BrowserScreenshotTool captures the current browser page as an image and
+// attaches it to the conversation (vision models see it inline; others get a
+// file path for ImageDecode).
+type BrowserScreenshotTool struct {
+	browserToolBase
+	config *config.Config
+}
+
+// NewBrowserScreenshotTool creates a new browser screenshot tool
+func NewBrowserScreenshotTool(cfg *config.Config, rateLimiter domain.RateLimiter, driver domain.BrowserDriver) *BrowserScreenshotTool {
+	return &BrowserScreenshotTool{
+		browserToolBase: browserToolBase{
+			name:        "BrowserScreenshot",
+			enabled:     cfg.BrowserUse.Enabled && cfg.BrowserUse.Tools.Screenshot.Enabled,
+			driver:      driver,
+			rateLimiter: rateLimiter,
+		},
+		config: cfg,
+	}
+}
+
+// Definition returns the tool definition for the LLM
+func (t *BrowserScreenshotTool) Definition() sdk.ChatCompletionTool {
+	description := t.config.Prompts.Tools.BrowserScreenshot.Description
+	return sdk.ChatCompletionTool{
+		Type: sdk.Function,
+		Function: sdk.FunctionObject{
+			Name:        "BrowserScreenshot",
+			Description: &description,
+			Parameters: &sdk.FunctionParameters{
+				"type":       "object",
+				"properties": map[string]any{},
+				"required":   []string{},
+			},
+		},
+	}
+}
+
+// Execute captures the screenshot and returns it as an attached image
+func (t *BrowserScreenshotTool) Execute(ctx context.Context, args map[string]any) (*domain.ToolExecutionResult, error) {
+	start := time.Now()
+
+	if err := t.checkRateLimit(); err != nil {
+		return t.errorResult(args, start, err.Error()), nil
+	}
+
+	res, err := t.driver.Screenshot(ctx)
+	if err != nil {
+		return t.errorResult(args, start, err.Error()), nil
+	}
+
+	var path string
+	if raw, derr := base64.StdEncoding.DecodeString(res.Data); derr == nil {
+		path, _ = t.persistScreenshot(raw)
+	}
+
+	attachment := domain.ImageAttachment{
+		Data:        res.Data,
+		MimeType:    res.MimeType,
+		DisplayName: "browser-screenshot",
+		SourcePath:  path,
+	}
+	return &domain.ToolExecutionResult{
+		ToolName:  t.name,
+		Arguments: args,
+		Success:   true,
+		Duration:  time.Since(start),
+		Data:      domain.BrowserToolResult{Action: "screenshot", URL: res.URL, Title: res.Title},
+		Images:    []domain.ImageAttachment{attachment},
+	}, nil
+}
+
+// Validate checks if the tool arguments are valid
+func (t *BrowserScreenshotTool) Validate(map[string]any) error {
+	return nil
+}
+
+// persistScreenshot writes the PNG to <configdir>/tmp/screenshots, the same
+// retention-managed scratch dir the computer-use screenshot server uses and
+// which is carved out of the tool sandbox so ImageDecode can read it back.
+func (t *BrowserScreenshotTool) persistScreenshot(data []byte) (string, error) {
+	dir := filepath.Join(t.config.GetConfigDir(), "tmp", "screenshots")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp(dir, "browser-*.png")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(data); err != nil {
+		return "", err
+	}
+	path := f.Name()
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return path, nil
+}

--- a/internal/agent/tools/browser_tabs.go
+++ b/internal/agent/tools/browser_tabs.go
@@ -1,0 +1,118 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	config "github.com/inference-gateway/cli/config"
+	domain "github.com/inference-gateway/cli/internal/domain"
+)
+
+// BrowserTabsTool lists the browser's open tabs and marks the active one, so
+// the agent knows what the user is currently looking at.
+type BrowserTabsTool struct {
+	browserToolBase
+	config *config.Config
+}
+
+// NewBrowserTabsTool creates a new browser tabs tool
+func NewBrowserTabsTool(cfg *config.Config, rateLimiter domain.RateLimiter, driver domain.BrowserDriver) *BrowserTabsTool {
+	return &BrowserTabsTool{
+		browserToolBase: browserToolBase{
+			name:        "BrowserTabs",
+			enabled:     cfg.BrowserUse.Enabled && cfg.BrowserUse.Tools.Tabs.Enabled,
+			driver:      driver,
+			rateLimiter: rateLimiter,
+		},
+		config: cfg,
+	}
+}
+
+// Definition returns the tool definition for the LLM
+func (t *BrowserTabsTool) Definition() sdk.ChatCompletionTool {
+	description := t.config.Prompts.Tools.BrowserTabs.Description
+	return sdk.ChatCompletionTool{
+		Type: sdk.Function,
+		Function: sdk.FunctionObject{
+			Name:        "BrowserTabs",
+			Description: &description,
+			Parameters: &sdk.FunctionParameters{
+				"type":       "object",
+				"properties": map[string]any{},
+				"required":   []string{},
+			},
+		},
+	}
+}
+
+// Execute lists the open tabs
+func (t *BrowserTabsTool) Execute(ctx context.Context, args map[string]any) (*domain.ToolExecutionResult, error) {
+	start := time.Now()
+
+	if err := t.checkRateLimit(); err != nil {
+		return t.errorResult(args, start, err.Error()), nil
+	}
+
+	tabs, err := t.driver.Tabs(ctx)
+	if err != nil {
+		return t.errorResult(args, start, err.Error()), nil
+	}
+	return &domain.ToolExecutionResult{
+		ToolName:  t.name,
+		Arguments: args,
+		Success:   true,
+		Duration:  time.Since(start),
+		Data:      tabs,
+	}, nil
+}
+
+// Validate checks if the tool arguments are valid
+func (t *BrowserTabsTool) Validate(map[string]any) error {
+	return nil
+}
+
+// FormatResult formats tool execution results for different contexts
+func (t *BrowserTabsTool) FormatResult(result *domain.ToolExecutionResult, formatType domain.FormatterType) string {
+	if formatType == domain.FormatterShort {
+		return t.FormatPreview(result)
+	}
+	return t.FormatForLLM(result)
+}
+
+// FormatPreview returns a short preview of the result for UI display
+func (t *BrowserTabsTool) FormatPreview(result *domain.ToolExecutionResult) string {
+	if result == nil || !result.Success {
+		return "BrowserTabs failed"
+	}
+	tabs, _ := result.Data.([]domain.BrowserTab)
+	return fmt.Sprintf("%d tab(s)", len(tabs))
+}
+
+// FormatForLLM formats the tab list for LLM consumption
+func (t *BrowserTabsTool) FormatForLLM(result *domain.ToolExecutionResult) string {
+	if result == nil || !result.Success {
+		return fmt.Sprintf("Error: %s", result.Error)
+	}
+	tabs, _ := result.Data.([]domain.BrowserTab)
+	if len(tabs) == 0 {
+		return "No open tabs."
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d open tab(s) (* marks the active tab):\n", len(tabs))
+	for _, tab := range tabs {
+		marker := " "
+		if tab.Active {
+			marker = "*"
+		}
+		title := tab.Title
+		if title == "" {
+			title = "(untitled)"
+		}
+		fmt.Fprintf(&sb, "[%s] %d  %s — %s\n", marker, tab.Index, title, tab.URL)
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/internal/agent/tools/browser_test.go
+++ b/internal/agent/tools/browser_test.go
@@ -26,6 +26,8 @@ func newBrowserTestTools(cfg *config.Config) []domain.Tool {
 		NewBrowserClickTool(cfg, limiter, session),
 		NewBrowserTypeTool(cfg, limiter, session),
 		NewBrowserReadTool(cfg, limiter, session),
+		NewBrowserScreenshotTool(cfg, limiter, session),
+		NewBrowserTabsTool(cfg, limiter, session),
 	}
 }
 
@@ -70,6 +72,10 @@ func TestBrowserToolsValidate(t *testing.T) {
 		{"navigate relative url", NewBrowserNavigateTool(cfg, limiter, session), map[string]any{"url": "/foo"}, true},
 		{"click valid", NewBrowserClickTool(cfg, limiter, session), map[string]any{"selector": "text=Sign in"}, false},
 		{"click missing selector", NewBrowserClickTool(cfg, limiter, session), map[string]any{}, true},
+		{"click coords valid", NewBrowserClickTool(cfg, limiter, session), map[string]any{"x": 10.0, "y": 20.0}, false},
+		{"click x without y", NewBrowserClickTool(cfg, limiter, session), map[string]any{"x": 10.0}, true},
+		{"screenshot no args", NewBrowserScreenshotTool(cfg, limiter, session), map[string]any{}, false},
+		{"tabs no args", NewBrowserTabsTool(cfg, limiter, session), map[string]any{}, false},
 		{"type valid", NewBrowserTypeTool(cfg, limiter, session), map[string]any{"selector": "input", "text": "hi"}, false},
 		{"type missing text", NewBrowserTypeTool(cfg, limiter, session), map[string]any{"selector": "input"}, true},
 		{"read no args", NewBrowserReadTool(cfg, limiter, session), map[string]any{}, false},
@@ -130,5 +136,61 @@ func TestBrowserToolFormatForLLM(t *testing.T) {
 	failed := &domain.ToolExecutionResult{ToolName: "BrowserRead", Success: false, Error: "boom"}
 	if out := tool.FormatForLLM(failed); !strings.Contains(out, "boom") {
 		t.Errorf("Expected error in output, got %q", out)
+	}
+}
+
+// TestBrowserReadRedaction locks the security invariant: a sensitive input's
+// value is never returned to the LLM. It exercises the real Go redaction path
+// (extractReadContent + isSensitiveField) against the exact JSON payload the
+// in-page reader (browserReadJS) emits, so no browser launch is needed.
+func TestBrowserReadRedaction(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{"password field", `{"field":true,"type":"password","name":"pw","value":"hunter2"}`, "[redacted]"},
+		{"current-password autocomplete", `{"field":true,"type":"text","autocomplete":"current-password","value":"hunter2"}`, "[redacted]"},
+		{"one-time code", `{"field":true,"type":"text","autocomplete":"one-time-code","value":"123456"}`, "[redacted]"},
+		{"secret-ish name", `{"field":true,"type":"text","name":"api_token","value":"sk-abc"}`, "[redacted]"},
+		{"cvc field", `{"field":true,"type":"text","id":"cardCvc","value":"999"}`, "[redacted]"},
+		{"plain search box", `{"field":true,"type":"text","name":"q","value":"cats"}`, "cats"},
+		{"container text", `{"field":false,"text":"hello world"}`, "hello world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractReadContent(tt.payload)
+			if got != tt.want {
+				t.Fatalf("extractReadContent(%s) = %q, want %q", tt.payload, got, tt.want)
+			}
+			if strings.Contains(got, "hunter2") {
+				t.Fatalf("leaked secret value: %q", got)
+			}
+		})
+	}
+}
+
+func TestBrowserTabsFormatForLLM(t *testing.T) {
+	cfg := browserTestConfig(true)
+	session := newBrowserSession(&cfg.BrowserUse)
+	limiter := utils.NewRateLimiter(cfg.BrowserUse.RateLimit)
+	tool := NewBrowserTabsTool(cfg, limiter, session)
+
+	result := &domain.ToolExecutionResult{
+		ToolName: "BrowserTabs",
+		Success:  true,
+		Data: []domain.BrowserTab{
+			{Index: 0, URL: "https://a.com", Title: "A", Active: false},
+			{Index: 1, URL: "https://b.com", Title: "B", Active: true},
+		},
+	}
+	out := tool.FormatForLLM(result)
+	for _, want := range []string{"https://a.com", "https://b.com", "A", "B", "*"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("FormatForLLM missing %q:\n%s", want, out)
+		}
+	}
+	if out := tool.FormatPreview(result); !strings.Contains(out, "2 tab") {
+		t.Errorf("FormatPreview = %q, want count", out)
 	}
 }

--- a/internal/agent/tools/registry.go
+++ b/internal/agent/tools/registry.go
@@ -283,6 +283,8 @@ func (r *Registry) registerBrowserUseTools() {
 	r.tools["BrowserClick"] = NewBrowserClickTool(cfg, rateLimiter, r.browserDriver)
 	r.tools["BrowserType"] = NewBrowserTypeTool(cfg, rateLimiter, r.browserDriver)
 	r.tools["BrowserRead"] = NewBrowserReadTool(cfg, rateLimiter, r.browserDriver)
+	r.tools["BrowserScreenshot"] = NewBrowserScreenshotTool(cfg, rateLimiter, r.browserDriver)
+	r.tools["BrowserTabs"] = NewBrowserTabsTool(cfg, rateLimiter, r.browserDriver)
 }
 
 // SetBrowserDriver swaps the browser backend (e.g. the opentask extension

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -153,15 +153,44 @@ type BrowserToolResult struct {
 	Events   []string `json:"events,omitempty"`
 }
 
+// BrowserTab describes one open tab/page as reported by BrowserTabs. Active
+// marks the tab the browser-use verbs currently act on.
+type BrowserTab struct {
+	Index  int    `json:"index"`
+	URL    string `json:"url"`
+	Title  string `json:"title"`
+	Active bool   `json:"active"`
+}
+
+// BrowserScreenshotResult carries a screenshot of the current page. Data is
+// base64-encoded image bytes; the BrowserScreenshot tool persists them and
+// sets the attachment's on-disk source path.
+type BrowserScreenshotResult struct {
+	Data     string `json:"-"`
+	MimeType string `json:"mime_type"`
+	URL      string `json:"url,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Width    int    `json:"width,omitempty"`
+	Height   int    `json:"height,omitempty"`
+}
+
 // BrowserDriver executes browser-use verbs against a browser backend: a
 // Playwright-launched browser, or the user's real browser via the opentask
 // extension bridge.
 type BrowserDriver interface {
 	Navigate(ctx context.Context, url string) (BrowserToolResult, error)
 	Click(ctx context.Context, selector string) (BrowserToolResult, error)
+	// ClickAt clicks at viewport coordinates (CSS pixels), for use with a
+	// screenshot. Not every backend supports it (the extension bridge does not).
+	ClickAt(ctx context.Context, x, y float64) (BrowserToolResult, error)
 	Type(ctx context.Context, selector, text string, pressEnter bool) (BrowserToolResult, error)
 	// Read returns element text in Content and drained browser events in Events.
+	// Sensitive input values (passwords, tokens) MUST be redacted before return.
 	Read(ctx context.Context, selector string) (BrowserToolResult, error)
+	// Screenshot captures the current page/active tab as an image.
+	Screenshot(ctx context.Context) (BrowserScreenshotResult, error)
+	// Tabs lists the open tabs, marking the active one.
+	Tabs(ctx context.Context) ([]BrowserTab, error)
 	Close()
 }
 

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -25,23 +25,27 @@ import (
 
 // extensionProtocolVersion is the wire protocol version sent in the hello ack.
 // Documented in docs/browser-extension-protocol.md. v2 adds the approval flow
-// (approval_request / approval_response / approval_resolved).
-const extensionProtocolVersion = 2
+// (approval_request / approval_response / approval_resolved); v3 adds the
+// screenshot and tabs commands and requires read-redaction of secret inputs.
+const extensionProtocolVersion = 3
 
 // Bridge wire messages. One flat envelope per frame, discriminated by Type;
 // unknown types are ignored for forward compatibility.
 type extInbound struct {
-	Type             string   `json:"type"`
-	Token            string   `json:"token,omitempty"`
-	ExtensionVersion string   `json:"extension_version,omitempty"`
-	ID               string   `json:"id,omitempty"`
-	URL              string   `json:"url,omitempty"`
-	Title            string   `json:"title,omitempty"`
-	Content          string   `json:"content,omitempty"`
-	Events           []string `json:"events,omitempty"`
-	Error            string   `json:"error,omitempty"`
-	RequestID        string   `json:"request_id,omitempty"`
-	Action           string   `json:"action,omitempty"`
+	Type             string              `json:"type"`
+	Token            string              `json:"token,omitempty"`
+	ExtensionVersion string              `json:"extension_version,omitempty"`
+	ID               string              `json:"id,omitempty"`
+	URL              string              `json:"url,omitempty"`
+	Title            string              `json:"title,omitempty"`
+	Content          string              `json:"content,omitempty"`
+	Events           []string            `json:"events,omitempty"`
+	Error            string              `json:"error,omitempty"`
+	RequestID        string              `json:"request_id,omitempty"`
+	Action           string              `json:"action,omitempty"`
+	Image            string              `json:"image,omitempty"` // base64 screenshot bytes
+	ImageMimeType    string              `json:"image_mime_type,omitempty"`
+	Tabs             []domain.BrowserTab `json:"tabs,omitempty"`
 }
 
 type extApprovalRequest struct {
@@ -527,6 +531,43 @@ func (b *ExtensionBridge) Read(ctx context.Context, selector string) (domain.Bro
 		Content:  result.Content,
 		Events:   result.Events,
 	}, nil
+}
+
+// ClickAt implements domain.BrowserDriver. The extension bridge drives clicks
+// through chrome.scripting (untrusted synthetic events), which have no reliable
+// viewport-coordinate form - that needs chrome.debugger/CDP. Fail clearly.
+func (b *ExtensionBridge) ClickAt(_ context.Context, _, _ float64) (domain.BrowserToolResult, error) {
+	return domain.BrowserToolResult{}, fmt.Errorf("coordinate click isn't supported on the extension backend; use a CSS or text= selector with BrowserClick")
+}
+
+// Screenshot implements domain.BrowserDriver via the extension's captureVisibleTab.
+func (b *ExtensionBridge) Screenshot(ctx context.Context) (domain.BrowserScreenshotResult, error) {
+	result, err := b.send(ctx, extBrowserCommand{Type: "browser_command", Action: "screenshot"})
+	if err != nil {
+		return domain.BrowserScreenshotResult{}, err
+	}
+	if result.Image == "" {
+		return domain.BrowserScreenshotResult{}, fmt.Errorf("extension returned no screenshot data")
+	}
+	mime := result.ImageMimeType
+	if mime == "" {
+		mime = "image/png"
+	}
+	return domain.BrowserScreenshotResult{
+		Data:     result.Image,
+		MimeType: mime,
+		URL:      result.URL,
+		Title:    result.Title,
+	}, nil
+}
+
+// Tabs implements domain.BrowserDriver via the extension's chrome.tabs query.
+func (b *ExtensionBridge) Tabs(ctx context.Context) ([]domain.BrowserTab, error) {
+	result, err := b.send(ctx, extBrowserCommand{Type: "browser_command", Action: "tabs"})
+	if err != nil {
+		return nil, err
+	}
+	return result.Tabs, nil
 }
 
 // Close implements domain.BrowserDriver: shuts the server and any connection.

--- a/tests/mocks/domain/fake_browser_driver.go
+++ b/tests/mocks/domain/fake_browser_driver.go
@@ -23,6 +23,21 @@ type FakeBrowserDriver struct {
 		result1 domain.BrowserToolResult
 		result2 error
 	}
+	ClickAtStub        func(context.Context, float64, float64) (domain.BrowserToolResult, error)
+	clickAtMutex       sync.RWMutex
+	clickAtArgsForCall []struct {
+		arg1 context.Context
+		arg2 float64
+		arg3 float64
+	}
+	clickAtReturns struct {
+		result1 domain.BrowserToolResult
+		result2 error
+	}
+	clickAtReturnsOnCall map[int]struct {
+		result1 domain.BrowserToolResult
+		result2 error
+	}
 	CloseStub        func()
 	closeMutex       sync.RWMutex
 	closeArgsForCall []struct {
@@ -53,6 +68,32 @@ type FakeBrowserDriver struct {
 	}
 	readReturnsOnCall map[int]struct {
 		result1 domain.BrowserToolResult
+		result2 error
+	}
+	ScreenshotStub        func(context.Context) (domain.BrowserScreenshotResult, error)
+	screenshotMutex       sync.RWMutex
+	screenshotArgsForCall []struct {
+		arg1 context.Context
+	}
+	screenshotReturns struct {
+		result1 domain.BrowserScreenshotResult
+		result2 error
+	}
+	screenshotReturnsOnCall map[int]struct {
+		result1 domain.BrowserScreenshotResult
+		result2 error
+	}
+	TabsStub        func(context.Context) ([]domain.BrowserTab, error)
+	tabsMutex       sync.RWMutex
+	tabsArgsForCall []struct {
+		arg1 context.Context
+	}
+	tabsReturns struct {
+		result1 []domain.BrowserTab
+		result2 error
+	}
+	tabsReturnsOnCall map[int]struct {
+		result1 []domain.BrowserTab
 		result2 error
 	}
 	TypeStub        func(context.Context, string, string, bool) (domain.BrowserToolResult, error)
@@ -135,6 +176,72 @@ func (fake *FakeBrowserDriver) ClickReturnsOnCall(i int, result1 domain.BrowserT
 		})
 	}
 	fake.clickReturnsOnCall[i] = struct {
+		result1 domain.BrowserToolResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBrowserDriver) ClickAt(arg1 context.Context, arg2 float64, arg3 float64) (domain.BrowserToolResult, error) {
+	fake.clickAtMutex.Lock()
+	ret, specificReturn := fake.clickAtReturnsOnCall[len(fake.clickAtArgsForCall)]
+	fake.clickAtArgsForCall = append(fake.clickAtArgsForCall, struct {
+		arg1 context.Context
+		arg2 float64
+		arg3 float64
+	}{arg1, arg2, arg3})
+	stub := fake.ClickAtStub
+	fakeReturns := fake.clickAtReturns
+	fake.recordInvocation("ClickAt", []interface{}{arg1, arg2, arg3})
+	fake.clickAtMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBrowserDriver) ClickAtCallCount() int {
+	fake.clickAtMutex.RLock()
+	defer fake.clickAtMutex.RUnlock()
+	return len(fake.clickAtArgsForCall)
+}
+
+func (fake *FakeBrowserDriver) ClickAtCalls(stub func(context.Context, float64, float64) (domain.BrowserToolResult, error)) {
+	fake.clickAtMutex.Lock()
+	defer fake.clickAtMutex.Unlock()
+	fake.ClickAtStub = stub
+}
+
+func (fake *FakeBrowserDriver) ClickAtArgsForCall(i int) (context.Context, float64, float64) {
+	fake.clickAtMutex.RLock()
+	defer fake.clickAtMutex.RUnlock()
+	argsForCall := fake.clickAtArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeBrowserDriver) ClickAtReturns(result1 domain.BrowserToolResult, result2 error) {
+	fake.clickAtMutex.Lock()
+	defer fake.clickAtMutex.Unlock()
+	fake.ClickAtStub = nil
+	fake.clickAtReturns = struct {
+		result1 domain.BrowserToolResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBrowserDriver) ClickAtReturnsOnCall(i int, result1 domain.BrowserToolResult, result2 error) {
+	fake.clickAtMutex.Lock()
+	defer fake.clickAtMutex.Unlock()
+	fake.ClickAtStub = nil
+	if fake.clickAtReturnsOnCall == nil {
+		fake.clickAtReturnsOnCall = make(map[int]struct {
+			result1 domain.BrowserToolResult
+			result2 error
+		})
+	}
+	fake.clickAtReturnsOnCall[i] = struct {
 		result1 domain.BrowserToolResult
 		result2 error
 	}{result1, result2}
@@ -290,6 +397,134 @@ func (fake *FakeBrowserDriver) ReadReturnsOnCall(i int, result1 domain.BrowserTo
 	}
 	fake.readReturnsOnCall[i] = struct {
 		result1 domain.BrowserToolResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBrowserDriver) Screenshot(arg1 context.Context) (domain.BrowserScreenshotResult, error) {
+	fake.screenshotMutex.Lock()
+	ret, specificReturn := fake.screenshotReturnsOnCall[len(fake.screenshotArgsForCall)]
+	fake.screenshotArgsForCall = append(fake.screenshotArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.ScreenshotStub
+	fakeReturns := fake.screenshotReturns
+	fake.recordInvocation("Screenshot", []interface{}{arg1})
+	fake.screenshotMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBrowserDriver) ScreenshotCallCount() int {
+	fake.screenshotMutex.RLock()
+	defer fake.screenshotMutex.RUnlock()
+	return len(fake.screenshotArgsForCall)
+}
+
+func (fake *FakeBrowserDriver) ScreenshotCalls(stub func(context.Context) (domain.BrowserScreenshotResult, error)) {
+	fake.screenshotMutex.Lock()
+	defer fake.screenshotMutex.Unlock()
+	fake.ScreenshotStub = stub
+}
+
+func (fake *FakeBrowserDriver) ScreenshotArgsForCall(i int) context.Context {
+	fake.screenshotMutex.RLock()
+	defer fake.screenshotMutex.RUnlock()
+	argsForCall := fake.screenshotArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeBrowserDriver) ScreenshotReturns(result1 domain.BrowserScreenshotResult, result2 error) {
+	fake.screenshotMutex.Lock()
+	defer fake.screenshotMutex.Unlock()
+	fake.ScreenshotStub = nil
+	fake.screenshotReturns = struct {
+		result1 domain.BrowserScreenshotResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBrowserDriver) ScreenshotReturnsOnCall(i int, result1 domain.BrowserScreenshotResult, result2 error) {
+	fake.screenshotMutex.Lock()
+	defer fake.screenshotMutex.Unlock()
+	fake.ScreenshotStub = nil
+	if fake.screenshotReturnsOnCall == nil {
+		fake.screenshotReturnsOnCall = make(map[int]struct {
+			result1 domain.BrowserScreenshotResult
+			result2 error
+		})
+	}
+	fake.screenshotReturnsOnCall[i] = struct {
+		result1 domain.BrowserScreenshotResult
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBrowserDriver) Tabs(arg1 context.Context) ([]domain.BrowserTab, error) {
+	fake.tabsMutex.Lock()
+	ret, specificReturn := fake.tabsReturnsOnCall[len(fake.tabsArgsForCall)]
+	fake.tabsArgsForCall = append(fake.tabsArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.TabsStub
+	fakeReturns := fake.tabsReturns
+	fake.recordInvocation("Tabs", []interface{}{arg1})
+	fake.tabsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBrowserDriver) TabsCallCount() int {
+	fake.tabsMutex.RLock()
+	defer fake.tabsMutex.RUnlock()
+	return len(fake.tabsArgsForCall)
+}
+
+func (fake *FakeBrowserDriver) TabsCalls(stub func(context.Context) ([]domain.BrowserTab, error)) {
+	fake.tabsMutex.Lock()
+	defer fake.tabsMutex.Unlock()
+	fake.TabsStub = stub
+}
+
+func (fake *FakeBrowserDriver) TabsArgsForCall(i int) context.Context {
+	fake.tabsMutex.RLock()
+	defer fake.tabsMutex.RUnlock()
+	argsForCall := fake.tabsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeBrowserDriver) TabsReturns(result1 []domain.BrowserTab, result2 error) {
+	fake.tabsMutex.Lock()
+	defer fake.tabsMutex.Unlock()
+	fake.TabsStub = nil
+	fake.tabsReturns = struct {
+		result1 []domain.BrowserTab
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBrowserDriver) TabsReturnsOnCall(i int, result1 []domain.BrowserTab, result2 error) {
+	fake.tabsMutex.Lock()
+	defer fake.tabsMutex.Unlock()
+	fake.TabsStub = nil
+	if fake.tabsReturnsOnCall == nil {
+		fake.tabsReturnsOnCall = make(map[int]struct {
+			result1 []domain.BrowserTab
+			result2 error
+		})
+	}
+	fake.tabsReturnsOnCall[i] = struct {
+		result1 []domain.BrowserTab
 		result2 error
 	}{result1, result2}
 }


### PR DESCRIPTION
## Summary

Expands the browser-use tools so an agent can **see and understand the current tab** — the "context is king" use case for opentask.

### New tools (both backends: Playwright/CDP and the opentask extension bridge)
- **BrowserScreenshot** — captures the current tab as an image, delivered through the existing vision pipeline (inline for vision models, `ImageDecode` fallback otherwise). Saved to `<configdir>/tmp/screenshots` (retention-managed, inside the sandbox carve-out).
- **BrowserTabs** — lists the open tabs and marks the active one.
- **BrowserClick** — gains optional `x`/`y` coordinate clicking for acting on a screenshot; selector clicks unchanged. Coordinate click is unsupported on the extension backend (untrusted synthetic events) and returns a clear error.

### Security
- **BrowserRead** now returns rendered text only (never input values); reading a `password` / `current-password` / `new-password` / `one-time-code` field, or one whose name/id/aria matches `pass|secret|token|otp|cvc|card`, returns `[redacted]`. The redaction decision is pure, unit-tested Go so it can't silently regress.

### Other
- Read-only browser tools (Read/Screenshot/Tabs) bypass approval, matching `GetLatestFrame`.
- Extension-bridge protocol bumped to **v3** (`screenshot`/`tabs` actions + read-redaction requirement) — see `docs/browser-extension-protocol.md`. Companion extension change: inference-gateway/opentask#144.

### Tests
- Redaction, coordinate-click validation, and tab formatting (fast unit tests).
- `browser_live_test.go` — gated behind `INFER_BROWSER_LIVE=1`, exercises the real Playwright driver end-to-end (navigate, redacted read, screenshot, tabs, coordinate click) against headless Chromium.

Deferred by design: tab recording (stills cover it), element-ref accessibility snapshot, and scroll/press-key/evaluate/console tools.
