### PR TITLE
fix(computer-use): make screen analysis work in headless sessions

### DIFF
--- a/cmd/headless.go
+++ b/cmd/headless.go
@@ -28,6 +28,24 @@ import (
 	telemetry "github.com/inference-gateway/cli/internal/telemetry"
 )
 
+// startHeadlessScreenshotServer starts the screenshot capture server and
+// registers the "screen" frame source so GetLatestFrame is available, exactly
+// as interactive chat does. It logs instead of printing: headless stdout
+// carries the ag-ui/json protocol stream. Returns nil when streaming is off or
+// the server failed to start.
+func startHeadlessScreenshotServer(cfg *config.Config, svc *container.ServiceContainer, sessionID string) *services.ScreenshotServer {
+	if !cfg.ComputerUse.Enabled || !cfg.ComputerUse.Screenshot.StreamingEnabled {
+		return nil
+	}
+	screenshotServer := services.NewScreenshotServer(cfg, svc.GetImageService(), sessionID)
+	if err := screenshotServer.Start(); err != nil {
+		logger.Warn("failed to start screenshot server", "error", err)
+		return nil
+	}
+	svc.GetToolRegistry().RegisterFrameSource("screen", screenshotServer)
+	return screenshotServer
+}
+
 // inheritedSubagentMode returns the coding mode a subagent should start in,
 // read from INFER_SUBAGENT_AGENT_MODE. Returns Standard when unset or
 // unrecognized, so top-level infer headless runs are unaffected.
@@ -176,6 +194,14 @@ func runHeadless(cfg *config.Config, opts headlessOptions) (err error) { //nolin
 			sessionID = resolved
 			groupKey = gk
 		}
+	}
+
+	if screenshotServer := startHeadlessScreenshotServer(cfg, svc, sessionID); screenshotServer != nil {
+		defer func() {
+			if stopErr := screenshotServer.Stop(); stopErr != nil {
+				logger.Error("failed to stop screenshot server", "error", stopErr)
+			}
+		}()
 	}
 
 	ctx := context.Background()

