### PR TITLE
feat(sandbox): prompt to extend the sandbox on denied paths

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1487,6 +1487,10 @@ func (c *Config) GetTimeout() int {
 	return c.Gateway.Timeout
 }
 
+// GetSandboxDirectories returns only the configured directories, without
+// runtime grants (AddSandboxDirectory): it feeds the system prompt, which must
+// stay byte-stable within a session to keep the provider prompt cache warm.
+// Validation consults the grants separately.
 func (c *Config) GetSandboxDirectories() []string {
 	return c.Tools.Sandbox.Directories
 }
@@ -1605,7 +1609,7 @@ func (c *Config) ValidatePathInSandbox(path string) error {
 		return nil
 	}
 
-	for _, sandboxDir := range c.Tools.Sandbox.Directories {
+	for _, sandboxDir := range append(grantedSandboxDirectories(), c.Tools.Sandbox.Directories...) {
 		absSandboxDir, err := filepath.Abs(sandboxDir)
 		if err != nil {
 			continue
@@ -1621,7 +1625,7 @@ func (c *Config) ValidatePathInSandbox(path string) error {
 		}
 	}
 
-	return fmt.Errorf("path '%s' is outside configured sandbox directories", path)
+	return &SandboxPathError{Path: path}
 }
 
 // ValidatePathInSandboxWrite is like ValidatePathInSandbox but additionally

--- a/config/sandbox.go
+++ b/config/sandbox.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"sync"
+)
+
+// SandboxPathError is returned when a path is denied by the sandbox
+// allow-list, so callers can offer to extend the sandbox instead of just
+// failing the tool call.
+type SandboxPathError struct{ Path string }
+
+func (e *SandboxPathError) Error() string {
+	return fmt.Sprintf("path '%s' is outside configured sandbox directories", e.Path)
+}
+
+// Runtime sandbox grants: directories the user approved after a denial.
+// ponytail: process-wide state like the port registry below it; fold into
+// Config if one process ever runs multiple configs.
+var (
+	sandboxGrantsMu sync.RWMutex
+	sandboxGrants   []string
+)
+
+// AddSandboxDirectory grants dir as an additional sandbox directory for the
+// rest of the process. Idempotent.
+func AddSandboxDirectory(dir string) {
+	sandboxGrantsMu.Lock()
+	defer sandboxGrantsMu.Unlock()
+	if !slices.Contains(sandboxGrants, dir) {
+		sandboxGrants = append(sandboxGrants, dir)
+	}
+}
+
+func grantedSandboxDirectories() []string {
+	sandboxGrantsMu.RLock()
+	defer sandboxGrantsMu.RUnlock()
+	return slices.Clone(sandboxGrants)
+}
+
+var sandboxDeniedRe = regexp.MustCompile(`path '(.+)' is outside configured sandbox directories`)
+
+// SandboxDeniedPath extracts the denied path from a SandboxPathError message
+// that has been flattened into a tool-result error string.
+func SandboxDeniedPath(msg string) (string, bool) {
+	m := sandboxDeniedRe.FindStringSubmatch(msg)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}

