### PR TITLE
feat(bridge): serve generated artifacts over HTTP for the extension panel

### DIFF
--- a/docs/browser-extension-protocol.md
+++ b/docs/browser-extension-protocol.md
@@ -123,6 +123,22 @@ agent is busy, exactly like typing in the TUI):
 {"type": "user_message", "content": "please also check the docs page"}
 ```
 
+## Artifacts (generated images)
+
+Chat text can reference files the agent saved under the artifacts dir
+(`~/.infer/artifacts/<...>`, e.g. `ImageGeneration` output). An MV3 extension
+cannot load a local file path in `<img>`, so alongside `/ws` the CLI serves that
+directory read-only over HTTP:
+
+```text
+GET http://127.0.0.1:<port>/artifacts/<relative-path>
+```
+
+The extension rewrites a markdown image whose URL contains `/.infer/artifacts/`
+to this route (stripping the prefix through and including `artifacts/`) and
+renders it inline. The route is loopback-only and unauthenticated (the artifacts
+are the user's own generated files); path traversal is blocked by `http.Dir`.
+
 ## Tool approvals (protocol v2)
 
 When a tool call needs the user's approval, the CLI sends an approval request

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -228,7 +228,7 @@ func (c *ServiceContainer) initializeExtensionBridge() {
 		c.stateManager.SetEventBridge(eventBridge)
 	}
 
-	c.extensionBridge = services.NewExtensionBridge(buCfg, c.uiNotifier, c.conversationRepo, eventBridge, string(c.sessionID))
+	c.extensionBridge = services.NewExtensionBridge(buCfg, c.uiNotifier, c.conversationRepo, eventBridge, string(c.sessionID), c.config.ArtifactsDir())
 	c.toolRegistry.SetBrowserDriver(c.extensionBridge)
 }
 

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -94,11 +94,12 @@ type extChatEvent struct {
 // ponytail: one connection, one implied tab - multi-tab / multi-CLI routing
 // when someone actually needs it.
 type ExtensionBridge struct {
-	cfg       *config.BrowserUseConfig
-	notifier  domain.UINotifier
-	repo      domain.ConversationRepository
-	events    domain.EventBridge
-	sessionID string
+	cfg          *config.BrowserUseConfig
+	notifier     domain.UINotifier
+	repo         domain.ConversationRepository
+	events       domain.EventBridge
+	sessionID    string
+	artifactsDir string
 
 	server   *http.Server
 	addr     string
@@ -114,14 +115,17 @@ type ExtensionBridge struct {
 }
 
 // NewExtensionBridge builds the bridge. notifier, repo, and events may be nil
-// (conversation sync is then skipped); cfg must not be nil.
-func NewExtensionBridge(cfg *config.BrowserUseConfig, notifier domain.UINotifier, repo domain.ConversationRepository, events domain.EventBridge, sessionID string) *ExtensionBridge {
+// (conversation sync is then skipped); cfg must not be nil. artifactsDir, when
+// non-empty, is served read-only at /artifacts/ so the panel can display
+// generated images the agent saved locally.
+func NewExtensionBridge(cfg *config.BrowserUseConfig, notifier domain.UINotifier, repo domain.ConversationRepository, events domain.EventBridge, sessionID, artifactsDir string) *ExtensionBridge {
 	return &ExtensionBridge{
 		cfg:              cfg,
 		notifier:         notifier,
 		repo:             repo,
 		events:           events,
 		sessionID:        sessionID,
+		artifactsDir:     artifactsDir,
 		pending:          make(map[string]chan extInbound),
 		pendingApprovals: make(map[string]sdk.ChatCompletionMessageToolCall),
 	}
@@ -145,6 +149,9 @@ func (b *ExtensionBridge) Start() error {
 	b.addr = listener.Addr().String()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", b.handleWS)
+	if b.artifactsDir != "" {
+		mux.Handle("/artifacts/", http.StripPrefix("/artifacts/", http.FileServer(http.Dir(b.artifactsDir))))
+	}
 	b.server = &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 	go func() {
 		if err := b.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/internal/services/extension_bridge_test.go
+++ b/internal/services/extension_bridge_test.go
@@ -2,6 +2,10 @@ package services
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -192,7 +196,7 @@ func bridgeConfig() *config.BrowserUseConfig {
 
 func startBridge(t *testing.T, cfg *config.BrowserUseConfig, notifier domain.UINotifier, events domain.EventBridge) *ExtensionBridge {
 	t.Helper()
-	bridge := NewExtensionBridge(cfg, notifier, nil, events, "test-session")
+	bridge := NewExtensionBridge(cfg, notifier, nil, events, "test-session", "")
 	if err := bridge.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -251,7 +255,7 @@ func TestExtensionBridgeFailsFastWithoutConnection(t *testing.T) {
 func TestExtensionBridgeRefusesToStartWithoutToken(t *testing.T) {
 	cfg := bridgeConfig()
 	cfg.Extension.Token = ""
-	bridge := NewExtensionBridge(cfg, nil, nil, nil, "s")
+	bridge := NewExtensionBridge(cfg, nil, nil, nil, "s", "")
 	if err := bridge.Start(); err == nil || !strings.Contains(err.Error(), "token is empty") {
 		t.Fatalf("expected token error, got %v", err)
 	}
@@ -393,4 +397,48 @@ func TestExtensionBridgeReplacesConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read after replacement: %v", err)
 	}
+}
+
+func TestExtensionBridgeServesArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cat.png"), []byte("PNGDATA"), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	bridge := NewExtensionBridge(bridgeConfig(), nil, nil, nil, "s", dir)
+	if err := bridge.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(bridge.Close)
+
+	body, status := httpGet(t, "http://"+bridge.Addr()+"/artifacts/cat.png")
+	if status != http.StatusOK || body != "PNGDATA" {
+		t.Fatalf("serve artifact: status=%d body=%q", status, body)
+	}
+
+	_, status = httpGet(t, "http://"+bridge.Addr()+"/artifacts/../extension_bridge.go")
+	if status == http.StatusOK {
+		t.Fatalf("path traversal was not blocked (status %d)", status)
+	}
+}
+
+func TestExtensionBridgeWithoutArtifactsDirHasNoRoute(t *testing.T) {
+	bridge := startBridge(t, bridgeConfig(), nil, nil)
+	if _, status := httpGet(t, "http://"+bridge.Addr()+"/artifacts/cat.png"); status == http.StatusOK {
+		t.Fatalf("expected no /artifacts/ route, got status %d", status)
+	}
+}
+
+func httpGet(t *testing.T, url string) (string, int) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(body), resp.StatusCode
 }


### PR DESCRIPTION
## What

Serve the artifacts directory read-only at `/artifacts/` on the existing extension-bridge HTTP server, so the opentask sidepanel can display images the agent generated locally.

## Why

The bridge mirrors the conversation to the panel, but an MV3 extension **cannot** load a local file path (`/Users/…/.infer/artifacts/…png`) in an `<img>`. `ImageGeneration` saves PNGs under `~/.infer/artifacts/` and only the path reaches the panel, so generated images never render.

## How

- Add a `/artifacts/` route (`http.StripPrefix` + `http.FileServer(http.Dir(artifactsDir))`) alongside `/ws` on the same `ServeMux`.
- Registered only when an artifacts dir is threaded in; `container.go` passes `config.ArtifactsDir()`.
- Loopback-only and unauthenticated (the files are the user's own generated content); `http.Dir` blocks `..` traversal.
- Documented the route in `docs/browser-extension-protocol.md`.

The extension side (markdown `![]()` rendering + rewriting `…/.infer/artifacts/<x>` → `http://127.0.0.1:<port>/artifacts/<x>`) is a companion PR in `inference-gateway/opentask`.

## Test

- New `TestExtensionBridgeServesArtifacts` (serves a file, blocks `../` traversal) and `TestExtensionBridgeWithoutArtifactsDirHasNoRoute`.
- `gofmt` / `go vet` / `go build ./...` clean; `internal/services` tests pass; pre-commit hook green.