### PR TITLE
feat(bridge): add list_skills frame and drop protocol versioning

### DIFF
--- a/docs/browser-extension-protocol.md
+++ b/docs/browser-extension-protocol.md
@@ -43,7 +43,7 @@ Extension → CLI, first frame, within 5 seconds of connecting:
 CLI → extension on success (on failure the socket is closed):
 
 ```json
-{"type": "browser_hello_ack", "protocol_version": 4}
+{"type": "browser_hello_ack"}
 ```
 
 ## Browser commands (CLI → extension)
@@ -72,11 +72,11 @@ One shape, six actions; only the fields relevant to the action are set.
   `one-time-code`, or inputs whose name/id/aria-label matches
   `/pass|secret|token|otp|cvc|card/i` — substitute `"[redacted]"`. `innerText`
   already excludes input values; this rule binds any richer extraction.
-- `screenshot` (v3): capture the visible controlled tab
+- `screenshot`: capture the visible controlled tab
   (`chrome.tabs.captureVisibleTab`) and return it as base64 in the result's
   `image` field. Passwords render masked by the browser, so no extra redaction
   is required.
-- `tabs` (v3): enumerate the open tabs (`chrome.tabs.query`) and return them in
+- `tabs`: enumerate the open tabs (`chrome.tabs.query`) and return them in
   the result's `tabs` array, flagging the controlled/active one.
 
 Extension → CLI, exactly one result per command id:
@@ -95,9 +95,8 @@ Extension → CLI, exactly one result per command id:
 
 ## Conversation sync
 
-The panel drives which conversation it shows (protocol v4). Before v4 the CLI
-auto-sent a snapshot of the current conversation right after the handshake;
-that implicit backfill is gone — the panel now lists and resumes explicitly.
+The panel drives which conversation it shows. The CLI does not auto-send a
+snapshot on connect — the panel lists and resumes conversations explicitly.
 
 Extension → CLI, list the user's stored conversations (the same ones `infer`
 resumes from, under `.infer/conversations`):