--- a/config/prompts.go
+++ b/config/prompts.go
@@ -693,10 +693,10 @@ Each subagent is independent and cannot itself spawn further subagents. Prefer n
 			Description: `Submit work to an A2A agent server and delegate it to run in the background. IMPORTANT: This tool returns IMMEDIATELY after submission. DO NOT poll, query, or download artifacts right after submission. The system automatically monitors the task in the background and you will be AUTOMATICALLY NOTIFIED when it completes - the result will appear in the conversation. After submission, you MUST wait for the automatic notification before taking any follow-up actions. You can tell the user the task is running and you're waiting for it to complete. Use this for ANY interaction where you need an agent to respond with answers or complete work. The A2A_QueryTask tool is ONLY for retrieving metadata/capabilities or checking status of previously submitted tasks, NOT for polling just-submitted tasks.`,
 		},
 		MouseMove: PromptsToolDescription{
-			Description: `Moves the mouse cursor to absolute screen coordinates. Requires user approval unless in auto-accept mode.`,
+			Description: `Moves the mouse cursor. Coordinates are in the screenshot coordinate space (the same space as GetLatestFrame bounding boxes), not physical screen pixels; they are scaled to the real display on execution. Requires user approval unless in auto-accept mode.`,
 		},
 		MouseClick: PromptsToolDescription{
-			Description: `Performs a mouse click. Can click at current position or move to coordinates first. Supports left, right, and middle buttons. Requires user approval unless in auto-accept mode.`,
+			Description: `Performs a mouse click. Can click at current position or move to coordinates first; coordinates are in the screenshot coordinate space (the same space as GetLatestFrame bounding boxes), not physical screen pixels. Supports left, right, and middle buttons. Requires user approval unless in auto-accept mode.`,
 		},
 		MouseScroll: PromptsToolDescription{
 			Description: `Scrolls the mouse wheel up or down. Useful for navigating web pages, documents, and long content. Positive values scroll down, negative values scroll up.`,

--- a/internal/agent/tools/coordinate_scaler.go
+++ b/internal/agent/tools/coordinate_scaler.go
@@ -1,6 +1,9 @@
 package tools
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 // ScaleAPIToScreen converts coordinates from API space (Claude's screenshot)
 // to screen space (actual display) using Anthropic's proportional scaling approach.
@@ -17,18 +20,27 @@ import "math"
 //
 // Returns:
 //   - screenX, screenY: Coordinates in actual screen space for mouse operations
+//   - error when the input lies outside the API space; the message stays in API
+//     space so a model that never saw the real display cannot misread it as
+//     screen bounds
 //
 // Example:
 //
 //	API screenshot: 1024x768
 //	Actual screen: 2048x1536
 //	API coordinate (512, 384) → Screen coordinate (1024, 768)
-func ScaleAPIToScreen(apiX, apiY, apiWidth, apiHeight, screenWidth, screenHeight int) (int, int) {
+func ScaleAPIToScreen(apiX, apiY, apiWidth, apiHeight, screenWidth, screenHeight int) (int, int, error) {
+	if apiX < 0 || apiY < 0 || apiX > apiWidth || apiY > apiHeight {
+		return 0, 0, fmt.Errorf(
+			"coordinates (%d,%d) are outside the %dx%d screenshot coordinate space (same space as GetLatestFrame bounding boxes)",
+			apiX, apiY, apiWidth, apiHeight)
+	}
+
 	xScale := float64(apiWidth) / float64(screenWidth)
 	yScale := float64(apiHeight) / float64(screenHeight)
 
 	screenX := int(math.Round(float64(apiX) / xScale))
 	screenY := int(math.Round(float64(apiY) / yScale))
 
-	return screenX, screenY
+	return screenX, screenY, nil
 }

--- a/internal/agent/tools/coordinate_scaler_test.go
+++ b/internal/agent/tools/coordinate_scaler_test.go
@@ -1,0 +1,30 @@
+package tools
+
+import "testing"
+
+func TestScaleAPIToScreen(t *testing.T) {
+	tests := []struct {
+		name             string
+		apiX, apiY       int
+		screenX, screenY int
+		wantErr          bool
+	}{
+		{"origin", 0, 0, 0, 0, false},
+		{"center", 512, 384, 756, 491, false},
+		{"max corner", 1024, 768, 1512, 982, false},
+		{"x out of bounds", 1025, 100, 0, 0, true},
+		{"y out of bounds", 100, 769, 0, 0, true},
+		{"negative", -1, 0, 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x, y, err := ScaleAPIToScreen(tt.apiX, tt.apiY, 1024, 768, 1512, 982)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && (x != tt.screenX || y != tt.screenY) {
+				t.Fatalf("got (%d,%d), want (%d,%d)", x, y, tt.screenX, tt.screenY)
+			}
+		})
+	}
+}

--- a/internal/agent/tools/get_latest_frame.go
+++ b/internal/agent/tools/get_latest_frame.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -101,6 +102,7 @@ func (t *GetLatestFrameTool) Execute(ctx context.Context, args map[string]any) (
 	if err != nil {
 		return fail(err.Error())
 	}
+	t.recordCall(sourceName)
 
 	attachment := domain.ImageAttachment{
 		Data:        frame.Data,
@@ -155,18 +157,25 @@ func (t *GetLatestFrameTool) resolveSource(args map[string]any) (string, domain.
 }
 
 // checkRateLimit enforces the per-source minimum call interval; it returns a
-// wait message when the call is too soon.
+// wait message when the call is too soon. Only successful frame fetches count
+// as calls (see recordCall), so a cold-buffer failure never throttles the retry.
 func (t *GetLatestFrameTool) checkRateLimit(source string) string {
 	t.lastCallMu.Lock()
 	defer t.lastCallMu.Unlock()
 	if last, ok := t.lastCallTimes[source]; ok {
 		if since := time.Since(last); since < t.minCallInterval {
-			wait := t.minCallInterval - since
-			return fmt.Sprintf("please wait %v before requesting another frame from %q (last called %v ago)", wait.Round(time.Second), source, since.Round(time.Second))
+			wait := time.Duration(math.Ceil((t.minCallInterval - since).Seconds())) * time.Second
+			return fmt.Sprintf("please wait %v before requesting another frame from %q (last called %v ago)", wait, source, since.Round(time.Second))
 		}
 	}
-	t.lastCallTimes[source] = time.Now()
 	return ""
+}
+
+// recordCall stamps the per-source rate limit after a successful frame fetch.
+func (t *GetLatestFrameTool) recordCall(source string) {
+	t.lastCallMu.Lock()
+	defer t.lastCallMu.Unlock()
+	t.lastCallTimes[source] = time.Now()
 }
 
 // wantAnnotated resolves the format: explicit wins; omitted defaults to

--- a/internal/agent/tools/mouse_click.go
+++ b/internal/agent/tools/mouse_click.go
@@ -59,11 +59,11 @@ func (t *MouseClickTool) Definition() sdk.ChatCompletionTool {
 					},
 					"x": map[string]any{
 						"type":        "integer",
-						"description": "Optional: X coordinate to move to before clicking",
+						"description": "Optional: X coordinate to move to before clicking, in the screenshot coordinate space (same space as GetLatestFrame bounding boxes)",
 					},
 					"y": map[string]any{
 						"type":        "integer",
-						"description": "Optional: Y coordinate to move to before clicking",
+						"description": "Optional: Y coordinate to move to before clicking, in the screenshot coordinate space (same space as GetLatestFrame bounding boxes)",
 					},
 				},
 				"required": []string{},
@@ -167,7 +167,10 @@ func (t *MouseClickTool) handleMovement(ctx context.Context, controller display.
 		return cursorX, cursorY, nil
 	}
 
-	targetX, targetY := t.scaleCoordinates(ctx, controller, x, y)
+	targetX, targetY, err := t.scaleCoordinates(ctx, controller, x, y)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to move mouse: %w", err)
+	}
 
 	if err := controller.MoveMouse(ctx, targetX, targetY); err != nil {
 		return 0, 0, fmt.Errorf("failed to move mouse: %w", err)
@@ -178,27 +181,25 @@ func (t *MouseClickTool) handleMovement(ctx context.Context, controller display.
 
 // scaleCoordinates converts API coordinates to screen coordinates using Anthropic's proportional scaling.
 // This follows the official computer-use-demo implementation strategy.
-func (t *MouseClickTool) scaleCoordinates(ctx context.Context, controller display.DisplayController, x, y int) (int, int) {
+func (t *MouseClickTool) scaleCoordinates(ctx context.Context, controller display.DisplayController, x, y int) (int, int, error) {
 	if isDirectExec := ctx.Value(domain.DirectExecutionKey); isDirectExec != nil && isDirectExec.(bool) {
-		return x, y
+		return x, y, nil
 	}
 
 	screenWidth, screenHeight, err := controller.GetScreenDimensions(ctx)
 	if err != nil {
 		logger.Warn("failed to get screen dimensions, no scaling", "error", err)
-		return x, y
+		return x, y, nil
 	}
 
 	apiWidth := t.config.ComputerUse.Screenshot.TargetWidth
 	apiHeight := t.config.ComputerUse.Screenshot.TargetHeight
 
 	if apiWidth == 0 || apiHeight == 0 {
-		return x, y
+		return x, y, nil
 	}
 
-	screenX, screenY := ScaleAPIToScreen(x, y, apiWidth, apiHeight, screenWidth, screenHeight)
-
-	return screenX, screenY
+	return ScaleAPIToScreen(x, y, apiWidth, apiHeight, screenWidth, screenHeight)
 }
 
 func (t *MouseClickTool) updateStateAfterClick(ctx context.Context, controller display.DisplayController, x, y int) {

--- a/internal/agent/tools/mouse_move.go
+++ b/internal/agent/tools/mouse_move.go
@@ -47,11 +47,11 @@ func (t *MouseMoveTool) Definition() sdk.ChatCompletionTool {
 				"properties": map[string]any{
 					"x": map[string]any{
 						"type":        "integer",
-						"description": "X coordinate (absolute position from left edge of screen)",
+						"description": "X coordinate in the screenshot coordinate space (same space as GetLatestFrame bounding boxes), scaled to the real screen on execution",
 					},
 					"y": map[string]any{
 						"type":        "integer",
-						"description": "Y coordinate (absolute position from top edge of screen)",
+						"description": "Y coordinate in the screenshot coordinate space (same space as GetLatestFrame bounding boxes), scaled to the real screen on execution",
 					},
 				},
 				"required": []string{"x", "y"},
@@ -113,7 +113,16 @@ func (t *MouseMoveTool) Execute(ctx context.Context, args map[string]any) (*doma
 		}
 	}()
 
-	targetX, targetY := t.scaleCoordinates(ctx, controller, int(x), int(y))
+	targetX, targetY, err := t.scaleCoordinates(ctx, controller, int(x), int(y))
+	if err != nil {
+		return &domain.ToolExecutionResult{
+			ToolName:  "MouseMove",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(start),
+			Error:     fmt.Sprintf("failed to move mouse: %v", err),
+		}, nil
+	}
 
 	fromX, fromY, _ := controller.GetCursorPosition(ctx)
 
@@ -221,27 +230,25 @@ func (t *MouseMoveTool) ShouldAlwaysExpand() bool {
 
 // scaleCoordinates converts API coordinates to screen coordinates using Anthropic's proportional scaling.
 // This follows the official computer-use-demo implementation strategy.
-func (t *MouseMoveTool) scaleCoordinates(ctx context.Context, controller display.DisplayController, x, y int) (int, int) {
+func (t *MouseMoveTool) scaleCoordinates(ctx context.Context, controller display.DisplayController, x, y int) (int, int, error) {
 	if isDirectExec := ctx.Value(domain.DirectExecutionKey); isDirectExec != nil && isDirectExec.(bool) {
-		return x, y
+		return x, y, nil
 	}
 
 	screenWidth, screenHeight, err := controller.GetScreenDimensions(ctx)
 	if err != nil {
 		logger.Warn("failed to get screen dimensions", "error", err)
-		return x, y
+		return x, y, nil
 	}
 
 	apiWidth := t.config.ComputerUse.Screenshot.TargetWidth
 	apiHeight := t.config.ComputerUse.Screenshot.TargetHeight
 
 	if apiWidth == 0 || apiHeight == 0 {
-		return x, y
+		return x, y, nil
 	}
 
-	screenX, screenY := ScaleAPIToScreen(x, y, apiWidth, apiHeight, screenWidth, screenHeight)
-
-	return screenX, screenY
+	return ScaleAPIToScreen(x, y, apiWidth, apiHeight, screenWidth, screenHeight)
 }
 
 // broadcastMoveEvent broadcasts a visual move indicator event for user feedback

--- a/internal/services/screenshot_server.go
+++ b/internal/services/screenshot_server.go
@@ -159,6 +159,10 @@ func (s *ScreenshotServer) startCaptureLoop() {
 	ticker := time.NewTicker(time.Duration(interval) * time.Second)
 	defer ticker.Stop()
 
+	if err := s.captureScreenshot(); err != nil {
+		logger.Warn("screenshot capture failed", "error", err)
+	}
+
 	for {
 		select {
 		case <-s.captureCtx.Done():


### PR DESCRIPTION
## Summary

Computer-use sessions spawned by the desktop app (`infer headless --format ag-ui`) offered mouse tools but no way to see the screen: the screenshot server was only started by interactive chat, so GetLatestFrame was silently disabled and a text-only model had to guess click coordinates from source code and error messages. On top of that, the mouse tool descriptions claimed coordinates were absolute screen pixels while the tools actually scale them from the screenshot space, and two cold-start bugs made the first GetLatestFrame calls of a session fail.

## Changes

- Headless mode now starts the screenshot server and registers the "screen" frame source under the same conditions as chat (`computer_use.enabled` + `screenshot.streaming_enabled`), logging instead of printing so the protocol stream on stdout stays clean.
- MouseMove/MouseClick schemas and prompt descriptions now say coordinates are in the screenshot coordinate space (the same space as GetLatestFrame bounding boxes), and `ScaleAPIToScreen` rejects out-of-space input with an error phrased in that same space instead of leaking post-scale numbers against real screen bounds. Added a table test.
- The capture loop takes its first screenshot immediately instead of waiting a full `capture_interval`, the GetLatestFrame rate limit only counts successful fetches (a cold-buffer failure no longer throttles the retry), and the wait message rounds up so it can never say "wait 0s".

Verified end to end against the desktop app with `deepseek-v4-flash` as the session model and the Haiku vision annotator enabled: the agent now goes GetFocusedApp -> annotated GetLatestFrame -> a single MouseMove that lands on the target, where it previously spent minutes reading repo source and probing MouseMove errors to reverse-engineer the coordinate scaling.