### PR TITLE
fix(gateway): stop orphaning the local gateway on exit

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/signal"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -29,6 +27,7 @@ import (
 	render "github.com/inference-gateway/cli/internal/platform/render"
 	streamevent "github.com/inference-gateway/cli/internal/platform/streamevent"
 	telemetry "github.com/inference-gateway/cli/internal/platform/telemetry"
+	utils "github.com/inference-gateway/cli/internal/platform/utils"
 	app "github.com/inference-gateway/cli/internal/presentation/tui/app"
 	colors "github.com/inference-gateway/cli/internal/presentation/tui/styles/colors"
 	web "github.com/inference-gateway/cli/internal/presentation/web"
@@ -118,33 +117,19 @@ func StartChatSession(cfg *config.Config, sessionID string) error {
 	sessionStart := time.Now()
 	endSessionSpan := telemetryRec.StartSession(services.GetStateManager().GetAgentMode().AllowedlistKey())
 
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
-
-	shutdownComplete := make(chan struct{})
-	var shutdownOnce sync.Once
-
-	doShutdown := func() {
-		shutdownOnce.Do(func() {
-			logger.Info("received shutdown signal, cleaning up...")
-			endSessionSpan(telemetry.RunSuccess)
-			telemetryRec.RecordSession(services.GetStateManager().GetAgentMode().AllowedlistKey(), telemetry.RunSuccess, time.Since(sessionStart))
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-			defer cancel()
-			if err := services.Shutdown(ctx); err != nil {
-				logger.Error("error during shutdown", "error", err)
-			}
-			close(shutdownComplete)
-		})
-	}
+	doShutdown := sync.OnceFunc(func() {
+		logger.Info("received shutdown signal, cleaning up...")
+		endSessionSpan(telemetry.RunSuccess)
+		telemetryRec.RecordSession(services.GetStateManager().GetAgentMode().AllowedlistKey(), telemetry.RunSuccess, time.Since(sessionStart))
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		if err := services.Shutdown(ctx); err != nil {
+			logger.Error("error during shutdown", "error", err)
+		}
+	})
 
 	defer doShutdown()
-
-	go func() {
-		<-sigChan
-		doShutdown()
-		os.Exit(0)
-	}()
+	utils.OnShutdownSignal(doShutdown)
 
 	if err := services.GetGatewayManager().EnsureStarted(); err != nil {
 		fmt.Printf("\n⚠️  Failed to start gateway automatically: %v\n", err)
@@ -347,11 +332,13 @@ func runNonInteractiveChat(cfg *config.Config) error {
 	_ = streamevent.SetWriter(io.Discard)
 
 	services := container.NewServiceContainer(cfg)
-	defer func() {
+	doShutdown := sync.OnceFunc(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 		_ = services.Shutdown(ctx)
-	}()
+	})
+	defer doShutdown()
+	utils.OnShutdownSignal(doShutdown)
 
 	if err := services.GetGatewayManager().EnsureStarted(); err != nil {
 		return fmt.Errorf("failed to start gateway: %w", err)

--- a/internal/gateway/manager.go
+++ b/internal/gateway/manager.go
@@ -114,8 +114,12 @@ func (gm *Manager) startBinary(ctx context.Context) error {
 	fmt.Println("• Waiting for gateway to become ready...")
 
 	if err := gm.waitForReady(ctx); err != nil {
-		if stopErr := gm.Stop(ctx); stopErr != nil {
-			logger.Warn("failed to stop gateway during error cleanup", "error", stopErr)
+		if gm.binaryCmd != nil && gm.binaryCmd.Process != nil {
+			if killErr := gm.binaryCmd.Process.Kill(); killErr != nil {
+				logger.Warn("failed to kill gateway binary during error cleanup", "error", killErr)
+			}
+			_ = gm.binaryCmd.Wait()
+			gm.binaryCmd = nil
 		}
 		return fmt.Errorf("gateway failed to become ready: %w", err)
 	}
@@ -164,6 +168,8 @@ func (gm *Manager) startContainer(ctx context.Context) error {
 		return fmt.Errorf("failed to start gateway container: %w", err)
 	}
 
+	gm.isRunning = true
+
 	fmt.Println("• Waiting for gateway to become ready...")
 
 	if err := gm.waitForReady(ctx); err != nil {
@@ -173,7 +179,6 @@ func (gm *Manager) startContainer(ctx context.Context) error {
 		return fmt.Errorf("gateway failed to become ready: %w", err)
 	}
 
-	gm.isRunning = true
 	actualURL := gm.GetGatewayURL()
 	fmt.Printf("• Gateway is ready at %s\n\n", actualURL)
 	logger.Info("gateway container started successfully", "session", gm.sessionID, "url", actualURL, "port", gm.assignedPort)
@@ -212,7 +217,7 @@ func (gm *Manager) stopBinary() error {
 	gm.deregisterPID()
 
 	if gm.pruneAndCheckLive() {
-		logger.Debug("other gateway users still active, deferring binary shutdown")
+		logger.Info("other gateway users still active, deferring binary shutdown")
 	} else {
 		gm.killGateway()
 		gm.removeGatewayPID()
@@ -226,20 +231,21 @@ func (gm *Manager) stopBinary() error {
 // killGateway kills the shared gateway process, using the saved gateway
 // PID file or the in-process binaryCmd handle as fallback.
 func (gm *Manager) killGateway() {
-	if pid := gm.readGatewayPID(); pid > 0 {
+	if gm.binaryCmd != nil && gm.binaryCmd.Process != nil {
+		logger.Info("last process stopping gateway binary", "pid", gm.binaryCmd.Process.Pid)
+		if err := gm.binaryCmd.Process.Kill(); err != nil {
+			logger.Warn("failed to kill gateway binary", "error", err)
+		}
+		return
+	}
+
+	if pid := gm.readGatewayPID(); pid > 0 && utils.ProcessAlive(pid) {
 		logger.Info("last process stopping gateway binary", "pid", pid)
 		proc, err := os.FindProcess(pid)
 		if err == nil {
 			if err := proc.Kill(); err != nil {
 				logger.Warn("failed to kill gateway binary", "pid", pid, "error", err)
 			}
-		}
-		return
-	}
-	if gm.binaryCmd != nil && gm.binaryCmd.Process != nil {
-		logger.Info("last process stopping gateway binary", "pid", gm.binaryCmd.Process.Pid)
-		if err := gm.binaryCmd.Process.Kill(); err != nil {
-			logger.Warn("failed to kill gateway binary", "error", err)
 		}
 	}
 }

--- a/internal/platform/telemetry/recorder.go
+++ b/internal/platform/telemetry/recorder.go
@@ -472,10 +472,10 @@ func (r *Recorder) Shutdown(ctx context.Context) {
 		}
 	}
 	if r.recvSrv != nil {
-		// Give the gateway's batch exporter time to flush pending spans
-		// (default batch delay is 5s, so 6s gives a comfortable margin).
-		// Override receiverGracePeriod to 0 in tests.
-		time.Sleep(receiverGracePeriod)
+		select {
+		case <-time.After(receiverGracePeriod):
+		case <-ctx.Done():
+		}
 		_ = r.recvSrv.Close()
 	}
 	if r.file != nil {

--- a/internal/platform/utils/signals.go
+++ b/internal/platform/utils/signals.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// OnShutdownSignal runs fn on SIGINT, SIGTERM or SIGHUP and then exits. SIGHUP
+// matters as much as the other two: it is what a closing terminal sends, and it
+// is the path on which cleanup was previously skipped entirely.
+//
+// Pair it with sync.OnceFunc and defer the same fn on the normal exit path, so
+// whichever route wins runs the cleanup exactly once.
+func OnShutdownSignal(fn func()) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+	go func() {
+		<-sig
+		fn()
+		os.Exit(0)
+	}()
+}

--- a/internal/presentation/headless/headless.go
+++ b/internal/presentation/headless/headless.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
 	ipc "github.com/inference-gateway/cli/internal/platform/ipc"
@@ -28,6 +29,7 @@ import (
 	models "github.com/inference-gateway/cli/internal/platform/models"
 	render "github.com/inference-gateway/cli/internal/platform/render"
 	telemetry "github.com/inference-gateway/cli/internal/platform/telemetry"
+	utils "github.com/inference-gateway/cli/internal/platform/utils"
 )
 
 // fileRefPattern matches @file references in the task description.
@@ -90,11 +92,13 @@ func Run(cfg *config.Config, opts Options) (err error) { //nolint:gocyclo,cyclop
 
 	svc := container.NewServiceContainer(cfg)
 	svc.StartExtensionBridge()
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdown := sync.OnceFunc(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 		_ = svc.Shutdown(ctx)
-	}()
+	})
+	defer shutdown()
+	utils.OnShutdownSignal(shutdown)
 
 	if err := svc.GetGatewayManager().EnsureStarted(); err != nil {
 		return fmt.Errorf("failed to start inference gateway: %w", err)

--- a/internal/presentation/web/pty_manager.go
+++ b/internal/presentation/web/pty_manager.go
@@ -172,11 +172,20 @@ func NewLocalPTYSession(cfg *config.Config) *LocalPTYSession {
 // isolated tmux server (-L infer-web, so the user's own tmux is untouched) in a
 // fresh session, which lets interactive subagents open visible panes via
 // `tmux split-window`. Otherwise it runs `infer chat` directly.
+//
+// destroy-unattached makes the tmux server reap the session the moment the PTY
+// client dies. Without it the chat survives as a child of the tmux daemon,
+// holding its ~/.infer/run/pids entry forever and silently deferring the
+// gateway shutdown of every later session. It is set before new-session so the
+// session is never briefly unprotected, and -g is safe because the
+// -L infer-web server is ours alone.
 func buildLocalSessionCommand(cfg *config.Config, execPath string) *exec.Cmd {
 	if cfg != nil && cfg.Web.Tmux && tmuxInstalled() {
 		sessionName := fmt.Sprintf("infer-web-%d", time.Now().UnixNano())
 		inner := fmt.Sprintf("'%s' chat", strings.ReplaceAll(execPath, "'", `'\''`))
-		return exec.Command("tmux", "-L", "infer-web", "new-session", "-s", sessionName, inner)
+		return exec.Command("tmux", "-L", "infer-web",
+			"set-option", "-g", "destroy-unattached", "on", ";",
+			"new-session", "-s", sessionName, inner)
 	}
 	return exec.Command(execPath, "chat")
 }

--- a/internal/presentation/web/pty_manager_test.go
+++ b/internal/presentation/web/pty_manager_test.go
@@ -1,0 +1,46 @@
+package web
+
+import (
+	"slices"
+	"testing"
+
+	config "github.com/inference-gateway/cli/config"
+)
+
+// TestBuildLocalSessionCommandSelfReapsTmuxSession guards the tmux teardown. Its
+// regression mode is silent: drop destroy-unattached and every web chat outlives
+// its browser session as a child of the tmux daemon, holding a
+// ~/.infer/run/pids entry that defers the gateway shutdown of every later
+// session - with nothing logged anywhere.
+func TestBuildLocalSessionCommandSelfReapsTmuxSession(t *testing.T) {
+	if !tmuxInstalled() {
+		t.Skip("tmux not installed")
+	}
+
+	args := buildLocalSessionCommand(&config.Config{Web: config.WebConfig{Tmux: true}}, "/usr/local/bin/infer").Args
+
+	opt := slices.Index(args, "destroy-unattached")
+	if opt < 0 {
+		t.Fatalf("destroy-unattached missing from tmux command: %v", args)
+	}
+	if args[opt+1] != "on" {
+		t.Errorf("destroy-unattached = %q, want \"on\"", args[opt+1])
+	}
+
+	newSession := slices.Index(args, "new-session")
+	if newSession < 0 {
+		t.Fatalf("new-session missing from tmux command: %v", args)
+	}
+	if opt > newSession {
+		t.Errorf("destroy-unattached set at %d, after new-session at %d: the session must never be briefly unprotected", opt, newSession)
+	}
+}
+
+func TestBuildLocalSessionCommandWithoutTmux(t *testing.T) {
+	args := buildLocalSessionCommand(&config.Config{}, "/usr/local/bin/infer").Args
+
+	want := []string{"/usr/local/bin/infer", "chat"}
+	if !slices.Equal(args, want) {
+		t.Errorf("args = %v, want %v", args, want)
+	}
+}

--- a/internal/presentation/web/server.go
+++ b/internal/presentation/web/server.go
@@ -386,7 +386,7 @@ func (s *WebTerminalServer) findServerConfig(serverID, sessionID string, conn *w
 
 func (s *WebTerminalServer) handleShutdown() {
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	<-sigChan
 
 	fmt.Println("\n\nShutting down web terminal server...")


### PR DESCRIPTION
## Problem

The local `inference-gateway` binary was sometimes left running after the CLI exited.

The gateway is shared across CLI sessions and killed by whichever session exits last, tracked by PID files under `~/.infer/run/pids`. The shutdown path itself was fine — the **reference count was poisoned**.

The web terminal hosts chat in `tmux -L infer-web new-session`, so the PTY child is the tmux *client* while `infer chat` is a child of the tmux *daemon*. Teardown signalled only the client, so the chat survived indefinitely holding its registration. On the machine this was found on, two such chats were 4.5 h old. The effect is self-perpetuating: from the moment they registered, **every later session declined to stop the gateway**.

It was invisible because that deferral logged at `Debug`, and debug logging is off by default:

| shutdowns in one day's log | 19 |
| `gateway binary stopped` | 13 — none after the abandoned sessions appeared |

## Fixes

| File | Change |
|---|---|
| `web/pty_manager.go` | `destroy-unattached on` — the tmux server reaps the session when the PTY client dies. Also covers a hard kill of the web server, which a `kill-session` in `Close()` would not. |
| `gateway/manager.go` | `startBinary` set `isRunning` *after* its own error cleanup, so `Stop()` early-returned and a readiness timeout orphaned the binary it had just spawned, with no `gateway.pid` written. Kill it directly — routing through `Stop` would only defer the kill onto the reference count. The container path has no reference counting, so there `isRunning` moves up instead. |
| `gateway/manager.go` | `killGateway` trusted a stale `gateway.pid` and returned before it could fall back to the process handle it owned. Prefer that handle; liveness-check the PID file. |
| `gateway/manager.go` | Deferral log `Debug` → `Info`. |
| `platform/utils/signals.go` | New 6-line `OnShutdownSignal` (SIGINT, SIGTERM, **SIGHUP**). |
| `cmd/chat.go`, `headless.go`, `web/server.go` | `headless` had no signal handler at all — SIGHUP on terminal close skipped its deferred `Shutdown` entirely. All three now share the helper via stdlib `sync.OnceFunc`; the dead `shutdownComplete` channel is deleted. |
| `telemetry/recorder.go` | `Shutdown` opened with a non-cancellable `time.Sleep(6s)`, longer than headless's entire 5 s budget, so every `docker stop` behind it failed on an expired context. Honour `ctx`; headless gets the same 20 s budget as chat. |

Net **+6 lines** across the modified files, plus the helper and one test.

## Verification

- tmux behaviour probed live: attached → session alive; client `SIGKILL`ed → session **and** pane process reaped.
- Terminal close (SIGHUP) on a real `go run . chat`: `gateway binary stopped`, PID dead, `gateway.pid` removed.
- Reference counting intact — session A quits → gateway survives for B; B quits → gateway stopped.
- `TestBuildLocalSessionCommandSelfReapsTmuxSession` fails without the fix, passes with it. It guards the one change whose regression is otherwise silent.
- `task test` green, `task precommit:run` 0 issues.

## Deliberately not fixed

The gateway shares the CLI's process group (measured: pgid identical for both), so closing a terminal SIGHUPs it dead as collateral even when another session is using it. That is the opposite complaint, is pre-existing, and fixing it needs `Setsid` plus build-tagged files — while removing the accidental rescue that has been masking this leak. Worth a separate change if it bites.

Also skipped: a startup prune of `~/.infer/run/pids` (after this fix, entries can only be live-and-correct or dead-and-reaped by the existing `pruneAndCheckLive`), and PID identity checks beyond liveness.
