### PR TITLE
fix(bridge): stop extension double-render after WebSocket reconnect

### DIFF
--- a/internal/display/macos/event_bridge.go
+++ b/internal/display/macos/event_bridge.go
@@ -74,31 +74,34 @@ func (s *subscriber) enqueue(event domain.ChatEvent, droppable bool) {
 	s.ch <- event
 }
 
-// Subscribe creates a new event channel and returns it
-// The subscriber will receive all future events published to the bridge
-func (eb *EventBridge) Subscribe() chan domain.ChatEvent {
+// Subscribe registers a subscriber and replays the recent-event ring buffer so
+// backfill-less subscribers (the floating window) catch up on connect.
+func (eb *EventBridge) Subscribe() chan domain.ChatEvent { return eb.subscribe(true) }
+
+// SubscribeFuture is Subscribe without the ring-buffer replay, for subscribers
+// that backfill history another way (the extension bridge's conversation
+// snapshot) where a replay would double-render the last turn.
+func (eb *EventBridge) SubscribeFuture() chan domain.ChatEvent { return eb.subscribe(false) }
+
+func (eb *EventBridge) subscribe(replay bool) chan domain.ChatEvent {
 	ch := make(chan domain.ChatEvent, 100)
-	sub := &subscriber{
-		ch:     ch,
-		closed: false,
-	}
+	sub := &subscriber{ch: ch}
 
 	eb.subMutex.Lock()
 	defer eb.subMutex.Unlock()
 
 	eb.subscribers = append(eb.subscribers, sub)
 
-	eb.eventBuffer.Do(func(val any) {
-		if val != nil {
-			event, ok := val.(domain.ChatEvent)
-			if ok {
+	if replay {
+		eb.eventBuffer.Do(func(val any) {
+			if event, ok := val.(domain.ChatEvent); ok {
 				select {
 				case ch <- event:
 				default:
 				}
 			}
-		}
-	})
+		})
+	}
 
 	return ch
 }

--- a/internal/display/macos/event_bridge_test.go
+++ b/internal/display/macos/event_bridge_test.go
@@ -31,6 +31,33 @@ func TestPublish_DeliversControlEventWhenBufferFull(t *testing.T) {
 	}
 }
 
+// SubscribeFuture must not replay the ring buffer: subscribers that backfill
+// history another way (the extension bridge snapshot) would otherwise
+// double-render the last turn (issue #1067). Subscribe, by contrast, replays.
+func TestSubscribeFuture_SkipsRingBuffer(t *testing.T) {
+	eb := NewEventBridge()
+
+	eb.Publish(domain.ChatChunkEvent{Content: "past-1"})
+	eb.Publish(domain.ChatChunkEvent{Content: "past-2"})
+
+	if replay := eb.Subscribe(); len(replay) != 2 {
+		t.Fatalf("Subscribe replayed %d events, want 2", len(replay))
+	}
+
+	future := eb.SubscribeFuture()
+	if len(future) != 0 {
+		t.Fatalf("SubscribeFuture replayed %d buffered events, want 0", len(future))
+	}
+
+	eb.Publish(domain.ChatChunkEvent{Content: "new"})
+	if got := len(future); got != 1 {
+		t.Fatalf("SubscribeFuture buffered %d events after one publish, want 1", got)
+	}
+	if ev := (<-future).(domain.ChatChunkEvent); ev.Content != "new" {
+		t.Fatalf("got %q, want the post-subscribe event", ev.Content)
+	}
+}
+
 // Streaming chunks stay lossy so a slow subscriber can't apply backpressure to
 // the whole bus over cosmetic deltas.
 func TestPublish_DropsChunksWhenBufferFull(t *testing.T) {

--- a/internal/domain/interfaces.go
+++ b/internal/domain/interfaces.go
@@ -341,6 +341,10 @@ type EventBridge interface {
 	// Subscribe creates a new event channel and returns it
 	Subscribe() chan ChatEvent
 
+	// SubscribeFuture is Subscribe without the ring-buffer replay, for
+	// subscribers that backfill history another way.
+	SubscribeFuture() chan ChatEvent
+
 	// Unsubscribe removes a subscriber and closes its channel
 	Unsubscribe(ch chan ChatEvent)
 }

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -278,7 +278,7 @@ func (b *ExtensionBridge) chatPump(conn *websocket.Conn, stop chan struct{}) {
 	if b.events == nil {
 		return
 	}
-	sub := b.events.Subscribe()
+	sub := b.events.SubscribeFuture()
 	defer b.events.Unsubscribe(sub)
 
 	filtered := make(chan domain.ChatEvent, 100)

--- a/internal/services/toolcoordinator/coordinator_test.go
+++ b/internal/services/toolcoordinator/coordinator_test.go
@@ -38,7 +38,10 @@ func (r *recordingEventBridge) Tap(input <-chan domain.ChatEvent) <-chan domain.
 func (r *recordingEventBridge) Publish(event domain.ChatEvent) {
 	r.published = append(r.published, event)
 }
-func (r *recordingEventBridge) Subscribe() chan domain.ChatEvent     { return make(chan domain.ChatEvent) }
+func (r *recordingEventBridge) Subscribe() chan domain.ChatEvent { return make(chan domain.ChatEvent) }
+func (r *recordingEventBridge) SubscribeFuture() chan domain.ChatEvent {
+	return make(chan domain.ChatEvent)
+}
 func (r *recordingEventBridge) Unsubscribe(ch chan domain.ChatEvent) {}
 
 func TestCoordinator_ActiveToolCallID(t *testing.T) {


### PR DESCRIPTION
## Summary

The opentask extension rendered every assistant message **twice** after a WebSocket bridge reconnect.

`ExtensionBridge.adopt` backfills history via `sendSnapshot` (`conversation_snapshot`) and **then** starts `chatPump`, which subscribed to the `EventBridge`. `EventBridge.Subscribe()` replays its ~50-event ring buffer to every new subscriber — so on reconnect the extension received the just-finished turn a second time and re-folded it through `reduceAgui` into a duplicate copy of each message.

The ring-buffer replay exists to backfill subscribers that have **no** snapshot of their own (the macOS floating window). The extension bridge isn't one of those — it backfills via the snapshot — so for it the replay is pure duplication.

## Fix

Add `EventBridge.SubscribeFuture()`, a `Subscribe()` variant that skips the ring-buffer replay, and use it in `chatPump`. `Subscribe()` keeps replaying for the floating window, which depends on it.

- `event_bridge.go` — extract `subscribe(replay bool)`; `Subscribe` / `SubscribeFuture` are thin wrappers.
- `interfaces.go` — add `SubscribeFuture()` to the `EventBridge` interface.
- `extension_bridge.go` — `chatPump` now calls `SubscribeFuture()`.

Concurrency is unchanged: replay still writes into the fresh channel under `subMutex` (which `Publish` also holds), so subscribe and publish stay serialized. Future-only just skips the replay loop.

## Tests

- New `TestSubscribeFuture_SkipsRingBuffer` — `Subscribe()` replays 2 buffered events, `SubscribeFuture()` replays 0 and only sees post-subscribe events.
- Full `internal/services/...` + `internal/display/macos/` suites pass; `task precommit:run` clean.

Closes #1067