@@ -152,6 +151,29 @@ agent is busy, exactly like typing in the TUI):
 {"type": "user_message", "content": "please also check the docs page"}
 ```
 
+## Skills
+
+The panel offers a "/" autocomplete of the agent's skills. It asks the CLI for
+the merged, scope-tagged list the CLI already resolves (project, `.agents`,
+user, plugin, catalog), so the menu mirrors what the TUI offers.
+
+Extension → CLI, list the available skills:
+
+```json
+{"type": "list_skills"}
+```
+
+CLI → extension, the discovered skills (empty when skills are unavailable):
+
+```json
+{"type": "skills", "skills": [{"name": "tmux", "description": "...", "scope": "user"}]}
+```
+
+- `name` is the qualified skill name (`pluginName:skillName` for plugin skills).
+- `scope` is one of `project`, `agents`, `user`, `plugin`, `catalog`; name
+  conflicts are already resolved by precedence, so each name appears once.
+  Unknown scopes are ignored by the extension.
+
 ## Artifacts (generated images)
 
 Chat text can reference files the agent saved under the artifacts dir
@@ -168,7 +190,7 @@ to this route (stripping the prefix through and including `artifacts/`) and
 renders it inline. The route is loopback-only and unauthenticated (the artifacts
 are the user's own generated files); path traversal is blocked by `http.Dir`.
 
-## Tool approvals (protocol v2)
+## Tool approvals
 
 When a tool call needs the user's approval, the CLI sends an approval request
 instead of mirroring it as a chat line. The extension shows Approve/Deny and

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -228,7 +228,7 @@ func (c *ServiceContainer) initializeExtensionBridge() {
 		c.stateManager.SetEventBridge(eventBridge)
 	}
 
-	c.extensionBridge = services.NewExtensionBridge(buCfg, c.uiNotifier, c.conversationRepo, eventBridge, string(c.sessionID), c.config.ArtifactsDir())
+	c.extensionBridge = services.NewExtensionBridge(buCfg, c.uiNotifier, c.conversationRepo, eventBridge, c.skillsService, string(c.sessionID), c.config.ArtifactsDir())
 	c.toolRegistry.SetBrowserDriver(c.extensionBridge)
 }
 
@@ -401,6 +401,12 @@ func (c *ServiceContainer) initializeDomainServices() {
 		c.jobSupervisor.SetConversationRepo(c.conversationRepo)
 	}
 
+	skillsSvc := skills.New(c.config)
+	if err := skillsSvc.Load(context.Background()); err != nil {
+		logger.Warn("failed to load skills", "error", err)
+	}
+	c.skillsService = skillsSvc
+
 	c.initializeExtensionBridge()
 
 	modelClient := c.createRawSDKClient()
@@ -459,12 +465,6 @@ func (c *ServiceContainer) initializeDomainServices() {
 	}
 
 	c.a2aAgentService = services.NewA2AAgentService(c.config)
-
-	skillsSvc := skills.New(c.config)
-	if err := skillsSvc.Load(context.Background()); err != nil {
-		logger.Warn("failed to load skills", "error", err)
-	}
-	c.skillsService = skillsSvc
 
 	c.githubIssueService = githubissues.New()
 

--- a/internal/domain/skills.go
+++ b/internal/domain/skills.go
@@ -37,6 +37,19 @@ func (s Skill) DisplayName() string {
 	return s.Name
 }
 
+// SkillSummary is the serializable projection of a Skill (qualified name,
+// description, scope) used wherever skills cross a wire boundary.
+type SkillSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Scope       string `json:"scope"`
+}
+
+// Summary returns the wire-serializable projection of the skill.
+func (s Skill) Summary() SkillSummary {
+	return SkillSummary{Name: s.DisplayName(), Description: s.Description, Scope: string(s.Scope)}
+}
+
 // SkillLoadError records a per-skill validation failure so `infer skills
 // list` can surface why a directory was skipped without crashing startup.
 type SkillLoadError struct {

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -86,15 +86,9 @@ type extConversations struct {
 	Conversations []extConversationSummary `json:"conversations"`
 }
 
-type extSkill struct {
-	Name        string `json:"name"` // Skill.DisplayName() - "plugin:name" for plugins
-	Description string `json:"description"`
-	Scope       string `json:"scope"` // project|agents|user|plugin|catalog
-}
-
 type extSkills struct {
-	Type   string     `json:"type"`
-	Skills []extSkill `json:"skills"`
+	Type   string                `json:"type"`
+	Skills []domain.SkillSummary `json:"skills"`
 }
 
 type extChatEvent struct {
@@ -313,17 +307,13 @@ func (b *ExtensionBridge) resumeConversation(conn *websocket.Conn, id string) {
 // Sends an empty list when skills are unavailable.
 func (b *ExtensionBridge) sendSkillList(conn *websocket.Conn) {
 	if b.skills == nil {
-		b.write(conn, extSkills{Type: "skills", Skills: []extSkill{}})
+		b.write(conn, extSkills{Type: "skills", Skills: []domain.SkillSummary{}})
 		return
 	}
 	loaded := b.skills.List()
-	out := make([]extSkill, 0, len(loaded))
+	out := make([]domain.SkillSummary, 0, len(loaded))
 	for _, sk := range loaded {
-		out = append(out, extSkill{
-			Name:        sk.DisplayName(),
-			Description: sk.Description,
-			Scope:       string(sk.Scope),
-		})
+		out = append(out, sk.Summary())
 	}
 	b.write(conn, extSkills{Type: "skills", Skills: out})
 }

--- a/internal/services/extension_bridge.go
+++ b/internal/services/extension_bridge.go
@@ -23,14 +23,6 @@ import (
 	render "github.com/inference-gateway/cli/internal/render"
 )
 
-// extensionProtocolVersion is the wire protocol version sent in the hello ack.
-// Documented in docs/browser-extension-protocol.md. v2 adds the approval flow
-// (approval_request / approval_response / approval_resolved); v3 adds the
-// screenshot and tabs commands and requires read-redaction of secret inputs;
-// v4 adds the list_conversations / conversations and resume_conversation frames
-// and drops the implicit conversation_snapshot on connect (the panel picks).
-const extensionProtocolVersion = 4
-
 // Bridge wire messages. One flat envelope per frame, discriminated by Type;
 // unknown types are ignored for forward compatibility.
 type extInbound struct {
@@ -63,8 +55,7 @@ type extApprovalResolved struct {
 }
 
 type extHelloAck struct {
-	Type            string `json:"type"`
-	ProtocolVersion int    `json:"protocol_version"`
+	Type string `json:"type"`
 }
 
 type extBrowserCommand struct {
@@ -95,6 +86,17 @@ type extConversations struct {
 	Conversations []extConversationSummary `json:"conversations"`
 }
 
+type extSkill struct {
+	Name        string `json:"name"` // Skill.DisplayName() - "plugin:name" for plugins
+	Description string `json:"description"`
+	Scope       string `json:"scope"` // project|agents|user|plugin|catalog
+}
+
+type extSkills struct {
+	Type   string     `json:"type"`
+	Skills []extSkill `json:"skills"`
+}
+
 type extChatEvent struct {
 	Type  string          `json:"type"`
 	Event json.RawMessage `json:"event"`
@@ -112,6 +114,7 @@ type ExtensionBridge struct {
 	notifier     domain.UINotifier
 	repo         domain.ConversationRepository
 	events       domain.EventBridge
+	skills       domain.SkillsService
 	sessionID    string
 	artifactsDir string
 
@@ -128,16 +131,17 @@ type ExtensionBridge struct {
 	writeMu sync.Mutex // serializes writes to conn
 }
 
-// NewExtensionBridge builds the bridge. notifier, repo, and events may be nil
-// (conversation sync is then skipped); cfg must not be nil. artifactsDir, when
-// non-empty, is served read-only at /artifacts/ so the panel can display
-// generated images the agent saved locally.
-func NewExtensionBridge(cfg *config.BrowserUseConfig, notifier domain.UINotifier, repo domain.ConversationRepository, events domain.EventBridge, sessionID, artifactsDir string) *ExtensionBridge {
+// NewExtensionBridge builds the bridge. notifier, repo, events, and skills may
+// be nil (the matching feature is then skipped); cfg must not be nil.
+// artifactsDir, when non-empty, is served read-only at /artifacts/ so the panel
+// can display generated images the agent saved locally.
+func NewExtensionBridge(cfg *config.BrowserUseConfig, notifier domain.UINotifier, repo domain.ConversationRepository, events domain.EventBridge, skills domain.SkillsService, sessionID, artifactsDir string) *ExtensionBridge {
 	return &ExtensionBridge{
 		cfg:              cfg,
 		notifier:         notifier,
 		repo:             repo,
 		events:           events,
+		skills:           skills,
 		sessionID:        sessionID,
 		artifactsDir:     artifactsDir,
 		pending:          make(map[string]chan extInbound),
@@ -211,7 +215,7 @@ func (b *ExtensionBridge) handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = conn.SetReadDeadline(time.Time{})
 
-	if err := conn.WriteJSON(extHelloAck{Type: "browser_hello_ack", ProtocolVersion: extensionProtocolVersion}); err != nil {
+	if err := conn.WriteJSON(extHelloAck{Type: "browser_hello_ack"}); err != nil {
 		_ = conn.Close()
 		return
 	}
@@ -303,6 +307,27 @@ func (b *ExtensionBridge) resumeConversation(conn *websocket.Conn, id string) {
 	b.sendSnapshot(conn)
 }
 
+// sendSkillList answers list_skills with the agent's discovered skills - the
+// same set (project, .agents, user, plugin, catalog) the skills service already
+// merged with precedence, so the panel's "/" menu mirrors what the TUI offers.
+// Sends an empty list when skills are unavailable.
+func (b *ExtensionBridge) sendSkillList(conn *websocket.Conn) {
+	if b.skills == nil {
+		b.write(conn, extSkills{Type: "skills", Skills: []extSkill{}})
+		return
+	}
+	loaded := b.skills.List()
+	out := make([]extSkill, 0, len(loaded))
+	for _, sk := range loaded {
+		out = append(out, extSkill{
+			Name:        sk.DisplayName(),
+			Description: sk.Description,
+			Scope:       string(sk.Scope),
+		})
+	}
+	b.write(conn, extSkills{Type: "skills", Skills: out})
+}
+
 // readLoop handles frames from the extension until the connection dies or is
 // replaced.
 func (b *ExtensionBridge) readLoop(conn *websocket.Conn, stop chan struct{}) {
@@ -327,6 +352,8 @@ func (b *ExtensionBridge) readLoop(conn *websocket.Conn, stop chan struct{}) {
 			}
 		case "list_conversations":
 			b.sendConversationList(conn)
+		case "list_skills":
+			b.sendSkillList(conn)
 		case "resume_conversation":
 			b.resumeConversation(conn, msg.ID)
 		case "approval_response":

--- a/internal/services/extension_bridge_test.go
+++ b/internal/services/extension_bridge_test.go
@@ -13,11 +13,12 @@ import (
 	websocket "github.com/gorilla/websocket"
 	sdk "github.com/inference-gateway/sdk"
 
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
+
 	config "github.com/inference-gateway/cli/config"
 	macos "github.com/inference-gateway/cli/internal/display/macos"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
-	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
 // readFrameOfType reads frames until one with the given type arrives, failing

--- a/internal/services/extension_bridge_test.go
+++ b/internal/services/extension_bridge_test.go
@@ -17,6 +17,7 @@ import (
 	macos "github.com/inference-gateway/cli/internal/display/macos"
 	domain "github.com/inference-gateway/cli/internal/domain"
 	storage "github.com/inference-gateway/cli/internal/infra/storage"
+	domainmocks "github.com/inference-gateway/cli/tests/mocks/domain"
 )
 
 // readFrameOfType reads frames until one with the given type arrives, failing
@@ -197,7 +198,7 @@ func bridgeConfig() *config.BrowserUseConfig {
 
 func startBridge(t *testing.T, cfg *config.BrowserUseConfig, notifier domain.UINotifier, events domain.EventBridge) *ExtensionBridge {
 	t.Helper()
-	bridge := NewExtensionBridge(cfg, notifier, nil, events, "test-session", "")
+	bridge := NewExtensionBridge(cfg, notifier, nil, events, nil, "test-session", "")
 	if err := bridge.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -207,7 +208,17 @@ func startBridge(t *testing.T, cfg *config.BrowserUseConfig, notifier domain.UIN
 
 func startBridgeWithRepo(t *testing.T, cfg *config.BrowserUseConfig, repo domain.ConversationRepository) *ExtensionBridge {
 	t.Helper()
-	bridge := NewExtensionBridge(cfg, nil, repo, nil, "test-session", "")
+	bridge := NewExtensionBridge(cfg, nil, repo, nil, nil, "test-session", "")
+	if err := bridge.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(bridge.Close)
+	return bridge
+}
+
+func startBridgeWithSkills(t *testing.T, cfg *config.BrowserUseConfig, skills domain.SkillsService) *ExtensionBridge {
+	t.Helper()
+	bridge := NewExtensionBridge(cfg, nil, nil, nil, skills, "test-session", "")
 	if err := bridge.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -290,7 +301,7 @@ func TestExtensionBridgeFailsFastWithoutConnection(t *testing.T) {
 func TestExtensionBridgeRefusesToStartWithoutToken(t *testing.T) {
 	cfg := bridgeConfig()
 	cfg.Extension.Token = ""
-	bridge := NewExtensionBridge(cfg, nil, nil, nil, "s", "")
+	bridge := NewExtensionBridge(cfg, nil, nil, nil, nil, "s", "")
 	if err := bridge.Start(); err == nil || !strings.Contains(err.Error(), "token is empty") {
 		t.Fatalf("expected token error, got %v", err)
 	}
@@ -440,7 +451,7 @@ func TestExtensionBridgeServesArtifacts(t *testing.T) {
 		t.Fatalf("write artifact: %v", err)
 	}
 
-	bridge := NewExtensionBridge(bridgeConfig(), nil, nil, nil, "s", dir)
+	bridge := NewExtensionBridge(bridgeConfig(), nil, nil, nil, nil, "s", dir)
 	if err := bridge.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -564,5 +575,57 @@ func TestExtensionBridgeNoAutoSnapshotOnConnect(t *testing.T) {
 	var frame map[string]any
 	if err := conn.ReadJSON(&frame); err == nil {
 		t.Fatalf("expected no unsolicited frame after connect, got %v", frame)
+	}
+}
+
+func TestExtensionBridgeListSkills(t *testing.T) {
+	skills := &domainmocks.FakeSkillsService{}
+	skills.ListReturns([]domain.Skill{
+		{Name: "tmux", Description: "drive tmux", Scope: domain.SkillScopeUser},
+		{Name: "deploy", Description: "ship it", Scope: domain.SkillScopeAgents},
+		{Name: "notion", Scope: domain.SkillScopePlugin, PluginName: "notion"},
+	})
+	bridge := startBridgeWithSkills(t, bridgeConfig(), skills)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	if err := conn.WriteJSON(map[string]string{"type": "list_skills"}); err != nil {
+		t.Fatalf("write list_skills: %v", err)
+	}
+
+	frame := readFrameOfType(t, conn, "skills")
+	raw, ok := frame["skills"].([]any)
+	if !ok || len(raw) != 3 {
+		t.Fatalf("expected 3 skills, got %v", frame["skills"])
+	}
+
+	byName := map[string]map[string]any{}
+	for _, s := range raw {
+		e := s.(map[string]any)
+		byName[e["name"].(string)] = e
+	}
+	if byName["tmux"]["scope"] != "user" {
+		t.Fatalf("tmux scope = %v, want user", byName["tmux"]["scope"])
+	}
+	if byName["deploy"]["scope"] != "agents" {
+		t.Fatalf("deploy scope = %v, want agents", byName["deploy"]["scope"])
+	}
+	if _, ok := byName["notion:notion"]; !ok {
+		t.Fatalf("plugin skill missing qualified name, got keys %v", byName)
+	}
+}
+
+func TestExtensionBridgeListSkillsWithoutServiceIsEmpty(t *testing.T) {
+	bridge := startBridge(t, bridgeConfig(), nil, nil)
+	conn := dial(t, bridge)
+	hello(t, conn, "test-token")
+
+	if err := conn.WriteJSON(map[string]string{"type": "list_skills"}); err != nil {
+		t.Fatalf("write list_skills: %v", err)
+	}
+
+	frame := readFrameOfType(t, conn, "skills")
+	if raw, ok := frame["skills"].([]any); ok && len(raw) != 0 {
+		t.Fatalf("expected no skills, got %v", frame["skills"])
 	}
 }


### PR DESCRIPTION
## What

Adds a `list_skills` → `skills` frame to the browser-extension bridge so the opentask sidepanel can offer a `/` skills autocomplete, and removes the unused `protocol_version` handshake field.

## Why

The sidepanel (inference-gateway/opentask#150) needs the agent's available skills to power a caret-anchored `/` dropdown. The extension is MV3 and can't read the filesystem, and the CLI already discovers and merges skills across all scopes (`project`, `.agents`, `user`, `plugin`, `catalog`) with precedence. So the CLI is the right place to source them — the panel just renders what `List()` returns, exactly what the TUI's own `/` autocomplete offers.

## Changes

- **`extension_bridge.go`**: new `list_skills` inbound → `sendSkillList` replies with a `skills` frame mapping `SkillsService.List()` to `{name (DisplayName), description, scope}`. Wired a nilable `skills domain.SkillsService` into the bridge (guarded, like `notifier`/`repo`).
- **`container.go`**: load the skills service before building the bridge.
- **Removed protocol versioning**: `protocol_version` was written into `browser_hello_ack` but never read by the extension or branched on by the CLI. The new frame is additive and forward-compatible (unknown frame types are already ignored by contract), so no version bump is needed.
- **`docs/browser-extension-protocol.md`**: documents the Skills frame; drops `protocol_version` and the historical version tags.
- **Tests**: `list_skills` round-trip (name/scope/plugin display name) + nil-service empty case, using the counterfeiter `FakeSkillsService`.

## Verified

`go build`, `go test ./internal/services ./internal/container`, `gofmt`, `go vet`, `golangci-lint` (0 issues), `markdownlint` — all clean.

Pairs with the opentask sidepanel PR (renders this over the panel's `/` menu). Relates to inference-gateway/opentask#150.
