### PR TITLE
feat(bridge): conversation list + resume protocol for the extension

### DIFF
--- a/docs/browser-extension-protocol.md
+++ b/docs/browser-extension-protocol.md
@@ -43,10 +43,8 @@ Extension → CLI, first frame, within 5 seconds of connecting:
 CLI → extension on success (on failure the socket is closed):
 
 ```json
-{"type": "browser_hello_ack", "protocol_version": 3}
+{"type": "browser_hello_ack", "protocol_version": 4}
 ```
-
-Immediately after the ack the CLI sends a conversation snapshot (see below).
 
 ## Browser commands (CLI → extension)
 
@@ -97,15 +95,46 @@ Extension → CLI, exactly one result per command id:
 
 ## Conversation sync
 
-Sent by the CLI right after the handshake:
+The panel drives which conversation it shows (protocol v4). Before v4 the CLI
+auto-sent a snapshot of the current conversation right after the handshake;
+that implicit backfill is gone — the panel now lists and resumes explicitly.
+
+Extension → CLI, list the user's stored conversations (the same ones `infer`
+resumes from, under `.infer/conversations`):
+
+```json
+{"type": "list_conversations"}
+```
+
+CLI → extension, newest-first (sorted by `updated_at` descending):
+
+```json
+{"type": "conversations", "conversations": [{"id": "<uuid>", "title": "...", "updated_at": "2026-08-16T12:00:00Z", "message_count": 12}]}
+```
+
+- `title` is the conversation's title (an auto-derived first-message preview
+  until a better one is generated); `updated_at` is RFC 3339; `message_count`
+  is the number of stored messages.
+- The array is empty when the CLI runs without conversation persistence
+  (`storage.enabled: false`).
+
+Extension → CLI, resume one — makes it the active conversation:
+
+```json
+{"type": "resume_conversation", "id": "<uuid>"}
+```
+
+CLI → extension, the resumed conversation's history:
 
 ```json
 {"type": "conversation_snapshot", "messages": [{"role": "user", "content": "..."}, ...]}
 ```
 
-`messages` are the gateway SDK message objects of the current conversation.
+- `messages` are the gateway SDK message objects of the resumed conversation.
+- An unknown or empty `id` is ignored (no snapshot is sent).
 