--- a/config/sandbox_test.go
+++ b/config/sandbox_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSandboxDeniedPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      string
+		wantPath string
+		wantOK   bool
+	}{
+		{"denial message", (&SandboxPathError{Path: "/tmp/x"}).Error(), "/tmp/x", true},
+		{"wrapped in tool failure", "Tool execution failed: Read - path '/etc/hosts' is outside configured sandbox directories", "/etc/hosts", true},
+		{"unrelated error", "file not found", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, ok := SandboxDeniedPath(tt.msg)
+			if ok != tt.wantOK || path != tt.wantPath {
+				t.Fatalf("SandboxDeniedPath(%q) = (%q, %v), want (%q, %v)", tt.msg, path, ok, tt.wantPath, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestAddSandboxDirectoryGrantsAccessWithoutChangingPromptList(t *testing.T) {
+	t.Cleanup(func() {
+		sandboxGrantsMu.Lock()
+		sandboxGrants = nil
+		sandboxGrantsMu.Unlock()
+	})
+
+	sandbox := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "file.txt")
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.Tools.Sandbox.Directories = []string{sandbox}
+	cfg.Tools.Sandbox.ProtectedPaths = nil
+
+	if err := cfg.ValidatePathInSandbox(target); err == nil {
+		t.Fatal("expected denial before grant")
+	}
+
+	AddSandboxDirectory(outside)
+
+	if err := cfg.ValidatePathInSandbox(target); err != nil {
+		t.Fatalf("expected access after grant, got %v", err)
+	}
+	if got := cfg.GetSandboxDirectories(); len(got) != 1 || got[0] != sandbox {
+		t.Fatalf("GetSandboxDirectories must stay prompt-stable, got %v", got)
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime/debug"
 	"slices"
 	"strings"
@@ -24,6 +26,7 @@ import (
 	memory "github.com/inference-gateway/cli/internal/platform/memory"
 	models "github.com/inference-gateway/cli/internal/platform/models"
 	telemetry "github.com/inference-gateway/cli/internal/platform/telemetry"
+	utils "github.com/inference-gateway/cli/internal/platform/utils"
 	plugins "github.com/inference-gateway/cli/internal/plugins"
 	scheddomain "github.com/inference-gateway/cli/internal/scheduler/domain"
 )
@@ -1220,11 +1223,102 @@ func (s *AgentServiceImpl) executeTool(
 	return s.executeToolInternal(ctx, tc, eventPublisher, wasApproved, startTime)
 }
 
-// executeToolInternal performs the actual tool execution without approval checks
-// This is used by both executeTool() (after approval) and processNextTool() (approval already obtained)
+// executeToolInternal runs the tool once and, when the failure is a sandbox
+// denial and a user can answer prompts (chat TUI or IPC broker), asks them to
+// grant the denied directory and retries. Used by both executeTool() (after
+// approval) and processNextTool() (approval already obtained).
+func (s *AgentServiceImpl) executeToolInternal(
+	ctx context.Context,
+	tc sdk.ChatCompletionMessageToolCall,
+	eventPublisher *eventPublisher,
+	wasApproved bool,
+	startTime time.Time,
+) convdomain.ConversationEntry {
+	entry := s.executeToolOnce(ctx, tc, eventPublisher, wasApproved, startTime)
+	lastGrant := ""
+	for entry.ToolExecution != nil && !entry.ToolExecution.Success && agentdomain.SandboxApprovalAvailable(ctx) {
+		path, denied := config.SandboxDeniedPath(entry.ToolExecution.Error)
+		if !denied {
+			break
+		}
+		dir := sandboxGrantDir(path)
+		if dir == lastGrant {
+			break
+		}
+		allow, always := s.requestSandboxApproval(ctx, tc, eventPublisher, dir)
+		if !allow {
+			break
+		}
+		lastGrant = dir
+		config.AddSandboxDirectory(dir)
+		logger.Info("sandbox extended by user approval", "dir", dir, "tool", tc.Function.Name, "persisted", always)
+		if always {
+			if err := utils.PersistSandboxDirectory(dir, s.config.Tools.Sandbox.Directories); err != nil {
+				logger.Error("failed to persist sandbox directory", "dir", dir, "error", err)
+			}
+		}
+		entry = s.executeToolOnce(ctx, tc, eventPublisher, wasApproved, startTime)
+	}
+	return entry
+}
+
+// sandboxGrantDir maps a denied path to the directory worth granting: the path
+// itself when it is an existing directory, otherwise its parent.
+func sandboxGrantDir(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	if info, err := os.Stat(abs); err == nil && info.IsDir() {
+		return abs
+	}
+	return filepath.Dir(abs)
+}
+
+// requestSandboxApproval asks the user - through the standard approval
+// pipeline, as a synthetic SandboxAccess tool call - to allow dir outside the
+// sandbox. Approve grants it for this session; auto-accept ("always") also
+// persists it to the userspace config.
+func (s *AgentServiceImpl) requestSandboxApproval(
+	ctx context.Context,
+	tc sdk.ChatCompletionMessageToolCall,
+	eventPublisher *eventPublisher,
+	dir string,
+) (allow, always bool) {
+	args, err := json.Marshal(map[string]string{"path": dir, "tool": tc.Function.Name})
+	if err != nil {
+		return false, false
+	}
+
+	responseChan := make(chan agentdomain.ApprovalAction, 1)
+	eventPublisher.chatEvents <- agentdomain.ToolApprovalRequestedEvent{
+		RequestID: eventPublisher.requestID,
+		Timestamp: time.Now(),
+		ToolCall: sdk.ChatCompletionMessageToolCall{
+			ID:   tc.ID + "-sandbox",
+			Type: tc.Type,
+			Function: sdk.ChatCompletionMessageToolCallFunction{
+				Name:      "SandboxAccess",
+				Arguments: string(args),
+			},
+		},
+		ResponseChan: responseChan,
+	}
+
+	select {
+	case response := <-responseChan:
+		allow = response == agentdomain.ApprovalApprove || response == agentdomain.ApprovalAutoAccept
+		return allow, response == agentdomain.ApprovalAutoAccept
+	case <-ctx.Done():
+	case <-time.After(constants.ApprovalTimeout):
+	}
+	return false, false
+}
+
+// executeToolOnce performs the actual tool execution without approval checks
 //
 //nolint:funlen,gocyclo,cyclop // Tool execution requires comprehensive error handling and status updates
-func (s *AgentServiceImpl) executeToolInternal(
+func (s *AgentServiceImpl) executeToolOnce(
 	ctx context.Context,
 	tc sdk.ChatCompletionMessageToolCall,
 	eventPublisher *eventPublisher,

--- a/internal/agent/agent_event_driven.go
+++ b/internal/agent/agent_event_driven.go
@@ -77,6 +77,8 @@ func NewEventDrivenAgent(
 ) *EventDrivenAgent {
 	stateMachine := NewAgentStateMachine()
 
+	ctx = agentdomain.WithSandboxApprovalAvailable(ctx, req.IsChatMode || req.ApprovalBrokerAttached)
+
 	agentCtx := &states.AgentContext{
 		RequestID:        req.RequestID,
 		Conversation:     conversation,

--- a/internal/agent/domain/context.go
+++ b/internal/agent/domain/context.go
@@ -56,6 +56,11 @@ const ToolCallIDKey ContextKey = "tool_call_id"
 // TraceEnvKey is the context key for the W3C trace-context subprocess environment
 const TraceEnvKey ContextKey = "trace_env"
 
+// SandboxApprovalKey is the context key marking that a user can answer a
+// sandbox-extension prompt in this run (chat TUI, or headless with an IPC
+// approval broker attached). When unset, sandbox denials fail as before.
+const SandboxApprovalKey ContextKey = "sandbox_approval"
+
 // UserQuestionBrokerKey is the context key for the interactive question broker.
 // It is injected only on the chat path (where a TUI event loop exists), so the
 // AskUserQuestion tool sees a nil broker on headless/no-TTY runs and degrades

--- a/internal/agent/domain/context_helpers.go
+++ b/internal/agent/domain/context_helpers.go
@@ -22,6 +22,19 @@ func IsToolApproved(ctx context.Context) bool {
 	return ok && val
 }
 
+// WithSandboxApprovalAvailable marks whether a user can answer a
+// sandbox-extension prompt in this run.
+func WithSandboxApprovalAvailable(ctx context.Context, available bool) context.Context {
+	return context.WithValue(ctx, SandboxApprovalKey, available)
+}
+
+// SandboxApprovalAvailable reports whether a sandbox-extension prompt can be
+// answered by a user in this run. Defaults to false when unset.
+func SandboxApprovalAvailable(ctx context.Context) bool {
+	val, ok := ctx.Value(SandboxApprovalKey).(bool)
+	return ok && val
+}
+
 // ========================================
 // Direct Execution
 // ========================================

--- a/internal/agent/sandbox_approval_test.go
+++ b/internal/agent/sandbox_approval_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	sdk "github.com/inference-gateway/sdk"
+
+	agentdomain "github.com/inference-gateway/cli/internal/agent/domain"
+)
+
+func TestRequestSandboxApproval(t *testing.T) {
+	tests := []struct {
+		name       string
+		response   agentdomain.ApprovalAction
+		wantAllow  bool
+		wantAlways bool
+	}{
+		{"approve grants session-only", agentdomain.ApprovalApprove, true, false},
+		{"auto-accept grants and persists", agentdomain.ApprovalAutoAccept, true, true},
+		{"reject denies", agentdomain.ApprovalReject, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := make(chan agentdomain.ChatEvent, 1)
+			pub := newEventPublisher("req-1", events)
+			svc := &AgentServiceImpl{}
+			tc := sdk.ChatCompletionMessageToolCall{
+				ID:       "call-1",
+				Function: sdk.ChatCompletionMessageToolCallFunction{Name: "Read"},
+			}
+
+			go func() {
+				ev := (<-events).(agentdomain.ToolApprovalRequestedEvent)
+				assert.Equal(t, "SandboxAccess", ev.ToolCall.Function.Name)
+				assert.Equal(t, "call-1-sandbox", ev.ToolCall.ID)
+				var args map[string]string
+				require.NoError(t, json.Unmarshal([]byte(ev.ToolCall.Function.Arguments), &args))
+				assert.Equal(t, "/granted/dir", args["path"])
+				assert.Equal(t, "Read", args["tool"])
+				ev.ResponseChan <- tt.response
+			}()
+
+			allow, always := svc.requestSandboxApproval(context.Background(), tc, pub, "/granted/dir")
+			assert.Equal(t, tt.wantAllow, allow)
+			assert.Equal(t, tt.wantAlways, always)
+		})
+	}
+}
+
+func TestSandboxGrantDir(t *testing.T) {
+	dir := t.TempDir()
+	assert.Equal(t, dir, sandboxGrantDir(dir))
+	assert.Equal(t, dir, sandboxGrantDir(filepath.Join(dir, "missing.txt")))
+}

--- a/internal/platform/ipc/ipc.go
+++ b/internal/platform/ipc/ipc.go
@@ -14,6 +14,7 @@ type ApprovalResponse struct {
 	Type       string `json:"type"` // "approval_response"
 	ToolCallID string `json:"tool_call_id"`
 	Approved   bool   `json:"approved"`
+	Scope      string `json:"scope,omitempty"`
 }
 
 // ComputerUseControlMessage is written to the agent's stdin by a host UI to

--- a/internal/platform/render/render.go
+++ b/internal/platform/render/render.go
@@ -132,9 +132,12 @@ func answerApproval(e agentdomain.ToolApprovalRequestedEvent, approvals <-chan i
 		if resp.ToolCallID != "" && resp.ToolCallID != e.ToolCall.ID {
 			continue
 		}
-		if resp.Approved {
+		switch {
+		case resp.Approved && resp.Scope == "always":
+			e.ResponseChan <- agentdomain.ApprovalAutoAccept
+		case resp.Approved:
 			e.ResponseChan <- agentdomain.ApprovalApprove
-		} else {
+		default:
 			e.ResponseChan <- agentdomain.ApprovalReject
 		}
 		return

--- a/internal/platform/utils/config.go
+++ b/internal/platform/utils/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	viper "github.com/spf13/viper"
 	yaml "gopkg.in/yaml.v3"
@@ -82,4 +83,33 @@ func WriteViperConfigSparse(v *viper.Viper, indent int) error {
 	}
 
 	return nil
+}
+
+// PersistSandboxDirectory appends dir to tools.sandbox.directories in the
+// userspace ~/.infer/config.yaml. current seeds the key when the file does not
+// declare it, so persisting never shrinks the effective allow-list.
+func PersistSandboxDirectory(dir string, current []string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to resolve home directory: %w", err)
+	}
+	path := filepath.Join(home, config.ConfigDirName, config.ConfigFileName)
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	if _, err := os.Stat(path); err == nil {
+		if err := v.ReadInConfig(); err != nil {
+			return fmt.Errorf("failed to read %s: %w", path, err)
+		}
+	}
+
+	dirs := v.GetStringSlice("tools.sandbox.directories")
+	if len(dirs) == 0 {
+		dirs = slices.Clone(current)
+	}
+	if slices.Contains(dirs, dir) {
+		return nil
+	}
+	v.Set("tools.sandbox.directories", append(dirs, dir))
+	return WriteViperConfigWithIndent(v, 2)
 }


### PR DESCRIPTION
## Problem

When a tool call hits a path outside `tools.sandbox.directories`, the denial is a dead end: the agent thrashes on repeated `outside configured sandbox directories` errors (or works around them via Bash) and the user has no way to grant access. Seen in a real desktop session where the agent burned a whole conversation failing to read a repo one directory above its workspace.

## Change

When a tool fails with a sandbox denial **and** a user can answer prompts (chat TUI, or headless with `--require-approval` / an IPC broker attached), the agent raises a synthetic `SandboxAccess` approval request through the existing approval pipeline, carrying the denied directory and the requesting tool:

- **Approve** grants the directory for the rest of the session and retries the tool immediately.
- **Always** (TUI Auto-Approve, or IPC `approval_response` with the new optional `"scope": "always"` field) additionally persists the directory to `tools.sandbox.directories` in the userspace `~/.infer/config.yaml`.
- **Deny** returns the original error. Headless without an approver behaves exactly as before.

The denied path maps to a grant of the containing directory (the path itself when it is a directory, otherwise its parent).

## Prompt-cache safety

Runtime grants are consulted only by `ValidatePathInSandbox`. `GetSandboxDirectories()` — which feeds the system prompt's sandbox section — deliberately excludes them, so the system prompt stays byte-stable within a session and the provider prompt cache stays warm. The model learns about the grant from the retried tool's success.

## Implementation

- `config/sandbox.go`: typed `SandboxPathError`, process-wide runtime grants (`AddSandboxDirectory`), and `SandboxDeniedPath` to recover the path from a flattened tool-result error.
- `internal/agent/agent.go`: `executeToolInternal` is now a thin retry wrapper around the (renamed) `executeToolOnce`; `requestSandboxApproval` reuses `ToolApprovalRequestedEvent`, so every surface (TUI, IPC/desktop, AG-UI) renders it with zero UI changes.
- `internal/platform/ipc`: optional `scope` on `ApprovalResponse`; the headless renderer maps `approved + scope=always` to auto-accept.
- `internal/platform/utils`: `PersistSandboxDirectory` appends to the userspace config, seeding from the current effective list so a sparse file never shrinks the allow-list.

## Testing

- `config/sandbox_test.go`: denial-message round-trip; a grant unblocks validation while `GetSandboxDirectories()` stays prompt-stable.
- `internal/agent/sandbox_approval_test.go`: approve/always/deny response mapping and grant-directory resolution.
- `task precommit:run` and full `go test ./...` pass.

## Follow-ups (separate PRs)

- Desktop: third "Always allow" button sending `"scope": "always"` (works today with Approve/Deny, approve = session-only).
- Bash is still not sandbox-enforced; only Read/Grep/Tree/Edit/Write/Delete are.