### PR TITLE
feat(sandbox): carve out the desktop's projects.json from the protected .infer dir

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1589,7 +1589,7 @@ func (c *Config) ValidatePathInSandbox(path string) error {
 
 	carveOut := (c.Agent.Skills.Enabled && isWithinSkillsDir(absPath)) ||
 		(c.Plugins.Enabled && c.isWithinPluginsDir(absPath)) ||
-		c.isWithinConfigSubdir(absPath, "tmp", "plans", ArtifactsDirName) ||
+		c.isWithinConfigSubdir(absPath, "tmp", "plans", ArtifactsDirName, "projects.json") ||
 		isWithinMemoryDir(absPath, c.Memory) ||
 		isWithinGoLibDirs(absPath)
 
@@ -1673,7 +1673,7 @@ func isWithinSkillsDir(absPath string) bool {
 // subdirectories of the config dir. It checks both the project-relative
 // ConfigDirName (./.infer/<name>) and the resolved config dir
 // (GetConfigDir()/<name>) so that operational areas - tmp scratch, persisted
-// plans - stay reachable even when the config was loaded from the userspace
+// plans, the desktop's projects.json - stay reachable even when the config was loaded from the userspace
 // location (~/.infer). This keeps the rest of .infer/ protected as a whole.
 func (c *Config) isWithinConfigSubdir(absPath string, names ...string) bool {
 	configDirs := []string{ConfigDirName}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1134,6 +1134,7 @@ func TestValidatePathInSandbox_ConfigDirUserspace(t *testing.T) {
 	allowed := []string{
 		filepath.Join(userspaceConfigDir, "tmp", "scratch.txt"),
 		filepath.Join(userspaceConfigDir, "plans", "2026-06-01-do-thing.md"),
+		filepath.Join(userspaceConfigDir, "projects.json"),
 	}
 	for _, p := range allowed {
 		t.Run("allow "+p, func(t *testing.T) {
@@ -1155,6 +1156,13 @@ func TestValidatePathInSandbox_ConfigDirUserspace(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("projects.json is writable", func(t *testing.T) {
+		p := filepath.Join(userspaceConfigDir, "projects.json")
+		if err := cfg.ValidatePathInSandboxWrite(p); err != nil {
+			t.Fatalf("expected %s writable, got %v", p, err)
+		}
+	})
 }
 
 func TestSkillsRepository(t *testing.T) {


### PR DESCRIPTION
## Problem

The desktop app groups sidebar chats into projects via `~/.infer/projects.json`, but the whole `.infer/` directory is a protected path and outside the sandbox, so an agent asked to organize chats cannot touch the file with Read/Edit/Write - in a real session the agent gave up and tried to modify the app's source code instead.

## Change

Adds `projects.json` to the existing config-dir carve-out (`tmp`, `plans`, artifacts) in `ValidatePathInSandbox`, making `<config-dir>/projects.json` readable and writable by the file tools. Pairs with the desktop change that documents the file's schema in the agent's custom instructions and reloads the sidebar after each run.

## Testing

Extended `TestValidatePathInSandbox_ConfigDirUserspace`: `projects.json` is allowed for read and write while sibling config files (`config.yaml`, `agents.yaml`) stay denied. `task precommit:run` passes.