### PR TITLE
feat(computer-use): only one foreground session may control the screen

### DIFF
--- a/internal/agent/tools/activate_app.go
+++ b/internal/agent/tools/activate_app.go
@@ -74,6 +74,10 @@ func (t *ActivateAppTool) Execute(ctx context.Context, args map[string]any) (*do
 	appID, _ := args["app_id"].(string)
 	name, _ := args["name"].(string)
 
+	if err := acquireScreenLock(); err != nil {
+		return nil, err
+	}
+
 	appProvider, err := display.DetectAppProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect app provider: %w", err)

--- a/internal/agent/tools/keyboard_type.go
+++ b/internal/agent/tools/keyboard_type.go
@@ -71,6 +71,16 @@ func (t *KeyboardTypeTool) Execute(ctx context.Context, args map[string]any) (*d
 		}, nil
 	}
 
+	if err := acquireScreenLock(); err != nil {
+		return &domain.ToolExecutionResult{
+			ToolName:  "KeyboardType",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(start),
+			Error:     err.Error(),
+		}, nil
+	}
+
 	text, hasText := args["text"].(string)
 	keyCombo, hasKeyCombo := args["key_combo"].(string)
 

--- a/internal/agent/tools/mouse_click.go
+++ b/internal/agent/tools/mouse_click.go
@@ -80,6 +80,10 @@ func (t *MouseClickTool) Execute(ctx context.Context, args map[string]any) (*dom
 		return t.errorResult(args, start, err.Error()), nil
 	}
 
+	if err := acquireScreenLock(); err != nil {
+		return t.errorResult(args, start, err.Error()), nil
+	}
+
 	button := t.getButton(args)
 	clicks := t.getClicks(args)
 	finalX, finalY, shouldMove := t.getCoordinates(args)

--- a/internal/agent/tools/mouse_move.go
+++ b/internal/agent/tools/mouse_move.go
@@ -74,6 +74,16 @@ func (t *MouseMoveTool) Execute(ctx context.Context, args map[string]any) (*doma
 		}, nil
 	}
 
+	if err := acquireScreenLock(); err != nil {
+		return &domain.ToolExecutionResult{
+			ToolName:  "MouseMove",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(start),
+			Error:     err.Error(),
+		}, nil
+	}
+
 	x, xOk := args["x"].(float64)
 	y, yOk := args["y"].(float64)
 

--- a/internal/agent/tools/mouse_scroll.go
+++ b/internal/agent/tools/mouse_scroll.go
@@ -73,6 +73,16 @@ func (t *MouseScrollTool) Execute(ctx context.Context, args map[string]any) (*do
 		}, nil
 	}
 
+	if err := acquireScreenLock(); err != nil {
+		return &domain.ToolExecutionResult{
+			ToolName:  "MouseScroll",
+			Arguments: args,
+			Success:   false,
+			Duration:  time.Since(start),
+			Error:     err.Error(),
+		}, nil
+	}
+
 	clicks, clicksOk := args["clicks"].(float64)
 	if !clicksOk {
 		return &domain.ToolExecutionResult{

--- a/internal/agent/tools/screen_lock.go
+++ b/internal/agent/tools/screen_lock.go
@@ -1,0 +1,59 @@
+//go:build !windows
+
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+// The screen is a machine-wide resource: two concurrent computer-use sessions
+// would fight over one mouse and keyboard. The first session to execute a
+// computer-use tool takes an exclusive flock on a lock file under ~/.infer/run;
+// any other process's computer-use tools fail with an instruction to abort.
+// The kernel releases the lock when the process exits, so a crashed session
+// can never wedge the screen.
+// ponytail: single foreground session only - when background mode lands, scope
+// the lock to foreground sessions instead of every computer-use tool call.
+var (
+	screenLockMu   sync.Mutex
+	screenLockFile *os.File
+)
+
+// acquireScreenLock takes (or re-confirms) this process's exclusive claim on
+// the screen. It returns an error telling the model to abort when another
+// process already holds the claim.
+func acquireScreenLock() error {
+	screenLockMu.Lock()
+	defer screenLockMu.Unlock()
+
+	if screenLockFile != nil {
+		return nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to resolve home directory for screen lock: %w", err)
+	}
+	dir := filepath.Join(home, ".infer", "run")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create %s: %w", dir, err)
+	}
+
+	f, err := os.OpenFile(filepath.Join(dir, "computer-use.lock"), os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open screen lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("another computer-use session is already controlling the screen; abort this computer-use task and tell the user only one foreground computer-use session can run at a time")
+	}
+
+	_ = f.Truncate(0)
+	_, _ = fmt.Fprintf(f, "%d\n", os.Getpid())
+	screenLockFile = f
+	return nil
+}

--- a/internal/agent/tools/screen_lock_test.go
+++ b/internal/agent/tools/screen_lock_test.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestAcquireScreenLock(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	screenLockMu.Lock()
+	saved := screenLockFile
+	screenLockFile = nil
+	screenLockMu.Unlock()
+	defer func() {
+		screenLockMu.Lock()
+		if screenLockFile != nil {
+			_ = screenLockFile.Close()
+		}
+		screenLockFile = saved
+		screenLockMu.Unlock()
+	}()
+
+	if err := acquireScreenLock(); err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	if err := acquireScreenLock(); err != nil {
+		t.Fatalf("re-acquire in the same process failed: %v", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	f, err := os.OpenFile(filepath.Join(home, ".infer", "run", "computer-use.lock"), os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("failed to open lock file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err == nil {
+		t.Fatal("second flock on a held lock unexpectedly succeeded")
+	}
+}

--- a/internal/agent/tools/screen_lock_windows.go
+++ b/internal/agent/tools/screen_lock_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package tools
+
+// Computer use is not supported on Windows (see registerComputerUseTools), so
+// the screen lock has nothing to protect there.
+func acquireScreenLock() error {
+	return nil
+}


### PR DESCRIPTION
## Summary

If a user starts two computer-use sessions at once (e.g. two conversations in the desktop app), both processes would drive the same mouse and keyboard. The screen is a machine-wide resource, so the first session now wins and the second is told to abort. When background mode is added later, multiple sessions can coexist and the lock will scope to foreground sessions only.

## Changes

- The first process to execute an input tool (MouseMove, MouseClick, MouseScroll, KeyboardType, ActivateApp) takes an exclusive `flock` on `~/.infer/run/computer-use.lock` and holds it for its lifetime; the kernel releases it on exit, so a crashed session can never wedge the screen.
- Input tools in any other process fail with "another computer-use session is already controlling the screen; abort this computer-use task", so the losing agent stops immediately instead of stealing the cursor mid-action.
- Read-only tools (GetFocusedApp, GetLatestFrame) are not gated.
- Windows stub (computer use is already disabled there) and a test covering re-acquisition in the same process plus flock contention on a held lock.