### PR TITLE
fix(nix): drop the deleted Swift floating-window build from the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,6 @@
                 || baseName == ".task"
                 || baseName == "node_modules"
                 || (type == "regular" && relPath == "infer")
-                || (type == "directory" && lib.hasPrefix "internal/display/macos/ComputerUse/build" relPath)
               );
           };
 
@@ -73,16 +72,12 @@
 
           nativeBuildInputs = [
             pkgs.installShellFiles
-          ]
-          ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.swift ];
+          ];
 
           buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk ];
 
           preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
             export SDKROOT="${pkgs.apple-sdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
-            pushd internal/display/macos/ComputerUse > /dev/null
-            bash ./build.sh
-            popd > /dev/null
           '';
 
           postInstall = ''


### PR DESCRIPTION
## Summary

Building the CLI via the nix flake on macOS has been broken since #1079: the darwin `preBuild` still ran `build.sh` inside `internal/display/macos/ComputerUse`, a directory that PR removed, so `nix build` fails with `pushd: internal/display/macos/ComputerUse: No such file or directory`. This breaks every consumer pinning the flake - the desktop repo's flox dev environment cannot move past v0.175.0 until this lands in a release.

## Changes

- Remove the darwin-only Swift build step (`pushd .../ComputerUse && bash ./build.sh`) and the `pkgs.swift` native build input.
- Remove the dead source-filter entry for `internal/display/macos/ComputerUse/build`.
- Keep `pkgs.apple-sdk` and the `SDKROOT` export: the computer-use cgo code still links AppKit (`client_darwin.go`) and ApplicationServices (`controller_darwin.go`), and hermetic nix builds cannot see the system Xcode SDK.

Verified with a hermetic `nix build .#` on aarch64-darwin at this commit: `result/bin/infer` reports `infer version 0.176.0`.

no docs ticket: internal-only build fix

## Cross-repo impact

- `inference-gateway/desktop`: unblocks bumping the flox pin (`.flox/env/manifest.toml`) past v0.175.0 once this ships in the next release.