-Then the CLI streams live chat activity, one frame per
+After the snapshot the CLI streams live chat activity for the active
+conversation, one frame per
 [AG-UI](https://docs.ag-ui.com/) event (same encoding as
 `infer headless --output ag-ui`, see `docs/ag-ui-output.md`):
 

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -26,8 +26,10 @@ import (
 // extensionProtocolVersion is the wire protocol version sent in the hello ack.
 // Documented in docs/browser-extension-protocol.md. v2 adds the approval flow
 // (approval_request / approval_response / approval_resolved); v3 adds the
-// screenshot and tabs commands and requires read-redaction of secret inputs.
-const extensionProtocolVersion = 3
+// screenshot and tabs commands and requires read-redaction of secret inputs;
+// v4 adds the list_conversations / conversations and resume_conversation frames
+// and drops the implicit conversation_snapshot on connect (the panel picks).
+const extensionProtocolVersion = 4
 
 // Bridge wire messages. One flat envelope per frame, discriminated by Type;
 // unknown types are ignored for forward compatibility.
@@ -79,6 +81,18 @@ type extBrowserCommand struct {
 type extSnapshot struct {
 	Type     string        `json:"type"`
 	Messages []sdk.Message `json:"messages"`
+}
+
+type extConversationSummary struct {
+	ID           string    `json:"id"`
+	Title        string    `json:"title"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	MessageCount int       `json:"message_count"`
+}
+
+type extConversations struct {
+	Type          string                   `json:"type"`
+	Conversations []extConversationSummary `json:"conversations"`
 }
 
 type extChatEvent struct {
@@ -221,14 +235,13 @@ func (b *ExtensionBridge) adopt(conn *websocket.Conn) {
 	b.pendingApprovals = make(map[string]sdk.ChatCompletionMessageToolCall)
 	b.mu.Unlock()
 
-	b.sendSnapshot(conn)
 	go b.readLoop(conn, stop)
 	go b.chatPump(conn, stop)
 	go b.pingLoop(conn, stop)
 }
 
-// sendSnapshot backfills the conversation so a late-joining extension shows
-// history, not just events from now on.
+// sendSnapshot ships the current conversation's history so the panel shows it,
+// not just events from now on. Sent as the resume_conversation response.
 func (b *ExtensionBridge) sendSnapshot(conn *websocket.Conn) {
 	if b.repo == nil {
 		return
@@ -239,6 +252,55 @@ func (b *ExtensionBridge) sendSnapshot(conn *websocket.Conn) {
 		messages = append(messages, entry.Message)
 	}
 	b.write(conn, extSnapshot{Type: "conversation_snapshot", Messages: messages})
+}
+
+// conversationListLimit caps list_conversations, mirroring the TUI selector.
+const conversationListLimit = 50
+
+// conversationLister is the slice of the persistent repo the panel picker needs.
+// Declared here (not in domain) because the in-memory fallback repo has no
+// listing - the type assertion simply fails there and yields an empty list.
+type conversationLister interface {
+	ListSavedConversations(ctx context.Context, limit, offset int) ([]domain.ConversationSummary, error)
+}
+
+// sendConversationList answers list_conversations with the stored conversations
+// (newest-first), so the panel can offer the same picker the CLI resumes from.
+func (b *ExtensionBridge) sendConversationList(conn *websocket.Conn) {
+	lister, ok := b.repo.(conversationLister)
+	if !ok {
+		b.write(conn, extConversations{Type: "conversations"})
+		return
+	}
+	summaries, err := lister.ListSavedConversations(context.Background(), conversationListLimit, 0)
+	if err != nil {
+		logger.Debug("extension bridge failed to list conversations", "error", err)
+		b.write(conn, extConversations{Type: "conversations"})
+		return
+	}
+	out := make([]extConversationSummary, 0, len(summaries))
+	for _, s := range summaries {
+		out = append(out, extConversationSummary{
+			ID:           s.ID,
+			Title:        s.Title,
+			UpdatedAt:    s.UpdatedAt,
+			MessageCount: s.MessageCount,
+		})
+	}
+	b.write(conn, extConversations{Type: "conversations", Conversations: out})
+}
+
+// resumeConversation switches the active conversation to id and snapshots it to
+// the panel; the running chat pump then streams live events into it.
+func (b *ExtensionBridge) resumeConversation(conn *websocket.Conn, id string) {
+	if b.repo == nil || id == "" {
+		return
+	}
+	if err := b.repo.LoadConversation(context.Background(), id); err != nil {
+		logger.Debug("extension bridge failed to resume conversation", "id", id, "error", err)
+		return
+	}
+	b.sendSnapshot(conn)
 }
 
 // readLoop handles frames from the extension until the connection dies or is
@@ -263,6 +325,10 @@ func (b *ExtensionBridge) readLoop(conn *websocket.Conn, stop chan struct{}) {
 			if b.notifier != nil && msg.Content != "" {
 				b.notifier.Notify(domain.UserInputEvent{Content: msg.Content})
 			}
+		case "list_conversations":
+			b.sendConversationList(conn)
+		case "resume_conversation":
+			b.resumeConversation(conn, msg.ID)
 		case "approval_response":
 			b.answerApproval(conn, msg.RequestID, msg.Action)
 		default:

--- a/internal/services/extension_bridge_test.go
+++ b/internal/services/extension_bridge_test.go
@@ -16,6 +16,7 @@ import (
 	config "github.com/inference-gateway/cli/config"
 	macos "github.com/inference-gateway/cli/internal/display/macos"
 	domain "github.com/inference-gateway/cli/internal/domain"
+	storage "github.com/inference-gateway/cli/internal/infra/storage"
 )
 
 // readFrameOfType reads frames until one with the given type arrives, failing
@@ -202,6 +203,40 @@ func startBridge(t *testing.T, cfg *config.BrowserUseConfig, notifier domain.UIN
 	}
 	t.Cleanup(bridge.Close)
 	return bridge
+}
+
+func startBridgeWithRepo(t *testing.T, cfg *config.BrowserUseConfig, repo domain.ConversationRepository) *ExtensionBridge {
+	t.Helper()
+	bridge := NewExtensionBridge(cfg, nil, repo, nil, "test-session", "")
+	if err := bridge.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(bridge.Close)
+	return bridge
+}
+
+// newBridgeRepo builds a persistent repo backed by in-memory storage.
+func newBridgeRepo() *PersistentConversationRepository {
+	return NewPersistentConversationRepository(&ToolFormatterService{}, nil, storage.NewMemoryStorage())
+}
+
+// seedConversation starts, fills, and saves a conversation, returning its id.
+func seedConversation(t *testing.T, repo *PersistentConversationRepository, title, content string) string {
+	t.Helper()
+	if err := repo.StartNewConversation(title); err != nil {
+		t.Fatalf("StartNewConversation: %v", err)
+	}
+	entry := domain.ConversationEntry{
+		Message: sdk.Message{Role: sdk.User, Content: sdk.NewMessageContent(content)},
+		Time:    time.Now(),
+	}
+	if err := repo.AddMessage(entry); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+	if err := repo.SaveConversation(context.Background()); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+	return repo.GetCurrentConversationID()
 }
 
 func dial(t *testing.T, bridge *ExtensionBridge) *websocket.Conn {
@@ -441,4 +476,93 @@ func httpGet(t *testing.T, url string) (string, int) {
 		t.Fatalf("read body: %v", err)
 	}
 	return string(body), resp.StatusCode
+}
+
+func TestExtensionBridgeListConversations(t *testing.T) {
+	repo := newBridgeRepo()
+	firstID := seedConversation(t, repo, "First convo", "hello one")
+	secondID := seedConversation(t, repo, "Second convo", "hello two")
+
+	bridge := startBridgeWithRepo(t, bridgeConfig(), repo)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	if err := conn.WriteJSON(map[string]string{"type": "list_conversations"}); err != nil {
+		t.Fatalf("write list_conversations: %v", err)
+	}
+
+	frame := readFrameOfType(t, conn, "conversations")
+	raw, ok := frame["conversations"].([]any)
+	if !ok || len(raw) != 2 {
+		t.Fatalf("expected 2 conversations, got %v", frame["conversations"])
+	}
+
+	byID := map[string]map[string]any{}
+	for _, c := range raw {
+		entry := c.(map[string]any)
+		byID[entry["id"].(string)] = entry
+	}
+
+	first, ok := byID[firstID]
+	if !ok {
+		t.Fatalf("first conversation %s missing from %v", firstID, byID)
+	}
+	if first["title"] != "First convo" {
+		t.Fatalf("first title = %v, want %q", first["title"], "First convo")
+	}
+	if count, _ := first["message_count"].(float64); count != 1 {
+		t.Fatalf("first message_count = %v, want 1", first["message_count"])
+	}
+	if at, _ := first["updated_at"].(string); at == "" {
+		t.Fatalf("first updated_at missing: %v", first["updated_at"])
+	}
+
+	second, ok := byID[secondID]
+	if !ok {
+		t.Fatalf("second conversation %s missing from %v", secondID, byID)
+	}
+	if second["title"] != "Second convo" {
+		t.Fatalf("second title = %v, want %q", second["title"], "Second convo")
+	}
+}
+
+func TestExtensionBridgeResumeConversation(t *testing.T) {
+	repo := newBridgeRepo()
+	targetID := seedConversation(t, repo, "Older convo", "resume me please")
+	seedConversation(t, repo, "Current convo", "current message")
+
+	bridge := startBridgeWithRepo(t, bridgeConfig(), repo)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	if err := conn.WriteJSON(map[string]string{"type": "resume_conversation", "id": targetID}); err != nil {
+		t.Fatalf("write resume_conversation: %v", err)
+	}
+
+	frame := readFrameOfType(t, conn, "conversation_snapshot")
+	msgs, ok := frame["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 message in snapshot, got %v", frame["messages"])
+	}
+	if content := msgs[0].(map[string]any)["content"]; content != "resume me please" {
+		t.Fatalf("snapshot content = %v, want %q", content, "resume me please")
+	}
+	if got := repo.GetCurrentConversationID(); got != targetID {
+		t.Fatalf("active conversation = %s, want %s", got, targetID)
+	}
+}
+
+func TestExtensionBridgeNoAutoSnapshotOnConnect(t *testing.T) {
+	repo := newBridgeRepo()
+	seedConversation(t, repo, "Some convo", "hello")
+
+	bridge := startBridgeWithRepo(t, bridgeConfig(), repo)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	var frame map[string]any
+	if err := conn.ReadJSON(&frame); err == nil {
+		t.Fatalf("expected no unsolicited frame after connect, got %v", frame)
+	}
 }


### PR DESCRIPTION
## Summary

CLI half of opentask#146. Adds bridge protocol frames so the opentask sidepanel can list the user's stored conversations and resume a chosen one, mirroring the CLI 1:1 (the same conversations `infer` persists and resumes from under `.infer/conversations`).

Closes #1068.

## New wire frames (protocol v4)

| Direction | Frame | Purpose |
|-----------|-------|---------|
| ext → CLI | `{"type":"list_conversations"}` | request the stored list |
| CLI → ext | `{"type":"conversations","conversations":[{"id","title","updated_at","message_count"}]}` | response, newest-first |
| ext → CLI | `{"type":"resume_conversation","id":"<id>"}` | switch active conversation to `id` |
| CLI → ext | `{"type":"conversation_snapshot","messages":[...]}` | existing frame, now the resume response |

After a resume, the running chat pump streams live `chat_event` frames into the now-active conversation.

## Implementation notes

- **resume** reuses the repo's existing `LoadConversation(ctx, id)` + `sendSnapshot` — both already on the `domain.ConversationRepository` interface, so no interface change.
- **list** type-asserts `b.repo` to a small local `conversationLister` interface (the `ListSavedConversations` method lives only on the concrete `*PersistentConversationRepository`). This keeps `internal/domain/interfaces.go` untouched (no counterfeiter regen) and lets the in-memory fallback repo cleanly return an empty list.
- The implicit **auto-backfill-on-connect** (`sendSnapshot` in `adopt`) is **removed** — the panel now lists/resumes explicitly. Existing tests all inject a `nil` repo where `sendSnapshot` was already a no-op, so blast radius is nil.
- `protocol_version` bumped `3` → `4` in the `browser_hello_ack`.
- Concurrency: `PersistentConversationRepository` guards its own state, so calling these from the per-connection `readLoop` goroutine is race-safe (verified with `-race`).

## Docs

`docs/browser-extension-protocol.md` — reworked the **Conversation sync** section to document the new frames in the existing house style; bumped the handshake `protocol_version` to 4. Public-docs follow-up filed: inference-gateway/docs#555.

## Tests

Three new tests in `extension_bridge_test.go` against a real persistent repo backed by in-memory storage:
- `TestExtensionBridgeListConversations` — list returns both seeded conversations with id/title/updated_at/message_count.
- `TestExtensionBridgeResumeConversation` — resume ships the target conversation's snapshot and switches the active conversation.
- `TestExtensionBridgeNoAutoSnapshotOnConnect` — regression guard: no unsolicited snapshot after connect.

`go test -race ./internal/services -run TestExtensionBridge` and full `task test` both green; `task precommit:run` clean.

## Deliberately deferred

- Pagination params on `list_conversations` (hardcoded limit 50, matching the TUI selector).
- Refreshing the terminal TUI when the panel resumes (resume swaps the shared active conversation but emits no TUI-refresh event).
- An error frame back to the panel on a failed resume (bad id) — currently logged, no snapshot.